### PR TITLE
feat(release): batch accumulation controls for standing PR strategy

### DIFF
--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -279,6 +279,10 @@ export const StandingPrConfigSchema = z.object({
   labels: z.array(z.string()).default(['release']),
   /** Whether to auto-delete the release branch after PR merge. Default: true */
   deleteBranchOnMerge: z.boolean().default(true),
+  /** Minimum age of the standing PR before it can be merged. Duration string (e.g. '6h', '30m', '1d'). Gate enforced via the releasekit/standing-pr status check. */
+  minAge: z.string().optional(),
+  /** Minimum number of packages with releasable changes required to create/maintain the standing PR. Below this threshold, the PR is closed and no new PR is created. */
+  minPackages: z.number().int().positive().optional(),
 });
 
 export const CIConfigSchema = z.object({

--- a/packages/release/src/duration.ts
+++ b/packages/release/src/duration.ts
@@ -1,15 +1,22 @@
-const MULTIPLIERS: Record<string, number> = {
-  s: 1_000,
-  m: 60_000,
-  h: 3_600_000,
-  d: 86_400_000,
-};
-
 export function parseDuration(str: string): number | null {
   const match = /^(\d+)(s|m|h|d)$/.exec(str);
   if (!match) return null;
-  const value = parseInt(match[1], 10);
-  return value * MULTIPLIERS[match[2]];
+  const digits = match[1];
+  const unit = match[2];
+  if (!digits || !unit) return null;
+  const value = parseInt(digits, 10);
+  switch (unit) {
+    case 's':
+      return value * 1_000;
+    case 'm':
+      return value * 60_000;
+    case 'h':
+      return value * 3_600_000;
+    case 'd':
+      return value * 86_400_000;
+    default:
+      return null;
+  }
 }
 
 export function formatDuration(ms: number): string {

--- a/packages/release/src/duration.ts
+++ b/packages/release/src/duration.ts
@@ -1,0 +1,23 @@
+const MULTIPLIERS: Record<string, number> = {
+  s: 1_000,
+  m: 60_000,
+  h: 3_600_000,
+  d: 86_400_000,
+};
+
+export function parseDuration(str: string): number | null {
+  const match = /^(\d+)(s|m|h|d)$/.exec(str);
+  if (!match) return null;
+  const value = parseInt(match[1], 10);
+  return value * MULTIPLIERS[match[2]];
+}
+
+export function formatDuration(ms: number): string {
+  const hours = Math.floor(ms / 3_600_000);
+  const minutes = Math.floor((ms % 3_600_000) / 60_000);
+  const parts: string[] = [];
+  if (hours > 0) parts.push(`${hours}h`);
+  if (minutes > 0) parts.push(`${minutes}m`);
+  if (parts.length === 0) parts.push(`${Math.ceil(ms / 1000)}s`);
+  return parts.join(' ');
+}

--- a/packages/release/src/standing-pr-status.ts
+++ b/packages/release/src/standing-pr-status.ts
@@ -1,0 +1,21 @@
+import type { createOctokit } from './preview-github.js';
+
+type OctokitInstance = ReturnType<typeof createOctokit>;
+
+export async function postStandingPRStatus(
+  octokit: OctokitInstance,
+  owner: string,
+  repo: string,
+  sha: string,
+  state: 'success' | 'pending' | 'failure',
+  description: string,
+): Promise<void> {
+  await octokit.rest.repos.createCommitStatus({
+    owner,
+    repo,
+    sha,
+    state,
+    context: 'releasekit/standing-pr',
+    description,
+  });
+}

--- a/packages/release/src/standing-pr.ts
+++ b/packages/release/src/standing-pr.ts
@@ -434,6 +434,8 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
       const existingManifest = parseManifest(existingManifestComment.body);
       if (existingManifest.firstUpdatedAt) {
         firstUpdatedAt = existingManifest.firstUpdatedAt;
+      } else {
+        firstUpdatedAt = existingManifest.createdAt;
       }
     } catch {
       // Use current time if the existing manifest can't be parsed

--- a/packages/release/src/standing-pr.ts
+++ b/packages/release/src/standing-pr.ts
@@ -476,7 +476,11 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
 
   if (minAge !== undefined) {
     const minAgeMs = parseDuration(minAge);
-    if (minAgeMs !== null && manifest.firstUpdatedAt) {
+    if (minAgeMs === null) {
+      warn(
+        `ci.standingPr.minAge value "${minAge}" is not a valid duration (e.g. "6h", "30m", "1d") — gate is inactive`,
+      );
+    } else if (manifest.firstUpdatedAt) {
       const ageMs = Date.now() - new Date(manifest.firstUpdatedAt).getTime();
       if (ageMs < minAgeMs) {
         statusState = 'pending';

--- a/packages/release/src/standing-pr.ts
+++ b/packages/release/src/standing-pr.ts
@@ -3,12 +3,15 @@ import * as fs from 'node:fs';
 import { loadConfig as loadReleaseKitConfig } from '@releasekit/config';
 import type { VersionOutput } from '@releasekit/core';
 import { error, info, success, warn } from '@releasekit/core';
+import { formatDuration, parseDuration } from './duration.js';
 import { createOctokit } from './preview-github.js';
+import { postStandingPRStatus } from './standing-pr-status.js';
 import { runNotesStep, runPublishStep, runVersionStep } from './steps.js';
 import type { ReleaseOptions, ReleaseOutput } from './types.js';
 
 const MANIFEST_MARKER = '<!-- releasekit-manifest -->';
-const MANIFEST_SCHEMA_VERSION = 1;
+const MANIFEST_SCHEMA_VERSION = 2;
+const MANIFEST_SCHEMA_MIN_VERSION = 1;
 
 export interface StandingPROptions {
   config?: string;
@@ -27,12 +30,14 @@ export interface StandingPRResult {
 }
 
 export interface StandingPRManifest {
-  schemaVersion: 1;
+  schemaVersion: 1 | 2;
   versionOutput: VersionOutput;
   releaseNotes: Record<string, string>;
   notesFiles: string[];
   createdAt: string;
   baseSha: string;
+  /** ISO timestamp of when this standing PR was first created. Preserved across updates. Added in schema v2. */
+  firstUpdatedAt?: string;
 }
 
 function getGitHubContext(): { owner: string; repo: string; token: string } | null {
@@ -177,9 +182,9 @@ export function parseManifest(commentBody: string): StandingPRManifest {
   }
 
   const m = parsed as StandingPRManifest;
-  if (m.schemaVersion !== MANIFEST_SCHEMA_VERSION) {
+  if (m.schemaVersion < MANIFEST_SCHEMA_MIN_VERSION || m.schemaVersion > MANIFEST_SCHEMA_VERSION) {
     throw new Error(
-      `Release manifest schema version ${m.schemaVersion} is incompatible (expected ${MANIFEST_SCHEMA_VERSION}). Re-run 'standing-pr update' to regenerate.`,
+      `Release manifest schema version ${m.schemaVersion} is incompatible (expected ${MANIFEST_SCHEMA_MIN_VERSION}–${MANIFEST_SCHEMA_VERSION}). Re-run 'standing-pr update' to regenerate.`,
     );
   }
 
@@ -210,33 +215,6 @@ async function findManifestComment(
   }
 
   return null;
-}
-
-async function findOrCreateManifestComment(
-  octokit: OctokitInstance,
-  owner: string,
-  repo: string,
-  prNumber: number,
-  manifest: StandingPRManifest,
-): Promise<void> {
-  const body = serializeManifest(manifest);
-  const existing = await findManifestComment(octokit, owner, repo, prNumber);
-
-  if (existing) {
-    await octokit.rest.issues.updateComment({
-      owner,
-      repo,
-      comment_id: existing.id,
-      body,
-    });
-  } else {
-    await octokit.rest.issues.createComment({
-      owner,
-      repo,
-      issue_number: prNumber,
-      body,
-    });
-  }
 }
 
 export async function findStandingPR(
@@ -327,6 +305,35 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
     return { action: 'noop' };
   }
 
+  // minPackages gate: close existing PR and noop if package count is below threshold
+  const minPackages = standingPrConfig?.minPackages;
+  if (minPackages !== undefined && versionOutputDry.updates.length < minPackages) {
+    info(
+      `Package count (${versionOutputDry.updates.length}) is below minPackages threshold (${minPackages}), skipping`,
+    );
+    if (githubContext) {
+      const octokit = createOctokit(githubContext.token);
+      const existing = await findStandingPR(octokit, githubContext.owner, githubContext.repo, branch);
+      if (existing) {
+        await octokit.rest.issues.createComment({
+          owner: githubContext.owner,
+          repo: githubContext.repo,
+          issue_number: existing.number,
+          body: `Not enough packages with releasable changes (${versionOutputDry.updates.length} of ${minPackages} required). Closing until the threshold is reached.`,
+        });
+        await octokit.rest.pulls.update({
+          owner: githubContext.owner,
+          repo: githubContext.repo,
+          pull_number: existing.number,
+          state: 'closed',
+        });
+        info(`Closed standing PR #${existing.number} (minPackages not met)`);
+        return { action: 'closed', prNumber: existing.number, prUrl: existing.url };
+      }
+    }
+    return { action: 'noop' };
+  }
+
   // Capture baseSha before switching branches
   const baseSha = getHeadSha(cwd);
 
@@ -346,6 +353,9 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
   // Commit and force-push the release branch
   info(`Committing and pushing '${branch}'...`);
   commitAndForcePush(branch, cwd);
+
+  // Capture the release branch HEAD SHA for the status check (we're still on the release branch)
+  const releaseBranchSha = getHeadSha(cwd);
 
   success(`Release branch '${branch}' updated`);
 
@@ -416,18 +426,70 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
     }
   }
 
+  // Find existing manifest to preserve firstUpdatedAt across updates
+  let firstUpdatedAt = new Date().toISOString();
+  const existingManifestComment = await findManifestComment(octokit, owner, repo, prNumber);
+  if (existingManifestComment) {
+    try {
+      const existingManifest = parseManifest(existingManifestComment.body);
+      if (existingManifest.firstUpdatedAt) {
+        firstUpdatedAt = existingManifest.firstUpdatedAt;
+      }
+    } catch {
+      // Use current time if the existing manifest can't be parsed
+    }
+  }
+
   // Store manifest as a bot comment
   const manifest: StandingPRManifest = {
-    schemaVersion: 1,
+    schemaVersion: 2,
     versionOutput,
     releaseNotes: notesResult.releaseNotes ?? {},
     notesFiles: notesResult.files,
     createdAt: new Date().toISOString(),
     baseSha,
+    firstUpdatedAt,
   };
 
-  await findOrCreateManifestComment(octokit, owner, repo, prNumber, manifest);
+  const manifestBody = serializeManifest(manifest);
+  if (existingManifestComment) {
+    await octokit.rest.issues.updateComment({
+      owner,
+      repo,
+      comment_id: existingManifestComment.id,
+      body: manifestBody,
+    });
+  } else {
+    await octokit.rest.issues.createComment({
+      owner,
+      repo,
+      issue_number: prNumber,
+      body: manifestBody,
+    });
+  }
   success(`Manifest written to PR #${prNumber}`);
+
+  // Post commit status check — gates determine pending vs success
+  const minAge = standingPrConfig?.minAge;
+  let statusState: 'success' | 'pending' = 'success';
+  let statusDescription = 'Ready to merge';
+
+  if (minAge !== undefined) {
+    const minAgeMs = parseDuration(minAge);
+    if (minAgeMs !== null && manifest.firstUpdatedAt) {
+      const ageMs = Date.now() - new Date(manifest.firstUpdatedAt).getTime();
+      if (ageMs < minAgeMs) {
+        statusState = 'pending';
+        statusDescription = `Waiting ${formatDuration(minAgeMs - ageMs)} for minAge`;
+      }
+    }
+  }
+
+  try {
+    await postStandingPRStatus(octokit, owner, repo, releaseBranchSha, statusState, statusDescription);
+  } catch {
+    warn('Failed to post standing PR status check');
+  }
 
   return { action, prNumber, prUrl, versionOutput };
 }

--- a/packages/release/test/unit/duration.spec.ts
+++ b/packages/release/test/unit/duration.spec.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { formatDuration, parseDuration } from '../../src/duration.js';
+
+describe('parseDuration', () => {
+  it('parses seconds', () => {
+    expect(parseDuration('45s')).toBe(45_000);
+  });
+
+  it('parses minutes', () => {
+    expect(parseDuration('30m')).toBe(1_800_000);
+  });
+
+  it('parses hours', () => {
+    expect(parseDuration('6h')).toBe(21_600_000);
+  });
+
+  it('parses days', () => {
+    expect(parseDuration('1d')).toBe(86_400_000);
+  });
+
+  it('parses multi-digit values', () => {
+    expect(parseDuration('24h')).toBe(86_400_000);
+    expect(parseDuration('90m')).toBe(5_400_000);
+  });
+
+  it('returns null for empty string', () => {
+    expect(parseDuration('')).toBeNull();
+  });
+
+  it('returns null for unknown unit', () => {
+    expect(parseDuration('1x')).toBeNull();
+    expect(parseDuration('1y')).toBeNull();
+  });
+
+  it('returns null for missing unit', () => {
+    expect(parseDuration('60')).toBeNull();
+  });
+
+  it('returns null for non-numeric prefix', () => {
+    expect(parseDuration('fiveH')).toBeNull();
+    expect(parseDuration('abch')).toBeNull();
+  });
+
+  it('returns null for mixed invalid input', () => {
+    expect(parseDuration('1h30m')).toBeNull();
+    expect(parseDuration(' 1h')).toBeNull();
+  });
+});
+
+describe('formatDuration', () => {
+  it('formats hours and minutes', () => {
+    expect(formatDuration(2 * 3_600_000 + 15 * 60_000)).toBe('2h 15m');
+  });
+
+  it('formats hours only', () => {
+    expect(formatDuration(3 * 3_600_000)).toBe('3h');
+  });
+
+  it('formats minutes only', () => {
+    expect(formatDuration(45 * 60_000)).toBe('45m');
+  });
+
+  it('formats seconds when less than a minute', () => {
+    expect(formatDuration(30_000)).toBe('30s');
+  });
+
+  it('rounds up partial seconds', () => {
+    expect(formatDuration(500)).toBe('1s');
+  });
+});

--- a/packages/release/test/unit/standing-pr.spec.ts
+++ b/packages/release/test/unit/standing-pr.spec.ts
@@ -52,6 +52,7 @@ function createMockOctokit(overrides: Record<string, unknown> = {}) {
     .mockResolvedValue({ data: { number: 42, html_url: 'https://github.com/owner/repo/pull/42' } });
   const pullsUpdate = vi.fn().mockResolvedValue({});
   const issuesSetLabels = vi.fn().mockResolvedValue({});
+  const createCommitStatus = vi.fn().mockResolvedValue({});
 
   const paginate = {
     iterator: vi.fn().mockReturnValue({
@@ -76,10 +77,22 @@ function createMockOctokit(overrides: Record<string, unknown> = {}) {
           create: pullsCreate,
           update: pullsUpdate,
         },
+        repos: {
+          createCommitStatus,
+        },
       },
       ...overrides,
     },
-    mocks: { createComment, updateComment, pullsList, pullsCreate, pullsUpdate, issuesSetLabels, paginate },
+    mocks: {
+      createComment,
+      updateComment,
+      pullsList,
+      pullsCreate,
+      pullsUpdate,
+      issuesSetLabels,
+      paginate,
+      createCommitStatus,
+    },
   };
 }
 
@@ -117,6 +130,27 @@ describe('serializeManifest / parseManifest', () => {
   it('should throw when schemaVersion is incompatible', () => {
     const wrongVersion = serializeManifest({ ...baseManifest, schemaVersion: 99 as unknown as 1 });
     expect(() => parseManifest(wrongVersion)).toThrow(/incompatible/);
+  });
+
+  it('should accept a v1 manifest without firstUpdatedAt (backward compat)', () => {
+    // v1 manifests from before schema v2 have no firstUpdatedAt
+    const v1Manifest = { ...baseManifest, schemaVersion: 1 as const };
+    const serialized = serializeManifest(v1Manifest);
+    const parsed = parseManifest(serialized);
+    expect(parsed.schemaVersion).toBe(1);
+    expect(parsed.firstUpdatedAt).toBeUndefined();
+  });
+
+  it('should round-trip a v2 manifest with firstUpdatedAt', () => {
+    const v2Manifest = {
+      ...baseManifest,
+      schemaVersion: 2 as const,
+      firstUpdatedAt: '2024-06-01T12:00:00.000Z',
+    };
+    const serialized = serializeManifest(v2Manifest);
+    const parsed = parseManifest(serialized);
+    expect(parsed.schemaVersion).toBe(2);
+    expect(parsed.firstUpdatedAt).toBe('2024-06-01T12:00:00.000Z');
   });
 });
 
@@ -319,6 +353,212 @@ describe('runStandingPRUpdate', () => {
     expect(result.action).toBe('noop');
     expect(result.versionOutput).toBeDefined();
     expect(result.versionOutput?.updates).toHaveLength(1);
+  });
+
+  it('should return noop when package count is below minPackages threshold', async () => {
+    const { loadConfig } = await import('@releasekit/config');
+    vi.mocked(loadConfig).mockReturnValue({
+      ...defaultConfig,
+      ci: { ...defaultConfig.ci, standingPr: { ...defaultConfig.ci.standingPr, minPackages: 3 } },
+    } as ReturnType<typeof loadConfig>);
+
+    const { runVersionStep } = await import('../../src/steps.js');
+    // Only 1 package changed — below threshold of 3
+    const versionOutput = createMockVersionOutput([{ packageName: '@scope/core', newVersion: '1.2.3' }]);
+    vi.mocked(runVersionStep).mockResolvedValue(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>);
+
+    const { createOctokit } = await import('../../src/preview-github.js');
+    const { mocks, octokit } = createMockOctokit();
+    mocks.pullsList.mockResolvedValue({ data: [] });
+    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+
+    const result = await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
+
+    expect(result.action).toBe('noop');
+    expect(mocks.pullsCreate).not.toHaveBeenCalled();
+  });
+
+  it('should close existing PR when package count is below minPackages threshold', async () => {
+    const { loadConfig } = await import('@releasekit/config');
+    vi.mocked(loadConfig).mockReturnValue({
+      ...defaultConfig,
+      ci: { ...defaultConfig.ci, standingPr: { ...defaultConfig.ci.standingPr, minPackages: 3 } },
+    } as ReturnType<typeof loadConfig>);
+
+    const { runVersionStep } = await import('../../src/steps.js');
+    const versionOutput = createMockVersionOutput([{ packageName: '@scope/core', newVersion: '1.2.3' }]);
+    vi.mocked(runVersionStep).mockResolvedValue(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>);
+
+    const { createOctokit } = await import('../../src/preview-github.js');
+    const { mocks, octokit } = createMockOctokit();
+    mocks.pullsList.mockResolvedValue({ data: [{ number: 55, html_url: 'https://github.com/owner/repo/pull/55' }] });
+    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+
+    const result = await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
+
+    expect(result.action).toBe('closed');
+    expect(result.prNumber).toBe(55);
+    expect(mocks.pullsUpdate).toHaveBeenCalledWith(expect.objectContaining({ state: 'closed', pull_number: 55 }));
+    expect(mocks.createComment).toHaveBeenCalledWith(
+      expect.objectContaining({ body: expect.stringContaining('1 of 3 required') }),
+    );
+  });
+
+  it('should post success status check when all gates are satisfied', async () => {
+    const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
+    const versionOutput = createMockVersionOutput([{ packageName: '@scope/core', newVersion: '1.2.3' }]);
+    vi.mocked(runVersionStep)
+      .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>)
+      .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>);
+    vi.mocked(runNotesStep).mockResolvedValue({ packageNotes: {}, releaseNotes: {}, files: [] });
+
+    const { createOctokit } = await import('../../src/preview-github.js');
+    const { mocks, octokit } = createMockOctokit();
+    mocks.pullsList.mockResolvedValue({ data: [] });
+    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+
+    await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
+
+    expect(mocks.createCommitStatus).toHaveBeenCalledWith(
+      expect.objectContaining({ state: 'success', description: 'Ready to merge', context: 'releasekit/standing-pr' }),
+    );
+  });
+
+  it('should post pending status check when minAge has not elapsed', async () => {
+    const { loadConfig } = await import('@releasekit/config');
+    vi.mocked(loadConfig).mockReturnValue({
+      ...defaultConfig,
+      ci: { ...defaultConfig.ci, standingPr: { ...defaultConfig.ci.standingPr, minAge: '6h' } },
+    } as ReturnType<typeof loadConfig>);
+
+    const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
+    const versionOutput = createMockVersionOutput([{ packageName: '@scope/core', newVersion: '1.2.3' }]);
+    vi.mocked(runVersionStep)
+      .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>)
+      .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>);
+    vi.mocked(runNotesStep).mockResolvedValue({ packageNotes: {}, releaseNotes: {}, files: [] });
+
+    const { createOctokit } = await import('../../src/preview-github.js');
+    const { mocks, octokit } = createMockOctokit();
+    // Existing PR with a manifest that has a recent firstUpdatedAt (5 minutes ago)
+    mocks.pullsList.mockResolvedValue({ data: [{ number: 99, html_url: 'https://github.com/owner/repo/pull/99' }] });
+    const recentTimestamp = new Date(Date.now() - 5 * 60_000).toISOString();
+    const existingManifest = serializeManifest({
+      ...baseManifest,
+      schemaVersion: 2,
+      firstUpdatedAt: recentTimestamp,
+    });
+    mocks.paginate.iterator.mockReturnValue({
+      async *[Symbol.asyncIterator]() {
+        yield { data: [{ id: 77, body: existingManifest }] };
+      },
+    });
+    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+
+    await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
+
+    expect(mocks.createCommitStatus).toHaveBeenCalledWith(
+      expect.objectContaining({
+        state: 'pending',
+        context: 'releasekit/standing-pr',
+        description: expect.stringMatching(/Waiting .+ for minAge/),
+      }),
+    );
+  });
+
+  it('should post success status check when minAge has elapsed', async () => {
+    const { loadConfig } = await import('@releasekit/config');
+    vi.mocked(loadConfig).mockReturnValue({
+      ...defaultConfig,
+      ci: { ...defaultConfig.ci, standingPr: { ...defaultConfig.ci.standingPr, minAge: '1h' } },
+    } as ReturnType<typeof loadConfig>);
+
+    const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
+    const versionOutput = createMockVersionOutput([{ packageName: '@scope/core', newVersion: '1.2.3' }]);
+    vi.mocked(runVersionStep)
+      .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>)
+      .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>);
+    vi.mocked(runNotesStep).mockResolvedValue({ packageNotes: {}, releaseNotes: {}, files: [] });
+
+    const { createOctokit } = await import('../../src/preview-github.js');
+    const { mocks, octokit } = createMockOctokit();
+    mocks.pullsList.mockResolvedValue({ data: [{ number: 99, html_url: 'https://github.com/owner/repo/pull/99' }] });
+    // firstUpdatedAt is 2 hours ago — minAge of 1h is satisfied
+    const oldTimestamp = new Date(Date.now() - 2 * 3_600_000).toISOString();
+    const existingManifest = serializeManifest({
+      ...baseManifest,
+      schemaVersion: 2,
+      firstUpdatedAt: oldTimestamp,
+    });
+    mocks.paginate.iterator.mockReturnValue({
+      async *[Symbol.asyncIterator]() {
+        yield { data: [{ id: 77, body: existingManifest }] };
+      },
+    });
+    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+
+    await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
+
+    expect(mocks.createCommitStatus).toHaveBeenCalledWith(
+      expect.objectContaining({ state: 'success', description: 'Ready to merge' }),
+    );
+  });
+
+  it('should preserve firstUpdatedAt from existing manifest across updates', async () => {
+    const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
+    const versionOutput = createMockVersionOutput([{ packageName: '@scope/core', newVersion: '1.2.3' }]);
+    vi.mocked(runVersionStep)
+      .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>)
+      .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>);
+    vi.mocked(runNotesStep).mockResolvedValue({ packageNotes: {}, releaseNotes: {}, files: [] });
+
+    const { createOctokit } = await import('../../src/preview-github.js');
+    const { mocks, octokit } = createMockOctokit();
+    mocks.pullsList.mockResolvedValue({ data: [{ number: 99, html_url: 'https://github.com/owner/repo/pull/99' }] });
+
+    const originalTimestamp = '2024-01-15T08:00:00.000Z';
+    const existingManifest = serializeManifest({
+      ...baseManifest,
+      schemaVersion: 2,
+      firstUpdatedAt: originalTimestamp,
+    });
+    mocks.paginate.iterator.mockReturnValue({
+      async *[Symbol.asyncIterator]() {
+        yield { data: [{ id: 77, body: existingManifest }] };
+      },
+    });
+    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+
+    await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
+
+    // The manifest comment update should contain the original firstUpdatedAt
+    const updateCall = mocks.updateComment.mock.calls.find(
+      (c) => typeof c[0]?.body === 'string' && c[0].body.includes('<!-- releasekit-manifest -->'),
+    );
+    expect(updateCall).toBeDefined();
+    const writtenBody = updateCall?.[0]?.body as string;
+    const writtenManifest = parseManifest(writtenBody);
+    expect(writtenManifest.firstUpdatedAt).toBe(originalTimestamp);
+  });
+
+  it('should not fail update when status check post throws', async () => {
+    const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
+    const versionOutput = createMockVersionOutput([{ packageName: '@scope/core', newVersion: '1.2.3' }]);
+    vi.mocked(runVersionStep)
+      .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>)
+      .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>);
+    vi.mocked(runNotesStep).mockResolvedValue({ packageNotes: {}, releaseNotes: {}, files: [] });
+
+    const { createOctokit } = await import('../../src/preview-github.js');
+    const { mocks, octokit } = createMockOctokit();
+    mocks.pullsList.mockResolvedValue({ data: [] });
+    mocks.createCommitStatus.mockRejectedValue(new Error('API rate limit exceeded'));
+    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+
+    // Should resolve (not throw) even when status check post fails
+    const result = await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
+
+    expect(result.action).toBe('created');
   });
 });
 

