### PR TITLE
fix: pure rust publishing without a package.json

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,9 +1,20 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.4.10/schema.json",
-  "vcs": { "enabled": false, "clientKind": "git", "useIgnoreFile": false },
+  "vcs": {
+    "enabled": false,
+    "clientKind": "git",
+    "useIgnoreFile": false
+  },
   "files": {
     "ignoreUnknown": false,
-    "includes": ["**", "!**/coverage", "!**/dist", "!**/out", "!.turbo", "!**/node_modules"]
+    "includes": [
+      "**",
+      "!**/coverage",
+      "!**/dist",
+      "!**/out",
+      "!.turbo",
+      "!**/node_modules"
+    ]
   },
   "formatter": {
     "enabled": true,
@@ -20,8 +31,15 @@
   },
   "linter": {
     "enabled": true,
-    "includes": ["**"],
-    "rules": { "recommended": true, "style": { "useBlockStatements": "off" } }
+    "includes": [
+      "**"
+    ],
+    "rules": {
+      "recommended": true,
+      "style": {
+        "useBlockStatements": "off"
+      }
+    }
   },
   "javascript": {
     "formatter": {
@@ -36,12 +54,21 @@
       "bracketSpacing": true
     }
   },
+  "json": {
+    "formatter": {
+      "expand": "always"
+    }
+  },
   "overrides": [
     {
-      "includes": ["**/*.ts"],
+      "includes": [
+        "**/*.ts"
+      ],
       "linter": {
         "rules": {
-          "complexity": { "noUselessTypeConstraint": "error" },
+          "complexity": {
+            "noUselessTypeConstraint": "error"
+          },
           "correctness": {
             "noUndeclaredVariables": "off",
             "noUnusedVariables": "error"
@@ -61,17 +88,29 @@
       }
     },
     {
-      "includes": ["**/*.spec.ts", "**/mocks/*.ts"],
+      "includes": [
+        "**/*.spec.ts",
+        "**/mocks/*.ts"
+      ],
       "linter": {
         "rules": {
-          "complexity": { "useArrowFunction": "off" },
-          "suspicious": { "noExplicitAny": "off", "noTemplateCurlyInString": "off" }
+          "complexity": {
+            "useArrowFunction": "off"
+          },
+          "suspicious": {
+            "noExplicitAny": "off",
+            "noTemplateCurlyInString": "off"
+          }
         }
       }
     }
   ],
   "assist": {
     "enabled": true,
-    "actions": { "source": { "organizeImports": "on" } }
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
   }
 }

--- a/packages/config/src/packageFiltering.ts
+++ b/packages/config/src/packageFiltering.ts
@@ -36,13 +36,7 @@ export function filterPackagesByConfig(packages: Package[], configTargets: strin
     }
   }
 
