### PR TITLE
refactor(notes): update LLM provider interfaces and enhance message handling

### DIFF
--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -251,6 +251,7 @@ export const LLMConfigSchema = z.object({
       pullRequests: z.boolean().default(true),
     })
     .default({ pullRequests: true }),
+  categoryOrder: z.array(z.string()).default(['Breaking', 'New', 'Changed', 'Fixed', 'Developer']),
 });
 
 export const ReleaseNotesConfigSchema = z.object({
@@ -258,6 +259,12 @@ export const ReleaseNotesConfigSchema = z.object({
   file: z.string().optional(),
   templates: TemplateConfigSchema.optional(),
   llm: LLMConfigSchema.optional(),
+  links: z
+    .object({
+      items: z.array(z.object({ label: z.string(), url: z.string().url() })).optional(),
+      fromPRBodyMarker: z.string().optional(),
+    })
+    .optional(),
 });
 
 export const NotesInputConfigSchema = z.object({

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -263,6 +263,7 @@ export const ReleaseNotesConfigSchema = z.object({
     .object({
       items: z.array(z.object({ label: z.string(), url: z.string().url() })).optional(),
       fromPRBodyMarker: z.string().optional(),
+      title: z.string().optional(),
     })
     .optional(),
 });

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -251,7 +251,7 @@ export const LLMConfigSchema = z.object({
       pullRequests: z.boolean().default(true),
     })
     .default({ pullRequests: true }),
-  categoryOrder: z.array(z.string()).default(['Breaking', 'New', 'Changed', 'Fixed', 'Developer']),
+  categoryOrder: z.array(z.string()).optional(),
 });
 
 export const ReleaseNotesConfigSchema = z.object({

--- a/packages/notes/src/core/pipeline.ts
+++ b/packages/notes/src/core/pipeline.ts
@@ -417,6 +417,8 @@ export async function runPipeline(input: ChangelogInput, config: Config, dryRun:
 
   const fmtOpts: FormatVersionOptions = {
     includePackageName: contexts.length > 1 || contexts.some((c) => c.packageName.includes('/')),
+    categoryOrder: llmConfig?.categoryOrder,
+    links: releaseNotesConfig !== false ? releaseNotesConfig?.links : undefined,
   };
 
   if (changelogConfig !== false && changelogConfig.mode) {

--- a/packages/notes/src/core/types.ts
+++ b/packages/notes/src/core/types.ts
@@ -163,6 +163,7 @@ export interface LLMConfig {
     pullRequests?: boolean;
   };
   examples?: number;
+  categoryOrder?: string[];
   categories?: Array<{ name: string; description: string; scopes?: string[] }>;
   style?: string;
   scopes?: ScopeConfig;
@@ -179,9 +180,15 @@ export interface ChangelogConfig {
   templates?: TemplateConfig;
 }
 
+export interface LinksConfig {
+  items?: Array<{ label: string; url: string }>;
+  fromPRBodyMarker?: string;
+}
+
 export interface ReleaseNotesConfig {
   mode?: LocationMode;
   file?: string;
   templates?: TemplateConfig;
   llm?: LLMConfig;
+  links?: LinksConfig;
 }

--- a/packages/notes/src/core/types.ts
+++ b/packages/notes/src/core/types.ts
@@ -183,6 +183,7 @@ export interface ChangelogConfig {
 export interface LinksConfig {
   items?: Array<{ label: string; url: string }>;
   fromPRBodyMarker?: string;
+  title?: string;
 }
 
 export interface ReleaseNotesConfig {

--- a/packages/notes/src/llm/openai-compatible.ts
+++ b/packages/notes/src/llm/openai-compatible.ts
@@ -18,7 +18,7 @@ export class OpenAICompatibleProvider extends BaseLLMProvider {
   readonly name = 'openai-compatible';
   readonly capabilities: ProviderCapabilities = {
     systemRole: true,
-    structuredOutputs: true,
+    structuredOutputs: false,
     toolUse: false,
   };
 

--- a/packages/notes/src/llm/tasks/categorize.ts
+++ b/packages/notes/src/llm/tasks/categorize.ts
@@ -1,4 +1,6 @@
+import { warn } from '@releasekit/core';
 import type { ChangelogEntry, LLMCategory } from '../../core/types.js';
+import { LLMError } from '../../errors/index.js';
 import { extractJsonFromResponse } from '../../utils/json.js';
 import type { ValidationResult } from '../correctiveRetry.js';
 import { withCorrectiveRetry } from '../correctiveRetry.js';
@@ -141,16 +143,24 @@ export async function categorizeEntries(
   const schema = buildCategorizeSchema(context.categories ?? []);
   const validate = makeValidator(entries, context);
 
-  return withCorrectiveRetry(
-    (messages, isFirstAttempt) =>
-      provider.complete(
-        messages,
-        isFirstAttempt && provider.capabilities.structuredOutputs
-          ? { schema, toolName: 'categorize_entries' }
-          : undefined,
-      ),
-    validate,
-    buildCorrectionMessages,
-    initialMessages,
-  );
+  try {
+    return await withCorrectiveRetry(
+      (messages, isFirstAttempt) =>
+        provider.complete(
+          messages,
+          isFirstAttempt && provider.capabilities.structuredOutputs
+            ? { schema, toolName: 'categorize_entries' }
+            : undefined,
+        ),
+      validate,
+      buildCorrectionMessages,
+      initialMessages,
+    );
+  } catch (error) {
+    if (error instanceof LLMError) {
+      warn(`categorizeEntries failed after all attempts: ${error.message}. Returning entries under General.`);
+      return [{ category: 'General', entries }];
+    }
+    throw error;
+  }
 }

--- a/packages/notes/src/llm/tasks/enhance-and-categorize.ts
+++ b/packages/notes/src/llm/tasks/enhance-and-categorize.ts
@@ -1,4 +1,6 @@
+import { warn } from '@releasekit/core';
 import type { ChangelogEntry, LLMCategory } from '../../core/types.js';
+import { LLMError } from '../../errors/index.js';
 import { extractJsonFromResponse } from '../../utils/json.js';
 import type { ValidationResult } from '../correctiveRetry.js';
 import { withCorrectiveRetry } from '../correctiveRetry.js';
@@ -180,16 +182,24 @@ export async function enhanceAndCategorize(
   const schema = buildEnhanceAndCategorizeSchema(context.categories ?? []);
   const validate = makeValidator(entries, context);
 
-  return withCorrectiveRetry(
-    (messages, isFirstAttempt) =>
-      provider.complete(
-        messages,
-        isFirstAttempt && provider.capabilities.structuredOutputs
-          ? { schema, toolName: 'emit_release_notes' }
-          : undefined,
-      ),
-    validate,
-    buildCorrectionMessages,
-    initialMessages,
-  );
+  try {
+    return await withCorrectiveRetry(
+      (messages, isFirstAttempt) =>
+        provider.complete(
+          messages,
+          isFirstAttempt && provider.capabilities.structuredOutputs
+            ? { schema, toolName: 'emit_release_notes' }
+            : undefined,
+        ),
+      validate,
+      buildCorrectionMessages,
+      initialMessages,
+    );
+  } catch (error) {
+    if (error instanceof LLMError) {
+      warn(`enhanceAndCategorize failed after all attempts: ${error.message}. Returning entries ungrouped.`);
+      return { enhancedEntries: entries, categories: [{ category: 'General', entries }] };
+    }
+    throw error;
+  }
 }

--- a/packages/notes/src/output/markdown.ts
+++ b/packages/notes/src/output/markdown.ts
@@ -135,7 +135,9 @@ function applyOrder(categories: EnhancedCategory[], order: string[]): EnhancedCa
   return [...categories].sort((a, b) => {
     const ai = order.indexOf(a.name);
     const bi = order.indexOf(b.name);
-    return (ai === -1 ? order.length : ai) - (bi === -1 ? order.length : bi);
+    // Breaking not in order: pin before all explicitly-ordered categories
+    const rank = (name: string, idx: number) => (idx === -1 ? (name === 'Breaking' ? -1 : order.length) : idx);
+    return rank(a.name, ai) - rank(b.name, bi);
   });
 }
 

--- a/packages/notes/src/output/markdown.ts
+++ b/packages/notes/src/output/markdown.ts
@@ -33,7 +33,9 @@ function groupEntriesByType(entries: ChangelogEntry[]): Map<ChangelogEntry['type
 function formatEntry(entry: ChangelogEntry, opts?: { hideScope?: boolean }): string {
   let line: string;
 
-  if (entry.leadIn) {
+  if (entry.leadIn && entry.breaking) {
+    line = `- **BREAKING** **${entry.leadIn}**: ${entry.description}`;
+  } else if (entry.leadIn) {
     line = `- **${entry.leadIn}**: ${entry.description}`;
   } else if (entry.breaking && entry.scope && !opts?.hideScope) {
     line = `- **BREAKING** **${entry.scope}**: ${entry.description}`;

--- a/packages/notes/src/output/markdown.ts
+++ b/packages/notes/src/output/markdown.ts
@@ -72,33 +72,31 @@ function formatCategorySection(name: string, entries: ChangelogEntry[]): string[
       lines.push(formatEntry(entry));
     }
   } else {
-    // Render scope groups in order of first appearance, then ungrouped entries
-    const renderedScopes = new Set<string>();
-    const ungrouped: ChangelogEntry[] = [];
+    // Render in a single pass preserving original order.
+    // When a grouped scope is first encountered, expand the full group inline.
     const byScope = new Map<string, ChangelogEntry[]>();
-
     for (const entry of entries) {
       if (entry.scope && groupedScopes.has(entry.scope)) {
         const group = byScope.get(entry.scope) ?? [];
         group.push(entry);
         byScope.set(entry.scope, group);
-      } else {
-        ungrouped.push(entry);
       }
     }
 
+    const renderedScopes = new Set<string>();
     for (const entry of entries) {
-      if (entry.scope && groupedScopes.has(entry.scope) && !renderedScopes.has(entry.scope)) {
-        renderedScopes.add(entry.scope);
-        lines.push(`**${entry.scope}**:`);
-        for (const e of byScope.get(entry.scope) ?? []) {
-          lines.push(formatEntry(e, { hideScope: true }));
+      if (entry.scope && groupedScopes.has(entry.scope)) {
+        if (!renderedScopes.has(entry.scope)) {
+          renderedScopes.add(entry.scope);
+          lines.push(`**${entry.scope}**:`);
+          for (const e of byScope.get(entry.scope) ?? []) {
+            lines.push(formatEntry(e, { hideScope: true }));
+          }
         }
+        // Remaining entries in this group already rendered above — skip
+      } else {
+        lines.push(formatEntry(entry));
       }
-    }
-
-    for (const entry of ungrouped) {
-      lines.push(formatEntry(entry));
     }
   }
 
@@ -231,7 +229,7 @@ export function formatVersion(context: TemplateContext, options?: FormatVersionO
 
     const links = resolveLinks(context.entries, options?.links);
     if (links.length > 0) {
-      lines.push('### Migration');
+      lines.push(`### ${options?.links?.title ?? 'Links'}`);
       for (const link of links) {
         lines.push(`- [${link.label}](${link.url})`);
       }

--- a/packages/notes/src/output/markdown.ts
+++ b/packages/notes/src/output/markdown.ts
@@ -1,7 +1,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { info, success } from '@releasekit/core';
-import type { ChangelogEntry, Config, TemplateContext } from '../core/types.js';
+import type { ChangelogEntry, Config, EnhancedCategory, LinksConfig, TemplateContext } from '../core/types.js';
 
 const TYPE_ORDER: ChangelogEntry['type'][] = ['added', 'changed', 'deprecated', 'removed', 'fixed', 'security'];
 
@@ -30,14 +30,16 @@ function groupEntriesByType(entries: ChangelogEntry[]): Map<ChangelogEntry['type
   return grouped;
 }
 
-function formatEntry(entry: ChangelogEntry): string {
+function formatEntry(entry: ChangelogEntry, opts?: { hideScope?: boolean }): string {
   let line: string;
 
-  if (entry.breaking && entry.scope) {
+  if (entry.leadIn) {
+    line = `- **${entry.leadIn}**: ${entry.description}`;
+  } else if (entry.breaking && entry.scope && !opts?.hideScope) {
     line = `- **BREAKING** **${entry.scope}**: ${entry.description}`;
   } else if (entry.breaking) {
     line = `- **BREAKING** ${entry.description}`;
-  } else if (entry.scope) {
+  } else if (entry.scope && !opts?.hideScope) {
     line = `- **${entry.scope}**: ${entry.description}`;
   } else {
     line = `- ${entry.description}`;
@@ -50,9 +52,151 @@ function formatEntry(entry: ChangelogEntry): string {
   return line;
 }
 
+function formatCategorySection(name: string, entries: ChangelogEntry[]): string[] {
+  const lines: string[] = [];
+  lines.push(`### ${name}`);
+
+  // Identify scopes that appear on 2+ entries → group them
+  const scopeCounts = new Map<string, number>();
+  for (const entry of entries) {
+    if (entry.scope) scopeCounts.set(entry.scope, (scopeCounts.get(entry.scope) ?? 0) + 1);
+  }
+  const groupedScopes = new Set<string>();
+  for (const [scope, count] of scopeCounts) {
+    if (count > 1) groupedScopes.add(scope);
+  }
+
+  if (groupedScopes.size === 0) {
+    // No scope grouping — render flat
+    for (const entry of entries) {
+      lines.push(formatEntry(entry));
+    }
+  } else {
+    // Render scope groups in order of first appearance, then ungrouped entries
+    const renderedScopes = new Set<string>();
+    const ungrouped: ChangelogEntry[] = [];
+    const byScope = new Map<string, ChangelogEntry[]>();
+
+    for (const entry of entries) {
+      if (entry.scope && groupedScopes.has(entry.scope)) {
+        const group = byScope.get(entry.scope) ?? [];
+        group.push(entry);
+        byScope.set(entry.scope, group);
+      } else {
+        ungrouped.push(entry);
+      }
+    }
+
+    for (const entry of entries) {
+      if (entry.scope && groupedScopes.has(entry.scope) && !renderedScopes.has(entry.scope)) {
+        renderedScopes.add(entry.scope);
+        lines.push(`**${entry.scope}**:`);
+        for (const e of byScope.get(entry.scope) ?? []) {
+          lines.push(formatEntry(e, { hideScope: true }));
+        }
+      }
+    }
+
+    for (const entry of ungrouped) {
+      lines.push(formatEntry(entry));
+    }
+  }
+
+  lines.push('');
+  return lines;
+}
+
+function rerouteBreakingEntries(categories: EnhancedCategory[]): EnhancedCategory[] {
+  const hasBreaking = categories.some((c) => c.entries.some((e) => e.breaking));
+  if (!hasBreaking) return categories;
+
+  const breakingEntries: ChangelogEntry[] = [];
+  const stripped = categories.map((c) => ({
+    ...c,
+    entries: c.entries.filter((e) => {
+      if (e.breaking) {
+        breakingEntries.push(e);
+        return false;
+      }
+      return true;
+    }),
+  }));
+
+  const breakingCatIdx = stripped.findIndex((c) => c.name === 'Breaking');
+  if (breakingCatIdx >= 0) {
+    return stripped.map((c, i) => (i === breakingCatIdx ? { ...c, entries: [...breakingEntries, ...c.entries] } : c));
+  }
+  // Create a "Breaking" category if it doesn't exist yet
+  return [{ name: 'Breaking', entries: breakingEntries }, ...stripped.filter((c) => c.entries.length > 0)];
+}
+
+function applyOrder(categories: EnhancedCategory[], order: string[]): EnhancedCategory[] {
+  if (order.length === 0) return categories;
+  return [...categories].sort((a, b) => {
+    const ai = order.indexOf(a.name);
+    const bi = order.indexOf(b.name);
+    return (ai === -1 ? order.length : ai) - (bi === -1 ? order.length : bi);
+  });
+}
+
+interface LinkItem {
+  label: string;
+  url: string;
+}
+
+function extractLinksFromPRBodies(entries: ChangelogEntry[], marker: string): LinkItem[] {
+  const seen = new Set<string>();
+  const links: LinkItem[] = [];
+  for (const entry of entries) {
+    for (const pr of entry.context?.prs ?? []) {
+      for (const line of pr.body.split('\n')) {
+        const trimmed = line.trim();
+        if (!trimmed.startsWith(marker)) continue;
+        const rest = trimmed.slice(marker.length).trim();
+        const mdMatch = rest.match(/\[([^\]]+)\]\((https?:\/\/[^)]+)\)/);
+        if (mdMatch) {
+          if (!seen.has(mdMatch[2]!)) {
+            seen.add(mdMatch[2]!);
+            links.push({ label: mdMatch[1]!, url: mdMatch[2]! });
+          }
+        } else if (/^https?:\/\//.test(rest)) {
+          const url = rest.split(/\s/)[0]!;
+          if (!seen.has(url)) {
+            seen.add(url);
+            links.push({ label: marker.replace(/:$/, ''), url });
+          }
+        }
+      }
+    }
+  }
+  return links;
+}
+
+function resolveLinks(entries: ChangelogEntry[], linksConfig: LinksConfig | undefined): LinkItem[] {
+  if (!linksConfig) return [];
+  const items = linksConfig.items ?? [];
+  const discovered = linksConfig.fromPRBodyMarker
+    ? extractLinksFromPRBodies(entries, linksConfig.fromPRBodyMarker)
+    : [];
+  // Merge, de-dup by URL (explicit items take precedence)
+  const seen = new Set(items.map((i) => i.url));
+  const merged = [...items];
+  for (const link of discovered) {
+    if (!seen.has(link.url)) {
+      seen.add(link.url);
+      merged.push(link);
+    }
+  }
+  return merged;
+}
+
 export interface FormatVersionOptions {
   /** Include the package name in the version header (e.g. `## [pkg@1.0.0]`). */
   includePackageName?: boolean;
+  /** Order to render LLM-categorised sections. Only applies when enhanced.categories is present. */
+  categoryOrder?: string[];
+  /** Migration/doc links to render at the end of the release notes section. */
+  links?: LinksConfig;
 }
 
 export function formatVersion(context: TemplateContext, options?: FormatVersionOptions): string {
@@ -75,16 +219,37 @@ export function formatVersion(context: TemplateContext, options?: FormatVersionO
     lines.push('');
   }
 
-  const grouped = groupEntriesByType(context.entries);
+  if (context.enhanced?.categories && context.enhanced.categories.length > 0) {
+    // LLM-enhanced path: category-based rendering with breaking re-routing and scope grouping
+    let categories = rerouteBreakingEntries(context.enhanced.categories);
+    categories = applyOrder(categories, options?.categoryOrder ?? []);
 
-  for (const [type, entries] of grouped) {
-    if (entries.length === 0) continue;
-
-    lines.push(`### ${TYPE_LABELS[type]}`);
-    for (const entry of entries) {
-      lines.push(formatEntry(entry));
+    for (const category of categories) {
+      if (category.entries.length === 0) continue;
+      lines.push(...formatCategorySection(category.name, category.entries));
     }
-    lines.push('');
+
+    const links = resolveLinks(context.entries, options?.links);
+    if (links.length > 0) {
+      lines.push('### Migration');
+      for (const link of links) {
+        lines.push(`- [${link.label}](${link.url})`);
+      }
+      lines.push('');
+    }
+  } else {
+    // Non-LLM / changelog path: type-based grouping
+    const grouped = groupEntriesByType(context.entries);
+
+    for (const [type, entries] of grouped) {
+      if (entries.length === 0) continue;
+
+      lines.push(`### ${TYPE_LABELS[type]}`);
+      for (const entry of entries) {
+        lines.push(formatEntry(entry));
+      }
+      lines.push('');
+    }
   }
 
   return lines.join('\n');

--- a/packages/notes/test/integration/llm-pipeline.spec.ts
+++ b/packages/notes/test/integration/llm-pipeline.spec.ts
@@ -164,9 +164,11 @@ describe('LLM tasks: categorize', () => {
     expect(result.find((c) => c.category === 'Fixes')?.entries[0]?.description).toBe('Fix null pointer');
   });
 
-  it('should throw on persistent invalid JSON (corrective retry exhausted)', async () => {
+  it('should return General fallback on persistent invalid JSON (corrective retry exhausted)', async () => {
     const provider = makeMockProvider('not json');
-    await expect(categorizeEntries(provider, sampleInput.packages[0]?.entries, {})).rejects.toThrow();
+    const result = await categorizeEntries(provider, sampleInput.packages[0]?.entries ?? [], {});
+    expect(result).toHaveLength(1);
+    expect(result[0]?.category).toBe('General');
   });
 });
 

--- a/packages/notes/test/unit/llm.spec.ts
+++ b/packages/notes/test/unit/llm.spec.ts
@@ -330,9 +330,12 @@ describe('categorizeEntries()', () => {
     expect(fixedCategory?.entries[0]?.scope).toBeUndefined();
   });
 
-  it('should throw when corrective retry is exhausted on persistent invalid JSON', async () => {
+  it('should return General fallback when corrective retry is exhausted on persistent invalid JSON', async () => {
     const provider = makeMockProvider('not valid json at all');
-    await expect(categorizeEntries(provider, sampleEntries, llmContext)).rejects.toThrow();
+    const result = await categorizeEntries(provider, sampleEntries, llmContext);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.category).toBe('General');
+    expect(result[0]?.entries).toEqual(sampleEntries);
   });
 });
 
@@ -478,9 +481,12 @@ describe('enhanceAndCategorize()', () => {
     expect(result.categories).toHaveLength(3);
   });
 
-  it('should throw when all corrective retry attempts fail', async () => {
+  it('should return General fallback when all corrective retry attempts fail', async () => {
     const provider = makeMockProvider('always invalid json');
-    await expect(enhanceAndCategorize(provider, sampleEntries, llmContext)).rejects.toThrow();
+    const result = await enhanceAndCategorize(provider, sampleEntries, llmContext);
+    expect(result.enhancedEntries).toEqual(sampleEntries);
+    expect(result.categories).toHaveLength(1);
+    expect(result.categories[0]?.category).toBe('General');
     expect(provider.callCount).toBe(3); // 1 initial + 2 corrective
   });
 
@@ -560,14 +566,16 @@ describe('enhanceAndCategorize()', () => {
     expect(systemMsg?.content).toContain('Focus on user impact.');
   });
 
-  it('should throw LLMError when response has fewer entries than input', async () => {
-    // Only 1 entry in response for 3 inputs — count mismatch is a validation error.
+  it('should return General fallback when response has fewer entries than input', async () => {
+    // Only 1 entry in response for 3 inputs — count mismatch exhausts corrective retries → fallback.
     const response = JSON.stringify({
       entries: [{ description: 'Only first', category: 'New', scope: null, breaking: null, leadIn: null }],
     });
 
     const provider = makeMockProvider(response);
-    await expect(enhanceAndCategorize(provider, sampleEntries, llmContext)).rejects.toThrow(LLMError);
+    const result = await enhanceAndCategorize(provider, sampleEntries, llmContext);
+    expect(result.enhancedEntries).toEqual(sampleEntries);
+    expect(result.categories[0]?.category).toBe('General');
   });
 });
 

--- a/packages/notes/test/unit/output/markdown.spec.ts
+++ b/packages/notes/test/unit/output/markdown.spec.ts
@@ -102,6 +102,24 @@ describe('formatVersion: leadIn phrases', () => {
     expect(result).toContain('- Fix bug');
     expect(result).not.toContain('**');
   });
+
+  it('should prefix BREAKING before leadIn when both are set', async () => {
+    const { formatVersion } = await import('../../../src/output/markdown.js');
+
+    const ctx = makeContext({
+      enhanced: {
+        categories: [
+          {
+            name: 'Breaking',
+            entries: [{ type: 'changed', description: 'Removed old API', leadIn: 'API removal', breaking: true }],
+          },
+        ],
+      },
+    });
+
+    const result = formatVersion(ctx);
+    expect(result).toContain('- **BREAKING** **API removal**: Removed old API');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/notes/test/unit/output/markdown.spec.ts
+++ b/packages/notes/test/unit/output/markdown.spec.ts
@@ -70,3 +70,364 @@ describe('writeMarkdown: dry run', () => {
     expect(header).toMatch(/Release notes/i);
   });
 });
+
+// ---------------------------------------------------------------------------
+// formatVersion — leadIn rendering
+// ---------------------------------------------------------------------------
+
+describe('formatVersion: leadIn phrases', () => {
+  it('should render bold leadIn prefix when present', async () => {
+    const { formatVersion } = await import('../../../src/output/markdown.js');
+
+    const ctx = makeContext({
+      enhanced: {
+        categories: [{ name: 'New', entries: [{ type: 'added', description: 'New API', leadIn: 'deeplink' }] }],
+      },
+    });
+
+    const result = formatVersion(ctx);
+    expect(result).toContain('- **deeplink**: New API');
+  });
+
+  it('should fall back to plain description when leadIn is absent', async () => {
+    const { formatVersion } = await import('../../../src/output/markdown.js');
+
+    const ctx = makeContext({
+      enhanced: {
+        categories: [{ name: 'Fixed', entries: [{ type: 'fixed', description: 'Fix bug' }] }],
+      },
+    });
+
+    const result = formatVersion(ctx);
+    expect(result).toContain('- Fix bug');
+    expect(result).not.toContain('**');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatVersion — scope grouping
+// ---------------------------------------------------------------------------
+
+describe('formatVersion: scope grouping', () => {
+  it('should group multiple entries with the same scope under a bold scope header', async () => {
+    const { formatVersion } = await import('../../../src/output/markdown.js');
+
+    const ctx = makeContext({
+      enhanced: {
+        categories: [
+          {
+            name: 'New',
+            entries: [
+              { type: 'added', description: 'Feature A', scope: 'api' },
+              { type: 'added', description: 'Feature B', scope: 'api' },
+            ],
+          },
+        ],
+      },
+    });
+
+    const result = formatVersion(ctx);
+    expect(result).toContain('**api**:');
+    // Individual entries should NOT repeat the scope prefix
+    expect(result).not.toContain('**api**: Feature A');
+    expect(result).toContain('- Feature A');
+    expect(result).toContain('- Feature B');
+  });
+
+  it('should not create a scope group header for a single entry with that scope', async () => {
+    const { formatVersion } = await import('../../../src/output/markdown.js');
+
+    const ctx = makeContext({
+      enhanced: {
+        categories: [
+          {
+            name: 'Fixed',
+            entries: [
+              { type: 'fixed', description: 'Fix A', scope: 'core' },
+              { type: 'fixed', description: 'Fix B', scope: 'ui' },
+            ],
+          },
+        ],
+      },
+    });
+
+    const result = formatVersion(ctx);
+    // Group headers appear on their own line (not prefixed with '-')
+    expect(result).not.toMatch(/^\*\*core\*\*:/m);
+    expect(result).not.toMatch(/^\*\*ui\*\*:/m);
+    // Scope still appears inline in the entry
+    expect(result).toContain('**core**: Fix A');
+    expect(result).toContain('**ui**: Fix B');
+  });
+
+  it('should render ungrouped entries after scoped groups', async () => {
+    const { formatVersion } = await import('../../../src/output/markdown.js');
+
+    const ctx = makeContext({
+      enhanced: {
+        categories: [
+          {
+            name: 'New',
+            entries: [
+              { type: 'added', description: 'Scoped 1', scope: 'api' },
+              { type: 'added', description: 'Scoped 2', scope: 'api' },
+              { type: 'added', description: 'No scope' },
+            ],
+          },
+        ],
+      },
+    });
+
+    const result = formatVersion(ctx);
+    const apiPos = result.indexOf('**api**:');
+    const noScopePos = result.indexOf('- No scope');
+    expect(apiPos).toBeLessThan(noScopePos);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatVersion — breaking changes re-routing
+// ---------------------------------------------------------------------------
+
+describe('formatVersion: breaking changes section', () => {
+  it('should route breaking entries into the Breaking category', async () => {
+    const { formatVersion } = await import('../../../src/output/markdown.js');
+
+    const ctx = makeContext({
+      enhanced: {
+        categories: [
+          {
+            name: 'Changed',
+            entries: [
+              { type: 'changed', description: 'Breaking change', breaking: true },
+              { type: 'changed', description: 'Normal change' },
+            ],
+          },
+        ],
+      },
+    });
+
+    const result = formatVersion(ctx);
+    const breakingPos = result.indexOf('### Breaking');
+    const changedPos = result.indexOf('### Changed');
+    expect(breakingPos).toBeGreaterThanOrEqual(0);
+    expect(breakingPos).toBeLessThan(changedPos);
+    expect(result).toContain('- **BREAKING** Breaking change');
+  });
+
+  it('should not render a Breaking section when no entries have breaking: true', async () => {
+    const { formatVersion } = await import('../../../src/output/markdown.js');
+
+    const ctx = makeContext({
+      enhanced: {
+        categories: [{ name: 'New', entries: [{ type: 'added', description: 'Feature' }] }],
+      },
+    });
+
+    expect(formatVersion(ctx)).not.toContain('### Breaking');
+  });
+
+  it('should render Breaking section first when categoryOrder includes Breaking', async () => {
+    const { formatVersion } = await import('../../../src/output/markdown.js');
+
+    const ctx = makeContext({
+      enhanced: {
+        categories: [
+          { name: 'New', entries: [{ type: 'added', description: 'Feature' }] },
+          { name: 'Changed', entries: [{ type: 'changed', description: 'Breaking thing', breaking: true }] },
+        ],
+      },
+    });
+
+    const result = formatVersion(ctx, { categoryOrder: ['Breaking', 'New', 'Changed'] });
+    const breakingPos = result.indexOf('### Breaking');
+    const newPos = result.indexOf('### New');
+    expect(breakingPos).toBeLessThan(newPos);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatVersion — categoryOrder
+// ---------------------------------------------------------------------------
+
+describe('formatVersion: categoryOrder', () => {
+  it('should sort categories according to provided order', async () => {
+    const { formatVersion } = await import('../../../src/output/markdown.js');
+
+    const ctx = makeContext({
+      enhanced: {
+        categories: [
+          { name: 'Fixed', entries: [{ type: 'fixed', description: 'Fix' }] },
+          { name: 'New', entries: [{ type: 'added', description: 'Feature' }] },
+        ],
+      },
+    });
+
+    const result = formatVersion(ctx, { categoryOrder: ['New', 'Fixed'] });
+    expect(result.indexOf('### New')).toBeLessThan(result.indexOf('### Fixed'));
+  });
+
+  it('should append categories not in categoryOrder at the end', async () => {
+    const { formatVersion } = await import('../../../src/output/markdown.js');
+
+    const ctx = makeContext({
+      enhanced: {
+        categories: [
+          { name: 'Unknown', entries: [{ type: 'changed', description: 'Unknown change' }] },
+          { name: 'New', entries: [{ type: 'added', description: 'Feature' }] },
+        ],
+      },
+    });
+
+    const result = formatVersion(ctx, { categoryOrder: ['New'] });
+    expect(result.indexOf('### New')).toBeLessThan(result.indexOf('### Unknown'));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatVersion — migration links
+// ---------------------------------------------------------------------------
+
+describe('formatVersion: migration links', () => {
+  it('should render explicit link items in a ### Migration section', async () => {
+    const { formatVersion } = await import('../../../src/output/markdown.js');
+
+    const ctx = makeContext({
+      enhanced: {
+        categories: [{ name: 'New', entries: [{ type: 'added', description: 'Feature' }] }],
+      },
+    });
+
+    const result = formatVersion(ctx, {
+      links: { items: [{ label: 'Migration guide', url: 'https://example.com/migrate' }] },
+    });
+
+    expect(result).toContain('### Migration');
+    expect(result).toContain('- [Migration guide](https://example.com/migrate)');
+  });
+
+  it('should discover links from PR body marker', async () => {
+    const { formatVersion } = await import('../../../src/output/markdown.js');
+
+    const ctx = makeContext({
+      entries: [
+        {
+          type: 'changed' as const,
+          description: 'Breaking change',
+          context: {
+            prs: [{ number: 1, title: 'PR', body: 'Migration: https://example.com/guide' }],
+          },
+        },
+      ],
+      enhanced: {
+        categories: [{ name: 'Changed', entries: [{ type: 'changed', description: 'Breaking change' }] }],
+      },
+    });
+
+    const result = formatVersion(ctx, { links: { fromPRBodyMarker: 'Migration:' } });
+    expect(result).toContain('### Migration');
+    expect(result).toContain('https://example.com/guide');
+  });
+
+  it('should discover markdown links from PR body marker', async () => {
+    const { formatVersion } = await import('../../../src/output/markdown.js');
+
+    const ctx = makeContext({
+      entries: [
+        {
+          type: 'changed' as const,
+          description: 'Change',
+          context: {
+            prs: [
+              {
+                number: 2,
+                title: 'PR',
+                body: 'Migration: [Full guide](https://example.com/full-guide)',
+              },
+            ],
+          },
+        },
+      ],
+      enhanced: {
+        categories: [{ name: 'Changed', entries: [{ type: 'changed', description: 'Change' }] }],
+      },
+    });
+
+    const result = formatVersion(ctx, { links: { fromPRBodyMarker: 'Migration:' } });
+    expect(result).toContain('- [Full guide](https://example.com/full-guide)');
+  });
+
+  it('should deduplicate links by URL', async () => {
+    const { formatVersion } = await import('../../../src/output/markdown.js');
+
+    const ctx = makeContext({
+      entries: [
+        {
+          type: 'changed' as const,
+          description: 'Change',
+          context: {
+            prs: [{ number: 3, title: 'PR', body: 'Migration: https://example.com/guide' }],
+          },
+        },
+      ],
+      enhanced: {
+        categories: [{ name: 'Changed', entries: [{ type: 'changed', description: 'Change' }] }],
+      },
+    });
+
+    const result = formatVersion(ctx, {
+      links: {
+        items: [{ label: 'guide', url: 'https://example.com/guide' }],
+        fromPRBodyMarker: 'Migration:',
+      },
+    });
+
+    const count = (result.match(/https:\/\/example\.com\/guide/g) ?? []).length;
+    expect(count).toBe(1);
+  });
+
+  it('should not render Migration section when no links found', async () => {
+    const { formatVersion } = await import('../../../src/output/markdown.js');
+
+    const ctx = makeContext({
+      enhanced: {
+        categories: [{ name: 'New', entries: [{ type: 'added', description: 'Feature' }] }],
+      },
+    });
+
+    expect(formatVersion(ctx)).not.toContain('### Migration');
+  });
+
+  it('should not render Migration section in non-LLM path', async () => {
+    const { formatVersion } = await import('../../../src/output/markdown.js');
+
+    // No enhanced.categories → type-based path
+    const ctx = makeContext();
+    const result = formatVersion(ctx, {
+      links: { items: [{ label: 'guide', url: 'https://example.com/guide' }] },
+    });
+
+    expect(result).not.toContain('### Migration');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatVersion — non-LLM path unchanged
+// ---------------------------------------------------------------------------
+
+describe('formatVersion: non-LLM path', () => {
+  it('should use type-based grouping when no enhanced categories', async () => {
+    const { formatVersion } = await import('../../../src/output/markdown.js');
+
+    const ctx = makeContext({
+      entries: [
+        { type: 'added', description: 'Feature' },
+        { type: 'fixed', description: 'Bug fix' },
+      ],
+    });
+
+    const result = formatVersion(ctx);
+    expect(result).toContain('### Added');
+    expect(result).toContain('### Fixed');
+  });
+});

--- a/packages/notes/test/unit/output/markdown.spec.ts
+++ b/packages/notes/test/unit/output/markdown.spec.ts
@@ -282,6 +282,107 @@ describe('formatVersion: breaking changes section', () => {
     expect(breakingPos).toBeGreaterThanOrEqual(0);
     expect(breakingPos).toBeLessThan(newPos);
   });
+
+  it('should merge breaking entries into an existing Breaking category returned by the LLM', async () => {
+    const { formatVersion } = await import('../../../src/output/markdown.js');
+
+    const ctx = makeContext({
+      enhanced: {
+        categories: [
+          { name: 'Breaking', entries: [{ type: 'removed', description: 'Already-breaking entry' }] },
+          {
+            name: 'Changed',
+            entries: [
+              { type: 'changed', description: 'Another breaking change', breaking: true },
+              { type: 'changed', description: 'Normal change' },
+            ],
+          },
+        ],
+      },
+    });
+
+    const result = formatVersion(ctx);
+    // Only one Breaking section
+    const firstBreaking = result.indexOf('### Breaking');
+    const secondBreaking = result.indexOf('### Breaking', firstBreaking + 1);
+    expect(firstBreaking).toBeGreaterThanOrEqual(0);
+    expect(secondBreaking).toBe(-1);
+    // Both entries present under it
+    expect(result).toContain('Already-breaking entry');
+    expect(result).toContain('Another breaking change');
+  });
+
+  it('should not render an empty source category after all entries are rerouted', async () => {
+    const { formatVersion } = await import('../../../src/output/markdown.js');
+
+    const ctx = makeContext({
+      enhanced: {
+        categories: [
+          // All entries in this category are breaking — it should vanish after rerouting
+          { name: 'Removed', entries: [{ type: 'removed', description: 'Dropped endpoint', breaking: true }] },
+          { name: 'New', entries: [{ type: 'added', description: 'Feature' }] },
+        ],
+      },
+    });
+
+    const result = formatVersion(ctx);
+    expect(result).toContain('### Breaking');
+    expect(result).not.toContain('### Removed');
+  });
+
+  it('should preserve LLM category order when categoryOrder is absent', async () => {
+    const { formatVersion } = await import('../../../src/output/markdown.js');
+
+    // Simulate a realistic LLM-returned category list with no categoryOrder configured
+    const ctx = makeContext({
+      enhanced: {
+        categories: [
+          { name: 'New features', entries: [{ type: 'added', description: 'Dark mode' }] },
+          { name: 'Bug fixes', entries: [{ type: 'fixed', description: 'Crash on startup' }] },
+          { name: 'Performance', entries: [{ type: 'changed', description: 'Faster build' }] },
+        ],
+      },
+    });
+
+    const result = formatVersion(ctx);
+    const newPos = result.indexOf('### New features');
+    const fixPos = result.indexOf('### Bug fixes');
+    const perfPos = result.indexOf('### Performance');
+    expect(newPos).toBeLessThan(fixPos);
+    expect(fixPos).toBeLessThan(perfPos);
+  });
+
+  it('should pin synthetic Breaking before all other categories when categoryOrder is absent', async () => {
+    const { formatVersion } = await import('../../../src/output/markdown.js');
+
+    // Realistic LLM output: no Breaking category returned, breaking flag on one entry
+    const ctx = makeContext({
+      enhanced: {
+        categories: [
+          { name: 'New features', entries: [{ type: 'added', description: 'New API' }] },
+          { name: 'Bug fixes', entries: [{ type: 'fixed', description: 'Fix crash' }] },
+          {
+            name: 'Changed',
+            entries: [
+              { type: 'changed', description: 'Dropped support for Node 16', breaking: true },
+              { type: 'changed', description: 'Updated defaults' },
+            ],
+          },
+        ],
+      },
+    });
+
+    const result = formatVersion(ctx);
+    const breakingPos = result.indexOf('### Breaking');
+    const newPos = result.indexOf('### New features');
+    const fixPos = result.indexOf('### Bug fixes');
+    expect(breakingPos).toBeGreaterThanOrEqual(0);
+    expect(breakingPos).toBeLessThan(newPos);
+    expect(breakingPos).toBeLessThan(fixPos);
+    // Source category still renders (has a non-breaking entry left)
+    expect(result).toContain('### Changed');
+    expect(result).toContain('Updated defaults');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/notes/test/unit/output/markdown.spec.ts
+++ b/packages/notes/test/unit/output/markdown.spec.ts
@@ -289,7 +289,7 @@ describe('formatVersion: categoryOrder', () => {
 // ---------------------------------------------------------------------------
 
 describe('formatVersion: migration links', () => {
-  it('should render explicit link items in a ### Migration section', async () => {
+  it('should render explicit link items under ### Links by default', async () => {
     const { formatVersion } = await import('../../../src/output/markdown.js');
 
     const ctx = makeContext({
@@ -302,8 +302,24 @@ describe('formatVersion: migration links', () => {
       links: { items: [{ label: 'Migration guide', url: 'https://example.com/migrate' }] },
     });
 
-    expect(result).toContain('### Migration');
+    expect(result).toContain('### Links');
     expect(result).toContain('- [Migration guide](https://example.com/migrate)');
+  });
+
+  it('should use custom title when links.title is set', async () => {
+    const { formatVersion } = await import('../../../src/output/markdown.js');
+
+    const ctx = makeContext({
+      enhanced: {
+        categories: [{ name: 'New', entries: [{ type: 'added', description: 'Feature' }] }],
+      },
+    });
+
+    const result = formatVersion(ctx, {
+      links: { title: 'Migration', items: [{ label: 'Guide', url: 'https://example.com/guide' }] },
+    });
+
+    expect(result).toContain('### Migration');
   });
 
   it('should discover links from PR body marker', async () => {
@@ -325,7 +341,7 @@ describe('formatVersion: migration links', () => {
     });
 
     const result = formatVersion(ctx, { links: { fromPRBodyMarker: 'Migration:' } });
-    expect(result).toContain('### Migration');
+    expect(result).toContain('### Links');
     expect(result).toContain('https://example.com/guide');
   });
 
@@ -386,7 +402,7 @@ describe('formatVersion: migration links', () => {
     expect(count).toBe(1);
   });
 
-  it('should not render Migration section when no links found', async () => {
+  it('should not render links section when no links found', async () => {
     const { formatVersion } = await import('../../../src/output/markdown.js');
 
     const ctx = makeContext({
@@ -395,10 +411,10 @@ describe('formatVersion: migration links', () => {
       },
     });
 
-    expect(formatVersion(ctx)).not.toContain('### Migration');
+    expect(formatVersion(ctx)).not.toContain('### Links');
   });
 
-  it('should not render Migration section in non-LLM path', async () => {
+  it('should not render links section in non-LLM path', async () => {
     const { formatVersion } = await import('../../../src/output/markdown.js');
 
     // No enhanced.categories → type-based path
@@ -407,7 +423,7 @@ describe('formatVersion: migration links', () => {
       links: { items: [{ label: 'guide', url: 'https://example.com/guide' }] },
     });
 
-    expect(result).not.toContain('### Migration');
+    expect(result).not.toContain('### Links');
   });
 });
 

--- a/packages/notes/test/unit/output/markdown.spec.ts
+++ b/packages/notes/test/unit/output/markdown.spec.ts
@@ -262,6 +262,26 @@ describe('formatVersion: breaking changes section', () => {
     const newPos = result.indexOf('### New');
     expect(breakingPos).toBeLessThan(newPos);
   });
+
+  it('should still render Breaking section first when Breaking is absent from categoryOrder', async () => {
+    const { formatVersion } = await import('../../../src/output/markdown.js');
+
+    const ctx = makeContext({
+      enhanced: {
+        categories: [
+          { name: 'New', entries: [{ type: 'added', description: 'Feature' }] },
+          { name: 'Changed', entries: [{ type: 'changed', description: 'Breaking thing', breaking: true }] },
+        ],
+      },
+    });
+
+    // categoryOrder only lists New and Changed — Breaking is omitted but must still land first
+    const result = formatVersion(ctx, { categoryOrder: ['New', 'Changed'] });
+    const breakingPos = result.indexOf('### Breaking');
+    const newPos = result.indexOf('### New');
+    expect(breakingPos).toBeGreaterThanOrEqual(0);
+    expect(breakingPos).toBeLessThan(newPos);
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
- Modified LLMProvider interface to accept an array of messages instead of a single prompt string, improving flexibility for structured inputs.
- Introduced capabilities property to LLMProvider for better provider feature management.
- Enhanced error handling in LLM processing, providing clearer fallback messages for debugging.
- Added new corrective retry mechanism to improve output validation and error correction during LLM interactions.
- Introduced new message types and schemas for structured output, enhancing the overall LLM integration.
- Updated various LLM provider implementations (Anthropic, OpenAI, Ollama) to support the new message structure and capabilities.
- Refactored prompt resolution logic to accommodate new system prompts and user instructions.