--- a/packages/release/test/unit/standing-pr.spec.ts
+++ b/packages/release/test/unit/standing-pr.spec.ts
@@ -548,6 +548,37 @@ describe('runStandingPRUpdate', () => {
     expect(writtenManifest.firstUpdatedAt).toBe(originalTimestamp);
   });
 
+  it('should use createdAt as firstUpdatedAt fallback when migrating from v1 manifest', async () => {
+    const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
+    const versionOutput = createMockVersionOutput([{ packageName: '@scope/core', newVersion: '1.2.3' }]);
+    vi.mocked(runVersionStep)
+      .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>)
+      .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>);
+    vi.mocked(runNotesStep).mockResolvedValue({ packageNotes: {}, releaseNotes: {}, files: [] });
+
+    const { createOctokit } = await import('../../src/preview-github.js');
+    const { mocks, octokit } = createMockOctokit();
+    mocks.pullsList.mockResolvedValue({ data: [{ number: 99, html_url: 'https://github.com/owner/repo/pull/99' }] });
+
+    // v1 manifest has no firstUpdatedAt — should fall back to createdAt
+    const v1Manifest = serializeManifest({ ...baseManifest, schemaVersion: 1 });
+    mocks.paginate.iterator.mockReturnValue({
+      async *[Symbol.asyncIterator]() {
+        yield { data: [{ id: 77, body: v1Manifest }] };
+      },
+    });
+    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+
+    await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
+
+    const updateCall = mocks.updateComment.mock.calls.find(
+      (c) => typeof c[0]?.body === 'string' && c[0].body.includes('<!-- releasekit-manifest -->'),
+    );
+    expect(updateCall).toBeDefined();
+    const writtenManifest = parseManifest(updateCall?.[0]?.body as string);
+    expect(writtenManifest.firstUpdatedAt).toBe(baseManifest.createdAt);
+  });
+
   it('should not fail update when status check post throws', async () => {
     const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
     const versionOutput = createMockVersionOutput([{ packageName: '@scope/core', newVersion: '1.2.3' }]);

--- a/releasekit.schema.json
+++ b/releasekit.schema.json
@@ -691,6 +691,15 @@
               "type": "boolean",
               "default": true,
               "description": "Whether to auto-delete the release branch after the PR is merged."
+            },
+            "minAge": {
+              "type": "string",
+              "description": "Minimum age of the standing PR before it can be merged. Duration string, e.g. '6h', '30m', '1d'. Gate enforced via the releasekit/standing-pr commit status check; configure it as a required status check in branch protection to block merges."
+            },
+            "minPackages": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Minimum number of packages with releasable changes required to create or maintain the standing PR. Below this threshold the PR is closed and no new PR is opened."
             }
           }
         }

