### PR TITLE
fix(notes): replace ReDoS-prone markdown link regex with linear scan

### DIFF
--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -241,7 +241,7 @@ export const LLMConfigSchema = z.object({
   concurrency: z.number().int().positive().optional(),
   retry: LLMRetryConfigSchema.optional(),
   tasks: LLMTasksConfigSchema.optional(),
-  categories: z.array(LLMCategorySchema).default([
+  categories: z.array(LLMCategorySchema).default(() => [
     { name: 'Breaking', description: 'Breaking changes that require user action to upgrade' },
     { name: 'New', description: 'New features and capabilities' },
     { name: 'Changed', description: 'Changes to existing functionality' },

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -241,8 +241,18 @@ export const LLMConfigSchema = z.object({
   concurrency: z.number().int().positive().optional(),
   retry: LLMRetryConfigSchema.optional(),
   tasks: LLMTasksConfigSchema.optional(),
-  categories: z.array(LLMCategorySchema).optional(),
-  style: z.string().optional(),
+  categories: z.array(LLMCategorySchema).default([
+    { name: 'Breaking', description: 'Breaking changes that require user action to upgrade' },
+    { name: 'New', description: 'New features and capabilities' },
+    { name: 'Changed', description: 'Changes to existing functionality' },
+    { name: 'Fixed', description: 'Bug fixes' },
+    { name: 'Developer', description: 'Internal changes: CI, tooling, dependencies, refactoring' },
+  ]),
+  style: z
+    .string()
+    .default(
+      'Write in present tense ("Add feature", not "Added feature"). Be concise and user-focused. Lead with the impact, not the implementation detail.',
+    ),
   scopes: ScopeConfigSchema.optional(),
   prompts: LLMPromptsConfigSchema.optional(),
   examples: z.number().int().min(0).max(5).default(3),

--- a/packages/notes/src/llm/context/prFetcher.ts
+++ b/packages/notes/src/llm/context/prFetcher.ts
@@ -1,5 +1,6 @@
+import { RequestError } from '@octokit/request-error';
 import { Octokit } from '@octokit/rest';
-import { debug } from '@releasekit/core';
+import { debug, warn } from '@releasekit/core';
 import type { PRContext } from '../../core/types.js';
 
 const BODY_CAP = 2048;
@@ -78,7 +79,11 @@ export async function fetchPullRequestContext(
           const body = truncateBody(sanitiseBody(raw));
           cache.set(number, { number, title: data.title, body });
         } catch (error) {
-          debug(`Failed to fetch PR #${number}: ${error instanceof Error ? error.message : String(error)}`);
+          if (error instanceof RequestError && (error.status === 401 || error.status === 403)) {
+            warn(`GitHub API auth error fetching PR #${number} (${error.status}): check GITHUB_TOKEN permissions`);
+          } else {
+            debug(`Failed to fetch PR #${number}: ${error instanceof Error ? error.message : String(error)}`);
+          }
         }
       }),
     );

--- a/packages/notes/src/llm/openai-compatible.ts
+++ b/packages/notes/src/llm/openai-compatible.ts
@@ -50,9 +50,6 @@ export class OpenAICompatibleProvider extends BaseLLMProvider {
         max_tokens: this.getMaxTokens(options),
         temperature: this.getTemperature(options),
         stream: false as const,
-        ...(options?.schema && {
-          response_format: { type: 'json_object' as const },
-        }),
       };
 
       const response = await this.client.chat.completions.create(requestParams);

--- a/packages/notes/src/llm/openai-compatible.ts
+++ b/packages/notes/src/llm/openai-compatible.ts
@@ -50,6 +50,7 @@ export class OpenAICompatibleProvider extends BaseLLMProvider {
         max_tokens: this.getMaxTokens(options),
         temperature: this.getTemperature(options),
         stream: false as const,
+        ...(options?.schema && { response_format: { type: 'json_object' as const } }),
       };
 
       const response = await this.client.chat.completions.create(requestParams);

--- a/packages/notes/src/output/markdown.ts
+++ b/packages/notes/src/output/markdown.ts
@@ -146,6 +146,17 @@ interface LinkItem {
   url: string;
 }
 
+function parseMdLink(text: string): { label: string; url: string } | null {
+  if (text[0] !== '[') return null;
+  const bracketClose = text.indexOf(']', 1);
+  if (bracketClose === -1 || text[bracketClose + 1] !== '(') return null;
+  const parenClose = text.indexOf(')', bracketClose + 2);
+  if (parenClose === -1) return null;
+  const label = text.slice(1, bracketClose);
+  const url = text.slice(bracketClose + 2, parenClose);
+  return /^https?:\/\//.test(url) ? { label, url } : null;
+}
+
 function extractLinksFromPRBodies(entries: ChangelogEntry[], marker: string): LinkItem[] {
   const seen = new Set<string>();
   const links: LinkItem[] = [];
@@ -155,11 +166,11 @@ function extractLinksFromPRBodies(entries: ChangelogEntry[], marker: string): Li
         const trimmed = line.trim();
         if (!trimmed.startsWith(marker)) continue;
         const rest = trimmed.slice(marker.length).trim();
-        const mdMatch = rest.match(/\[([^\]]+)\]\((https?:\/\/[^)]+)\)/);
-        if (mdMatch) {
-          if (!seen.has(mdMatch[2]!)) {
-            seen.add(mdMatch[2]!);
-            links.push({ label: mdMatch[1]!, url: mdMatch[2]! });
+        const mdLink = parseMdLink(rest);
+        if (mdLink) {
+          if (!seen.has(mdLink.url)) {
+            seen.add(mdLink.url);
+            links.push(mdLink);
           }
         } else if (/^https?:\/\//.test(rest)) {
           const url = rest.split(/\s/)[0]!;

--- a/packages/notes/src/output/markdown.ts
+++ b/packages/notes/src/output/markdown.ts
@@ -147,12 +147,13 @@ interface LinkItem {
 }
 
 function parseMdLink(text: string): { label: string; url: string } | null {
-  if (text[0] !== '[') return null;
-  const bracketClose = text.indexOf(']', 1);
+  const bracketOpen = text.indexOf('[');
+  if (bracketOpen === -1) return null;
+  const bracketClose = text.indexOf(']', bracketOpen + 1);
   if (bracketClose === -1 || text[bracketClose + 1] !== '(') return null;
   const parenClose = text.indexOf(')', bracketClose + 2);
   if (parenClose === -1) return null;
-  const label = text.slice(1, bracketClose);
+  const label = text.slice(bracketOpen + 1, bracketClose);
   const url = text.slice(bracketClose + 2, parenClose);
   return /^https?:\/\//.test(url) ? { label, url } : null;
 }

--- a/packages/notes/src/output/markdown.ts
+++ b/packages/notes/src/output/markdown.ts
@@ -147,15 +147,24 @@ interface LinkItem {
 }
 
 function parseMdLink(text: string): { label: string; url: string } | null {
-  const bracketOpen = text.indexOf('[');
-  if (bracketOpen === -1) return null;
-  const bracketClose = text.indexOf(']', bracketOpen + 1);
-  if (bracketClose === -1 || text[bracketClose + 1] !== '(') return null;
-  const parenClose = text.indexOf(')', bracketClose + 2);
-  if (parenClose === -1) return null;
-  const label = text.slice(bracketOpen + 1, bracketClose);
-  const url = text.slice(bracketClose + 2, parenClose);
-  return /^https?:\/\//.test(url) ? { label, url } : null;
+  let search = 0;
+  while (search < text.length) {
+    const bracketOpen = text.indexOf('[', search);
+    if (bracketOpen === -1) return null;
+    const bracketClose = text.indexOf(']', bracketOpen + 1);
+    if (bracketClose === -1) return null;
+    if (text[bracketClose + 1] !== '(') {
+      search = bracketClose + 1;
+      continue;
+    }
+    const parenClose = text.indexOf(')', bracketClose + 2);
+    if (parenClose === -1) return null;
+    const label = text.slice(bracketOpen + 1, bracketClose);
+    const url = text.slice(bracketClose + 2, parenClose);
+    if (/^https?:\/\//.test(url)) return { label, url };
+    search = parenClose + 1;
+  }
+  return null;
 }
 
 function extractLinksFromPRBodies(entries: ChangelogEntry[], marker: string): LinkItem[] {

--- a/packages/notes/test/integration/snapshot.spec.ts
+++ b/packages/notes/test/integration/snapshot.spec.ts
@@ -1,0 +1,134 @@
+import * as fs from 'node:fs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ChangelogInput } from '../../src/core/types.js';
+import type { CompleteResult, LLMMessage } from '../../src/llm/messages.js';
+import type { LLMProvider } from '../../src/llm/provider.js';
+
+vi.mock('../../src/llm/index.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/llm/index.js')>();
+  return { ...actual, createProvider: vi.fn() };
+});
+
+vi.mock('node:fs');
+
+// ---------------------------------------------------------------------------
+// Input fixture — representative entries that exercise all render features
+// ---------------------------------------------------------------------------
+
+const sampleInput: ChangelogInput = {
+  source: 'version',
+  packages: [
+    {
+      packageName: '@acme/app',
+      version: '2.0.0',
+      previousVersion: 'v1.5.0',
+      revisionRange: 'v1.5.0..HEAD',
+      repoUrl: null, // disables example / PR-context fetching
+      date: '2026-01-15',
+      entries: [
+        { type: 'changed', description: 'Rename connect() to initialize()', breaking: true },
+        { type: 'added', description: 'Add deep link support via triggerDeeplink()' },
+        { type: 'added', description: 'Add mock IPC support' },
+        { type: 'fixed', description: 'Resolve memory leak in renderer process' },
+        { type: 'changed', description: 'Migrate bundler to esbuild 0.20' },
+      ],
+    },
+  ],
+};
+
+// Deterministic enhanceAndCategorize response.
+// Exercises: breaking re-routing, leadIn phrases, scope grouping (ipc×2).
+const MOCK_RESPONSE = JSON.stringify({
+  entries: [
+    {
+      description: 'Rename connect() to initialize()',
+      category: 'Breaking',
+      scope: null,
+      breaking: true,
+      leadIn: 'API rename',
+    },
+    {
+      description: 'Add deep link support via triggerDeeplink()',
+      category: 'New',
+      scope: 'ipc',
+      breaking: null,
+      leadIn: 'Deeplink testing',
+    },
+    { description: 'Add mock IPC support', category: 'New', scope: 'ipc', breaking: null, leadIn: null },
+    {
+      description: 'Resolve memory leak in renderer process',
+      category: 'Fixed',
+      scope: null,
+      breaking: null,
+      leadIn: null,
+    },
+    {
+      description: 'Migrate bundler to esbuild 0.20',
+      category: 'Developer',
+      scope: null,
+      breaking: null,
+      leadIn: null,
+    },
+  ],
+});
+
+// ---------------------------------------------------------------------------
+// Snapshot test
+// ---------------------------------------------------------------------------
+
+describe('Pipeline: render snapshot', () => {
+  beforeEach(() => {
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+    vi.mocked(fs.mkdirSync).mockReturnValue(undefined as never);
+    vi.mocked(fs.writeFileSync).mockReturnValue(undefined);
+  });
+
+  it('renders Breaking first, scope groups, and leadIn phrases', async () => {
+    const { createProvider } = await import('../../src/llm/index.js');
+    const mockProvider: LLMProvider = {
+      name: 'mock',
+      capabilities: { systemRole: true, structuredOutputs: false, toolUse: false },
+      async complete(_messages: LLMMessage[]): Promise<CompleteResult> {
+        return { content: MOCK_RESPONSE, structured: JSON.parse(MOCK_RESPONSE) };
+      },
+    };
+    vi.mocked(createProvider).mockReturnValue(mockProvider);
+
+    const { runPipeline } = await import('../../src/core/pipeline.js');
+
+    const result = await runPipeline(
+      sampleInput,
+      {
+        changelog: false,
+        releaseNotes: {
+          llm: {
+            provider: 'mock',
+            model: 'mock',
+            tasks: { categorize: true, enhance: true },
+            examples: 0, // disable GitHub release fetching
+          },
+        },
+      },
+      false,
+    );
+
+    expect(result.packageNotes['@acme/app']).toMatchInlineSnapshot(`
+      "## [2.0.0] - 2026-01-15
+
+      ### Breaking
+      - **BREAKING** **API rename**: Rename connect() to initialize()
+
+      ### New
+      **ipc**:
+      - **Deeplink testing**: Add deep link support via triggerDeeplink()
+      - Add mock IPC support
+
+      ### Fixed
+      - Resolve memory leak in renderer process
+
+      ### Developer
+      - Migrate bundler to esbuild 0.20
+      "
+    `);
+  });
+});


### PR DESCRIPTION
- Modified LLMProvider interface to accept an array of messages instead of a single prompt string, improving flexibility for structured inputs.
- Introduced capabilities property to LLMProvider for better provider feature management.
- Enhanced error handling in LLM processing, providing clearer fallback messages for debugging.
- Added new corrective retry mechanism to improve output validation and error correction during LLM interactions.
- Introduced new message types and schemas for structured output, enhancing the overall LLM integration.
- Updated various LLM provider implementations (Anthropic, OpenAI, Ollama) to support the new message structure and capabilities.
- Refactored prompt resolution logic to accommodate new system prompts and user instructions.[^\]]+ and [^)+ have polynomial backtracking risk on crafted input.
parseMdLink uses indexOf to find ] and ) in one pass — O(n), no
backtracking.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>