### PR TITLE
feat(release): add standing PR commit status checks

### DIFF
--- a/packages/release/src/standing-pr-status.ts
+++ b/packages/release/src/standing-pr-status.ts
@@ -1,0 +1,41 @@
+import { warn } from '@releasekit/core';
+import type { createOctokit } from './preview-github.js';
+
+type OctokitInstance = ReturnType<typeof createOctokit>;
+
+const STATUS_CONTEXT = 'releasekit/standing-pr';
+
+export type CommitStatusState = 'success' | 'pending' | 'failure' | 'error';
+
+export async function postStandingPRStatus(
+  octokit: OctokitInstance,
+  owner: string,
+  repo: string,
+  sha: string,
+  state: CommitStatusState,
+  description: string,
+): Promise<void> {
+  await octokit.rest.repos.createCommitStatus({
+    owner,
+    repo,
+    sha,
+    state,
+    description,
+    context: STATUS_CONTEXT,
+  });
+}
+
+export async function postStandingPRStatusSafe(
+  octokit: OctokitInstance,
+  owner: string,
+  repo: string,
+  sha: string,
+  state: CommitStatusState,
+  description: string,
+): Promise<void> {
+  try {
+    await postStandingPRStatus(octokit, owner, repo, sha, state, description);
+  } catch (err) {
+    warn(`Failed to post commit status: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}

--- a/packages/release/src/standing-pr.ts
+++ b/packages/release/src/standing-pr.ts
@@ -347,7 +347,6 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
   // Commit and force-push the release branch
   info(`Committing and pushing '${branch}'...`);
   commitAndForcePush(branch, cwd);
-  const releaseBranchSha = getHeadSha(cwd);
 
   success(`Release branch '${branch}' updated`);
 
@@ -356,6 +355,7 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
     return { action: 'noop', versionOutput };
   }
 
+  const releaseBranchSha = getHeadSha(cwd);
   const octokit = createOctokit(githubContext.token);
   const { owner, repo } = githubContext;
 

--- a/packages/release/src/standing-pr.ts
+++ b/packages/release/src/standing-pr.ts
@@ -4,6 +4,7 @@ import { loadConfig as loadReleaseKitConfig } from '@releasekit/config';
 import type { VersionOutput } from '@releasekit/core';
 import { error, info, success, warn } from '@releasekit/core';
 import { createOctokit } from './preview-github.js';
+import { postStandingPRStatusSafe } from './standing-pr-status.js';
 import { runNotesStep, runPublishStep, runVersionStep } from './steps.js';
 import type { ReleaseOptions, ReleaseOutput } from './types.js';
 
@@ -346,6 +347,7 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
   // Commit and force-push the release branch
   info(`Committing and pushing '${branch}'...`);
   commitAndForcePush(branch, cwd);
+  const releaseBranchSha = getHeadSha(cwd);
 
   success(`Release branch '${branch}' updated`);
 
@@ -428,6 +430,8 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
 
   await findOrCreateManifestComment(octokit, owner, repo, prNumber, manifest);
   success(`Manifest written to PR #${prNumber}`);
+
+  await postStandingPRStatusSafe(octokit, owner, repo, releaseBranchSha, 'success', 'Ready to merge');
 
   return { action, prNumber, prUrl, versionOutput };
 }

--- a/packages/release/test/unit/standing-pr.spec.ts
+++ b/packages/release/test/unit/standing-pr.spec.ts
@@ -351,6 +351,9 @@ describe('runStandingPRUpdate', () => {
 
     expect(mocks.createCommitStatus).toHaveBeenCalledWith(
       expect.objectContaining({
+        owner: 'owner',
+        repo: 'repo',
+        sha: 'abc123',
         state: 'success',
         description: 'Ready to merge',
         context: 'releasekit/standing-pr',

--- a/packages/release/test/unit/standing-pr.spec.ts
+++ b/packages/release/test/unit/standing-pr.spec.ts
@@ -52,6 +52,7 @@ function createMockOctokit(overrides: Record<string, unknown> = {}) {
     .mockResolvedValue({ data: { number: 42, html_url: 'https://github.com/owner/repo/pull/42' } });
   const pullsUpdate = vi.fn().mockResolvedValue({});
   const issuesSetLabels = vi.fn().mockResolvedValue({});
+  const createCommitStatus = vi.fn().mockResolvedValue({});
 
   const paginate = {
     iterator: vi.fn().mockReturnValue({
@@ -76,10 +77,22 @@ function createMockOctokit(overrides: Record<string, unknown> = {}) {
           create: pullsCreate,
           update: pullsUpdate,
         },
+        repos: {
+          createCommitStatus,
+        },
       },
       ...overrides,
     },
-    mocks: { createComment, updateComment, pullsList, pullsCreate, pullsUpdate, issuesSetLabels, paginate },
+    mocks: {
+      createComment,
+      updateComment,
+      pullsList,
+      pullsCreate,
+      pullsUpdate,
+      issuesSetLabels,
+      paginate,
+      createCommitStatus,
+    },
   };
 }
 
@@ -319,6 +332,50 @@ describe('runStandingPRUpdate', () => {
     expect(result.action).toBe('noop');
     expect(result.versionOutput).toBeDefined();
     expect(result.versionOutput?.updates).toHaveLength(1);
+  });
+
+  it('should post success status check after successful update', async () => {
+    const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
+    const versionOutput = createMockVersionOutput([{ packageName: '@scope/core', newVersion: '1.2.3' }]);
+    vi.mocked(runVersionStep)
+      .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>)
+      .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>);
+    vi.mocked(runNotesStep).mockResolvedValue({ packageNotes: {}, releaseNotes: {}, files: [] });
+
+    const { createOctokit } = await import('../../src/preview-github.js');
+    const { mocks, octokit } = createMockOctokit();
+    mocks.pullsList.mockResolvedValue({ data: [] });
+    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+
+    await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
+
+    expect(mocks.createCommitStatus).toHaveBeenCalledWith(
+      expect.objectContaining({
+        state: 'success',
+        description: 'Ready to merge',
+        context: 'releasekit/standing-pr',
+      }),
+    );
+  });
+
+  it('should not fail the update when status post throws', async () => {
+    const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
+    const versionOutput = createMockVersionOutput([{ packageName: '@scope/core', newVersion: '1.2.3' }]);
+    vi.mocked(runVersionStep)
+      .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>)
+      .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>);
+    vi.mocked(runNotesStep).mockResolvedValue({ packageNotes: {}, releaseNotes: {}, files: [] });
+
+    const { createOctokit } = await import('../../src/preview-github.js');
+    const { mocks, octokit } = createMockOctokit();
+    mocks.pullsList.mockResolvedValue({ data: [] });
+    mocks.createCommitStatus.mockRejectedValue(new Error('GitHub API error'));
+    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+
+    const result = await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
+
+    expect(result.action).toBe('created');
+    expect(result.prNumber).toBe(42);
   });
 });
 


### PR DESCRIPTION
## Summary

Implements **Follow-up 3 — Standing PR status checks** from `AUTOMATION_PLAN.md`.

- Adds a new `standing-pr-status.ts` module with `postStandingPRStatus` (wraps `octokit.rest.repos.createCommitStatus`) and `postStandingPRStatusSafe` (catches/warns on failure so the update stays non-fatal)
- At the end of every successful `runStandingPRUpdate`, posts a `releasekit/standing-pr` commit status on the release branch HEAD with `state: success` and description `"Ready to merge"`
- The release branch HEAD SHA is captured immediately after the force-push, before any GitHub API calls
- Two new unit tests cover the success path and the error-resilient (status-post-failure) path

Maintainers can now configure `releasekit/standing-pr` as a required status check in branch protection to gate merges on a fresh standing PR update.

## Test plan

- [x] All 22 standing-pr unit tests pass (`vitest run test/unit/standing-pr.spec.ts`)
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] Biome linting passes (applied by pre-commit hook)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TqpBSjjS9c2fFo4RmFNxm5)_