--- a/templates/workflows/standing-pr.yml
+++ b/templates/workflows/standing-pr.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     types: [closed]
     branches: [main]
+  schedule:
+    - cron: '0 * * * *'  # Hourly — re-evaluates minAge status check as time passes
 
 concurrency:
   group: standing-release-pr
@@ -19,7 +21,7 @@ permissions:
 jobs:
   update-release-pr:
     name: Update Release PR
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' || github.event_name == 'schedule'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/templates/workflows/standing-pr.yml
+++ b/templates/workflows/standing-pr.yml
@@ -16,6 +16,7 @@ concurrency:
 permissions:
   contents: write
   pull-requests: write
+  statuses: write
   id-token: write
 
 jobs:


### PR DESCRIPTION
## Summary

Implements **Follow-up 4 — Batch release accumulation controls** from `AUTOMATION_PLAN.md`.

- **`ci.standingPr.minPackages`** — hard gate: if fewer than N packages have releasable changes, `standing-pr update` noops and closes any open standing PR with an explanatory comment
- **`ci.standingPr.minAge`** — soft gate: posts a `pending` commit status (`releasekit/standing-pr`) on the release branch HEAD until the PR has been open for the configured duration (e.g. `"6h"`, `"30m"`, `"1d"`); transitions to `success` once elapsed
- Manifest schema bumped **v1 → v2** with a new `firstUpdatedAt` field preserved across updates; `parseManifest` accepts both versions for backward compat
- Hourly `schedule` cron trigger added to the `standing-pr.yml` workflow template so the status check re-evaluates as time passes without needing a push
- New `duration.ts` module with `parseDuration` / `formatDuration` helpers
- New `standing-pr-status.ts` wrapping `repos.createCommitStatus` with context `releasekit/standing-pr`

