### PR TITLE
feat(publish): idempotent publish behaviour

### DIFF
--- a/packages/publish/src/stages/cargo-publish.ts
+++ b/packages/publish/src/stages/cargo-publish.ts
@@ -5,7 +5,9 @@ import { createPublishError, PublishErrorCode } from '../errors/index.js';
 import type { PipelineContext, PublishResult } from '../types.js';
 import { hasCargoAuth } from '../utils/auth.js';
 import { CRATES_IO_API_TIMEOUT_MS, CRATES_IO_USER_AGENT, extractPathDeps, parseCargoToml } from '../utils/cargo.js';
-import { execCommand, execCommandSafe } from '../utils/exec.js';
+import { execCommand, execCommandSafe, getExecErrorOutput } from '../utils/exec.js';
+
+const ALREADY_PUBLISHED_PATTERN = /already exists on crates\.io index|already uploaded/i;
 
 async function isCratePublished(name: string, version: string): Promise<boolean> {
   try {
@@ -114,6 +116,18 @@ export async function runCargoPublishStage(ctx: PipelineContext): Promise<void> 
       }
       ctx.output.cargo.push(result);
     } catch (error) {
+      // The pre-check API can lag the sparse index, so cargo may reject a publish
+      // that we believed was new. Treat that as already-published rather than a hard
+      // failure — this keeps re-runs of a partially-failed release idempotent.
+      if (ALREADY_PUBLISHED_PATTERN.test(getExecErrorOutput(error))) {
+        result.alreadyPublished = true;
+        result.skipped = true;
+        result.success = true;
+        result.reason = 'Already published on crates.io (detected from publish error)';
+        ctx.output.cargo.push(result);
+        warn(`${crate.name}@${crate.version} is already published on crates.io, skipping`);
+        continue;
+      }
       result.reason = error instanceof Error ? error.message : String(error);
       ctx.output.cargo.push(result);
       throw createPublishError(

--- a/packages/publish/src/stages/npm-publish.ts
+++ b/packages/publish/src/stages/npm-publish.ts
@@ -5,12 +5,11 @@ import { createPublishError, PublishErrorCode } from '../errors/index.js';
 import type { PipelineContext, PublishResult } from '../types.js';
 import { detectNpmAuth } from '../utils/auth.js';
 import { execCommand, execCommandSafe, getExecErrorOutput } from '../utils/exec.js';
-
-const ALREADY_PUBLISHED_PATTERN = /EPUBLISHCONFLICT|cannot publish over (?:the )?previously published versions?/i;
-
 import { createNpmSubprocessIsolation } from '../utils/npm-env.js';
 import { buildPublishCommand, buildViewCommand } from '../utils/package-manager.js';
 import { getDistTag } from '../utils/semver.js';
+
+const ALREADY_PUBLISHED_PATTERN = /EPUBLISHCONFLICT|cannot publish over (?:the )?previously published versions?/i;
 
 /** Error strategy: FAIL-FAST. First publish failure aborts the stage. */
 export async function runNpmPublishStage(ctx: PipelineContext): Promise<void> {

--- a/packages/publish/src/stages/npm-publish.ts
+++ b/packages/publish/src/stages/npm-publish.ts
@@ -4,7 +4,10 @@ import { debug, info, success, warn } from '@releasekit/core';
 import { createPublishError, PublishErrorCode } from '../errors/index.js';
 import type { PipelineContext, PublishResult } from '../types.js';
 import { detectNpmAuth } from '../utils/auth.js';
-import { execCommand, execCommandSafe } from '../utils/exec.js';
+import { execCommand, execCommandSafe, getExecErrorOutput } from '../utils/exec.js';
+
+const ALREADY_PUBLISHED_PATTERN = /EPUBLISHCONFLICT|cannot publish over (?:the )?previously published versions?/i;
+
 import { createNpmSubprocessIsolation } from '../utils/npm-env.js';
 import { buildPublishCommand, buildViewCommand } from '../utils/package-manager.js';
 import { getDistTag } from '../utils/semver.js';
@@ -148,6 +151,18 @@ export async function runNpmPublishStage(ctx: PipelineContext): Promise<void> {
         ctx.output.npm.push(result);
       } catch (error) {
         debug(`Publish command failed: ${error}`);
+        // If `npm view` and `npm publish` disagreed (rare — usually a transient view
+        // failure), treat the conflict as already-published so re-runs of a partially
+        // failed release are idempotent.
+        if (ALREADY_PUBLISHED_PATTERN.test(getExecErrorOutput(error))) {
+          result.alreadyPublished = true;
+          result.skipped = true;
+          result.success = true;
+          result.reason = 'Already published (detected from publish error)';
+          ctx.output.npm.push(result);
+          warn(`${update.packageName}@${update.newVersion} is already published, skipping`);
+          continue;
+        }
         result.reason = error instanceof Error ? error.message : String(error);
         ctx.output.npm.push(result);
         throw createPublishError(

--- a/packages/publish/src/utils/exec.ts
+++ b/packages/publish/src/utils/exec.ts
@@ -87,6 +87,15 @@ export async function execCommand(file: string, args: string[], options: ExecOpt
 }
 
 /**
+ * Combine an exec error's message, stdout, and stderr into a single string for pattern matching.
+ */
+export function getExecErrorOutput(error: unknown): string {
+  if (!error || typeof error !== 'object') return String(error);
+  const e = error as { message?: string; stdout?: string; stderr?: string };
+  return [e.message, e.stdout, e.stderr].filter(Boolean).join('\n');
+}
+
+/**
  * Execute a command and return the result without throwing on non-zero exit.
  * Useful for commands where non-zero exit is an expected outcome (e.g., npm view for unpublished packages).
  */

--- a/packages/publish/test/unit/stages/cargo-publish.spec.ts
+++ b/packages/publish/test/unit/stages/cargo-publish.spec.ts
@@ -6,10 +6,14 @@ import { getDefaultConfig } from '../../../src/config.js';
 import { runCargoPublishStage } from '../../../src/stages/cargo-publish.js';
 import type { PipelineContext } from '../../../src/types.js';
 
-vi.mock('../../../src/utils/exec.js', () => ({
-  execCommand: vi.fn().mockResolvedValue({ stdout: '', stderr: '', exitCode: 0 }),
-  execCommandSafe: vi.fn().mockResolvedValue({ stdout: '', stderr: '', exitCode: 1 }), // not published
-}));
+vi.mock('../../../src/utils/exec.js', async () => {
+  const actual = await vi.importActual<typeof import('../../../src/utils/exec.js')>('../../../src/utils/exec.js');
+  return {
+    ...actual,
+    execCommand: vi.fn().mockResolvedValue({ stdout: '', stderr: '', exitCode: 0 }),
+    execCommandSafe: vi.fn().mockResolvedValue({ stdout: '', stderr: '', exitCode: 1 }), // not published
+  };
+});
 
 vi.mock('../../../src/utils/auth.js', () => ({
   hasCargoAuth: vi.fn().mockReturnValue(true),
@@ -131,6 +135,55 @@ describe('cargo-publish stage', () => {
       .mock.calls.filter((c) => c[0] === 'cargo' && (c[1] as string[])[0] === 'publish');
     expect(publishCalls).toHaveLength(0);
     expect(ctx.output.cargo[0]?.alreadyPublished).toBe(true);
+  });
+
+  it('should treat "already exists on crates.io index" publish errors as already-published', async () => {
+    const { execCommand } = await import('../../../src/utils/exec.js');
+    // Pre-check returns 404 (API lag), but cargo publish then rejects.
+    vi.mocked(execCommand).mockImplementation(async (cmd, args) => {
+      if (cmd === 'cargo' && (args as string[])[0] === 'publish') {
+        throw Object.assign(new Error('Command failed: cargo publish ...'), {
+          stdout: '',
+          stderr: 'error: crate my-crate@0.5.0 already exists on crates.io index',
+          exitCode: 101,
+        });
+      }
+      return { stdout: '', stderr: '', exitCode: 0 };
+    });
+
+    const dir = createTmpDir();
+    const crateDir = path.join(dir, 'crates', 'my-crate');
+    fs.mkdirSync(crateDir, { recursive: true });
+    fs.writeFileSync(path.join(crateDir, 'Cargo.toml'), '[package]\nname = "my-crate"\nversion = "0.5.0"\n');
+
+    const ctx = createContext(dir);
+    await expect(runCargoPublishStage(ctx)).resolves.toBeUndefined();
+
+    expect(ctx.output.cargo[0]?.alreadyPublished).toBe(true);
+    expect(ctx.output.cargo[0]?.success).toBe(true);
+    expect(ctx.output.cargo[0]?.skipped).toBe(true);
+  });
+
+  it('should still throw on unrelated cargo publish failures', async () => {
+    const { execCommand } = await import('../../../src/utils/exec.js');
+    vi.mocked(execCommand).mockImplementation(async (cmd, args) => {
+      if (cmd === 'cargo' && (args as string[])[0] === 'publish') {
+        throw Object.assign(new Error('Command failed: cargo publish ...'), {
+          stdout: '',
+          stderr: 'error: failed to verify package tarball',
+          exitCode: 101,
+        });
+      }
+      return { stdout: '', stderr: '', exitCode: 0 };
+    });
+
+    const dir = createTmpDir();
+    const crateDir = path.join(dir, 'crates', 'my-crate');
+    fs.mkdirSync(crateDir, { recursive: true });
+    fs.writeFileSync(path.join(crateDir, 'Cargo.toml'), '[package]\nname = "my-crate"\nversion = "0.5.0"\n');
+
+    const ctx = createContext(dir);
+    await expect(runCargoPublishStage(ctx)).rejects.toThrow();
   });
 
   it('should pass --no-verify when configured', async () => {

--- a/packages/publish/test/unit/stages/npm-publish.spec.ts
+++ b/packages/publish/test/unit/stages/npm-publish.spec.ts
@@ -6,10 +6,14 @@ import { getDefaultConfig } from '../../../src/config.js';
 import { runNpmPublishStage } from '../../../src/stages/npm-publish.js';
 import type { PipelineContext } from '../../../src/types.js';
 
-vi.mock('../../../src/utils/exec.js', () => ({
-  execCommand: vi.fn().mockResolvedValue({ stdout: '', stderr: '', exitCode: 0 }),
-  execCommandSafe: vi.fn().mockResolvedValue({ stdout: '', stderr: '', exitCode: 1 }), // not published by default
-}));
+vi.mock('../../../src/utils/exec.js', async () => {
+  const actual = await vi.importActual<typeof import('../../../src/utils/exec.js')>('../../../src/utils/exec.js');
+  return {
+    ...actual,
+    execCommand: vi.fn().mockResolvedValue({ stdout: '', stderr: '', exitCode: 0 }),
+    execCommandSafe: vi.fn().mockResolvedValue({ stdout: '', stderr: '', exitCode: 1 }), // not published by default
+  };
+});
 
 vi.mock('../../../src/utils/auth.js', () => ({
   detectNpmAuth: vi.fn().mockReturnValue('token'),
@@ -232,6 +236,34 @@ describe('npm-publish stage', () => {
     expect(execCommand).toHaveBeenCalledTimes(2); // version check + publish
     const publishArgs = vi.mocked(execCommand).mock.calls[1]?.[1] as string[]; // publish is second
     expect(publishArgs).not.toContain('--provenance');
+  });
+
+  it('should treat EPUBLISHCONFLICT publish errors as already-published', async () => {
+    const { execCommand } = await import('../../../src/utils/exec.js');
+    // Pre-check (execCommandSafe) says not-published; npm publish then rejects.
+    vi.mocked(execCommand).mockImplementation(async (file, args) => {
+      if ((args as string[])?.includes('publish')) {
+        throw Object.assign(new Error('Command failed: pnpm publish'), {
+          stdout: '',
+          stderr:
+            'npm ERR! code EPUBLISHCONFLICT\nnpm ERR! 403 You cannot publish over the previously published versions: 1.0.0.',
+          exitCode: 1,
+        });
+      }
+      return { stdout: '', stderr: '', exitCode: 0 };
+    });
+
+    const dir = createTmpDir();
+    const pkgDir = path.join(dir, 'packages', 'pkg');
+    fs.mkdirSync(pkgDir, { recursive: true });
+    fs.writeFileSync(path.join(pkgDir, 'package.json'), JSON.stringify({ name: '@test/pkg', version: '1.0.0' }));
+
+    const ctx = createContext(dir);
+    await expect(runNpmPublishStage(ctx)).resolves.toBeUndefined();
+
+    expect(ctx.output.npm[0]?.alreadyPublished).toBe(true);
+    expect(ctx.output.npm[0]?.success).toBe(true);
+    expect(ctx.output.npm[0]?.skipped).toBe(true);
   });
 
   it('should throw on publish failure (fail-fast)', async () => {


### PR DESCRIPTION
Added a new utility function `getExecErrorOutput` to consolidate error messages from command executions. Updated the `runCargoPublishStage` and `runNpmPublishStage` functions to treat specific publish errors as indications that the package is already published, allowing for idempotent re-runs of the publish process. Enhanced unit tests to verify this behavior for both Cargo and npm publishing stages.
