### PR TITLE
fix(ci): add PUBLISH and RELEASE conditions to CI detection logic

### DIFF
--- a/.github/workflows/_ci-detect-changes.reusable.yml
+++ b/.github/workflows/_ci-detect-changes.reusable.yml
@@ -146,7 +146,7 @@ jobs:
             RUN_INTEGRATION="true"
           fi
 
-          if [ "$E2E" = "true" ] || [ "$INFRA" = "true" ] || [ "$NOTES" = "true" ] || [ "$VERSION" = "true" ]; then
+          if [ "$E2E" = "true" ] || [ "$INFRA" = "true" ] || [ "$NOTES" = "true" ] || [ "$VERSION" = "true" ] || [ "$PUBLISH" = "true" ] || [ "$RELEASE" = "true" ]; then
             RUN_E2E="true"
           fi
 


### PR DESCRIPTION
E2Es also need to run when publish and release packages are changed.