-  return Array.from(matchedPackages).filter((pkg) => {
-    if (pkg.packageJson.private) {
-      log(`Package "${pkg.packageJson.name || pkg.dir}" is private and will be excluded from release`, 'warn');
-      return false;
-    }
-    return true;
-  });
+  return Array.from(matchedPackages);
 }
 
 export function filterByDirectoryPattern(packages: Package[], pattern: string, workspaceRoot: string): Package[] {

--- a/packages/config/test/unit/packageFiltering.spec.ts
+++ b/packages/config/test/unit/packageFiltering.spec.ts
@@ -83,7 +83,7 @@ describe('filterPackagesByConfig', () => {
       expect(log).not.toHaveBeenCalledWith('No config targets specified, returning all non-private packages', 'debug');
     });
 
-    it('should filter packages by name patterns and exclude private matches', () => {
+    it('should include private packages when explicitly matched by a target', () => {
       vi.mocked(matchesPackageTarget).mockImplementation((name, pattern) => {
         if (pattern === '@scope/*') {
           return name.startsWith('@scope/');
@@ -98,13 +98,31 @@ describe('filterPackagesByConfig', () => {
 
       const result = filterPackagesByConfig(packagesWithPrivate, ['@scope/*'], workspaceRoot);
 
-      expect(result).toHaveLength(3);
-      expect(result.map((p) => p.packageJson.name)).toEqual(['@scope/pkg-a', '@scope/pkg-b', '@scope/pkg-c']);
+      // private packages matched by explicit targets are included; npm-publish handles skipping them
+      expect(result).toHaveLength(4);
+      expect(result.map((p) => p.packageJson.name)).toContain('@scope/private-pkg');
+    });
 
-      expect(log).toHaveBeenCalledWith(
-        'Package "@scope/private-pkg" is private and will be excluded from release',
-        'warn',
-      );
+    it('should include a pure Rust package (synthetic private:true) when explicitly targeted', () => {
+      vi.mocked(matchesPackageTarget).mockImplementation((name, pattern) => {
+        return pattern === 'my-crate' && name === 'my-crate';
+      });
+
+      const rustPkg = createMockPackage('my-crate', '/workspace/crates/my-crate', true);
+      const result = filterPackagesByConfig([...mockPackages, rustPkg], ['my-crate'], workspaceRoot);
+
+      expect(result.map((p) => p.packageJson.name)).toContain('my-crate');
+    });
+
+    it('should include a hybrid npm+cargo package with private:true when explicitly targeted', () => {
+      vi.mocked(matchesPackageTarget).mockImplementation((name, pattern) => {
+        return pattern === '@scope/hybrid' && name === '@scope/hybrid';
+      });
+
+      const hybridPkg = createMockPackage('@scope/hybrid', '/workspace/packages/hybrid', true);
+      const result = filterPackagesByConfig([...mockPackages, hybridPkg], ['@scope/hybrid'], workspaceRoot);
+
+      expect(result.map((p) => p.packageJson.name)).toContain('@scope/hybrid');
     });
 
     it('should handle exact directory matches', () => {

--- a/packages/version/src/core/versionEngine.ts
+++ b/packages/version/src/core/versionEngine.ts
@@ -118,8 +118,6 @@ export class VersionEngine {
               packageJson: {
                 name: cargoData.package.name,
                 version: cargoData.package.version,
-                // Add minimal required fields
-                private: true,
               },
               dir: packageDir,
               relativeDir: relativePath,

--- a/packages/version/test/unit/core/versionEngine.spec.ts
+++ b/packages/version/test/unit/core/versionEngine.spec.ts
@@ -402,7 +402,6 @@ describe('Version Engine', () => {
             packageJson: {
               name: 'test-rust-package',
               version: '0.1.0',
-              private: true,
             },
           },
         ],
@@ -440,7 +439,6 @@ describe('Version Engine', () => {
             packageJson: {
               name: 'pure-rust-package',
               version: '0.1.0',
-              private: true,
             },
           },
         ],
@@ -501,6 +499,55 @@ describe('Version Engine', () => {
 
       // Restore mocks
       discoverSpy.mockRestore();
+    });
+
+    it('should include a pure Rust package when explicitly named in config.packages', async () => {
+      const discoverSpy = vi.spyOn(VersionEngine.prototype as any, 'discoverCargoTomlPackages');
+      discoverSpy.mockReturnValue({
+        root: '/test/workspace',
+        packages: [
+          {
+            dir: '/test/workspace/crates/my-crate',
+            packageJson: { name: 'my-crate', version: '0.1.0' },
+          },
+        ],
+      });
+
+      vi.mocked(getPackagesSync).mockReturnValue({
+        root: '/test/workspace',
+        packages: [],
+      });
+
+      const config = { ...defaultConfig, packages: ['my-crate'] } as Config;
+      const engine = new VersionEngine(config);
+
+      const result = await engine.getWorkspacePackages();
+
+      expect(result.packages).toHaveLength(1);
+      expect(result.packages[0].packageJson.name).toBe('my-crate');
+
+      discoverSpy.mockRestore();
+    });
+
+    it('should include a private npm package when explicitly named in config.packages', async () => {
+      vi.mocked(getPackagesSync).mockReturnValue({
+        root: '/test/workspace',
+        packages: [
+          {
+            dir: '/test/workspace/packages/private-pkg',
+            relativeDir: 'packages/private-pkg',
+            packageJson: { name: '@test/private-pkg', version: '0.1.0', private: true },
+          },
+        ],
+      });
+
+      const config = { ...defaultConfig, packages: ['@test/private-pkg'] } as Config;
+      const engine = new VersionEngine(config);
+
+      const result = await engine.getWorkspacePackages();
+
+      expect(result.packages).toHaveLength(1);
+      expect(result.packages[0].packageJson.name).toBe('@test/private-pkg');
     });
   });
 });

--- a/test/e2e/rust-target.sh
+++ b/test/e2e/rust-target.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+# E2E tests for pure Rust and hybrid packages with --target
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/helpers.sh"
+
+trap cleanup_repo EXIT
+
+echo "=== E2E: Rust Package Target Tests ==="
+
+cd "$SCRIPT_DIR"
+
+# Test 1: Pure Rust package (Cargo.toml only) is versioned when explicitly targeted
+echo ""
+echo "--- Test: Pure Rust package (Cargo.toml only) targeted via --target ---"
+create_git_repo
+
+cat > package.json <<EOF
+{
+  "name": "test-rust-workspace",
+  "version": "0.0.1",
+  "private": true
+}
+EOF
+
+cat > pnpm-workspace.yaml <<EOF
+packages:
+  - 'packages/*'
+EOF
+
+# One npm package so the workspace is valid
+mkdir -p packages/lib
+cat > packages/lib/package.json <<EOF
+{
+  "name": "@test/lib",
+  "version": "0.1.0"
+}
+EOF
+
+# Pure Rust crate — no package.json
+mkdir -p crates/my-crate
+cat > crates/my-crate/Cargo.toml <<EOF
+[package]
+name = "my-crate"
+version = "0.1.0"
+edition = "2021"
+EOF
+
+create_releasekit_config '{"version":{"preset":"conventionalcommits","packages":["crates/my-crate"]}}'
+git_commit "chore: initial commit"
+
+echo "change" > crates/my-crate/change.txt
+git_commit "feat: add feature to my-crate"
+
+set +e
+output=$(run_cli_json releasekit release --dry-run --json --target my-crate --project-dir "$REPO_DIR")
+exit_code=$?
+set -e
+
+assert_exit_code 0 "$exit_code"
+assert_updated "my-crate" "$output"
+
+file_path=$(echo "$output" | jq -r '.versionOutput.updates[] | select(.packageName == "my-crate") | .filePath')
+if [[ "$file_path" != *"Cargo.toml" ]]; then
+  echo "FAIL: Expected filePath to end with Cargo.toml, got: $file_path"
+  exit 1
+fi
+echo "PASS: my-crate update has filePath ending in Cargo.toml"
+
+assert_not_updated "@test/lib" "$output"
+
+# Test 2: Hybrid package (package.json private:true + Cargo.toml) is versioned when targeted
+echo ""
+echo "--- Test: Hybrid package (private npm + Cargo.toml) targeted via --target ---"
+create_git_repo
+
+cat > package.json <<EOF
+{
+  "name": "test-hybrid-workspace",
+  "version": "0.0.1",
+  "private": true
+}
+EOF
+
+cat > pnpm-workspace.yaml <<EOF
+packages:
+  - 'packages/*'
+EOF
+
+mkdir -p packages/hybrid-pkg
+cat > packages/hybrid-pkg/package.json <<EOF
+{
+  "name": "@test/hybrid-pkg",
+  "version": "0.1.0",
+  "private": true
+}
+EOF
+
+cat > packages/hybrid-pkg/Cargo.toml <<EOF
+[package]
+name = "hybrid-pkg"
+version = "0.1.0"
+edition = "2021"
+EOF
+
+create_releasekit_config '{"version":{"preset":"conventionalcommits","packages":["packages/hybrid-pkg"]}}'
+git_commit "chore: initial commit"
+
+echo "change" > packages/hybrid-pkg/change.txt
+git_commit "feat: add hybrid feature"
+
+set +e
+output=$(run_cli_json releasekit release --dry-run --json --target @test/hybrid-pkg --project-dir "$REPO_DIR")
+exit_code=$?
+set -e
+
+assert_exit_code 0 "$exit_code"
+assert_updated "@test/hybrid-pkg" "$output"
+echo "PASS: hybrid package with private:true in package.json is included when explicitly targeted"
+
+echo ""
+echo "=== All Rust target tests passed ==="

--- a/test/e2e/rust-target.sh
+++ b/test/e2e/rust-target.sh
@@ -74,6 +74,7 @@ assert_not_updated "@test/lib" "$output"
 # Test 2: Hybrid package (package.json private:true + Cargo.toml) is versioned when targeted
 echo ""
 echo "--- Test: Hybrid package (private npm + Cargo.toml) targeted via --target ---"
+cleanup_repo
 create_git_repo
 
 cat > package.json <<EOF


### PR DESCRIPTION
Updated the `filterPackagesByConfig` function to include private packages when explicitly matched by a target, enhancing the filtering logic. Adjusted unit tests to reflect this change, ensuring that private packages are correctly included in the results when specified. Improved test descriptions for clarity.