## Changed files

| File | Change |
|------|--------|
| `packages/config/src/schema.ts` | Add `minAge`, `minPackages` to `StandingPrConfigSchema` |
| `releasekit.schema.json` | Mirror schema additions |
| `packages/release/src/duration.ts` | New — `parseDuration`, `formatDuration` |
| `packages/release/src/standing-pr-status.ts` | New — `postStandingPRStatus` |
| `packages/release/src/standing-pr.ts` | Manifest v2, `firstUpdatedAt`, `minPackages` gate, status check posting |
| `templates/workflows/standing-pr.yml` | Add `schedule` trigger; update job condition |
| `packages/release/test/unit/duration.spec.ts` | New — full unit tests for duration parsing/formatting |
| `packages/release/test/unit/standing-pr.spec.ts` | New tests: v1/v2 compat, minPackages gate, minAge status, firstUpdatedAt preservation, status failure resilience |

## Test plan

- [ ] All 44 tests in `duration.spec.ts` + `standing-pr.spec.ts` pass
- [ ] `minPackages: 3` with 1 changed package → noop, existing PR closed with comment
- [ ] `minAge: "6h"` with PR < 6h old → `pending` status posted
- [ ] `minAge: "1h"` with PR > 1h old → `success` status posted
- [ ] `firstUpdatedAt` preserved across multiple `standing-pr update` runs
- [ ] v1 manifests (no `firstUpdatedAt`) parsed without error
- [ ] Status check API failure caught and logged; update still succeeds

https://claude.ai/code/session_011GSASToKFMEpkMtWgytFXY

---
_Generated by [Claude Code](https://claude.ai/code/session_011GSASToKFMEpkMtWgytFXY)_