### PR TITLE
feat: release notes editing in standing PR

### DIFF
--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -279,6 +279,8 @@ export const StandingPrConfigSchema = z.object({
   labels: z.array(z.string()).default(['release']),
   /** Whether to auto-delete the release branch after PR merge. Default: true */
   deleteBranchOnMerge: z.boolean().default(true),
+  /** Allow teams to edit the release notes section in the PR body before publishing. Default: false */
+  editableNotes: z.boolean().default(false),
 });
 
 export const CIConfigSchema = z.object({

--- a/packages/release/src/index.ts
+++ b/packages/release/src/index.ts
@@ -4,7 +4,13 @@ export type { PreviewOptions } from './preview.js';
 export { runPreview } from './preview.js';
 export { resolveScopeToTarget, runRelease } from './release.js';
 export type { StandingPRManifest, StandingPROptions, StandingPRResult } from './standing-pr.js';
-export { runStandingPRPublish, runStandingPRUpdate } from './standing-pr.js';
+export {
+  extractEditableSection,
+  parseEditedNotes,
+  publishFromManifest,
+  runStandingPRPublish,
+  runStandingPRUpdate,
+} from './standing-pr.js';
 export type { NotesStepResult } from './steps.js';
 export { runNotesStep, runPublishStep, runVersionStep } from './steps.js';
 export type { ReleaseOptions, ReleaseOutput } from './types.js';

--- a/packages/release/src/standing-pr.ts
+++ b/packages/release/src/standing-pr.ts
@@ -147,7 +147,9 @@ export function extractEditableSection(body: string): string | null {
 // Splits on "#### <pkg> — <version>" headings; falls back gracefully for unrecognised lines.
 export function parseEditedNotes(section: string): Record<string, string> {
   const result: Record<string, string> = {};
-  const parts = section.split(/(?=^#### )/m);
+  // Split only on "#### <pkg> — <version>" lines (em dash U+2014), not on h4 subheadings
+  // within notes body (e.g. "#### Breaking Changes" has no em dash and must not split).
+  const parts = section.split(/(?=^#### .+ — .+$)/m);
   for (const part of parts) {
     const firstNewline = part.indexOf('\n');
     if (firstNewline === -1) continue;
@@ -189,7 +191,7 @@ function renderPrBody(
     const sectionContent = overrideSection ?? renderNotesSection(versionOutput, releaseNotes);
     lines.push('');
     if (editableNotes) {
-      lines.push(EDITABLE_START, sectionContent, EDITABLE_END);
+      lines.push(EDITABLE_START, sectionContent, EDITABLE_END, '');
     } else {
       lines.push(sectionContent, '');
     }

--- a/packages/release/src/standing-pr.ts
+++ b/packages/release/src/standing-pr.ts
@@ -143,26 +143,33 @@ export function extractEditableSection(body: string): string | null {
   return body.slice(start + EDITABLE_START.length, end).trim();
 }
 
-// Parses an editable section back into per-package notes.
-// Splits on "#### <pkg> — <version>" headings; falls back gracefully for unrecognised lines.
+// Parses an editable section back into per-package notes using a line-by-line accumulator.
+// Package headings are "#### <pkg> — <version>" (em dash U+2014). h4 subheadings within
+// notes (e.g. "#### Breaking Changes") have no em dash and are accumulated as content.
+// [^—]+ is used for the package-name portion to avoid backtracking ambiguity.
 export function parseEditedNotes(section: string): Record<string, string> {
   const result: Record<string, string> = {};
-  // Split only on "#### <pkg> — <version>" lines (em dash U+2014), not on h4 subheadings
-  // within notes body (e.g. "#### Breaking Changes" has no em dash and must not split).
-  const parts = section.split(/(?=^#### .+ — .+$)/m);
-  for (const part of parts) {
-    const firstNewline = part.indexOf('\n');
-    if (firstNewline === -1) continue;
-    const heading = part.slice(0, firstNewline).trim();
-    // Match "#### <pkg> — <version>" (em dash U+2014)
-    const headingMatch = heading.match(/^#### (.+?) — .+$/);
-    if (!headingMatch?.[1]) continue;
-    const pkg = headingMatch[1].trim();
-    const content = part.slice(firstNewline).trim();
-    if (pkg) {
-      result[pkg] = content;
+  let currentPkg: string | null = null;
+  const accum: string[] = [];
+
+  const flush = () => {
+    if (currentPkg !== null) {
+      result[currentPkg] = accum.join('\n').trim();
+      accum.length = 0;
+    }
+  };
+
+  for (const line of section.split('\n')) {
+    const headingMatch = line.match(/^#### ([^—]+) — \S/);
+    if (headingMatch?.[1]) {
+      flush();
+      currentPkg = headingMatch[1].trim();
+    } else if (currentPkg !== null) {
+      accum.push(line);
     }
   }
+  flush();
+
   return result;
 }
 

--- a/packages/release/src/standing-pr.ts
+++ b/packages/release/src/standing-pr.ts
@@ -1,4 +1,5 @@
 import { execSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
 import * as fs from 'node:fs';
 import { loadConfig as loadReleaseKitConfig } from '@releasekit/config';
 import type { VersionOutput } from '@releasekit/core';
@@ -9,6 +10,8 @@ import type { ReleaseOptions, ReleaseOutput } from './types.js';
 
 const MANIFEST_MARKER = '<!-- releasekit-manifest -->';
 const MANIFEST_SCHEMA_VERSION = 1;
+const EDITABLE_START = '<!-- releasekit-editable-start -->';
+const EDITABLE_END = '<!-- releasekit-editable-end -->';
 
 export interface StandingPROptions {
   config?: string;
@@ -33,6 +36,7 @@ export interface StandingPRManifest {
   notesFiles: string[];
   createdAt: string;
   baseSha: string;
+  notesHash?: string;
 }
 
 function getGitHubContext(): { owner: string; repo: string; token: string } | null {
@@ -110,7 +114,62 @@ function commitAndForcePush(branch: string, cwd: string): void {
   execSync(`git push --force-with-lease origin "${branch}"`, { encoding: 'utf-8', cwd, stdio: 'pipe' });
 }
 
-function renderPrBody(versionOutput: VersionOutput, releaseNotes: Record<string, string>): string {
+// Renders the release notes section content (without editable markers).
+// Used both for writing to PR bodies and for computing notesHash.
+function renderNotesSection(versionOutput: VersionOutput, releaseNotes: Record<string, string>): string {
+  const lines: string[] = ['### Release Notes', ''];
+  for (const [pkg, notes] of Object.entries(releaseNotes)) {
+    const update = versionOutput.updates.find((u) => u.packageName === pkg);
+    if (update) {
+      lines.push(`#### ${pkg} — ${update.newVersion}`, '');
+    } else {
+      lines.push(`#### ${pkg}`, '');
+    }
+    lines.push(notes.trim(), '');
+  }
+  if (lines[lines.length - 1] === '') lines.pop();
+  return lines.join('\n');
+}
+
+function computeNotesHash(section: string): string {
+  return createHash('sha256').update(section).digest('hex').slice(0, 16);
+}
+
+// Extracts the content between editable markers from a PR body, or null if markers are absent.
+export function extractEditableSection(body: string): string | null {
+  const start = body.indexOf(EDITABLE_START);
+  const end = body.indexOf(EDITABLE_END);
+  if (start === -1 || end === -1 || end < start) return null;
+  return body.slice(start + EDITABLE_START.length, end).trim();
+}
+
+// Parses an editable section back into per-package notes.
+// Splits on "#### <pkg> — <version>" headings; falls back gracefully for unrecognised lines.
+export function parseEditedNotes(section: string): Record<string, string> {
+  const result: Record<string, string> = {};
+  const parts = section.split(/(?=^#### )/m);
+  for (const part of parts) {
+    const firstNewline = part.indexOf('\n');
+    if (firstNewline === -1) continue;
+    const heading = part.slice(0, firstNewline).trim();
+    // Match "#### <pkg> — <version>" (em dash U+2014)
+    const headingMatch = heading.match(/^#### (.+?) — .+$/);
+    if (!headingMatch?.[1]) continue;
+    const pkg = headingMatch[1].trim();
+    const content = part.slice(firstNewline).trim();
+    if (pkg) {
+      result[pkg] = content;
+    }
+  }
+  return result;
+}
+
+function renderPrBody(
+  versionOutput: VersionOutput,
+  releaseNotes: Record<string, string>,
+  editableNotes = false,
+  overrideSection?: string,
+): string {
   const lines: string[] = [
     '## Release',
     '',
@@ -127,15 +186,12 @@ function renderPrBody(versionOutput: VersionOutput, releaseNotes: Record<string,
 
   const hasNotes = Object.keys(releaseNotes).length > 0;
   if (hasNotes) {
-    lines.push('', '### Release Notes', '');
-    for (const [pkg, notes] of Object.entries(releaseNotes)) {
-      const update = versionOutput.updates.find((u) => u.packageName === pkg);
-      if (update) {
-        lines.push(`#### ${pkg} — ${update.newVersion}`, '');
-      } else {
-        lines.push(`#### ${pkg}`, '');
-      }
-      lines.push(notes.trim(), '');
+    const sectionContent = overrideSection ?? renderNotesSection(versionOutput, releaseNotes);
+    lines.push('');
+    if (editableNotes) {
+      lines.push(EDITABLE_START, sectionContent, EDITABLE_END);
+    } else {
+      lines.push(sectionContent, '');
     }
   }
 
@@ -357,7 +413,7 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
   const octokit = createOctokit(githubContext.token);
   const { owner, repo } = githubContext;
 
-  // Build PR title
+  // Build PR title and labels
   const count = versionOutput.updates.length;
   const firstUpdate = versionOutput.updates[0];
   /* biome-ignore lint/suspicious/noTemplateCurlyInString: template string uses config variable */
@@ -366,10 +422,47 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
     .replace(/\$\{count\}/g, String(count))
     .replace(/\$\{version\}/g, firstUpdate?.newVersion ?? '');
 
-  const body = renderPrBody(versionOutput, notesResult.releaseNotes ?? {});
   const labels = standingPrConfig?.labels ?? ['release'];
+  const editableNotesEnabled = standingPrConfig?.editableNotes ?? false;
+  const hasNotes = Object.keys(notesResult.releaseNotes ?? {}).length > 0;
+
+  // Pre-compute fresh notes section and its hash for edit-detection tracking
+  const freshSection =
+    editableNotesEnabled && hasNotes ? renderNotesSection(versionOutput, notesResult.releaseNotes ?? {}) : undefined;
+  const notesHash = freshSection ? computeNotesHash(freshSection) : undefined;
 
   const existing = await findStandingPR(octokit, owner, repo, branch);
+
+  // When editableNotes is enabled and a PR exists, check whether the user has manually
+  // edited the notes section. If the current section hash differs from the stored hash,
+  // preserve the user's edits rather than overwriting them.
+  let overrideSection: string | undefined;
+  if (editableNotesEnabled && existing && freshSection) {
+    const existingManifestComment = await findManifestComment(octokit, owner, repo, existing.number);
+    if (existingManifestComment) {
+      try {
+        const existingManifest = parseManifest(existingManifestComment.body);
+        if (existingManifest.notesHash) {
+          const { data: prData } = await octokit.rest.pulls.get({
+            owner,
+            repo,
+            pull_number: existing.number,
+          });
+          if (prData.body) {
+            const currentSection = extractEditableSection(prData.body);
+            if (currentSection && computeNotesHash(currentSection) !== existingManifest.notesHash) {
+              warn('User has edited the release notes section — preserving edits');
+              overrideSection = currentSection;
+            }
+          }
+        }
+      } catch {
+        // Can't parse manifest — proceed with fresh generation
+      }
+    }
+  }
+
+  const body = renderPrBody(versionOutput, notesResult.releaseNotes ?? {}, editableNotesEnabled, overrideSection);
 
   let prNumber: number;
   let prUrl: string;
@@ -424,6 +517,7 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
     notesFiles: notesResult.files,
     createdAt: new Date().toISOString(),
     baseSha,
+    notesHash,
   };
 
   await findOrCreateManifestComment(octokit, owner, repo, prNumber, manifest);
@@ -432,46 +526,10 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
   return { action, prNumber, prUrl, versionOutput };
 }
 
-export async function runStandingPRPublish(options: StandingPROptions): Promise<ReleaseOutput | null> {
+// Core publish logic: finds manifest on the given PR, optionally extracts user-edited
+// notes from the PR body, then runs the publish step and cleans up the release branch.
+export async function publishFromManifest(prNumber: number, options: StandingPROptions): Promise<ReleaseOutput | null> {
   const cwd = options.projectDir;
-
-  // Guard: verify this is triggered by the release PR being merged
-  const eventPath = process.env.GITHUB_EVENT_PATH;
-  if (!eventPath) {
-    error('GITHUB_EVENT_PATH not set — standing-pr publish must run in GitHub Actions');
-    return null;
-  }
-
-  let event: { pull_request?: { head?: { ref?: string }; number?: number; merged?: boolean } };
-  try {
-    event = JSON.parse(fs.readFileSync(eventPath, 'utf-8'));
-  } catch (err) {
-    error(`Failed to read GitHub event: ${err instanceof Error ? err.message : String(err)}`);
-    return null;
-  }
-
-  const releaseKitConfig = loadReleaseKitConfig({ cwd, configPath: options.config });
-  const standingPrConfig = releaseKitConfig.ci?.standingPr;
-  const releaseBranch = standingPrConfig?.branch ?? 'release/next';
-
-  const headRef = event.pull_request?.head?.ref;
-  const merged = event.pull_request?.merged;
-  const prNumber = event.pull_request?.number;
-
-  if (!headRef || headRef !== releaseBranch) {
-    info(`Skipping: merged PR head ref '${headRef}' does not match release branch '${releaseBranch}'`);
-    return null;
-  }
-
-  if (!merged) {
-    info('Skipping: PR was not merged');
-    return null;
-  }
-
-  if (!prNumber) {
-    error('Could not determine PR number from GitHub event');
-    return null;
-  }
 
   const githubContext = getGitHubContext();
   if (!githubContext) {
@@ -482,7 +540,11 @@ export async function runStandingPRPublish(options: StandingPROptions): Promise<
   const octokit = createOctokit(githubContext.token);
   const { owner, repo } = githubContext;
 
-  // Find and parse manifest from the merged PR
+  const releaseKitConfig = loadReleaseKitConfig({ cwd, configPath: options.config });
+  const standingPrConfig = releaseKitConfig.ci?.standingPr;
+  const releaseBranch = standingPrConfig?.branch ?? 'release/next';
+
+  // Find and parse manifest from the PR
   const manifestComment = await findManifestComment(octokit, owner, repo, prNumber);
   if (!manifestComment) {
     throw new Error(`Release manifest not found on PR #${prNumber}. Re-run 'standing-pr update' to regenerate.`);
@@ -508,6 +570,28 @@ export async function runStandingPRPublish(options: StandingPROptions): Promise<
     warn(
       `Manifest baseSha (${manifest.baseSha}) is not an ancestor of current HEAD (${currentSha}) — history may have been rewritten`,
     );
+  }
+
+  // If editableNotes is enabled, extract any user edits from the PR body and merge them
+  // into the manifest's releaseNotes, falling back to manifest notes for missing packages.
+  if (standingPrConfig?.editableNotes) {
+    const { data: prData } = await octokit.rest.pulls.get({ owner, repo, pull_number: prNumber });
+    if (prData.body) {
+      const editableSection = extractEditableSection(prData.body);
+      if (editableSection) {
+        const editedNotes = parseEditedNotes(editableSection);
+        const mergedNotes: Record<string, string> = { ...manifest.releaseNotes };
+        for (const [pkg, notes] of Object.entries(editedNotes)) {
+          mergedNotes[pkg] = notes;
+        }
+        for (const pkg of Object.keys(manifest.releaseNotes)) {
+          if (!(pkg in editedNotes)) {
+            warn(`Package '${pkg}' heading not found in edited release notes — using original notes`);
+          }
+        }
+        manifest = { ...manifest, releaseNotes: mergedNotes };
+      }
+    }
   }
 
   info(`Publishing from manifest: ${manifest.versionOutput.updates.length} package(s)`);
@@ -559,4 +643,48 @@ export async function runStandingPRPublish(options: StandingPROptions): Promise<
     releaseNotes: manifest.releaseNotes,
     publishOutput,
   };
+}
+
+export async function runStandingPRPublish(options: StandingPROptions): Promise<ReleaseOutput | null> {
+  const cwd = options.projectDir;
+
+  // Guard: verify this is triggered by the release PR being merged
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (!eventPath) {
+    error('GITHUB_EVENT_PATH not set — standing-pr publish must run in GitHub Actions');
+    return null;
+  }
+
+  let event: { pull_request?: { head?: { ref?: string }; number?: number; merged?: boolean } };
+  try {
+    event = JSON.parse(fs.readFileSync(eventPath, 'utf-8'));
+  } catch (err) {
+    error(`Failed to read GitHub event: ${err instanceof Error ? err.message : String(err)}`);
+    return null;
+  }
+
+  const releaseKitConfig = loadReleaseKitConfig({ cwd, configPath: options.config });
+  const standingPrConfig = releaseKitConfig.ci?.standingPr;
+  const releaseBranch = standingPrConfig?.branch ?? 'release/next';
+
+  const headRef = event.pull_request?.head?.ref;
+  const merged = event.pull_request?.merged;
+  const prNumber = event.pull_request?.number;
+
+  if (!headRef || headRef !== releaseBranch) {
+    info(`Skipping: merged PR head ref '${headRef}' does not match release branch '${releaseBranch}'`);
+    return null;
+  }
+
+  if (!merged) {
+    info('Skipping: PR was not merged');
+    return null;
+  }
+
+  if (!prNumber) {
+    error('Could not determine PR number from GitHub event');
+    return null;
+  }
+
+  return publishFromManifest(prNumber, options);
 }

--- a/packages/release/test/unit/standing-pr.spec.ts
+++ b/packages/release/test/unit/standing-pr.spec.ts
@@ -1,6 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { StandingPRManifest } from '../../src/standing-pr.js';
-import { parseManifest, runStandingPRPublish, runStandingPRUpdate, serializeManifest } from '../../src/standing-pr.js';
+import {
+  extractEditableSection,
+  parseEditedNotes,
+  parseManifest,
+  publishFromManifest,
+  runStandingPRPublish,
+  runStandingPRUpdate,
+  serializeManifest,
+} from '../../src/standing-pr.js';
 
 vi.mock('node:child_process', () => ({
   execSync: vi.fn().mockReturnValue(''),
@@ -51,6 +59,7 @@ function createMockOctokit(overrides: Record<string, unknown> = {}) {
     .fn()
     .mockResolvedValue({ data: { number: 42, html_url: 'https://github.com/owner/repo/pull/42' } });
   const pullsUpdate = vi.fn().mockResolvedValue({});
+  const pullsGet = vi.fn().mockResolvedValue({ data: { body: '' } });
   const issuesSetLabels = vi.fn().mockResolvedValue({});
 
   const paginate = {
@@ -75,11 +84,12 @@ function createMockOctokit(overrides: Record<string, unknown> = {}) {
           list: pullsList,
           create: pullsCreate,
           update: pullsUpdate,
+          get: pullsGet,
         },
       },
       ...overrides,
     },
-    mocks: { createComment, updateComment, pullsList, pullsCreate, pullsUpdate, issuesSetLabels, paginate },
+    mocks: { createComment, updateComment, pullsList, pullsCreate, pullsUpdate, pullsGet, issuesSetLabels, paginate },
   };
 }
 
@@ -563,5 +573,483 @@ describe('runStandingPRPublish', () => {
     await expect(
       runStandingPRPublish({ projectDir: '/test', verbose: false, quiet: false, json: false }),
     ).rejects.toThrow(/invalid or incompatible/);
+  });
+});
+
+// ─── Editable notes helpers ───────────────────────────────────────────────────
+
+describe('extractEditableSection', () => {
+  const START = '<!-- releasekit-editable-start -->';
+  const END = '<!-- releasekit-editable-end -->';
+
+  it('returns the trimmed content between editable markers', () => {
+    const body = `some text\n\n${START}\n### Release Notes\n\n#### pkg — 1.0.0\n\n- note\n${END}\n---`;
+    expect(extractEditableSection(body)).toBe('### Release Notes\n\n#### pkg — 1.0.0\n\n- note');
+  });
+
+  it('returns null when start marker is absent', () => {
+    expect(extractEditableSection(`### Release Notes\n\n${END}`)).toBeNull();
+  });
+
+  it('returns null when end marker is absent', () => {
+    expect(extractEditableSection(`${START}\n### Release Notes`)).toBeNull();
+  });
+
+  it('returns null when both markers are absent', () => {
+    expect(extractEditableSection('### Release Notes\n\n- note')).toBeNull();
+  });
+
+  it('returns null when end marker precedes start marker', () => {
+    expect(extractEditableSection(`${END}\n${START}`)).toBeNull();
+  });
+});
+
+describe('parseEditedNotes', () => {
+  it('parses multiple packages from a section', () => {
+    const section = [
+      '### Release Notes',
+      '',
+      '#### @scope/core — 1.2.3',
+      '',
+      '- added feature',
+      '',
+      '#### @scope/cli — 2.0.0',
+      '',
+      '- fixed bug',
+    ].join('\n');
+
+    const result = parseEditedNotes(section);
+    expect(result['@scope/core']).toBe('- added feature');
+    expect(result['@scope/cli']).toBe('- fixed bug');
+  });
+
+  it('returns empty object for a section with no package headings', () => {
+    expect(parseEditedNotes('### Release Notes\n\nsome text')).toEqual({});
+  });
+
+  it('returns empty object for an empty string', () => {
+    expect(parseEditedNotes('')).toEqual({});
+  });
+
+  it('round-trips the content produced by renderPrBody editable markers', () => {
+    const versionOutput = createMockVersionOutput([
+      { packageName: '@scope/core', newVersion: '1.2.3' },
+      { packageName: '@scope/cli', newVersion: '2.0.0' },
+    ]);
+    const releaseNotes = {
+      '@scope/core': '- added feature',
+      '@scope/cli': '- fixed bug',
+    };
+
+    // Manually reconstruct what renderNotesSection/renderPrBody produces
+    const section = [
+      '### Release Notes',
+      '',
+      '#### @scope/core — 1.2.3',
+      '',
+      '- added feature',
+      '',
+      '#### @scope/cli — 2.0.0',
+      '',
+      '- fixed bug',
+    ].join('\n');
+
+    const parsed = parseEditedNotes(section);
+    expect(parsed).toEqual(releaseNotes);
+    // Suppress unused variable warning
+    void versionOutput;
+  });
+});
+
+// ─── editableNotes in runStandingPRUpdate ─────────────────────────────────────
+
+describe('runStandingPRUpdate — editableNotes', () => {
+  const originalEnv = { ...process.env };
+
+  const editableConfig = {
+    ci: {
+      standingPr: {
+        branch: 'release/next',
+        labels: ['release'],
+        deleteBranchOnMerge: true,
+        title: 'chore: release ${count} package(s)',
+        editableNotes: true,
+      },
+      releaseStrategy: 'standing-pr',
+      releaseTrigger: 'label',
+      prPreview: true,
+      autoRelease: false,
+      skipPatterns: ['chore: release '],
+      minChanges: 1,
+      labels: {
+        stable: 'release:stable',
+        prerelease: 'release:prerelease',
+        skip: 'release:skip',
+        major: 'bump:major',
+        minor: 'bump:minor',
+        patch: 'bump:patch',
+      },
+    },
+    git: { branch: 'main', remote: 'origin', pushMethod: 'auto' },
+    release: { ci: { skipPatterns: ['chore: release '] } },
+  };
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    process.env.GITHUB_REPOSITORY = 'owner/repo';
+    process.env.GITHUB_TOKEN = 'test-token';
+
+    const { loadConfig } = await import('@releasekit/config');
+    vi.mocked(loadConfig).mockReturnValue(editableConfig as ReturnType<typeof loadConfig>);
+
+    const { execSync } = await import('node:child_process');
+    vi.mocked(execSync).mockReturnValue('abc123\n' as unknown as Buffer);
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('stores notesHash in manifest when editableNotes is enabled and notes exist', async () => {
+    const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
+    const versionOutput = createMockVersionOutput([{ packageName: '@scope/core', newVersion: '1.2.3' }]);
+    vi.mocked(runVersionStep)
+      .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>)
+      .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>);
+    vi.mocked(runNotesStep).mockResolvedValue({
+      packageNotes: {},
+      releaseNotes: { '@scope/core': '- added feature' },
+      files: [],
+    });
+
+    const { createOctokit } = await import('../../src/preview-github.js');
+    const { mocks, octokit } = createMockOctokit();
+    mocks.pullsList.mockResolvedValue({ data: [] });
+    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+
+    await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
+
+    // The manifest comment should have been created; verify notesHash is present
+    const createCommentCall = mocks.createComment.mock.calls.find(
+      (c: unknown[]) =>
+        typeof c[0] === 'object' &&
+        c[0] !== null &&
+        'body' in (c[0] as Record<string, unknown>) &&
+        typeof (c[0] as Record<string, unknown>).body === 'string' &&
+        ((c[0] as Record<string, unknown>).body as string).includes('<!-- releasekit-manifest -->'),
+    );
+    expect(createCommentCall).toBeDefined();
+
+    const commentBody = (createCommentCall![0] as Record<string, unknown>).body as string;
+    const parsedManifest = parseManifest(commentBody);
+    expect(parsedManifest.notesHash).toBeDefined();
+    expect(typeof parsedManifest.notesHash).toBe('string');
+  });
+
+  it('includes editable markers in PR body when editableNotes is enabled', async () => {
+    const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
+    const versionOutput = createMockVersionOutput([{ packageName: '@scope/core', newVersion: '1.2.3' }]);
+    vi.mocked(runVersionStep)
+      .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>)
+      .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>);
+    vi.mocked(runNotesStep).mockResolvedValue({
+      packageNotes: {},
+      releaseNotes: { '@scope/core': '- added feature' },
+      files: [],
+    });
+
+    const { createOctokit } = await import('../../src/preview-github.js');
+    const { mocks, octokit } = createMockOctokit();
+    mocks.pullsList.mockResolvedValue({ data: [] });
+    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+
+    await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
+
+    expect(mocks.pullsCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.stringContaining('<!-- releasekit-editable-start -->'),
+      }),
+    );
+    expect(mocks.pullsCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.stringContaining('<!-- releasekit-editable-end -->'),
+      }),
+    );
+  });
+
+  it('preserves user edits when existing section hash does not match stored notesHash', async () => {
+    const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
+    const versionOutput = createMockVersionOutput([{ packageName: '@scope/core', newVersion: '1.2.3' }]);
+    vi.mocked(runVersionStep)
+      .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>)
+      .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>);
+    vi.mocked(runNotesStep).mockResolvedValue({
+      packageNotes: {},
+      releaseNotes: { '@scope/core': '- added feature' },
+      files: [],
+    });
+
+    // Manifest stored with a hash that does NOT match the current PR body section
+    const manifestWithDifferentHash: StandingPRManifest = {
+      ...baseManifest,
+      notesHash: 'aaaaaaaaaaaaaaaa', // intentionally wrong hash
+    };
+
+    const userEditedBody = [
+      '## Release',
+      '',
+      '<!-- releasekit-editable-start -->',
+      '### Release Notes',
+      '',
+      '#### @scope/core — 1.2.3',
+      '',
+      '- user-edited content here',
+      '<!-- releasekit-editable-end -->',
+      '---',
+    ].join('\n');
+
+    const { createOctokit } = await import('../../src/preview-github.js');
+    const { mocks, octokit } = createMockOctokit();
+    mocks.pullsList.mockResolvedValue({ data: [{ number: 99, html_url: 'https://github.com/owner/repo/pull/99' }] });
+    mocks.pullsGet.mockResolvedValue({ data: { body: userEditedBody } });
+    mocks.paginate.iterator.mockReturnValue({
+      async *[Symbol.asyncIterator]() {
+        yield { data: [{ id: 77, body: serializeManifest(manifestWithDifferentHash) }] };
+      },
+    });
+    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+
+    await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
+
+    // PR body should contain the user's edited content
+    expect(mocks.pullsUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.stringContaining('user-edited content here'),
+      }),
+    );
+  });
+
+  it('regenerates notes when existing section hash matches stored notesHash (user has not edited)', async () => {
+    const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
+    const versionOutput = createMockVersionOutput([{ packageName: '@scope/core', newVersion: '1.2.3' }]);
+    vi.mocked(runVersionStep)
+      .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>)
+      .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>);
+    vi.mocked(runNotesStep).mockResolvedValue({
+      packageNotes: {},
+      releaseNotes: { '@scope/core': '- added feature' },
+      files: [],
+    });
+
+    // Build a body with markers + the exact freshly-generated section, so the hash matches
+    const freshSection = '### Release Notes\n\n#### @scope/core — 1.2.3\n\n- added feature';
+    const { createHash } = await import('node:crypto');
+    const freshHash = createHash('sha256').update(freshSection).digest('hex').slice(0, 16);
+
+    const manifestWithMatchingHash: StandingPRManifest = {
+      ...baseManifest,
+      notesHash: freshHash,
+    };
+
+    const unedited = [
+      '## Release',
+      '',
+      '<!-- releasekit-editable-start -->',
+      freshSection,
+      '<!-- releasekit-editable-end -->',
+      '---',
+    ].join('\n');
+
+    const { createOctokit } = await import('../../src/preview-github.js');
+    const { mocks, octokit } = createMockOctokit();
+    mocks.pullsList.mockResolvedValue({ data: [{ number: 99, html_url: 'https://github.com/owner/repo/pull/99' }] });
+    mocks.pullsGet.mockResolvedValue({ data: { body: unedited } });
+    mocks.paginate.iterator.mockReturnValue({
+      async *[Symbol.asyncIterator]() {
+        yield { data: [{ id: 77, body: serializeManifest(manifestWithMatchingHash) }] };
+      },
+    });
+    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+
+    await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
+
+    // PR body should contain the freshly generated content (markers present, no user override)
+    expect(mocks.pullsUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.stringContaining('<!-- releasekit-editable-start -->'),
+      }),
+    );
+    expect(mocks.pullsUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.stringContaining('- added feature'),
+      }),
+    );
+  });
+});
+
+// ─── publishFromManifest ──────────────────────────────────────────────────────
+
+describe('publishFromManifest', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    process.env.GITHUB_REPOSITORY = 'owner/repo';
+    process.env.GITHUB_TOKEN = 'test-token';
+
+    const { loadConfig } = await import('@releasekit/config');
+    vi.mocked(loadConfig).mockReturnValue({
+      ci: { standingPr: { branch: 'release/next', deleteBranchOnMerge: true, editableNotes: false } },
+      git: { branch: 'main' },
+    } as ReturnType<typeof loadConfig>);
+
+    const { execSync } = await import('node:child_process');
+    vi.mocked(execSync).mockReturnValue('abc123\n' as unknown as Buffer);
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('returns null when no GitHub context is available', async () => {
+    delete process.env.GITHUB_REPOSITORY;
+    delete process.env.GITHUB_TOKEN;
+
+    const result = await publishFromManifest(42, {
+      projectDir: '/test',
+      verbose: false,
+      quiet: false,
+      json: false,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('throws when manifest comment is missing from PR', async () => {
+    const { createOctokit } = await import('../../src/preview-github.js');
+    const { octokit } = createMockOctokit();
+    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+
+    await expect(
+      publishFromManifest(42, { projectDir: '/test', verbose: false, quiet: false, json: false }),
+    ).rejects.toThrow(/manifest not found/);
+  });
+
+  it('publishes using manifest notes when editableNotes is disabled', async () => {
+    const { createOctokit } = await import('../../src/preview-github.js');
+    const { mocks, octokit } = createMockOctokit();
+    const manifestBody = serializeManifest(baseManifest);
+    mocks.paginate.iterator.mockReturnValue({
+      async *[Symbol.asyncIterator]() {
+        yield { data: [{ id: 1, body: manifestBody }] };
+      },
+    });
+    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+
+    const { runPublishStep } = await import('../../src/steps.js');
+    vi.mocked(runPublishStep).mockResolvedValue({ publishSucceeded: true } as unknown as Awaited<
+      ReturnType<typeof runPublishStep>
+    >);
+
+    const result = await publishFromManifest(42, {
+      projectDir: '/test',
+      verbose: false,
+      quiet: false,
+      json: false,
+    });
+
+    expect(result).not.toBeNull();
+    expect(vi.mocked(runPublishStep)).toHaveBeenCalledWith(
+      expect.objectContaining({ updates: baseManifest.versionOutput.updates }),
+      expect.objectContaining({ skipGitCommit: true }),
+      baseManifest.releaseNotes,
+      baseManifest.notesFiles,
+    );
+  });
+
+  it('uses edited notes from PR body when editableNotes is enabled', async () => {
+    const { loadConfig } = await import('@releasekit/config');
+    vi.mocked(loadConfig).mockReturnValue({
+      ci: { standingPr: { branch: 'release/next', deleteBranchOnMerge: true, editableNotes: true } },
+      git: { branch: 'main' },
+    } as ReturnType<typeof loadConfig>);
+
+    const editedBody = [
+      '<!-- releasekit-editable-start -->',
+      '### Release Notes',
+      '',
+      '#### @scope/core — 1.2.3',
+      '',
+      '- hand-crafted release note',
+      '<!-- releasekit-editable-end -->',
+    ].join('\n');
+
+    const { createOctokit } = await import('../../src/preview-github.js');
+    const { mocks, octokit } = createMockOctokit();
+    const manifestBody = serializeManifest(baseManifest);
+    mocks.paginate.iterator.mockReturnValue({
+      async *[Symbol.asyncIterator]() {
+        yield { data: [{ id: 1, body: manifestBody }] };
+      },
+    });
+    mocks.pullsGet.mockResolvedValue({ data: { body: editedBody } });
+    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+
+    const { runPublishStep } = await import('../../src/steps.js');
+    vi.mocked(runPublishStep).mockResolvedValue({ publishSucceeded: true } as unknown as Awaited<
+      ReturnType<typeof runPublishStep>
+    >);
+
+    await publishFromManifest(42, { projectDir: '/test', verbose: false, quiet: false, json: false });
+
+    expect(vi.mocked(runPublishStep)).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({ '@scope/core': '- hand-crafted release note' }),
+      expect.anything(),
+    );
+  });
+
+  it('falls back to manifest notes for packages missing from edited section', async () => {
+    const { loadConfig } = await import('@releasekit/config');
+    vi.mocked(loadConfig).mockReturnValue({
+      ci: { standingPr: { branch: 'release/next', deleteBranchOnMerge: true, editableNotes: true } },
+      git: { branch: 'main' },
+    } as ReturnType<typeof loadConfig>);
+
+    // editedBody has no package headings at all
+    const editedBody = [
+      '<!-- releasekit-editable-start -->',
+      '### Release Notes',
+      '',
+      'Some text without package headings.',
+      '<!-- releasekit-editable-end -->',
+    ].join('\n');
+
+    const { createOctokit } = await import('../../src/preview-github.js');
+    const { mocks, octokit } = createMockOctokit();
+    const manifestBody = serializeManifest(baseManifest);
+    mocks.paginate.iterator.mockReturnValue({
+      async *[Symbol.asyncIterator]() {
+        yield { data: [{ id: 1, body: manifestBody }] };
+      },
+    });
+    mocks.pullsGet.mockResolvedValue({ data: { body: editedBody } });
+    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+
+    const { runPublishStep } = await import('../../src/steps.js');
+    vi.mocked(runPublishStep).mockResolvedValue({ publishSucceeded: true } as unknown as Awaited<
+      ReturnType<typeof runPublishStep>
+    >);
+
+    await publishFromManifest(42, { projectDir: '/test', verbose: false, quiet: false, json: false });
+
+    // Should still use original manifest notes since edited section has no pkg headings
+    expect(vi.mocked(runPublishStep)).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({ '@scope/core': baseManifest.releaseNotes['@scope/core'] }),
+      expect.anything(),
+    );
   });
 });

--- a/packages/release/test/unit/standing-pr.spec.ts
+++ b/packages/release/test/unit/standing-pr.spec.ts
@@ -623,6 +623,26 @@ describe('parseEditedNotes', () => {
     expect(result['@scope/cli']).toBe('- fixed bug');
   });
 
+  it('preserves h4 subheadings within package notes without truncating content', () => {
+    const section = [
+      '### Release Notes',
+      '',
+      '#### @scope/core — 1.2.3',
+      '',
+      '#### Breaking Changes',
+      '- something important',
+      '',
+      '#### New Features',
+      '- another thing',
+    ].join('\n');
+
+    const result = parseEditedNotes(section);
+    expect(result['@scope/core']).toContain('#### Breaking Changes');
+    expect(result['@scope/core']).toContain('- something important');
+    expect(result['@scope/core']).toContain('#### New Features');
+    expect(result['@scope/core']).toContain('- another thing');
+  });
+
   it('returns empty object for a section with no package headings', () => {
     expect(parseEditedNotes('### Release Notes\n\nsome text')).toEqual({});
   });

--- a/releasekit.schema.json
+++ b/releasekit.schema.json
@@ -691,6 +691,11 @@
               "type": "boolean",
               "default": true,
               "description": "Whether to auto-delete the release branch after the PR is merged."
+            },
+            "editableNotes": {
+              "type": "boolean",
+              "default": false,
+              "description": "Allow teams to edit the release notes section in the PR body before publishing. When enabled, the notes section is wrapped in editable markers and preserved across updates if manually changed."
             }
           }
         }


### PR DESCRIPTION
## Summary

- Adds opt-in `ci.standingPr.editableNotes` config flag (default: `false`) that allows teams to hand-edit release notes in the standing PR before publishing
- When enabled, the notes section is wrapped in `<!-- releasekit-editable-start -->` / `<!-- releasekit-editable-end -->` markers and a SHA-256 hash of the generated content is stored in the manifest
- On each `standing-pr update`, the current body's section hash is compared to the stored hash — if they differ, the user's edits are preserved and only non-editable parts (title, package table, footer) are regenerated
- On `standing-pr publish`, the edited section is extracted from the PR body, parsed back into per-package notes, and merged into the manifest before publishing; missing package headings fall back to original manifest notes with a warning
- Extracts `publishFromManifest(prNumber, options)` as a reusable exported core function; `runStandingPRPublish` becomes a thin event-parsing wrapper (groundwork for Follow-up 1 `standing-pr merge`)

## Files changed

| File | Change |
|------|--------|
| `packages/config/src/schema.ts` | Add `editableNotes: z.boolean().default(false)` to `StandingPrConfigSchema` |
| `releasekit.schema.json` | Mirror `editableNotes` in JSON schema |
| `packages/release/src/standing-pr.ts` | Add helpers (`renderNotesSection`, `computeNotesHash`, `extractEditableSection`, `parseEditedNotes`), update `renderPrBody`, extract `publishFromManifest`, add hash-based edit detection to `runStandingPRUpdate` |
| `packages/release/src/index.ts` | Export `extractEditableSection`, `parseEditedNotes`, `publishFromManifest` |
| `packages/release/test/unit/standing-pr.spec.ts` | Add 13 new tests covering helpers, editable markers, hash-based detection, and publish with edited notes |

## Test plan

- [x] `extractEditableSection` — markers present/absent/reversed
- [x] `parseEditedNotes` — multi-package, empty section, round-trip
- [x] `runStandingPRUpdate` with `editableNotes: true` — `notesHash` stored in manifest, markers present in PR body, user edits preserved when hash mismatches, notes regenerated when hash matches
- [x] `publishFromManifest` — no GitHub context, missing manifest, uses manifest notes when `editableNotes: false`, uses edited notes when `editableNotes: true`, falls back for missing package headings
- [x] All 45 standing-PR unit tests pass; TypeScript clean

https://claude.ai/code/session_01GKENXWcdcsmj3LMLBtftPw

---
_Generated by [Claude Code](https://claude.ai/code/session_01GKENXWcdcsmj3LMLBtftPw)_