### PR TITLE
feat(release): enhance standing PR preview with merge prediction

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,16 +95,16 @@ jobs:
           # Only bump:* labels are supported (release:* labels are deprecated).
           LABELS=$(echo "$PRS_OUTPUT" | jq -r '.[].labels[].name' 2>/dev/null)
           
-          # Check for release:stable first (takes precedence over bump:* per ci-setup.md)
-          if echo "$LABELS" | grep -qE "^release:stable$"; then
+          # Check for channel:stable first (takes precedence over bump:* per ci-setup.md)
+          if echo "$LABELS" | grep -qE "^channel:stable$"; then
             echo "should_release=true" >> "$GITHUB_OUTPUT"
             echo "bump=auto" >> "$GITHUB_OUTPUT"
-            echo "release:stable label found — promoting prerelease to stable"
+            echo "channel:stable label found — promoting prerelease to stable"
             exit 0
           fi
           
-          # Check for release:prerelease + bump:* (creates prerelease)
-          if echo "$LABELS" | grep -qE "^release:prerelease$"; then
+          # Check for channel:prerelease + bump:* (creates prerelease)
+          if echo "$LABELS" | grep -qE "^channel:prerelease$"; then
             # Map bump label to prerelease bump type
             PRERELEASE_BUMP="prerelease"
             if echo "$LABELS" | grep -qE "^bump:patch$"; then
@@ -117,11 +117,11 @@ jobs:
             if echo "$LABELS" | grep -qE "^bump:(patch|minor|major)$"; then
               echo "should_release=true" >> "$GITHUB_OUTPUT"
               echo "bump=$PRERELEASE_BUMP" >> "$GITHUB_OUTPUT"
-              echo "release:prerelease + bump:* label found — creating $PRERELEASE_BUMP prerelease"
+              echo "channel:prerelease + bump:* label found — creating $PRERELEASE_BUMP prerelease"
               exit 0
             else
               echo "should_release=false" >> "$GITHUB_OUTPUT"
-              echo "release:prerelease requires a bump:* label — skipping release"
+              echo "channel:prerelease requires a bump:* label — skipping release"
               exit 0
             fi
           fi

--- a/.github/workflows/standing-pr.yml
+++ b/.github/workflows/standing-pr.yml
@@ -51,6 +51,43 @@ jobs:
           # ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
 
+  immediate-release:
+    name: Immediate Release (bypass standing PR)
+    if: >
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.merged == true &&
+      contains(github.event.pull_request.labels.*.name, 'release:immediate')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
+          token: ${{ github.token }}
+
+      - name: Setup workspace
+        uses: ./.github/workflows/actions/setup-workspace
+
+      - name: Build packages
+        run: pnpm build
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Direct release (bypassing standing PR)
+        run: node packages/release/dist/cli.js release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
+
+      - name: Reconcile standing PR
+        run: node packages/release/dist/cli.js standing-pr update
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
+
   publish-release:
     name: Publish Release
     if: >

--- a/AUTOMATION_PLAN.md
+++ b/AUTOMATION_PLAN.md
@@ -24,7 +24,7 @@ Future features to enable fully automated release workflows (e.g. commits to mai
 - Strategy-aware messaging: intro and no-changes messages adapt to configured `releaseStrategy`
 - Auto-detects prerelease versions from package.json files; defaults to prerelease preview
 - `--prerelease [identifier]` and `--stable` CLI flags for manual override
-- PR label `release:stable` support in workflow templates for graduation from prerelease
+- PR label `channel:stable` support in workflow templates for graduation from prerelease
 - Posts/updates a single PR comment via `@octokit/rest` using HTML marker (`<!-- releasekit-preview -->`)
 - Falls back to stdout when GitHub context unavailable
 - `--dry-run` flag prints comment markdown to stdout without posting
@@ -34,7 +34,7 @@ Future features to enable fully automated release workflows (e.g. commits to mai
 ### Push-Triggered Release Workflow (Feature 1)
 - `.github/workflows/release.yml` implements automated releases on main push
 - Uses `workflow_run` trigger to run after CI passes
-- Detects release labels on merged PRs (`bump:patch`, `bump:minor`, `bump:major`, `release:prerelease`, `release:stable`)
+- Detects release labels on merged PRs (`bump:patch`, `bump:minor`, `bump:major`, `channel:prerelease`, `channel:stable`)
 - Automatically determines bump type from label
 - Calls `_release.reusable.yml` reusable workflow for actual release
 - Manual trigger also available via `workflow_dispatch`

--- a/action.yml
+++ b/action.yml
@@ -151,7 +151,7 @@ outputs:
     description: Resolved target packages (gate mode)
     value: ${{ steps.run.outputs.gate-target }}
   gate-stable:
-    description: Whether the release should be a stable graduation (gate mode, release:stable label)
+    description: Whether the release should be a stable graduation (gate mode, channel:stable label)
     value: ${{ steps.run.outputs.gate-stable }}
   has-changes:
     description: "Whether a release has changes (release mode, requires json: true)"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -116,6 +116,8 @@ Both modes support `bump:major` as an override and `channel:stable`/`channel:pre
 | Skip a release | add `release:skip` label | omit bump label |
 | Override to major | add `bump:major` label | add `bump:major` label |
 
+> **In standing-pr strategy, label semantics differ.** Feeder PR labels (`bump:*`, `scope:*`, `channel:*`) are advisory — they're rendered in the preview but don't drive behavior on merge. The standing PR itself is the canonical override surface: add `bump:major` etc. to the standing PR to drive the next release. To bypass the queue and ship a single PR directly, label it `release:immediate`. See [CI setup → Label semantics in standing-pr mode](../packages/release/docs/ci-setup.md#label-semantics-in-standing-pr-mode).
+
 ---
 
 ## LLM enhancement

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -107,7 +107,7 @@ How the bump type is determined. Configure under `ci.releaseTrigger`.
 
 **`label`** (default) — A PR label (`bump:patch`, `bump:minor`, or `bump:major`) must be present for a release to fire. The label controls the bump type. PRs without a release label are silently skipped, giving reviewers direct control over when and at what level a release ships.
 
-Both modes support `bump:major` as an override and `release:stable`/`release:prerelease` as channel modifiers.
+Both modes support `bump:major` as an override and `channel:stable`/`channel:prerelease` as channel modifiers.
 
 | | Commit trigger | Label trigger |
 |---|---|---|

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -308,9 +308,10 @@ PR label names used for release control. Override to match your repository's lab
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `stable` | string | `"release:stable"` | Label to graduate a prerelease to stable |
-| `prerelease` | string | `"release:prerelease"` | Label to create a prerelease |
+| `stable` | string | `"channel:stable"` | Label to graduate a prerelease to stable |
+| `prerelease` | string | `"channel:prerelease"` | Label to create a prerelease |
 | `skip` | string | `"release:skip"` | Label to suppress a release on this PR |
+| `immediate` | string | `"release:immediate"` | Label to bypass the standing PR for one merge — triggers a direct release. Standing-pr mode only. |
 | `major` | string | `"bump:major"` | Label to force a major bump |
 | `minor` | string | `"bump:minor"` | Label to force a minor bump |
 | `patch` | string | `"bump:patch"` | Label to force a patch bump |

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -117,19 +117,25 @@ For a monorepo, change `changelog.mode` to `"packages"` and list your packages i
 
 | changesets concept | releasekit equivalent |
 |---|---|
-| `.changeset/*.md` files | `bump:*` PR labels (or conventional commits) |
-| `pnpm changeset` (create changeset) | Add `bump:minor` (or other) label to the PR |
-| `pnpm changeset version` | `releasekit standing-pr update` |
+| `.changeset/*.md` files | Conventional commits across feeder PRs (default) |
+| `pnpm changeset` (create changeset) | Write conventional commit messages (`feat:`, `fix:`); the standing PR's bump is computed from the union of commits |
+| Override the bump on the upcoming release | Add `bump:major` (or other) **on the standing PR itself** |
+| `pnpm changeset version` | `releasekit standing-pr update` (runs automatically) |
 | "Version Packages" PR | Standing release PR (`ci.releaseStrategy: "standing-pr"`) |
-| `pnpm changeset publish` | `releasekit standing-pr publish` (or `releasekit release`) |
+| `pnpm changeset publish` | Merge the standing PR (publish runs automatically) |
+| Ship one PR urgently without queueing | Add `release:immediate` to the feeder PR |
 | `.changeset/config.json` | `releasekit.config.json` |
 | `fixed` packages (move together) | `version.sync: true` |
 | `linked` packages | Not directly supported; use `version.sync` |
 | `ignore` packages | `version.skip` array |
 
-The main conceptual shift is that bump intent moves from committed markdown files to PR labels.
-This keeps your repository history clean and avoids merge conflicts on `.changeset/` files in
-active monorepos.
+The main conceptual shift is that bump intent moves from committed markdown files to **the
+standing PR itself**. Conventional commits across feeder PRs are aggregated into the standing
+PR's bump; if you need to override the magnitude (e.g. escalate from minor to major), add a
+`bump:*` label directly to the standing release PR. Feeder-PR labels are advisory only —
+they're shown in the preview but don't drive behavior. This keeps your repository history
+clean (no `.changeset/` files), avoids merge conflicts on changesets in active monorepos, and
+gives you one canonical place to see and adjust what's about to release.
 
 ### Why the standing-PR strategy feels most familiar
 
@@ -175,13 +181,13 @@ Optional guardrails mirror changesets' workflow:
    }
    ```
 
-3. **Choose a release trigger.**
-   - `"releaseTrigger": "commit"` — conventional commits drive bump types automatically.
-     Every merged PR can contribute to the standing PR. This is the closest equivalent to
-     changesets' commit-driven mode.
-   - `"releaseTrigger": "label"` — explicit `bump:patch/minor/major` labels on each PR
-     control the bump type, analogous to choosing the bump level when running
-     `pnpm changeset`.
+3. **Pick a release trigger** (in standing-pr mode, this only affects the
+   `release:immediate` bypass path — see step 6; the standing PR itself is always
+   commit-driven regardless of trigger).
+   - `"releaseTrigger": "commit"` — for the immediate-release path, every merged PR with
+     `release:immediate` ships using conventional commits to determine the bump.
+   - `"releaseTrigger": "label"` — for the immediate-release path, the merged PR must
+     also carry `bump:patch/minor/major` to specify the magnitude.
 
 4. **Add the standing-PR workflow.** Copy the template from
    `templates/workflows/standing-pr.yml` into `.github/workflows/`. See

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -234,7 +234,7 @@ Copy your existing `CHANGELOG.md` content into the file before the first Release
 Subsequent releases prepend new entries; existing content is left intact.
 
 **"My prerelease workflow is broken."**
-ReleaseKit uses the `--prerelease <id>` CLI flag or the `release:prerelease` PR label combined
+ReleaseKit uses the `--prerelease <id>` CLI flag or the `channel:prerelease` PR label combined
 with a `bump:*` label. See [CI setup](../packages/release/docs/ci-setup.md) for the label
 combination table and prerelease workflow examples.
 

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -310,8 +310,6 @@ export const StandingPrConfigSchema = z.object({
   labels: z.array(z.string()).default(['release']),
   /** Whether to auto-delete the release branch after PR merge. Default: true */
   deleteBranchOnMerge: z.boolean().default(true),
-  /** Allow teams to edit the release notes section in the PR body before publishing. Default: false */
-  editableNotes: z.boolean().default(false),
   /** Merge method to use when merging the standing release PR. Default: 'merge' */
   mergeMethod: z.enum(['merge', 'squash', 'rebase']).default('merge'),
   /** Minimum age of the standing PR before it can be merged. Duration string (e.g. '6h', '30m', '1d'). Gate enforced via the releasekit/standing-pr status check. */

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -290,9 +290,11 @@ export const NotesConfigSchema = z.object({
 });
 
 export const CILabelsConfigSchema = z.object({
-  stable: z.string().default('release:stable'),
-  prerelease: z.string().default('release:prerelease'),
+  stable: z.string().default('channel:stable'),
+  prerelease: z.string().default('channel:prerelease'),
   skip: z.string().default('release:skip'),
+  /** Bypass the standing PR for one merge — triggers a direct release. Standing-pr mode only. */
+  immediate: z.string().default('release:immediate'),
   major: z.string().default('bump:major'),
   minor: z.string().default('bump:minor'),
   patch: z.string().default('bump:patch'),
@@ -332,9 +334,10 @@ export const CIConfigSchema = z.object({
   skipPatterns: z.array(z.string()).default(['chore: release ']),
   minChanges: z.number().int().positive().default(1),
   labels: CILabelsConfigSchema.default({
-    stable: 'release:stable',
-    prerelease: 'release:prerelease',
+    stable: 'channel:stable',
+    prerelease: 'channel:prerelease',
     skip: 'release:skip',
+    immediate: 'release:immediate',
     major: 'bump:major',
     minor: 'bump:minor',
     patch: 'bump:patch',

--- a/packages/config/test/unit/schema.spec.ts
+++ b/packages/config/test/unit/schema.spec.ts
@@ -449,9 +449,10 @@ describe('CIConfigSchema', () => {
     expect(result.skipPatterns).toEqual(['chore: release ']);
     expect(result.minChanges).toBe(1);
     expect(result.labels).toEqual({
-      stable: 'release:stable',
-      prerelease: 'release:prerelease',
+      stable: 'channel:stable',
+      prerelease: 'channel:prerelease',
       skip: 'release:skip',
+      immediate: 'release:immediate',
       major: 'bump:major',
       minor: 'bump:minor',
       patch: 'bump:patch',
@@ -520,7 +521,7 @@ describe('CIConfigSchema', () => {
   it('should apply label defaults for partial labels config', () => {
     const result = CIConfigSchema.parse({ labels: { stable: 'custom-stable' } });
     expect(result.labels.stable).toBe('custom-stable');
-    expect(result.labels.prerelease).toBe('release:prerelease');
+    expect(result.labels.prerelease).toBe('channel:prerelease');
     expect(result.labels.skip).toBe('release:skip');
     expect(result.labels.major).toBe('bump:major');
     expect(result.labels.minor).toBe('bump:minor');

--- a/packages/release/README.md
+++ b/packages/release/README.md
@@ -287,8 +287,8 @@ The `ci` section controls automation behavior:
 
     // Customise PR label names
     "labels": {
-      "stable": "release:stable",
-      "prerelease": "release:prerelease",
+      "stable": "channel:stable",
+      "prerelease": "channel:prerelease",
       "skip": "release:skip",
       "major": "bump:major",
       "minor": "bump:minor",
@@ -311,7 +311,7 @@ The `ci` section controls automation behavior:
 
 **`commit`** — Conventional commits drive the bump type automatically. Every merge can trigger a release. Use the `release:skip` label to prevent a release, or `bump:major` to override the commit-derived bump to major.
 
-Both modes support `release:stable` and `release:prerelease` as channel modifiers. `release:stable` alone graduates any prerelease packages to their stable base version and skips packages that are already stable — no bump label required. `release:prerelease` must be combined with a `bump:*` label — alone, it does not trigger a release.
+Both modes support `channel:stable` and `channel:prerelease` as channel modifiers. `channel:stable` alone graduates any prerelease packages to their stable base version and skips packages that are already stable — no bump label required. `channel:prerelease` must be combined with a `bump:*` label — alone, it does not trigger a release.
 
 #### Release Strategy
 
@@ -359,7 +359,7 @@ Multiple scope labels are combined with OR logic. Without a `release:*` label, c
 
 In label trigger mode, conflicting labels will block the release and post a comment explaining the issue:
 - Multiple bump labels (`bump:major` + `bump:minor` + `bump:patch`) → blocked
-- Conflicting release type (`release:stable` + `release:prerelease`) → blocked (both modes)
+- Conflicting release type (`channel:stable` + `channel:prerelease`) → blocked (both modes)
 
 **How it works:**
 

--- a/packages/release/README.md
+++ b/packages/release/README.md
@@ -290,6 +290,7 @@ The `ci` section controls automation behavior:
       "stable": "channel:stable",
       "prerelease": "channel:prerelease",
       "skip": "release:skip",
+      "immediate": "release:immediate",
       "major": "bump:major",
       "minor": "bump:minor",
       "patch": "bump:patch"
@@ -312,6 +313,8 @@ The `ci` section controls automation behavior:
 **`commit`** — Conventional commits drive the bump type automatically. Every merge can trigger a release. Use the `release:skip` label to prevent a release, or `bump:major` to override the commit-derived bump to major.
 
 Both modes support `channel:stable` and `channel:prerelease` as channel modifiers. `channel:stable` alone graduates any prerelease packages to their stable base version and skips packages that are already stable — no bump label required. `channel:prerelease` must be combined with a `bump:*` label — alone, it does not trigger a release.
+
+> **Standing-pr strategy is different.** When `releaseStrategy: "standing-pr"`, labels on **feeder PRs** are advisory only — the standing PR itself is the canonical override surface (add `bump:major` etc. to the standing PR to drive the next release). To bypass the queue and ship one PR directly, label it `release:immediate`. See [CI setup → Label semantics in standing-pr mode](./docs/ci-setup.md#label-semantics-in-standing-pr-mode).
 
 #### Release Strategy
 
@@ -391,7 +394,7 @@ When `releaseStrategy: "standing-pr"`, the `ci.standingPr` block tunes the bot-m
 |---|---|---|
 | `branch` | `release/next` | Bot-maintained release branch name. Force-reset to `main` on every update. |
 | `title` | `chore: release ${count} package(s)` | PR title template. Variables: `${count}`, `${version}`. Must start with a string matching `release.ci.skipPatterns` (default `chore: release `). |
-| `labels` | `["release"]` | Labels applied to the PR. Avoid overlap with `bump:*` / `release:*` to prevent the label-driven release flow from firing on merge. |
+| `labels` | `["release"]` | Labels applied to the PR. Maintainer-added `bump:*` / `scope:*` / `channel:*` labels on the standing PR are preserved across updates and drive the next release as overrides — see [Label semantics in standing-pr mode](./docs/ci-setup.md#label-semantics-in-standing-pr-mode). |
 | `deleteBranchOnMerge` | `true` | Delete the release branch after publish completes. |
 | `mergeMethod` | `merge` | `merge` \| `squash` \| `rebase`. |
 | `editableNotes` | `false` | Wrap the release notes in editable markers; user edits are preserved across updates and flow through to publish. |

--- a/packages/release/docs/ci-setup.md
+++ b/packages/release/docs/ci-setup.md
@@ -65,8 +65,8 @@ Only release when a PR is merged with a release label. Conventional commits dete
 | `bump:patch` | Bump patch version |
 | `bump:minor` | Bump minor version |
 | `bump:major` | Bump major version |
-| `release:stable` | Graduate a prerelease to stable |
-| `release:prerelease` | Create a prerelease (requires bump:* label) |
+| `channel:stable` | Graduate a prerelease to stable |
+| `channel:prerelease` | Create a prerelease (requires bump:* label) |
 | `release:skip` | Suppress release on this PR |
 
 #### Label combinations
@@ -79,17 +79,17 @@ Only release when a PR is merged with a release label. Conventional commits dete
 | `bump:patch` | `1.0.0-next.6` | `1.0.1` — graduates prerelease to stable patch |
 | `bump:minor` | `1.0.0-next.6` | `1.1.0` — graduates prerelease to stable minor |
 | `bump:major` | `1.0.0-next.6` | `2.0.0` — graduates prerelease to stable major |
-| `release:prerelease` + `bump:patch` | `1.0.0` | `1.0.1-next.0` |
-| `release:prerelease` + `bump:minor` | `1.0.0` | `1.1.0-next.0` |
-| `release:prerelease` + `bump:major` | `1.0.0` | `2.0.0-next.0` |
-| `release:prerelease` + `bump:patch` | `1.0.0-next.6` | `1.0.0-next.7` — increments prerelease counter |
-| `release:prerelease` + `bump:minor` | `1.0.0-next.6` | `1.0.0-next.7` — increments prerelease counter |
-| `release:prerelease` + `bump:major` | `1.0.0-next.6` | `1.0.0-next.7` — increments prerelease counter |
-| `release:prerelease` alone | any | No release — add a `bump:*` label |
-| `release:stable` alone | `1.0.0-next.6` | `1.0.0` |
-| `release:stable` alone | `1.0.0` | No release — already at stable version |
-| `release:stable` + any `bump:*` | `1.0.0-next.6` | `1.0.0` — bump label is ignored during stable promotion |
-| `release:stable` + `bump:minor` | `1.0.0` | `1.1.0` — bump applies to already-stable packages |
+| `channel:prerelease` + `bump:patch` | `1.0.0` | `1.0.1-next.0` |
+| `channel:prerelease` + `bump:minor` | `1.0.0` | `1.1.0-next.0` |
+| `channel:prerelease` + `bump:major` | `1.0.0` | `2.0.0-next.0` |
+| `channel:prerelease` + `bump:patch` | `1.0.0-next.6` | `1.0.0-next.7` — increments prerelease counter |
+| `channel:prerelease` + `bump:minor` | `1.0.0-next.6` | `1.0.0-next.7` — increments prerelease counter |
+| `channel:prerelease` + `bump:major` | `1.0.0-next.6` | `1.0.0-next.7` — increments prerelease counter |
+| `channel:prerelease` alone | any | No release — add a `bump:*` label |
+| `channel:stable` alone | `1.0.0-next.6` | `1.0.0` |
+| `channel:stable` alone | `1.0.0` | No release — already at stable version |
+| `channel:stable` + any `bump:*` | `1.0.0-next.6` | `1.0.0` — bump label is ignored during stable promotion |
+| `channel:stable` + `bump:minor` | `1.0.0` | `1.1.0` — bump applies to already-stable packages |
 
 ```yaml
 # .github/workflows/release.yml
@@ -397,7 +397,7 @@ jobs:
 2. **Merge → publish:** Maintainers merge the standing PR when ready. The `pull_request.closed` trigger fires `standing-pr publish`, which reads the release manifest from the bot's PR comment and publishes the packages — no second version analysis is run, so the publish reflects exactly what was reviewed.
 3. **Recurring re-evaluation:** The hourly `schedule` trigger re-runs `update`, which is essentially free when nothing has changed but advances the `minAge` countdown so the status check transitions from `pending` to `success` as time passes.
 
-Use `release:stable` and `release:prerelease` labels on **the standing PR itself** to control release type during merge.
+Use `channel:stable` and `channel:prerelease` labels on **the standing PR itself** to control release type during merge.
 
 ### Lifecycle and edge cases
 
@@ -415,6 +415,48 @@ Use `release:stable` and `release:prerelease` labels on **the standing PR itself
   Each main-branch SHA gets its own group (so nothing is cancelled), while PR runs still cancel on new pushes.
 - **Status check `releasekit/standing-pr`:** posted on the release branch HEAD after each update. States: `success` (ready to merge), `pending` (one or more gates not yet satisfied — typically `minAge`). Configure as a required check in branch protection on the standing PR's base branch if you want gates enforced at merge time.
 
+### Label semantics in standing-pr mode
+
+Labels behave differently in standing-pr mode than in direct mode. There are two surfaces.
+
+**1. Feeder PRs (PRs being merged into `main`)** — labels are **advisory**.
+
+`bump:*`, `scope:*`, `channel:stable`, and `channel:prerelease` on a feeder PR are shown in the preview comment so reviewers know they were noticed, but they do **not** drive behavior on merge. Bumps for the standing PR come from conventional commits across the union of queued changes; scope is global (the standing PR aggregates everything).
+
+**2. The standing PR itself** — labels are the **canonical override surface**.
+
+A maintainer can edit labels directly on the standing PR (via the GitHub UI or `gh pr edit <n> --add-label bump:major`). The next `standing-pr update` reads those labels and applies them as overrides:
+
+| Label on standing PR | Effect |
+|---|---|
+| `bump:patch` / `bump:minor` / `bump:major` | Forces that bump magnitude, overriding what conventional commits would otherwise produce. |
+| `scope:foo` (per `ci.scopeLabels`) | Limits the release to scoped packages on the next update. |
+| `channel:stable` | Graduates a prerelease to stable. |
+| `channel:prerelease` | Switches the standing PR to prerelease versioning. |
+
+Conflicts (e.g. both `bump:patch` and `bump:major`) surface as a `pending` `releasekit/standing-pr` status check on the release branch and a workflow warning. The override is dropped (falls back to commit-driven) until the conflict is resolved by removing one of the labels.
+
+The `standing-pr update` workflow **preserves maintainer-added labels across runs** — labels you add stick until you remove them.
+
+**Why this design**: labels live in one canonical place. There's no question about which feeder PR's bump label "wins" when multiple PRs disagree — there is only the standing PR. Provenance is GitHub's own audit log (`gh pr view <n> --json events`).
+
+#### Bypassing the standing PR for one merge
+
+To ship a single PR directly without queueing it, label it **`release:immediate`** (configurable via `ci.labels.immediate`). Companion labels work normally:
+
+| Label combination on the feeder PR | Result |
+|---|---|
+| `release:immediate` alone | Direct release; bump magnitude from conventional commits in the PR. |
+| `release:immediate` + `bump:minor` | Direct release at minor magnitude. |
+| `release:immediate` + `scope:foo` | Direct release of only the scoped packages. |
+| `release:immediate` + `channel:prerelease` | Direct prerelease. |
+
+The `immediate-release` job in `standing-pr.yml` handles this:
+1. Runs `releasekit release` (versioning + notes + publish).
+2. Runs `releasekit standing-pr update` to reconcile the standing PR — released packages drop out of the queue, anything still queued stays.
+
+Result: the standing PR is up-to-date by the time the workflow exits — no staleness window.
+
 ### Troubleshooting
 
 | Symptom | Cause / fix |
@@ -424,46 +466,31 @@ Use `release:stable` and `release:prerelease` labels on **the standing PR itself
 | `error: too many arguments for 'preview'` | Pre-fix releasekit where `standing-pr` was missing from `cli.ts`. Upgrade `@releasekit/release`. |
 | Standing PR never appears despite merges | Check, in order: (1) the GitHub repo setting; (2) the head commit doesn't match `release.ci.skipPatterns`; (3) there are releasable conventional commits (`feat:`, `fix:`) since the last tag; (4) the `update-release-pr` job logs — they print the dry-run version output. |
 | Standing PR keeps closing immediately | `minPackages` is set higher than the current change count. Either lower the threshold or wait for more package changes to accumulate. |
+| Standing PR ignores my `bump:*` label on a feeder PR | By design — feeder labels are advisory in standing-pr mode. Add the label to the standing PR itself, or use `release:immediate` to bypass the queue. |
+| Standing PR shows `pending` status `Conflicting bump labels…` | Two conflicting labels on the standing PR (e.g. `bump:patch` + `bump:major`). Remove one and re-run `standing-pr update`. |
 | Force-push to `release/next` fails | Branch is protected. Remove protection on the release branch, or grant the bot bypass. |
 | `minAge` never advances | The hourly `schedule` trigger isn't running. Confirm the workflow has a `schedule:` block and that the repo isn't paused (GitHub disables `schedule` on inactive repos after 60 days). |
 
 ---
 
-## Combining Standing PR with Label-Triggered Direct Releases
+## Combining queued and immediate releases
 
-The two strategies can run side by side. This lets teams accumulate work in a standing PR by default, while still allowing any PR to trigger an immediate release by applying a label.
+Standing-pr mode handles both batched and one-off releases through a single workflow file (`standing-pr.yml`). There is no separate `release.yml` to wire up.
 
-**How they coexist:**
+**How it works:**
 
-- A PR merged **with** a `bump:*` label → `release.yml` fires and publishes immediately. The `standing-pr update` run for the same push sees the resulting release commit (which matches the default skip pattern `chore: release`) and exits as a noop. On the next real commit, `standing-pr update` computes bumps only from commits since the new tag — it starts fresh automatically.
-- A PR merged **without** a label → `release.yml` finds no bump label and exits. `standing-pr update` accumulates the change into the standing PR as normal.
-
-There is no double-publish risk: the standing PR only publishes when *its own branch* (`release/next`) is merged, which only happens when a maintainer explicitly merges it.
-
-**Setup:**
-
-Keep your existing `release.yml` unchanged. Add `standing-pr.yml` alongside it (shown above). In config, set `releaseStrategy: 'standing-pr'` so PR preview comments default to standing-PR messaging; label-triggered releases still work regardless of this setting.
-
-```json
-{
-  "ci": {
-    "releaseStrategy": "standing-pr",
-    "releaseTrigger": "label",
-    "standingPr": {
-      "branch": "release/next",
-      "mergeMethod": "squash"
-    }
-  }
-}
-```
+- A PR merged **without** `release:immediate` → `standing-pr update` accumulates the change into the standing PR. Any `bump:*` / `scope:*` / `channel:*` labels on the feeder PR are advisory only (see [Label semantics](#label-semantics-in-standing-pr-mode) above).
+- A PR merged **with** `release:immediate` → the `immediate-release` job in `standing-pr.yml` runs `releasekit release` directly (honouring companion `bump:*` / `scope:*` / `channel:*` labels), then chains `standing-pr update` to reconcile the standing PR.
+- The standing PR itself only publishes when its own branch (`release/next`) is merged by a maintainer — there's no double-publish risk.
 
 **Decision guide:**
 
 | Situation | Action |
 |-----------|--------|
-| Routine feature — batch with others | Merge PR without a label |
-| Critical fix or time-sensitive feature | Add `bump:patch` (or `minor`/`major`) to the PR |
-| Promote accumulated prereleases to stable | Add `release:stable` to the standing PR and merge it |
+| Routine feature — batch with others | Merge PR without a label. Bumps come from conventional commits. |
+| Critical fix that needs to ship now | Add `release:immediate` (optionally `+ bump:patch`) to the PR. |
+| Adjust the standing PR's bump magnitude | Add `bump:major` (etc.) to the standing PR itself; the next update applies it. |
+| Promote accumulated prereleases to stable | Add `channel:stable` to the standing PR and merge it. |
 
 ---
 

--- a/packages/release/package.json
+++ b/packages/release/package.json
@@ -63,6 +63,7 @@
     "conventional-changelog-angular": "^8.3.1",
     "conventional-changelog-conventionalcommits": "^9.3.1",
     "minimatch": "catalog:",
+    "semver": "catalog:",
     "smol-toml": "catalog:",
     "zod": "catalog:"
   },

--- a/packages/release/src/gate/evaluate-pr.ts
+++ b/packages/release/src/gate/evaluate-pr.ts
@@ -30,8 +30,8 @@ export interface PREvaluation {
  * Evaluate a single PR's labels against the gate's release rules.
  *
  * In `label` trigger mode:
- *  - `bump:*` or `release:stable` ⇒ release
- *  - `release:prerelease` alone ⇒ NO release (requires `bump:*`)
+ *  - `bump:*` or `channel:stable` ⇒ release
+ *  - `channel:prerelease` alone ⇒ NO release (requires `bump:*`)
  *  - No release labels ⇒ no release
  *  - Conflicting labels on the same PR ⇒ blocked
  *

--- a/packages/release/src/gate/gate.ts
+++ b/packages/release/src/gate/gate.ts
@@ -39,7 +39,7 @@ export interface GateOptions {
   quiet?: boolean;
   /**
    * When true (default), the gate posts a comment on PRs whose labels indicated release
-   * intent but did not produce a release (e.g. `release:prerelease` without `bump:*`, or
+   * intent but did not produce a release (e.g. `channel:prerelease` without `bump:*`, or
    * conflicting bump labels). Disable for dry-runs / local scripts.
    */
   notify?: boolean;

--- a/packages/release/src/index.ts
+++ b/packages/release/src/index.ts
@@ -5,8 +5,6 @@ export { runPreview } from './preview/preview.js';
 export { resolveScopeToTarget, runRelease } from './release.js';
 export type { StandingPRManifest, StandingPROptions, StandingPRResult } from './standing-pr/standing-pr.js';
 export {
-  extractEditableSection,
-  parseEditedNotes,
   publishFromManifest,
   runStandingPRMerge,
   runStandingPRPublish,

--- a/packages/release/src/label-utils.ts
+++ b/packages/release/src/label-utils.ts
@@ -2,15 +2,17 @@ export interface LabelConfig {
   stable: string;
   prerelease: string;
   skip: string;
+  immediate: string;
   major: string;
   minor: string;
   patch: string;
 }
 
 export const DEFAULT_LABELS: LabelConfig = {
-  stable: 'release:stable',
-  prerelease: 'release:prerelease',
+  stable: 'channel:stable',
+  prerelease: 'channel:prerelease',
   skip: 'release:skip',
+  immediate: 'release:immediate',
   major: 'bump:major',
   minor: 'bump:minor',
   patch: 'bump:patch',

--- a/packages/release/src/preview/format.ts
+++ b/packages/release/src/preview/format.ts
@@ -320,6 +320,16 @@ function renderQueuedTable(snapshot: StandingPRSnapshot): string[] {
 }
 
 function renderMergeTable(rows: MergedRow[]): string[] {
+  const allUnchanged = rows.every((r) => r.status === 'unchanged');
+  if (allUnchanged) {
+    return [
+      '### After merge — predicted release',
+      '',
+      "> No version changes — this PR's packages match the standing PR. Queued versions will release as-is.",
+      '',
+    ];
+  }
+
   const lines: string[] = [
     '### After merge — predicted release',
     '',

--- a/packages/release/src/preview/format.ts
+++ b/packages/release/src/preview/format.ts
@@ -1,6 +1,9 @@
 import type { VersionChangelogEntry, VersionPackageChangelog } from '@releasekit/core';
+import { formatDuration } from '../duration.js';
 import { MARKER } from '../github.js';
+import type { StandingPRSnapshot } from '../standing-pr/standing-pr.js';
 import type { ReleaseOutput } from '../types.js';
+import type { MergedRow } from './merge.js';
 
 export type ReleaseStrategy = 'manual' | 'direct' | 'standing-pr' | 'scheduled';
 const FOOTER = '*Updated automatically by [ReleaseKit](https://github.com/goosewobbler/releasekit)*';
@@ -52,6 +55,10 @@ export interface LabelContext {
 export interface FormatOptions {
   strategy?: ReleaseStrategy;
   standingPrNumber?: number;
+  /** Snapshot of the current standing PR (link, manifest, gate state). Rendered when strategy === 'standing-pr'. */
+  standingPrSnapshot?: StandingPRSnapshot;
+  /** Per-package merge rows combining standing PR + this PR's contribution. Populated only when both exist. */
+  mergedRows?: MergedRow[];
   labelContext?: LabelContext;
 }
 
@@ -176,6 +183,8 @@ function getLabelBanner(labelContext?: LabelContext): string[] {
 export function formatPreviewComment(result: ReleaseOutput | null, options?: FormatOptions): string {
   const strategy = options?.strategy ?? 'direct';
   const labelContext = options?.labelContext;
+  const standingPrSnapshot = strategy === 'standing-pr' ? options?.standingPrSnapshot : undefined;
+  const mergedRows = strategy === 'standing-pr' ? options?.mergedRows : undefined;
   const lines: string[] = [MARKER, ''];
 
   // Insert label-driven banner (outside the details block)
@@ -187,6 +196,10 @@ export function formatPreviewComment(result: ReleaseOutput | null, options?: For
     lines.push(...banner);
     if (!labelContext?.noBumpLabel) {
       lines.push(`> **Note:** No releasable changes detected. ${getNoChangesMessage(strategy)}`);
+    }
+    if (standingPrSnapshot) {
+      lines.push('', '---', '');
+      lines.push(...renderStandingPRSnapshot(standingPrSnapshot));
     }
     lines.push('', '---', FOOTER, '</details>');
     return lines.join('\n');
@@ -242,8 +255,50 @@ export function formatPreviewComment(result: ReleaseOutput | null, options?: For
     lines.push('');
   }
 
+  if (standingPrSnapshot) {
+    lines.push('---', '');
+    lines.push(...renderStandingPRSnapshot(standingPrSnapshot));
+    if (mergedRows && mergedRows.length > 0) {
+      lines.push(...renderMergeTable(mergedRows));
+    }
+  }
+
   lines.push('---', FOOTER, '</details>');
   return lines.join('\n');
+}
+
+function renderStandingPRSnapshot(snapshot: StandingPRSnapshot): string[] {
+  const updates = snapshot.manifest.versionOutput.updates;
+  const pkgCount = updates.length;
+  const gateBadge = snapshot.gateState === 'pending' ? `⏳ ${snapshot.gateReason}` : '✅ ready to merge';
+  const ageMs = Math.max(0, Date.now() - new Date(snapshot.openedAt).getTime());
+  const ageStr = formatDuration(ageMs);
+  const pkgWord = pkgCount === 1 ? 'package' : 'packages';
+  return [
+    `**Standing release PR:** [#${snapshot.number}](${snapshot.url}) · ${pkgCount} ${pkgWord} queued · open ${ageStr} · ${gateBadge}`,
+    '',
+  ];
+}
+
+function renderMergeTable(rows: MergedRow[]): string[] {
+  const lines: string[] = [
+    '### After merge — predicted release',
+    '',
+    '> Approximate. The standing PR rebuilds against `main` at merge time; if other commits land first, the prediction may shift.',
+    '',
+    '| Package | Standing PR | This PR | After merge |',
+    '|---------|-------------|---------|-------------|',
+  ];
+  for (const row of rows) {
+    const standing = row.standing ?? '—';
+    const current = row.current ?? '—';
+    let afterCell = row.afterMerge;
+    if (row.status === 'escalated' && row.standing) afterCell += ` ⚠ escalated from ${row.standing}`;
+    if (row.status === 'new-from-pr') afterCell += ' (new)';
+    lines.push(`| \`${row.packageName}\` | ${standing} | ${current} | ${afterCell} |`);
+  }
+  lines.push('');
+  return lines;
 }
 
 function renderEntries(entries: VersionChangelogEntry[]): string[] {

--- a/packages/release/src/preview/format.ts
+++ b/packages/release/src/preview/format.ts
@@ -340,18 +340,18 @@ function renderMergeTable(rows: MergedRow[]): string[] {
   // short-circuit message renders. 'standing-only' rows are pre-existing queued content
   // unrelated to this PR — including them would suppress the message in any real scenario.
   const prParticipatingRows = rows.filter((r) => r.status !== 'standing-only');
-  // No escalation when this PR contributes nothing to the standing scope (length === 0) OR when
-  // all packages it touches are already at a higher-or-equal version in the standing PR.
-  const noEscalation = prParticipatingRows.length === 0 || prParticipatingRows.every((r) => r.status === 'unchanged');
-  if (noEscalation) {
-    const lines: string[] = [
-      '### After merge — predicted release',
-      '',
-      "> No version escalation — this PR's changes will be included in the queued release without affecting the projected versions.",
-      '',
-    ];
-    // Show all rows so reviewers can see what's already queued for the packages this PR touches,
-    // even though no version escalation will occur.
+  const allUnchanged = prParticipatingRows.length > 0 && prParticipatingRows.every((r) => r.status === 'unchanged');
+  // When length === 0 the current PR's packages are entirely outside the standing PR's scope —
+  // they are NOT yet in the queue and won't be released until the standing PR rebuilds after merge.
+  // This needs a different message from allUnchanged (where they ARE already in the queue).
+  const outsideScope = prParticipatingRows.length === 0;
+
+  if (allUnchanged || outsideScope) {
+    const prose = outsideScope
+      ? "> This PR's packages are outside the standing PR's current scope — they will be picked up when the standing PR rebuilds after merge."
+      : "> No version escalation — this PR's changes will be included in the queued release without affecting the projected versions.";
+    const lines: string[] = ['### After merge — predicted release', '', prose, ''];
+    // Show all rows so reviewers can see what's already queued.
     if (rows.length > 0) {
       lines.push(
         '| Package | Standing PR | This PR | After merge |',

--- a/packages/release/src/preview/format.ts
+++ b/packages/release/src/preview/format.ts
@@ -261,7 +261,14 @@ export function formatPreviewComment(result: ReleaseOutput | null, options?: For
   const sharedEntries = versionOutput.sharedEntries?.length ? versionOutput.sharedEntries : undefined;
   const hasPackageChangelogs = versionOutput.changelogs.some((cl) => cl.entries.length > 0);
 
-  if (sharedEntries || hasPackageChangelogs) {
+  // Packages bumped via sync versioning have no individual changelog entries but are still in
+  // updates — collect them so they remain visible even though they don't drive the changelog.
+  const packagesWithChangelog = new Set(
+    versionOutput.changelogs.filter((cl) => cl.entries.length > 0).map((cl) => cl.packageName),
+  );
+  const syncBumpedOnly = versionOutput.updates.filter((u) => !packagesWithChangelog.has(u.packageName));
+
+  if (sharedEntries || hasPackageChangelogs || syncBumpedOnly.length > 0) {
     lines.push('### Changelog', '');
 
     // Project-wide entries (CI, infra, shared-package commits) rendered once
@@ -276,6 +283,14 @@ export function formatPreviewComment(result: ReleaseOutput | null, options?: For
       if (changelog.entries.length > 0) {
         lines.push(...formatPackageChangelog(changelog));
       }
+    }
+
+    // List sync-bumped packages that have no individual commits so they aren't invisible
+    if (syncBumpedOnly.length > 0) {
+      if (hasPackageChangelogs || sharedEntries) lines.push('**Also bumped** (sync versioning)', '');
+      else lines.push('**Bumped** (sync versioning — no individual changes)', '');
+      for (const u of syncBumpedOnly) lines.push(`- \`${u.packageName}\` → ${u.newVersion}`);
+      lines.push('');
     }
   }
 

--- a/packages/release/src/preview/format.ts
+++ b/packages/release/src/preview/format.ts
@@ -287,8 +287,9 @@ export function formatPreviewComment(result: ReleaseOutput | null, options?: For
 }
 
 function renderStandingPRSnapshot(snapshot: StandingPRSnapshot): string[] {
-  const updates = snapshot.manifest.versionOutput.updates;
-  const pkgCount = updates.length;
+  const pkgCount = snapshot.manifest.versionOutput.changelogs.filter(
+    (cl) => cl.entries.length > 0 || cl.version !== cl.previousVersion,
+  ).length;
   const gateBadge = snapshot.gateState === 'pending' ? `⏳ ${snapshot.gateReason ?? 'pending'}` : '✅ ready to merge';
   const ageMs = Math.max(0, Date.now() - new Date(snapshot.openedAt).getTime());
   const ageStr = formatDuration(ageMs);
@@ -300,7 +301,9 @@ function renderStandingPRSnapshot(snapshot: StandingPRSnapshot): string[] {
 }
 
 function renderQueuedTable(snapshot: StandingPRSnapshot): string[] {
-  const changelogs = snapshot.manifest.versionOutput.changelogs.filter((cl) => cl.entries.length > 0);
+  const changelogs = snapshot.manifest.versionOutput.changelogs.filter(
+    (cl) => cl.entries.length > 0 || cl.version !== cl.previousVersion,
+  );
   if (changelogs.length === 0) return [];
   const lines: string[] = [
     '',

--- a/packages/release/src/preview/format.ts
+++ b/packages/release/src/preview/format.ts
@@ -321,7 +321,11 @@ function renderQueuedTable(snapshot: StandingPRSnapshot): string[] {
 }
 
 function renderMergeTable(rows: MergedRow[]): string[] {
-  const allUnchanged = rows.every((r) => r.status === 'unchanged');
+  // Only rows the current PR participates in ('unchanged' or 'escalated') determine whether the
+  // short-circuit message renders. 'standing-only' rows are pre-existing queued content
+  // unrelated to this PR — including them would suppress the message in any real scenario.
+  const prParticipatingRows = rows.filter((r) => r.status !== 'standing-only');
+  const allUnchanged = prParticipatingRows.length > 0 && prParticipatingRows.every((r) => r.status === 'unchanged');
   if (allUnchanged) {
     return [
       '### After merge — predicted release',

--- a/packages/release/src/preview/format.ts
+++ b/packages/release/src/preview/format.ts
@@ -340,7 +340,6 @@ function renderMergeTable(rows: MergedRow[]): string[] {
   // short-circuit message renders. 'standing-only' rows are pre-existing queued content
   // unrelated to this PR — including them would suppress the message in any real scenario.
   const prParticipatingRows = rows.filter((r) => r.status !== 'standing-only');
-  const standingOnlyRows = rows.filter((r) => r.status === 'standing-only');
   const allUnchanged = prParticipatingRows.length > 0 && prParticipatingRows.every((r) => r.status === 'unchanged');
   if (allUnchanged) {
     const lines: string[] = [
@@ -349,13 +348,15 @@ function renderMergeTable(rows: MergedRow[]): string[] {
       "> No version escalation — this PR's changes will be included in the queued release without affecting the projected versions.",
       '',
     ];
-    if (standingOnlyRows.length > 0) {
+    // Show all rows so reviewers can see what's already queued for the packages this PR touches,
+    // even though no version escalation will occur.
+    if (rows.length > 0) {
       lines.push(
         '| Package | Standing PR | This PR | After merge |',
         '|---------|-------------|---------|-------------|',
       );
-      for (const row of standingOnlyRows) {
-        lines.push(`| \`${row.packageName}\` | ${row.standing ?? '—'} | — | ${row.afterMerge} |`);
+      for (const row of rows) {
+        lines.push(`| \`${row.packageName}\` | ${row.standing ?? '—'} | ${row.current ?? '—'} | ${row.afterMerge} |`);
       }
       lines.push('');
     }

--- a/packages/release/src/preview/format.ts
+++ b/packages/release/src/preview/format.ts
@@ -187,19 +187,26 @@ export function formatPreviewComment(result: ReleaseOutput | null, options?: For
   const mergedRows = strategy === 'standing-pr' ? options?.mergedRows : undefined;
   const lines: string[] = [MARKER, ''];
 
+  // Standing PR snapshot lives OUTSIDE the collapsible details so reviewers always see what's
+  // currently queued for release without having to expand the per-PR analysis.
+  if (standingPrSnapshot) {
+    lines.push(...renderStandingPRSnapshot(standingPrSnapshot));
+  }
+
   // Insert label-driven banner (outside the details block)
   const banner = getLabelBanner(labelContext);
 
   if (!result) {
-    // No changes or noBumpLabel — simple collapsed comment
-    lines.push('<details>', '<summary><b>Release Preview</b> — no release</summary>', '');
+    const summary = standingPrSnapshot
+      ? '<summary><b>Release Preview</b> — this PR contributes no changes</summary>'
+      : '<summary><b>Release Preview</b> — no release</summary>';
+    lines.push('<details>', summary, '');
     lines.push(...banner);
     if (!labelContext?.noBumpLabel) {
       lines.push(`> **Note:** No releasable changes detected. ${getNoChangesMessage(strategy)}`);
     }
     if (standingPrSnapshot) {
-      lines.push('', '---', '');
-      lines.push(...renderStandingPRSnapshot(standingPrSnapshot));
+      lines.push(...renderQueuedTable(standingPrSnapshot));
     }
     lines.push('', '---', FOOTER, '</details>');
     return lines.join('\n');
@@ -255,12 +262,8 @@ export function formatPreviewComment(result: ReleaseOutput | null, options?: For
     lines.push('');
   }
 
-  if (standingPrSnapshot) {
-    lines.push('---', '');
-    lines.push(...renderStandingPRSnapshot(standingPrSnapshot));
-    if (mergedRows && mergedRows.length > 0) {
-      lines.push(...renderMergeTable(mergedRows));
-    }
+  if (mergedRows && mergedRows.length > 0) {
+    lines.push(...renderMergeTable(mergedRows));
   }
 
   lines.push('---', FOOTER, '</details>');
@@ -278,6 +281,23 @@ function renderStandingPRSnapshot(snapshot: StandingPRSnapshot): string[] {
     `**Standing release PR:** [#${snapshot.number}](${snapshot.url}) · ${pkgCount} ${pkgWord} queued · open ${ageStr} · ${gateBadge}`,
     '',
   ];
+}
+
+function renderQueuedTable(snapshot: StandingPRSnapshot): string[] {
+  const changelogs = snapshot.manifest.versionOutput.changelogs.filter((cl) => cl.entries.length > 0);
+  if (changelogs.length === 0) return [];
+  const lines: string[] = [
+    '',
+    '### Currently queued for release',
+    '',
+    '| Package | Current | Next |',
+    '|---------|---------|------|',
+  ];
+  for (const cl of changelogs) {
+    lines.push(`| \`${cl.packageName}\` | ${cl.previousVersion ?? '—'} | ${cl.version} |`);
+  }
+  lines.push('');
+  return lines;
 }
 
 function renderMergeTable(rows: MergedRow[]): string[] {

--- a/packages/release/src/preview/format.ts
+++ b/packages/release/src/preview/format.ts
@@ -340,8 +340,10 @@ function renderMergeTable(rows: MergedRow[]): string[] {
   // short-circuit message renders. 'standing-only' rows are pre-existing queued content
   // unrelated to this PR — including them would suppress the message in any real scenario.
   const prParticipatingRows = rows.filter((r) => r.status !== 'standing-only');
-  const allUnchanged = prParticipatingRows.length > 0 && prParticipatingRows.every((r) => r.status === 'unchanged');
-  if (allUnchanged) {
+  // No escalation when this PR contributes nothing to the standing scope (length === 0) OR when
+  // all packages it touches are already at a higher-or-equal version in the standing PR.
+  const noEscalation = prParticipatingRows.length === 0 || prParticipatingRows.every((r) => r.status === 'unchanged');
+  if (noEscalation) {
     const lines: string[] = [
       '### After merge — predicted release',
       '',

--- a/packages/release/src/preview/format.ts
+++ b/packages/release/src/preview/format.ts
@@ -325,7 +325,7 @@ function renderMergeTable(rows: MergedRow[]): string[] {
     return [
       '### After merge — predicted release',
       '',
-      "> No version changes — this PR's packages match the standing PR. Queued versions will release as-is.",
+      "> No version escalation — this PR's changes will be included in the queued release without affecting the projected versions.",
       '',
     ];
   }

--- a/packages/release/src/preview/format.ts
+++ b/packages/release/src/preview/format.ts
@@ -306,7 +306,7 @@ export function formatPreviewComment(result: ReleaseOutput | null, options?: For
 function renderStandingPRSnapshot(snapshot: StandingPRSnapshot): string[] {
   const updates = snapshot.manifest.versionOutput.updates;
   const pkgCount = updates.length;
-  const gateBadge = snapshot.gateState === 'pending' ? `⏳ ${snapshot.gateReason}` : '✅ ready to merge';
+  const gateBadge = snapshot.gateState === 'pending' ? `⏳ ${snapshot.gateReason ?? 'pending'}` : '✅ ready to merge';
   const ageMs = Math.max(0, Date.now() - new Date(snapshot.openedAt).getTime());
   const ageStr = formatDuration(ageMs);
   const pkgWord = pkgCount === 1 ? 'package' : 'packages';

--- a/packages/release/src/preview/format.ts
+++ b/packages/release/src/preview/format.ts
@@ -254,7 +254,8 @@ export function formatPreviewComment(result: ReleaseOutput | null, options?: For
 
   lines.push('<details>', `<summary><b>Release Preview</b> — ${pkgSummary}</summary>`, '');
   lines.push(...banner);
-  lines.push(getIntroMessage(strategy, options?.standingPrNumber), '');
+  const effectiveStrategy = labelContext?.immediate ? 'direct' : strategy;
+  lines.push(getIntroMessage(effectiveStrategy, options?.standingPrNumber), '');
 
   // Changelog section
   const sharedEntries = versionOutput.sharedEntries?.length ? versionOutput.sharedEntries : undefined;

--- a/packages/release/src/preview/format.ts
+++ b/packages/release/src/preview/format.ts
@@ -256,14 +256,6 @@ export function formatPreviewComment(result: ReleaseOutput | null, options?: For
   lines.push(...banner);
   lines.push(getIntroMessage(strategy, options?.standingPrNumber), '');
 
-  // Package updates table
-  lines.push('### Packages', '');
-  lines.push('| Package | Version |', '|---------|---------|');
-  for (const update of versionOutput.updates) {
-    lines.push(`| \`${update.packageName}\` | ${update.newVersion} |`);
-  }
-  lines.push('');
-
   // Changelog section
   const sharedEntries = versionOutput.sharedEntries?.length ? versionOutput.sharedEntries : undefined;
   const hasPackageChangelogs = versionOutput.changelogs.some((cl) => cl.entries.length > 0);
@@ -284,15 +276,6 @@ export function formatPreviewComment(result: ReleaseOutput | null, options?: For
         lines.push(...formatPackageChangelog(changelog));
       }
     }
-  }
-
-  // Tags
-  if (versionOutput.tags.length > 0) {
-    lines.push('### Tags', '');
-    for (const tag of versionOutput.tags) {
-      lines.push(`- \`${tag}\``);
-    }
-    lines.push('');
   }
 
   if (mergedRows && mergedRows.length > 0) {

--- a/packages/release/src/preview/format.ts
+++ b/packages/release/src/preview/format.ts
@@ -325,14 +325,26 @@ function renderMergeTable(rows: MergedRow[]): string[] {
   // short-circuit message renders. 'standing-only' rows are pre-existing queued content
   // unrelated to this PR — including them would suppress the message in any real scenario.
   const prParticipatingRows = rows.filter((r) => r.status !== 'standing-only');
+  const standingOnlyRows = rows.filter((r) => r.status === 'standing-only');
   const allUnchanged = prParticipatingRows.length > 0 && prParticipatingRows.every((r) => r.status === 'unchanged');
   if (allUnchanged) {
-    return [
+    const lines: string[] = [
       '### After merge — predicted release',
       '',
       "> No version escalation — this PR's changes will be included in the queued release without affecting the projected versions.",
       '',
     ];
+    if (standingOnlyRows.length > 0) {
+      lines.push(
+        '| Package | Standing PR | This PR | After merge |',
+        '|---------|-------------|---------|-------------|',
+      );
+      for (const row of standingOnlyRows) {
+        lines.push(`| \`${row.packageName}\` | ${row.standing ?? '—'} | — | ${row.afterMerge} |`);
+      }
+      lines.push('');
+    }
+    return lines;
   }
 
   const lines: string[] = [

--- a/packages/release/src/preview/format.ts
+++ b/packages/release/src/preview/format.ts
@@ -39,6 +39,7 @@ export interface LabelContext {
     stable: string;
     prerelease: string;
     skip: string;
+    immediate: string;
     major: string;
     minor: string;
     patch: string;
@@ -46,10 +47,14 @@ export interface LabelContext {
   scopeLabels?: string[];
   /**
    * Human-readable reason from the gate's per-PR evaluation when the PR's labels would not
-   * trigger a release (e.g. "release:prerelease requires a bump:* label"). When set, the
+   * trigger a release (e.g. "channel:prerelease requires a bump:* label"). When set, the
    * preview banner uses this in place of the generic "No bump label detected" message.
    */
   gateReason?: string;
+  /** Standing-pr mode without `release:immediate` — bump/scope/channel labels are advisory only. */
+  advisoryInStandingPr?: boolean;
+  /** `release:immediate` is on the PR — preview should reflect a direct release, no standing-PR snapshot. */
+  immediate?: boolean;
 }
 
 export interface FormatOptions {
@@ -97,6 +102,31 @@ function getLabelBanner(labelContext?: LabelContext): string[] {
 
   const lines: string[] = [];
 
+  // `release:immediate` short-circuits all other label semantics — the PR is going to release
+  // directly, so the standard banners ("labeled for X", "no bump label", scope) would only confuse.
+  if (labelContext.immediate) {
+    const immediateLabel = labelContext.labels?.immediate ?? 'release:immediate';
+    lines.push(`> **\`${immediateLabel}\`** — bypassing the standing PR for a direct release.`, '');
+    return lines;
+  }
+
+  // In standing-pr mode without the immediate label, all bump/scope/channel labels are advisory.
+  // Show what was seen, point at the override surface (the standing PR) and the bypass label.
+  if (labelContext.advisoryInStandingPr) {
+    const seen: string[] = [];
+    if (labelContext.bumpLabel) seen.push(`\`bump:${labelContext.bumpLabel}\``);
+    if (labelContext.scopeLabels?.length) seen.push(...labelContext.scopeLabels.map((s) => `\`${s}\``));
+    if (labelContext.stable) seen.push(`\`${labelContext.labels?.stable ?? 'channel:stable'}\``);
+    if (labelContext.prerelease) seen.push(`\`${labelContext.labels?.prerelease ?? 'channel:prerelease'}\``);
+    const seenStr = seen.length ? ` (saw: ${seen.join(', ')})` : '';
+    const immediateLabel = labelContext.labels?.immediate ?? 'release:immediate';
+    lines.push(
+      `> **Note:** Labels on this PR are advisory in standing-pr mode${seenStr}. Bumps come from conventional commits in the standing PR; override by editing labels on the standing PR itself. Add \`${immediateLabel}\` to bypass the standing PR and release this PR directly.`,
+      '',
+    );
+    return lines;
+  }
+
   // Add scope label info if present
   if (labelContext.scopeLabels && labelContext.scopeLabels.length > 0) {
     lines.push(`> **Scope:** ${labelContext.scopeLabels.join(', ')}`, '');
@@ -116,8 +146,8 @@ function getLabelBanner(labelContext?: LabelContext): string[] {
   // Show prereleaseConflict error regardless of trigger mode
   if (labelContext.prereleaseConflict) {
     const labels = labelContext.labels;
-    const stableLabel = labels?.stable ?? 'release:stable';
-    const prereleaseLabel = labels?.prerelease ?? 'release:prerelease';
+    const stableLabel = labels?.stable ?? 'channel:stable';
+    const prereleaseLabel = labels?.prerelease ?? 'channel:prerelease';
     lines.push(
       '> **Error:** Conflicting release type labels detected.',
       `> **Note:** Please use only one of \`${stableLabel}\` or \`${prereleaseLabel}\` at a time.`,
@@ -171,7 +201,7 @@ function getLabelBanner(labelContext?: LabelContext): string[] {
       return lines;
     }
     if (labelContext.prerelease) {
-      // release:prerelease modifier set, bump driven by conventional commits
+      // channel:prerelease modifier set, bump driven by conventional commits
       lines.push('> This PR is labeled for a **prerelease** release (bump from conventional commits).', '');
       return lines;
     }
@@ -183,8 +213,11 @@ function getLabelBanner(labelContext?: LabelContext): string[] {
 export function formatPreviewComment(result: ReleaseOutput | null, options?: FormatOptions): string {
   const strategy = options?.strategy ?? 'direct';
   const labelContext = options?.labelContext;
-  const standingPrSnapshot = strategy === 'standing-pr' ? options?.standingPrSnapshot : undefined;
-  const mergedRows = strategy === 'standing-pr' ? options?.mergedRows : undefined;
+  // In standing-pr mode, the snapshot/merge are suppressed when `release:immediate` is set —
+  // the preview is showing a direct-release outcome, not a queued-state outcome.
+  const showStandingPrContext = strategy === 'standing-pr' && !labelContext?.immediate;
+  const standingPrSnapshot = showStandingPrContext ? options?.standingPrSnapshot : undefined;
+  const mergedRows = showStandingPrContext ? options?.mergedRows : undefined;
   const lines: string[] = [MARKER, ''];
 
   // Standing PR snapshot lives OUTSIDE the collapsible details so reviewers always see what's

--- a/packages/release/src/preview/merge.ts
+++ b/packages/release/src/preview/merge.ts
@@ -29,7 +29,7 @@ export function mergeForPreview(
   const byName = new Map<string, MergedRow>();
 
   for (const cl of standingChangelogs) {
-    if (!cl.entries.length) continue;
+    if (!cl.entries.length && cl.version === cl.previousVersion) continue;
     byName.set(cl.packageName, {
       packageName: cl.packageName,
       baseline: cl.previousVersion,
@@ -40,7 +40,7 @@ export function mergeForPreview(
   }
 
   for (const cl of currentChangelogs) {
-    if (!cl.entries.length) continue;
+    if (!cl.entries.length && cl.version === cl.previousVersion) continue;
     const existing = byName.get(cl.packageName);
     if (!existing) {
       byName.set(cl.packageName, {

--- a/packages/release/src/preview/merge.ts
+++ b/packages/release/src/preview/merge.ts
@@ -52,7 +52,9 @@ export function mergeForPreview(
       });
       continue;
     }
-    existing.current = cl.version;
+    // Only record a current version when it is parseable — an invalid string would surface
+    // as a garbled value in the "This PR" column of the rendered table.
+    if (semver.valid(cl.version)) existing.current = cl.version;
     // Guard semver comparison against malformed version strings (older manifests, unexpected
     // calculator output) — semver.gt throws on invalid input, which would otherwise abort the
     // entire preview. Treat unparseable versions as 'unchanged' to keep the preview non-fatal.

--- a/packages/release/src/preview/merge.ts
+++ b/packages/release/src/preview/merge.ts
@@ -62,6 +62,11 @@ export function mergeForPreview(
       existing.status = 'escalated';
     } else {
       existing.status = 'unchanged';
+      // When only the standing version is invalid, prefer the current PR's valid prediction so
+      // the rendered "After merge" cell shows a real version rather than a garbled string.
+      if (semver.valid(cl.version) && existing.standing && !semver.valid(existing.standing)) {
+        existing.afterMerge = cl.version;
+      }
     }
   }
 

--- a/packages/release/src/preview/merge.ts
+++ b/packages/release/src/preview/merge.ts
@@ -1,0 +1,65 @@
+import type { VersionPackageChangelog } from '@releasekit/core';
+import semver from 'semver';
+
+export interface MergedRow {
+  packageName: string;
+  /** Current published version (from changelogs[].previousVersion). null on first release. */
+  baseline: string | null;
+  /** New version proposed by the standing PR. undefined if the standing PR doesn't touch this package. */
+  standing?: string;
+  /** New version proposed by THIS PR. undefined if this PR doesn't touch this package. */
+  current?: string;
+  /** Predicted version after merge (max of standing, current). */
+  afterMerge: string;
+  status: 'unchanged' | 'escalated' | 'new-from-pr' | 'standing-only';
+}
+
+/**
+ * Merge a standing PR's queued package changelogs with the current PR's changelogs to
+ * predict the resulting per-package versions after merge. Higher semver wins per package
+ * (matches conventional-commits semantics: highest bump magnitude in the union of commits
+ * determines the bump).
+ *
+ * The result is sorted alphabetically by package name for stable output across re-runs.
+ */
+export function mergeForPreview(
+  standingChangelogs: VersionPackageChangelog[],
+  currentChangelogs: VersionPackageChangelog[],
+): MergedRow[] {
+  const byName = new Map<string, MergedRow>();
+
+  for (const cl of standingChangelogs) {
+    if (!cl.entries.length) continue;
+    byName.set(cl.packageName, {
+      packageName: cl.packageName,
+      baseline: cl.previousVersion,
+      standing: cl.version,
+      afterMerge: cl.version,
+      status: 'standing-only',
+    });
+  }
+
+  for (const cl of currentChangelogs) {
+    if (!cl.entries.length) continue;
+    const existing = byName.get(cl.packageName);
+    if (!existing) {
+      byName.set(cl.packageName, {
+        packageName: cl.packageName,
+        baseline: cl.previousVersion,
+        current: cl.version,
+        afterMerge: cl.version,
+        status: 'new-from-pr',
+      });
+      continue;
+    }
+    existing.current = cl.version;
+    if (existing.standing && semver.gt(cl.version, existing.standing)) {
+      existing.afterMerge = cl.version;
+      existing.status = 'escalated';
+    } else {
+      existing.status = 'unchanged';
+    }
+  }
+
+  return [...byName.values()].sort((a, b) => a.packageName.localeCompare(b.packageName));
+}

--- a/packages/release/src/preview/merge.ts
+++ b/packages/release/src/preview/merge.ts
@@ -53,7 +53,11 @@ export function mergeForPreview(
       continue;
     }
     existing.current = cl.version;
-    if (existing.standing && semver.gt(cl.version, existing.standing)) {
+    // Guard semver comparison against malformed version strings (older manifests, unexpected
+    // calculator output) — semver.gt throws on invalid input, which would otherwise abort the
+    // entire preview. Treat unparseable versions as 'unchanged' to keep the preview non-fatal.
+    const bothValid = semver.valid(cl.version) && existing.standing && semver.valid(existing.standing);
+    if (bothValid && existing.standing && semver.gt(cl.version, existing.standing)) {
       existing.afterMerge = cl.version;
       existing.status = 'escalated';
     } else {

--- a/packages/release/src/preview/preview.ts
+++ b/packages/release/src/preview/preview.ts
@@ -260,7 +260,7 @@ async function applyLabelOverrides(
   // In advisory-standing-pr mode, the labels are recorded for display only.
   if (!advisoryInStandingPr && matchedScopePatterns.length > 0) {
     result.target = matchedScopePatterns.join(', ');
-  } else if (!advisoryInStandingPr && !options.target && matchedScopePatterns.length === 0) {
+  } else if (!advisoryInStandingPr && !hasImmediate && !options.target && matchedScopePatterns.length === 0) {
     // Only require a scope target when a release is actually going to happen.
     // In label mode with no qualifying labels, release is skipped — no scope needed.
     const willRelease =

--- a/packages/release/src/preview/preview.ts
+++ b/packages/release/src/preview/preview.ts
@@ -2,14 +2,16 @@ import type { CIConfig } from '@releasekit/config';
 import { loadCIConfig, loadConfig } from '@releasekit/config';
 import { info, success, warn } from '@releasekit/core';
 import { evaluatePR } from '../gate/evaluate-pr.js';
-import { createOctokit, fetchPRLabels, findStandingPR, postOrUpdateComment } from '../github.js';
+import { createOctokit, fetchPRLabels, postOrUpdateComment } from '../github.js';
 import { DEFAULT_LABELS, detectLabelConflicts } from '../label-utils.js';
 import { runRelease } from '../release.js';
+import { fetchStandingPRSnapshot, type StandingPRSnapshot } from '../standing-pr/standing-pr.js';
 import type { PreviewContext } from './context.js';
 import { resolvePreviewContext } from './context.js';
 import { detectPrerelease } from './detect.js';
 import type { LabelContext } from './format.js';
 import { formatPreviewComment } from './format.js';
+import { type MergedRow, mergeForPreview } from './merge.js';
 
 export interface PreviewOptions {
   config?: string;
@@ -54,14 +56,14 @@ export async function runPreview(options: PreviewOptions): Promise<void> {
 
   const strategy = ciConfig?.releaseStrategy ?? 'direct';
 
-  // For standing-pr strategy, discover the current standing PR number for the preview comment
-  let standingPrNumber: number | undefined;
+  // For standing-pr strategy, fetch a read-only snapshot of the current standing PR (link,
+  // queued packages, minAge gate state) so the preview can render a true release preview.
+  let standingPrSnapshot: StandingPRSnapshot | undefined;
   if (strategy === 'standing-pr' && context && octokit) {
     try {
-      const standingPr = await findStandingPR(octokit, context.owner, context.repo, ciConfig);
-      standingPrNumber = standingPr?.number;
+      standingPrSnapshot = (await fetchStandingPRSnapshot(octokit, context.owner, context.repo, ciConfig)) ?? undefined;
     } catch {
-      // Non-fatal: preview still renders without the PR number
+      // Non-fatal: preview still renders without the snapshot
     }
   }
 
@@ -99,8 +101,20 @@ export async function runPreview(options: PreviewOptions): Promise<void> {
     info('No release label detected — skipping version analysis');
   }
 
+  // Compute the merge prediction when we have both a standing PR snapshot and a current-PR result.
+  let mergedRows: MergedRow[] | undefined;
+  if (standingPrSnapshot && result) {
+    mergedRows = mergeForPreview(standingPrSnapshot.manifest.versionOutput.changelogs, result.versionOutput.changelogs);
+  }
+
   // Format the comment
-  const commentBody = formatPreviewComment(result, { strategy, standingPrNumber, labelContext });
+  const commentBody = formatPreviewComment(result, {
+    strategy,
+    standingPrNumber: standingPrSnapshot?.number,
+    standingPrSnapshot,
+    mergedRows,
+    labelContext,
+  });
 
   if (!context || !octokit) {
     // Dry-run mode or GitHub context unavailable — print to stdout

--- a/packages/release/src/preview/preview.ts
+++ b/packages/release/src/preview/preview.ts
@@ -239,6 +239,9 @@ async function applyLabelOverrides(
   };
 
   // Scope labels — multi-scope is supported in preview (gate picks one; preview shows all).
+  // Track label names (for the banner) and patterns (for runRelease target) separately so the
+  // advisory banner shows e.g. `scope:docs` rather than the configured glob `packages/docs/**`.
+  const matchedScopeLabelNames: string[] = [];
   const matchedScopePatterns: string[] = [];
   for (const [labelName, packagePattern] of Object.entries(scopeLabels)) {
     if (prLabels.includes(labelName)) {
@@ -247,10 +250,11 @@ async function applyLabelOverrides(
       } else {
         info(`PR label "${labelName}" detected — limiting release to packages matching "${packagePattern}"`);
       }
+      matchedScopeLabelNames.push(labelName);
       matchedScopePatterns.push(packagePattern);
     }
   }
-  labelContext.scopeLabels = matchedScopePatterns;
+  labelContext.scopeLabels = matchedScopeLabelNames;
 
   // Only propagate scope to the runRelease target when it would actually drive a release.
   // In advisory-standing-pr mode, the labels are recorded for display only.

--- a/packages/release/src/preview/preview.ts
+++ b/packages/release/src/preview/preview.ts
@@ -1,3 +1,4 @@
+import * as fs from 'node:fs';
 import type { CIConfig } from '@releasekit/config';
 import { loadCIConfig, loadConfig } from '@releasekit/config';
 import { info, success, warn } from '@releasekit/core';
@@ -69,6 +70,22 @@ export async function runPreview(options: PreviewOptions): Promise<void> {
     }
   }
 
+  // In advisory standing-pr mode, scope the version analysis to only this PR's commits by
+  // using the PR's base SHA as the revision range start. Extracted from the GitHub Actions
+  // event payload (pull_request.base.sha) — non-fatal if unavailable.
+  let prBaseSha: string | undefined;
+  if (labelContext.advisoryInStandingPr) {
+    const eventPath = process.env.GITHUB_EVENT_PATH;
+    if (eventPath && fs.existsSync(eventPath)) {
+      try {
+        const event = JSON.parse(fs.readFileSync(eventPath, 'utf-8'));
+        prBaseSha = event.pull_request?.base?.sha as string | undefined;
+      } catch {
+        // Non-fatal: fall back to full commit history
+      }
+    }
+  }
+
   // Run version analysis unless release is skipped or in label mode with no bump label
   let result = null;
   if (!labelContext.skip && !labelContext.noBumpLabel) {
@@ -98,6 +115,7 @@ export async function runPreview(options: PreviewOptions): Promise<void> {
       quiet: true,
       projectDir: effectiveOptions.projectDir,
       target: effectiveOptions.target,
+      baseRef: prBaseSha,
     });
   } else {
     info('No release label detected — skipping version analysis');

--- a/packages/release/src/preview/preview.ts
+++ b/packages/release/src/preview/preview.ts
@@ -58,8 +58,10 @@ export async function runPreview(options: PreviewOptions): Promise<void> {
 
   // For standing-pr strategy, fetch a read-only snapshot of the current standing PR (link,
   // queued packages, minAge gate state) so the preview can render a true release preview.
+  // When `release:immediate` is set, skip the fetch — the preview reflects a direct release,
+  // not a queued-state outcome.
   let standingPrSnapshot: StandingPRSnapshot | undefined;
-  if (strategy === 'standing-pr' && context && octokit) {
+  if (strategy === 'standing-pr' && !labelContext.immediate && context && octokit) {
     try {
       standingPrSnapshot = (await fetchStandingPRSnapshot(octokit, context.owner, context.repo, ciConfig)) ?? undefined;
     } catch {
@@ -216,6 +218,13 @@ async function applyLabelOverrides(
     };
   }
 
+  const inStandingPr = (ciConfig?.releaseStrategy ?? 'direct') === 'standing-pr';
+  const hasImmediate = inStandingPr && prLabels.includes(labels.immediate);
+  // In standing-pr mode without `release:immediate`, all bump/scope/channel labels are advisory:
+  // they're rendered in the banner but do not drive runRelease. Bumps come from conventional
+  // commits in the standing PR; overrides happen by editing labels on the standing PR itself.
+  const advisoryInStandingPr = inStandingPr && !hasImmediate;
+
   const result = { ...options };
   const labelContext: LabelContext = {
     trigger,
@@ -225,21 +234,29 @@ async function applyLabelOverrides(
     prereleaseConflict: false,
     labels,
     scopeLabels: [],
+    advisoryInStandingPr,
+    immediate: hasImmediate,
   };
 
   // Scope labels — multi-scope is supported in preview (gate picks one; preview shows all).
   const matchedScopePatterns: string[] = [];
   for (const [labelName, packagePattern] of Object.entries(scopeLabels)) {
     if (prLabels.includes(labelName)) {
-      info(`PR label "${labelName}" detected — limiting release to packages matching "${packagePattern}"`);
+      if (advisoryInStandingPr) {
+        info(`PR label "${labelName}" seen — advisory in standing-pr mode, no scope filter applied`);
+      } else {
+        info(`PR label "${labelName}" detected — limiting release to packages matching "${packagePattern}"`);
+      }
       matchedScopePatterns.push(packagePattern);
     }
   }
   labelContext.scopeLabels = matchedScopePatterns;
 
-  if (matchedScopePatterns.length > 0) {
+  // Only propagate scope to the runRelease target when it would actually drive a release.
+  // In advisory-standing-pr mode, the labels are recorded for display only.
+  if (!advisoryInStandingPr && matchedScopePatterns.length > 0) {
     result.target = matchedScopePatterns.join(', ');
-  } else if (!options.target) {
+  } else if (!advisoryInStandingPr && !options.target && matchedScopePatterns.length === 0) {
     // Only require a scope target when a release is actually going to happen.
     // In label mode with no qualifying labels, release is skipped — no scope needed.
     const willRelease =
@@ -257,6 +274,18 @@ async function applyLabelOverrides(
           : 'No scope specified. Use --target flag to specify which packages to release.',
       );
     }
+  }
+
+  // In advisory-standing-pr mode, record any bump/channel labels for the banner only —
+  // do not propagate to `result`. Version analysis still runs (commit-driven) so the
+  // preview can show this PR's contribution to the standing PR via the merge table.
+  if (advisoryInStandingPr) {
+    if (prLabels.includes(labels.major)) labelContext.bumpLabel = 'major';
+    else if (prLabels.includes(labels.minor)) labelContext.bumpLabel = 'minor';
+    else if (prLabels.includes(labels.patch)) labelContext.bumpLabel = 'patch';
+    if (prLabels.includes(labels.stable)) labelContext.stable = true;
+    if (prLabels.includes(labels.prerelease)) labelContext.prerelease = true;
+    return { options: result, labelContext };
   }
 
   if (trigger === 'label') {

--- a/packages/release/src/preview/preview.ts
+++ b/packages/release/src/preview/preview.ts
@@ -124,7 +124,15 @@ export async function runPreview(options: PreviewOptions): Promise<void> {
   // Compute the merge prediction when we have both a standing PR snapshot and a current-PR result.
   let mergedRows: MergedRow[] | undefined;
   if (standingPrSnapshot && result) {
-    mergedRows = mergeForPreview(standingPrSnapshot.manifest.versionOutput.changelogs, result.versionOutput.changelogs);
+    // Scope the current-PR changelogs to packages the standing PR already tracks. Without this,
+    // packages this PR touches but the standing PR skips/excludes would appear as new-from-pr rows
+    // — a misleading prediction since the standing PR may not release those packages.
+    const standingScope = new Set([
+      ...standingPrSnapshot.manifest.versionOutput.updates.map((u) => u.packageName),
+      ...standingPrSnapshot.manifest.versionOutput.changelogs.map((cl) => cl.packageName),
+    ]);
+    const currentForMerge = result.versionOutput.changelogs.filter((cl) => standingScope.has(cl.packageName));
+    mergedRows = mergeForPreview(standingPrSnapshot.manifest.versionOutput.changelogs, currentForMerge);
   }
 
   // Format the comment

--- a/packages/release/src/release.ts
+++ b/packages/release/src/release.ts
@@ -169,7 +169,7 @@ export async function runRelease(inputOptions: ReleaseOptions): Promise<ReleaseO
 
   // Only apply scope labels in non-dry-run (release) mode
   // In dry-run/preview mode, preview.ts already handles scope labels via applyLabelOverrides
-  // However, we still call applyScopeLabelsFromPR to detect label conflicts (e.g., release:stable + release:prerelease)
+  // However, we still call applyScopeLabelsFromPR to detect label conflicts (e.g., channel:stable + channel:prerelease)
   const scopeResult = await applyScopeLabelsFromPR(ciConfig, options);
   if (scopeResult.blocked) {
     info('Release blocked due to conflicting PR labels');

--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -1,5 +1,5 @@
 import { execSync } from 'node:child_process';
-import { createHash } from 'node:crypto';
+
 import * as fs from 'node:fs';
 import { type CIConfig, loadConfig as loadReleaseKitConfig } from '@releasekit/config';
 import type { VersionOutput } from '@releasekit/core';
@@ -7,6 +7,7 @@ import { error, info, success, warn } from '@releasekit/core';
 import { formatDuration, parseDuration } from '../duration.js';
 import { getGitHubContext, getHeadCommitMessage, matchesSkipPattern } from '../git.js';
 import { createOctokit } from '../github.js';
+import { DEFAULT_LABELS } from '../label-utils.js';
 import { runNotesStep, runPublishStep, runVersionStep } from '../steps.js';
 import type { ReleaseOptions, ReleaseOutput } from '../types.js';
 import { postStandingPRStatusSafe } from './status.js';
@@ -14,8 +15,6 @@ import { postStandingPRStatusSafe } from './status.js';
 const MANIFEST_MARKER = '<!-- releasekit-manifest -->';
 const MANIFEST_SCHEMA_VERSION = 2;
 const MANIFEST_SCHEMA_MIN_VERSION = 1;
-const EDITABLE_START = '<!-- releasekit-editable-start -->';
-const EDITABLE_END = '<!-- releasekit-editable-end -->';
 
 export interface StandingPROptions {
   config?: string;
@@ -40,7 +39,6 @@ export interface StandingPRManifest {
   notesFiles: string[];
   createdAt: string;
   baseSha: string;
-  notesHash?: string;
   /** ISO timestamp of when this standing PR was first created. Preserved across updates. Added in schema v2. */
   firstUpdatedAt?: string;
 }
@@ -97,62 +95,74 @@ function commitAndForcePush(branch: string, cwd: string): void {
 }
 
 // Renders the release notes section content (without editable markers).
-// Used both for writing to PR bodies and for computing notesHash.
-function renderNotesSection(versionOutput: VersionOutput, releaseNotes: Record<string, string>): string {
-  const lines: string[] = ['### Release Notes', ''];
-  for (const [pkg, notes] of Object.entries(releaseNotes)) {
-    const update = versionOutput.updates.find((u) => u.packageName === pkg);
-    if (update) {
-      lines.push(`#### ${pkg} — ${update.newVersion}`, '');
-    } else {
-      lines.push(`#### ${pkg}`, '');
-    }
-    lines.push(notes.trim(), '');
+const CHANGELOG_TYPE_LABELS: Record<string, string> = {
+  feat: 'Added',
+  fix: 'Fixed',
+  added: 'Added',
+  changed: 'Changed',
+  fixed: 'Fixed',
+  perf: 'Performance',
+  refactor: 'Refactored',
+  security: 'Security',
+  docs: 'Documentation',
+  chore: 'Chores',
+  test: 'Tests',
+  build: 'Build',
+  ci: 'CI',
+  revert: 'Reverts',
+  style: 'Styles',
+};
+
+function renderChangelogEntries(entries: VersionOutput['changelogs'][number]['entries']): string[] {
+  const grouped = new Map<string, typeof entries>();
+  for (const entry of entries) {
+    if (!grouped.has(entry.type)) grouped.set(entry.type, []);
+    grouped.get(entry.type)!.push(entry);
   }
+  const lines: string[] = [];
+  const renderedTypes = new Set<string>();
+  for (const type of Object.keys(CHANGELOG_TYPE_LABELS)) {
+    const group = grouped.get(type);
+    if (group?.length) {
+      lines.push(`**${CHANGELOG_TYPE_LABELS[type]}**`, '');
+      for (const e of group) {
+        lines.push(
+          `- ${e.description}${e.scope ? ` (\`${e.scope}\`)` : ''}${e.issueIds?.length ? ` ${e.issueIds.join(', ')}` : ''}`,
+        );
+      }
+      lines.push('');
+      renderedTypes.add(type);
+    }
+  }
+  for (const [type, group] of grouped) {
+    if (!renderedTypes.has(type) && group?.length) {
+      const label = type.charAt(0).toUpperCase() + type.slice(1);
+      lines.push(`**${label}**`, '');
+      for (const e of group) {
+        lines.push(`- ${e.description}${e.scope ? ` (\`${e.scope}\`)` : ''}`);
+      }
+      lines.push('');
+    }
+  }
+  return lines;
+}
+
+function renderChangelogSection(versionOutput: VersionOutput): string {
+  const lines: string[] = ['### Changelog', ''];
+
+  if (versionOutput.sharedEntries?.length) {
+    lines.push('#### Project-wide changes', '');
+    lines.push(...renderChangelogEntries(versionOutput.sharedEntries));
+  }
+
+  for (const cl of versionOutput.changelogs) {
+    if (cl.entries.length === 0) continue;
+    lines.push(`#### ${cl.packageName} — ${cl.previousVersion ?? 'N/A'} → ${cl.version}`, '');
+    lines.push(...renderChangelogEntries(cl.entries));
+  }
+
   if (lines[lines.length - 1] === '') lines.pop();
   return lines.join('\n');
-}
-
-function computeNotesHash(section: string): string {
-  return createHash('sha256').update(section).digest('hex').slice(0, 16);
-}
-
-// Extracts the content between editable markers from a PR body, or null if markers are absent.
-export function extractEditableSection(body: string): string | null {
-  const start = body.indexOf(EDITABLE_START);
-  const end = body.indexOf(EDITABLE_END);
-  if (start === -1 || end === -1 || end < start) return null;
-  return body.slice(start + EDITABLE_START.length, end).trim();
-}
-
-// Parses an editable section back into per-package notes using a line-by-line accumulator.
-// Package headings are "#### <pkg> — <version>" (em dash U+2014). h4 subheadings within
-// notes (e.g. "#### Breaking Changes") have no em dash and are accumulated as content.
-// [^—]+ is used for the package-name portion to avoid backtracking ambiguity.
-export function parseEditedNotes(section: string): Record<string, string> {
-  const result: Record<string, string> = {};
-  let currentPkg: string | null = null;
-  const accum: string[] = [];
-
-  const flush = () => {
-    if (currentPkg !== null) {
-      result[currentPkg] = accum.join('\n').trim();
-      accum.length = 0;
-    }
-  };
-
-  for (const line of section.split('\n')) {
-    const headingMatch = line.match(/^#### ([^—]+) — \S/);
-    if (headingMatch?.[1]) {
-      flush();
-      currentPkg = headingMatch[1].trim();
-    } else if (currentPkg !== null) {
-      accum.push(line);
-    }
-  }
-  flush();
-
-  return result;
 }
 
 function deleteReleaseBranch(releaseBranch: string, cwd: string): void {
@@ -169,12 +179,7 @@ function deleteReleaseBranch(releaseBranch: string, cwd: string): void {
   }
 }
 
-function renderPrBody(
-  versionOutput: VersionOutput,
-  releaseNotes: Record<string, string>,
-  editableNotes = false,
-  overrideSection?: string,
-): string {
+function renderPrBody(versionOutput: VersionOutput): string {
   const lines: string[] = [
     '## Release',
     '',
@@ -189,17 +194,7 @@ function renderPrBody(
     lines.push(`| \`${update.packageName}\` | ${update.newVersion} |`);
   }
 
-  const hasNotes = Object.keys(releaseNotes).length > 0;
-  if (hasNotes) {
-    const sectionContent = overrideSection ?? renderNotesSection(versionOutput, releaseNotes);
-    lines.push('');
-    if (editableNotes) {
-      lines.push(EDITABLE_START, sectionContent, EDITABLE_END, '');
-    } else {
-      lines.push(sectionContent, '');
-    }
-  }
-
+  lines.push('', renderChangelogSection(versionOutput), '');
   lines.push('---', '> Merge this PR to publish. The release will be triggered automatically.');
   return lines.join('\n');
 }
@@ -374,15 +369,7 @@ interface StandingPrOverrides {
 function resolveStandingPrLabelOverrides(prLabels: string[], ciConfig: CIConfig | undefined): StandingPrOverrides {
   // Return a fresh object rather than a shared constant — callers may mutate `conflicts`.
   if (!prLabels || prLabels.length === 0) return { conflicts: [] };
-  const labels = ciConfig?.labels ?? {
-    stable: 'channel:stable',
-    prerelease: 'channel:prerelease',
-    skip: 'release:skip',
-    immediate: 'release:immediate',
-    major: 'bump:major',
-    minor: 'bump:minor',
-    patch: 'bump:patch',
-  };
+  const labels = ciConfig?.labels ?? DEFAULT_LABELS;
   const scopeLabels = ciConfig?.scopeLabels ?? {};
   const conflicts: string[] = [];
 
@@ -611,48 +598,12 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
     .replace(/\$\{version\}/g, firstUpdate?.newVersion ?? '');
 
   const labels = standingPrConfig?.labels ?? ['release'];
-  const editableNotesEnabled = standingPrConfig?.editableNotes ?? false;
-  const hasNotes = Object.keys(notesResult.releaseNotes ?? {}).length > 0;
-
-  // Pre-compute fresh notes section and its hash for edit-detection tracking
-  const freshSection =
-    editableNotesEnabled && hasNotes ? renderNotesSection(versionOutput, notesResult.releaseNotes ?? {}) : undefined;
-  const notesHash = freshSection ? computeNotesHash(freshSection) : undefined;
 
   // Reuse the standing PR fetched at the top of this function — same source of truth as the
   // label override resolution; saves an extra API call.
   const existing = existingStandingPr;
 
-  // When editableNotes is enabled and a PR exists, check whether the user has manually
-  // edited the notes section. If the current section hash differs from the stored hash,
-  // preserve the user's edits rather than overwriting them.
-  let overrideSection: string | undefined;
-  if (editableNotesEnabled && existing && freshSection) {
-    const existingManifestComment = await findManifestComment(octokit, owner, repo, existing.number);
-    if (existingManifestComment) {
-      try {
-        const existingManifest = parseManifest(existingManifestComment.body);
-        if (existingManifest.notesHash) {
-          const { data: prData } = await octokit.rest.pulls.get({
-            owner,
-            repo,
-            pull_number: existing.number,
-          });
-          if (prData.body) {
-            const currentSection = extractEditableSection(prData.body);
-            if (currentSection && computeNotesHash(currentSection) !== existingManifest.notesHash) {
-              warn('User has edited the release notes section — preserving edits');
-              overrideSection = currentSection;
-            }
-          }
-        }
-      } catch {
-        // Can't parse manifest — proceed with fresh generation
-      }
-    }
-  }
-
-  const body = renderPrBody(versionOutput, notesResult.releaseNotes ?? {}, editableNotesEnabled, overrideSection);
+  const body = renderPrBody(versionOutput);
 
   let prNumber: number;
   let prUrl: string;
@@ -742,7 +693,6 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
     notesFiles: notesResult.files,
     createdAt: new Date().toISOString(),
     baseSha,
-    notesHash,
     firstUpdatedAt,
   };
 
@@ -844,26 +794,6 @@ export async function publishFromManifest(prNumber: number, options: StandingPRO
 
   // If editableNotes is enabled, extract any user edits from the PR body and merge them
   // into the manifest's releaseNotes, falling back to manifest notes for missing packages.
-  if (standingPrConfig?.editableNotes) {
-    const { data: prData } = await octokit.rest.pulls.get({ owner, repo, pull_number: prNumber });
-    if (prData.body) {
-      const editableSection = extractEditableSection(prData.body);
-      if (editableSection) {
-        const editedNotes = parseEditedNotes(editableSection);
-        const mergedNotes: Record<string, string> = { ...manifest.releaseNotes };
-        for (const [pkg, notes] of Object.entries(editedNotes)) {
-          mergedNotes[pkg] = notes;
-        }
-        for (const pkg of Object.keys(manifest.releaseNotes)) {
-          if (!(pkg in editedNotes)) {
-            warn(`Package '${pkg}' heading not found in edited release notes — using original notes`);
-          }
-        }
-        manifest = { ...manifest, releaseNotes: mergedNotes };
-      }
-    }
-  }
-
   info(`Publishing from manifest: ${manifest.versionOutput.updates.length} package(s)`);
 
   const publishOptions: ReleaseOptions = {

--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -1,12 +1,12 @@
 import { execSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import * as fs from 'node:fs';
-import { loadConfig as loadReleaseKitConfig } from '@releasekit/config';
+import { type CIConfig, loadConfig as loadReleaseKitConfig } from '@releasekit/config';
 import type { VersionOutput } from '@releasekit/core';
 import { error, info, success, warn } from '@releasekit/core';
 import { formatDuration, parseDuration } from '../duration.js';
 import { getGitHubContext, getHeadCommitMessage, matchesSkipPattern } from '../git.js';
-import { createOctokit } from '../github.js';
+import { createOctokit, findStandingPR as findStandingPRFromConfig } from '../github.js';
 import { runNotesStep, runPublishStep, runVersionStep } from '../steps.js';
 import type { ReleaseOptions, ReleaseOutput } from '../types.js';
 import { postStandingPRStatusSafe } from './status.js';
@@ -249,7 +249,7 @@ export function parseManifest(commentBody: string): StandingPRManifest {
 
 type OctokitInstance = ReturnType<typeof createOctokit>;
 
-async function findManifestComment(
+export async function findManifestComment(
   octokit: OctokitInstance,
   owner: string,
   repo: string,
@@ -289,6 +289,62 @@ export async function findStandingPR(
 
   const pr = prs[0];
   return pr ? { number: pr.number, url: pr.html_url } : null;
+}
+
+/**
+ * Read-only snapshot of the current standing PR, used by the preview command to render
+ * a "true release preview" comment (queued packages + minAge gate state).
+ *
+ * Returns null when no standing PR exists or its manifest comment is missing/malformed.
+ */
+export interface StandingPRSnapshot {
+  number: number;
+  url: string;
+  manifest: StandingPRManifest;
+  /** ISO timestamp of when the standing PR was first opened. */
+  openedAt: string;
+  /** 'success' = ready to merge; 'pending' = waiting on minAge. */
+  gateState: 'success' | 'pending';
+  /** Humanized "Waiting Xh Ym for minAge" when gateState === 'pending'. */
+  gateReason?: string;
+}
+
+export async function fetchStandingPRSnapshot(
+  octokit: OctokitInstance,
+  owner: string,
+  repo: string,
+  ciConfig: CIConfig | undefined,
+): Promise<StandingPRSnapshot | null> {
+  const pr = await findStandingPRFromConfig(octokit, owner, repo, ciConfig);
+  if (!pr) return null;
+
+  const comment = await findManifestComment(octokit, owner, repo, pr.number);
+  if (!comment) return null;
+
+  let manifest: StandingPRManifest;
+  try {
+    manifest = parseManifest(comment.body);
+  } catch {
+    return null;
+  }
+
+  const openedAt = manifest.firstUpdatedAt ?? manifest.createdAt;
+  const minAge = ciConfig?.standingPr?.minAge;
+  let gateState: 'success' | 'pending' = 'success';
+  let gateReason: string | undefined;
+
+  if (minAge && manifest.firstUpdatedAt) {
+    const minAgeMs = parseDuration(minAge);
+    if (minAgeMs !== null) {
+      const ageMs = Date.now() - new Date(manifest.firstUpdatedAt).getTime();
+      if (ageMs < minAgeMs) {
+        gateState = 'pending';
+        gateReason = `Waiting ${formatDuration(minAgeMs - ageMs)} for minAge`;
+      }
+    }
+  }
+
+  return { number: pr.number, url: pr.url, manifest, openedAt, gateState, gateReason };
 }
 
 function buildBaseReleaseOptions(options: StandingPROptions, dryRun: boolean): ReleaseOptions {

--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -331,6 +331,9 @@ export async function fetchStandingPRSnapshot(
     return null;
   }
 
+  // firstUpdatedAt is only present on schema-v2 manifests. For schema-v1, createdAt is the
+  // latest-update timestamp (not the PR-open timestamp), so the displayed age will be ~0 until
+  // the next standing-pr update rewrites the manifest to schema v2.
   const openedAt = manifest.firstUpdatedAt ?? manifest.createdAt;
   const minAge = ciConfig?.standingPr?.minAge;
   let gateState: 'success' | 'pending' = 'success';
@@ -340,7 +343,7 @@ export async function fetchStandingPRSnapshot(
   const overrides = resolveStandingPrLabelOverrides(pr.labels, ciConfig);
   if (overrides.conflicts.length > 0) {
     gateState = 'pending';
-    gateReason = overrides.conflicts[0];
+    gateReason = overrides.conflicts.join('; ');
   } else if (minAge !== undefined && manifest.firstUpdatedAt) {
     const minAgeMs = parseDuration(minAge);
     if (minAgeMs !== null) {

--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -278,7 +278,7 @@ export async function findStandingPR(
   owner: string,
   repo: string,
   branch: string,
-): Promise<{ number: number; url: string } | null> {
+): Promise<{ number: number; url: string; labels: string[] } | null> {
   const { data: prs } = await octokit.rest.pulls.list({
     owner,
     repo,
@@ -288,7 +288,9 @@ export async function findStandingPR(
   });
 
   const pr = prs[0];
-  return pr ? { number: pr.number, url: pr.html_url } : null;
+  if (!pr) return null;
+  const labels = (pr.labels ?? []).map((l) => (typeof l === 'string' ? l : (l.name ?? ''))).filter(Boolean);
+  return { number: pr.number, url: pr.html_url, labels };
 }
 
 /**
@@ -347,11 +349,94 @@ export async function fetchStandingPRSnapshot(
   return { number: pr.number, url: pr.url, manifest, openedAt, gateState, gateReason };
 }
 
-function buildBaseReleaseOptions(options: StandingPROptions, dryRun: boolean): ReleaseOptions {
+/**
+ * Overrides resolved from labels on the standing PR itself. The standing PR is the canonical
+ * surface for adjusting bump magnitude, scope, and channel — feeder PR labels are advisory.
+ */
+interface StandingPrOverrides {
+  bump?: 'major' | 'minor' | 'patch';
+  target?: string;
+  stable?: boolean;
+  prerelease?: boolean;
+  /** Human-readable conflict descriptions (used for the pending status check). Empty when no conflict. */
+  conflicts: string[];
+}
+
+const NO_OVERRIDES: StandingPrOverrides = { conflicts: [] };
+
+function resolveStandingPrLabelOverrides(prLabels: string[], ciConfig: CIConfig | undefined): StandingPrOverrides {
+  if (!prLabels || prLabels.length === 0) return NO_OVERRIDES;
+  const labels = ciConfig?.labels ?? {
+    stable: 'channel:stable',
+    prerelease: 'channel:prerelease',
+    skip: 'release:skip',
+    immediate: 'release:immediate',
+    major: 'bump:major',
+    minor: 'bump:minor',
+    patch: 'bump:patch',
+  };
+  const scopeLabels = ciConfig?.scopeLabels ?? {};
+  const conflicts: string[] = [];
+
+  // Bump
+  let bump: 'major' | 'minor' | 'patch' | undefined;
+  const bumpsPresent = [
+    prLabels.includes(labels.major) ? labels.major : undefined,
+    prLabels.includes(labels.minor) ? labels.minor : undefined,
+    prLabels.includes(labels.patch) ? labels.patch : undefined,
+  ].filter(Boolean) as string[];
+  if (bumpsPresent.length > 1) {
+    conflicts.push(`Conflicting bump labels on standing PR (${bumpsPresent.join(', ')}) — remove all but one`);
+  } else if (prLabels.includes(labels.major)) bump = 'major';
+  else if (prLabels.includes(labels.minor)) bump = 'minor';
+  else if (prLabels.includes(labels.patch)) bump = 'patch';
+
+  // Channel modifiers
+  const hasStable = prLabels.includes(labels.stable);
+  const hasPrerelease = prLabels.includes(labels.prerelease);
+  let stable: boolean | undefined;
+  let prerelease: boolean | undefined;
+  if (hasStable && hasPrerelease) {
+    conflicts.push(`Conflicting channel labels on standing PR (${labels.stable} and ${labels.prerelease})`);
+  } else {
+    if (hasStable) stable = true;
+    if (hasPrerelease) prerelease = true;
+  }
+
+  // Scope: first matching configured scope label wins
+  let target: string | undefined;
+  for (const [labelName, pattern] of Object.entries(scopeLabels)) {
+    if (prLabels.includes(labelName)) {
+      target = pattern;
+      break;
+    }
+  }
+
+  return { bump, target, stable, prerelease, conflicts };
+}
+
+interface BuildOptionsExtras {
+  /** Per-package vs synced versioning. Inherited from version.sync config (default true). */
+  sync?: boolean;
+  bump?: 'major' | 'minor' | 'patch';
+  target?: string;
+  stable?: boolean;
+  prerelease?: boolean;
+}
+
+function buildBaseReleaseOptions(
+  options: StandingPROptions,
+  dryRun: boolean,
+  extras?: BuildOptionsExtras,
+): ReleaseOptions {
   return {
     config: options.config,
     dryRun,
-    sync: false,
+    sync: extras?.sync ?? true,
+    bump: extras?.bump,
+    target: extras?.target,
+    stable: extras?.stable,
+    prerelease: extras?.prerelease ? true : undefined,
     skipNotes: true,
     skipPublish: true,
     skipGit: true,
@@ -383,35 +468,66 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
     return { action: 'noop' };
   }
 
+  const githubContext = getGitHubContext();
+
+  // Look up the existing standing PR up front (one API call, reused throughout). Its labels
+  // are the canonical override surface — `bump:*` / `scope:*` / channel labels applied to
+  // the standing PR drive the next update.
+  let existingStandingPr: { number: number; url: string; labels: string[] } | null = null;
+  if (githubContext?.token) {
+    try {
+      const lookupOctokit = createOctokit(githubContext.token);
+      existingStandingPr = await findStandingPR(lookupOctokit, githubContext.owner, githubContext.repo, branch);
+    } catch (err) {
+      warn(`Could not look up standing PR for label overrides: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  const overrides = resolveStandingPrLabelOverrides(existingStandingPr?.labels ?? [], ciConfig);
+  if (overrides.bump) info(`Standing PR label override: bump=${overrides.bump}`);
+  if (overrides.target) info(`Standing PR label override: target=${overrides.target}`);
+  if (overrides.stable) info(`Standing PR label override: channel:stable`);
+  if (overrides.prerelease) info(`Standing PR label override: channel:prerelease`);
+  for (const conflict of overrides.conflicts) warn(conflict);
+
+  // Inherit sync from the loaded version config (defaults to true) — never silently force false.
+  const sync = releaseKitConfig.version?.sync ?? true;
+  // When labels conflict, drop the override (fall back to commit-driven) but keep the
+  // conflict descriptions for the final status check.
+  const buildExtras: BuildOptionsExtras = overrides.conflicts.length
+    ? { sync, target: overrides.target }
+    : {
+        sync,
+        bump: overrides.bump,
+        target: overrides.target,
+        stable: overrides.stable,
+        prerelease: overrides.prerelease,
+      };
+
   // Dry-run version analysis to compute bumps without writing
   info('Running version analysis (dry run)...');
-  const dryRunOptions = buildBaseReleaseOptions(options, true);
+  const dryRunOptions = buildBaseReleaseOptions(options, true, buildExtras);
   const versionOutputDry = await runVersionStep(dryRunOptions);
-
-  const githubContext = getGitHubContext();
 
   if (versionOutputDry.updates.length === 0) {
     info('No releasable changes found');
 
-    if (githubContext?.token) {
+    if (githubContext?.token && existingStandingPr) {
       const octokit = createOctokit(githubContext.token);
-      const existing = await findStandingPR(octokit, githubContext.owner, githubContext.repo, branch);
-      if (existing) {
-        await octokit.rest.issues.createComment({
-          owner: githubContext.owner,
-          repo: githubContext.repo,
-          issue_number: existing.number,
-          body: 'No releasable changes found. Closing this PR as the release queue is empty.',
-        });
-        await octokit.rest.pulls.update({
-          owner: githubContext.owner,
-          repo: githubContext.repo,
-          pull_number: existing.number,
-          state: 'closed',
-        });
-        info(`Closed standing PR #${existing.number}`);
-        return { action: 'closed', prNumber: existing.number, prUrl: existing.url };
-      }
+      await octokit.rest.issues.createComment({
+        owner: githubContext.owner,
+        repo: githubContext.repo,
+        issue_number: existingStandingPr.number,
+        body: 'No releasable changes found. Closing this PR as the release queue is empty.',
+      });
+      await octokit.rest.pulls.update({
+        owner: githubContext.owner,
+        repo: githubContext.repo,
+        pull_number: existingStandingPr.number,
+        state: 'closed',
+      });
+      info(`Closed standing PR #${existingStandingPr.number}`);
+      return { action: 'closed', prNumber: existingStandingPr.number, prUrl: existingStandingPr.url };
     }
 
     return { action: 'noop' };
@@ -423,25 +539,22 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
     info(
       `Package count (${versionOutputDry.updates.length}) is below minPackages threshold (${minPackages}), skipping`,
     );
-    if (githubContext?.token) {
+    if (githubContext?.token && existingStandingPr) {
       const octokit = createOctokit(githubContext.token);
-      const existing = await findStandingPR(octokit, githubContext.owner, githubContext.repo, branch);
-      if (existing) {
-        await octokit.rest.issues.createComment({
-          owner: githubContext.owner,
-          repo: githubContext.repo,
-          issue_number: existing.number,
-          body: `Not enough packages with releasable changes (${versionOutputDry.updates.length} of ${minPackages} required). Closing until the threshold is reached.`,
-        });
-        await octokit.rest.pulls.update({
-          owner: githubContext.owner,
-          repo: githubContext.repo,
-          pull_number: existing.number,
-          state: 'closed',
-        });
-        info(`Closed standing PR #${existing.number} (minPackages not met)`);
-        return { action: 'closed', prNumber: existing.number, prUrl: existing.url };
-      }
+      await octokit.rest.issues.createComment({
+        owner: githubContext.owner,
+        repo: githubContext.repo,
+        issue_number: existingStandingPr.number,
+        body: `Not enough packages with releasable changes (${versionOutputDry.updates.length} of ${minPackages} required). Closing until the threshold is reached.`,
+      });
+      await octokit.rest.pulls.update({
+        owner: githubContext.owner,
+        repo: githubContext.repo,
+        pull_number: existingStandingPr.number,
+        state: 'closed',
+      });
+      info(`Closed standing PR #${existingStandingPr.number} (minPackages not met)`);
+      return { action: 'closed', prNumber: existingStandingPr.number, prUrl: existingStandingPr.url };
     }
     return { action: 'noop' };
   }
@@ -455,7 +568,7 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
 
   // Materialize changes on release branch
   info('Writing version bumps...');
-  const writeOptions = buildBaseReleaseOptions(options, false);
+  const writeOptions = buildBaseReleaseOptions(options, false, buildExtras);
   const versionOutput = await runVersionStep(writeOptions);
 
   info('Generating release notes...');
@@ -497,7 +610,9 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
     editableNotesEnabled && hasNotes ? renderNotesSection(versionOutput, notesResult.releaseNotes ?? {}) : undefined;
   const notesHash = freshSection ? computeNotesHash(freshSection) : undefined;
 
-  const existing = await findStandingPR(octokit, owner, repo, branch);
+  // Reuse the standing PR fetched at the top of this function — same source of truth as the
+  // label override resolution; saves an extra API call.
+  const existing = existingStandingPr;
 
   // When editableNotes is enabled and a PR exists, check whether the user has manually
   // edited the notes section. If the current section hash differs from the stored hash,
@@ -561,14 +676,18 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
     info(`Created standing PR #${prNumber}`);
   }
 
-  // Apply labels
+  // Apply labels — preserve any maintainer-added labels (e.g. bump:major, scope:foo) by
+  // taking the union of currently-applied labels and the configured set. Without this,
+  // every update would wipe maintainer overrides.
   if (labels.length > 0) {
     try {
+      const currentLabels = existingStandingPr?.labels ?? [];
+      const mergedLabels = [...new Set([...currentLabels, ...labels])];
       await octokit.rest.issues.setLabels({
         owner,
         repo,
         issue_number: prNumber,
-        labels,
+        labels: mergedLabels,
       });
     } catch {
       warn('Failed to apply labels to standing PR (labels may not exist in the repository)');
@@ -625,6 +744,12 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
   const minAge = standingPrConfig?.minAge;
   let statusState: 'success' | 'pending' = 'success';
   let statusDescription = 'Ready to merge';
+
+  // Standing-PR label conflicts surface here as a pending check so the team notices.
+  if (overrides.conflicts.length > 0) {
+    statusState = 'pending';
+    statusDescription = overrides.conflicts.join('; ').slice(0, 140);
+  }
 
   if (minAge !== undefined) {
     const minAgeMs = parseDuration(minAge);

--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -498,8 +498,8 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
   if (overrides.prerelease) info(`Standing PR label override: channel:prerelease`);
   for (const conflict of overrides.conflicts) warn(conflict);
 
-  // Inherit sync from the loaded version config only when explicitly set — default false
-  // preserves the original per-package independent versioning behaviour for existing users.
+  // Use the version.sync setting from config; fall back to false (per-package versioning)
+  // when not set so existing repos without an explicit value are unaffected.
   const sync = releaseKitConfig.version?.sync ?? false;
   // When labels conflict, drop the override (fall back to commit-driven) but keep the
   // conflict descriptions for the final status check.

--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -750,7 +750,7 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
     statusDescription = overrides.conflicts.join('; ').slice(0, 140);
   }
 
-  if (minAge !== undefined) {
+  if (minAge !== undefined && overrides.conflicts.length === 0) {
     const minAgeMs = parseDuration(minAge);
     if (minAgeMs === null) {
       warn(

--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -139,7 +139,9 @@ function renderChangelogEntries(entries: VersionOutput['changelogs'][number]['en
       const label = type.charAt(0).toUpperCase() + type.slice(1);
       lines.push(`**${label}**`, '');
       for (const e of group) {
-        lines.push(`- ${e.description}${e.scope ? ` (\`${e.scope}\`)` : ''}`);
+        lines.push(
+          `- ${e.description}${e.scope ? ` (\`${e.scope}\`)` : ''}${e.issueIds?.length ? ` ${e.issueIds.join(', ')}` : ''}`,
+        );
       }
       lines.push('');
     }

--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -6,7 +6,7 @@ import type { VersionOutput } from '@releasekit/core';
 import { error, info, success, warn } from '@releasekit/core';
 import { formatDuration, parseDuration } from '../duration.js';
 import { getGitHubContext, getHeadCommitMessage, matchesSkipPattern } from '../git.js';
-import { createOctokit, findStandingPR as findStandingPRFromConfig } from '../github.js';
+import { createOctokit } from '../github.js';
 import { runNotesStep, runPublishStep, runVersionStep } from '../steps.js';
 import type { ReleaseOptions, ReleaseOutput } from '../types.js';
 import { postStandingPRStatusSafe } from './status.js';

--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -150,11 +150,15 @@ function renderChangelogEntries(entries: VersionOutput['changelogs'][number]['en
 }
 
 function renderChangelogSection(versionOutput: VersionOutput): string {
+  const hasShared = (versionOutput.sharedEntries?.length ?? 0) > 0;
+  const hasPackageEntries = versionOutput.changelogs.some((cl) => cl.entries.length > 0);
+  if (!hasShared && !hasPackageEntries) return '';
+
   const lines: string[] = ['### Changelog', ''];
 
-  if (versionOutput.sharedEntries?.length) {
+  if (hasShared) {
     lines.push('#### Project-wide changes', '');
-    lines.push(...renderChangelogEntries(versionOutput.sharedEntries));
+    lines.push(...renderChangelogEntries(versionOutput.sharedEntries!));
   }
 
   for (const cl of versionOutput.changelogs) {
@@ -196,7 +200,8 @@ function renderPrBody(versionOutput: VersionOutput): string {
     lines.push(`| \`${update.packageName}\` | ${update.newVersion} |`);
   }
 
-  lines.push('', renderChangelogSection(versionOutput), '');
+  const changelog = renderChangelogSection(versionOutput);
+  if (changelog) lines.push('', changelog, '');
   lines.push('---', '> Merge this PR to publish. The release will be triggered automatically.');
   return lines.join('\n');
 }

--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -362,10 +362,9 @@ interface StandingPrOverrides {
   conflicts: string[];
 }
 
-const NO_OVERRIDES: StandingPrOverrides = { conflicts: [] };
-
 function resolveStandingPrLabelOverrides(prLabels: string[], ciConfig: CIConfig | undefined): StandingPrOverrides {
-  if (!prLabels || prLabels.length === 0) return NO_OVERRIDES;
+  // Return a fresh object rather than a shared constant — callers may mutate `conflicts`.
+  if (!prLabels || prLabels.length === 0) return { conflicts: [] };
   const labels = ciConfig?.labels ?? {
     stable: 'channel:stable',
     prerelease: 'channel:prerelease',

--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -335,7 +335,7 @@ export async function fetchStandingPRSnapshot(
   let gateState: 'success' | 'pending' = 'success';
   let gateReason: string | undefined;
 
-  if (minAge && manifest.firstUpdatedAt) {
+  if (minAge !== undefined && manifest.firstUpdatedAt) {
     const minAgeMs = parseDuration(minAge);
     if (minAgeMs !== null) {
       const ageMs = Date.now() - new Date(manifest.firstUpdatedAt).getTime();

--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -305,9 +305,9 @@ export interface StandingPRSnapshot {
   manifest: StandingPRManifest;
   /** ISO timestamp of when the standing PR was first opened. */
   openedAt: string;
-  /** 'success' = ready to merge; 'pending' = waiting on minAge. */
+  /** 'success' = ready to merge; 'pending' = label conflict or minAge not yet elapsed. */
   gateState: 'success' | 'pending';
-  /** Humanized "Waiting Xh Ym for minAge" when gateState === 'pending'. */
+  /** Human-readable reason when gateState === 'pending' (conflict description or minAge wait). */
   gateReason?: string;
 }
 
@@ -317,7 +317,8 @@ export async function fetchStandingPRSnapshot(
   repo: string,
   ciConfig: CIConfig | undefined,
 ): Promise<StandingPRSnapshot | null> {
-  const pr = await findStandingPRFromConfig(octokit, owner, repo, ciConfig);
+  const branch = ciConfig?.standingPr?.branch ?? 'release/next';
+  const pr = await findStandingPR(octokit, owner, repo, branch);
   if (!pr) return null;
 
   const comment = await findManifestComment(octokit, owner, repo, pr.number);
@@ -335,7 +336,12 @@ export async function fetchStandingPRSnapshot(
   let gateState: 'success' | 'pending' = 'success';
   let gateReason: string | undefined;
 
-  if (minAge !== undefined && manifest.firstUpdatedAt) {
+  // Label conflicts take priority over minAge — they must be resolved before merging.
+  const overrides = resolveStandingPrLabelOverrides(pr.labels, ciConfig);
+  if (overrides.conflicts.length > 0) {
+    gateState = 'pending';
+    gateReason = overrides.conflicts[0];
+  } else if (minAge !== undefined && manifest.firstUpdatedAt) {
     const minAgeMs = parseDuration(minAge);
     if (minAgeMs !== null) {
       const ageMs = Date.now() - new Date(manifest.firstUpdatedAt).getTime();
@@ -431,7 +437,7 @@ function buildBaseReleaseOptions(
   return {
     config: options.config,
     dryRun,
-    sync: extras?.sync ?? true,
+    sync: extras?.sync ?? false,
     bump: extras?.bump,
     target: extras?.target,
     stable: extras?.stable,
@@ -489,8 +495,9 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
   if (overrides.prerelease) info(`Standing PR label override: channel:prerelease`);
   for (const conflict of overrides.conflicts) warn(conflict);
 
-  // Inherit sync from the loaded version config (defaults to true) — never silently force false.
-  const sync = releaseKitConfig.version?.sync ?? true;
+  // Inherit sync from the loaded version config only when explicitly set — default false
+  // preserves the original per-package independent versioning behaviour for existing users.
+  const sync = releaseKitConfig.version?.sync ?? false;
   // When labels conflict, drop the override (fall back to commit-driven) but keep the
   // conflict descriptions for the final status check.
   const buildExtras: BuildOptionsExtras = overrides.conflicts.length

--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -679,6 +679,21 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
   // taking the union of currently-applied labels and the configured set. Without this,
   // every update would wipe maintainer overrides.
   if (labels.length > 0) {
+    // Ensure each configured label exists in the repo with a description. createLabel
+    // throws 422 if the label already exists — that's expected and ignored.
+    for (const label of labels) {
+      try {
+        await octokit.rest.issues.createLabel({
+          owner,
+          repo,
+          name: label,
+          color: 'ededed',
+          description: 'ReleaseKit: marks this PR for automated release',
+        });
+      } catch {
+        // Label already exists — no action needed.
+      }
+    }
     try {
       const currentLabels = existingStandingPr?.labels ?? [];
       const mergedLabels = [...new Set([...currentLabels, ...labels])];
@@ -689,7 +704,7 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
         labels: mergedLabels,
       });
     } catch {
-      warn('Failed to apply labels to standing PR (labels may not exist in the repository)');
+      warn('Failed to apply labels to standing PR');
     }
   }
 

--- a/packages/release/src/steps.ts
+++ b/packages/release/src/steps.ts
@@ -23,6 +23,7 @@ export async function runVersionStep(options: ReleaseOptions): Promise<VersionOu
     dryRun: options.dryRun,
     sync: options.sync,
     targets,
+    baseRef: options.baseRef,
   };
 
   const engine = new VersionEngine(config, runOptions);

--- a/packages/release/src/types.ts
+++ b/packages/release/src/types.ts
@@ -22,6 +22,8 @@ export interface ReleaseOptions {
   quiet: boolean;
   projectDir: string;
   npmAuth?: 'auto' | 'oidc' | 'token';
+  /** When set, scope commit analysis (bump type + changelog) to commits after this SHA. */
+  baseRef?: string;
 }
 
 export interface ReleaseOutput {

--- a/packages/release/test/unit/duration.spec.ts
+++ b/packages/release/test/unit/duration.spec.ts
@@ -2,65 +2,65 @@ import { describe, expect, it } from 'vitest';
 import { formatDuration, parseDuration } from '../../src/duration.js';
 
 describe('parseDuration', () => {
-  it('parses seconds', () => {
+  it('should parse seconds', () => {
     expect(parseDuration('45s')).toBe(45_000);
   });
 
-  it('parses minutes', () => {
+  it('should parse minutes', () => {
     expect(parseDuration('30m')).toBe(1_800_000);
   });
 
-  it('parses hours', () => {
+  it('should parse hours', () => {
     expect(parseDuration('6h')).toBe(21_600_000);
   });
 
-  it('parses days', () => {
+  it('should parse days', () => {
     expect(parseDuration('1d')).toBe(86_400_000);
   });
 
-  it('parses multi-digit values', () => {
+  it('should parse multi-digit values', () => {
     expect(parseDuration('24h')).toBe(86_400_000);
     expect(parseDuration('90m')).toBe(5_400_000);
   });
 
-  it('returns null for empty string', () => {
+  it('should return null for empty string', () => {
     expect(parseDuration('')).toBeNull();
   });
 
-  it('returns null for unknown unit', () => {
+  it('should return null for unknown unit', () => {
     expect(parseDuration('1x')).toBeNull();
     expect(parseDuration('1y')).toBeNull();
   });
 
-  it('returns null for missing unit', () => {
+  it('should return null for missing unit', () => {
     expect(parseDuration('60')).toBeNull();
   });
 
-  it('returns null for non-numeric prefix', () => {
+  it('should return null for non-numeric prefix', () => {
     expect(parseDuration('fiveH')).toBeNull();
     expect(parseDuration('abch')).toBeNull();
   });
 
-  it('returns null for mixed invalid input', () => {
+  it('should return null for mixed invalid input', () => {
     expect(parseDuration('1h30m')).toBeNull();
     expect(parseDuration(' 1h')).toBeNull();
   });
 });
 
 describe('formatDuration', () => {
-  it('formats hours and minutes', () => {
+  it('should format hours and minutes', () => {
     expect(formatDuration(2 * 3_600_000 + 15 * 60_000)).toBe('2h 15m');
   });
 
-  it('formats hours only', () => {
+  it('should format hours only', () => {
     expect(formatDuration(3 * 3_600_000)).toBe('3h');
   });
 
-  it('formats minutes only', () => {
+  it('should format minutes only', () => {
     expect(formatDuration(45 * 60_000)).toBe('45m');
   });
 
-  it('formats seconds when less than a minute', () => {
+  it('should format seconds when less than a minute', () => {
     expect(formatDuration(30_000)).toBe('30s');
   });
 

--- a/packages/release/test/unit/gate.spec.ts
+++ b/packages/release/test/unit/gate.spec.ts
@@ -418,7 +418,7 @@ describe('Gate', () => {
       },
     };
 
-    it('does not produce preminor when an older prerelease-only PR is in the window', async () => {
+    it('should not produce preminor when an older prerelease-only PR is in the window', async () => {
       mockLoadReleaseKitConfig.mockReturnValue(fullConfig);
       // git-log order is newest-first: #224 (winner) before #225 (insufficient).
       mockFindMergedPRsSinceLastRelease.mockResolvedValue([224, 225]);
@@ -438,7 +438,7 @@ describe('Gate', () => {
       expect(result.labels).not.toContain('scope:tauri');
     });
 
-    it('exposes per-PR evaluations for both PRs', async () => {
+    it('should expose per-PR evaluations for both PRs', async () => {
       mockLoadReleaseKitConfig.mockReturnValue(fullConfig);
       mockFindMergedPRsSinceLastRelease.mockResolvedValue([224, 225]);
       mockFetchPRLabels
@@ -456,7 +456,7 @@ describe('Gate', () => {
       expect(skipped?.hasReleaseIntent).toBe(true);
     });
 
-    it('posts a notify comment on the prerelease-only PR but not the winner', async () => {
+    it('should post a notify comment on the prerelease-only PR but not the winner', async () => {
       mockLoadReleaseKitConfig.mockReturnValue(fullConfig);
       mockFindMergedPRsSinceLastRelease.mockResolvedValue([224, 225]);
       mockFetchPRLabels
@@ -477,7 +477,7 @@ describe('Gate', () => {
       expect(marker).toBe('<!-- releasekit-gate-notify -->');
     });
 
-    it('does not post notify when notify=false', async () => {
+    it('should not post notify when notify=false', async () => {
       mockLoadReleaseKitConfig.mockReturnValue(fullConfig);
       mockFindMergedPRsSinceLastRelease.mockResolvedValue([224, 225]);
       mockFetchPRLabels
@@ -491,7 +491,7 @@ describe('Gate', () => {
   });
 
   describe('notify — silence on PRs without release intent', () => {
-    it('does not post notify when a PR has only unrelated labels', async () => {
+    it('should not post notify when a PR has only unrelated labels', async () => {
       mockFindMergedPRsSinceLastRelease.mockResolvedValue([1, 2]);
       mockFetchPRLabels
         .mockResolvedValueOnce(['bump:minor']) // #1: winner
@@ -503,7 +503,7 @@ describe('Gate', () => {
       expect(mockPostOrUpdateComment).not.toHaveBeenCalled();
     });
 
-    it('posts notify on a single PR with conflicting bump labels', async () => {
+    it('should post notify on a single PR with conflicting bump labels', async () => {
       mockFindMergedPRsSinceLastRelease.mockResolvedValue([42]);
       mockFetchPRLabels.mockResolvedValueOnce(['bump:major', 'bump:minor']);
 
@@ -518,7 +518,7 @@ describe('Gate', () => {
       expect(body).toContain('bump:minor');
     });
 
-    it('does not post notify on commit-mode release:skip (intentional skip, not user error)', async () => {
+    it('should not post notify on commit-mode release:skip (intentional skip, not user error)', async () => {
       mockLoadReleaseKitConfig.mockReturnValue({
         ci: {
           releaseTrigger: 'commit',

--- a/packages/release/test/unit/gate.spec.ts
+++ b/packages/release/test/unit/gate.spec.ts
@@ -67,8 +67,8 @@ describe('Gate', () => {
           major: 'bump:major',
           minor: 'bump:minor',
           patch: 'bump:patch',
-          stable: 'release:stable',
-          prerelease: 'release:prerelease',
+          stable: 'channel:stable',
+          prerelease: 'channel:prerelease',
           skip: 'release:skip',
         },
       },
@@ -174,9 +174,9 @@ describe('Gate', () => {
     expect(result.shouldRelease).toBe(false);
   });
 
-  it('should return blocked: true when release:prerelease + release:stable conflict', async () => {
+  it('should return blocked: true when channel:prerelease + channel:stable conflict', async () => {
     mockFindMergedPRsSinceLastRelease.mockResolvedValue([123]);
-    mockFetchPRLabels.mockResolvedValue(['release:prerelease', 'release:stable']);
+    mockFetchPRLabels.mockResolvedValue(['channel:prerelease', 'channel:stable']);
 
     const result = await runGate();
 
@@ -202,9 +202,9 @@ describe('Gate', () => {
     expect(result.bump).toBe('patch');
   });
 
-  it('should return bump undefined when only release:stable label', async () => {
+  it('should return bump undefined when only channel:stable label', async () => {
     mockFindMergedPRsSinceLastRelease.mockResolvedValue([123]);
-    mockFetchPRLabels.mockResolvedValue(['release:stable']);
+    mockFetchPRLabels.mockResolvedValue(['channel:stable']);
 
     const result = await runGate();
 
@@ -224,21 +224,21 @@ describe('Gate', () => {
     expect(result.stable).toBe(false);
   });
 
-  it('should return stable: true when bump:patch and release:stable labels present (stable takes precedence over bump)', async () => {
+  it('should return stable: true when bump:patch and channel:stable labels present (stable takes precedence over bump)', async () => {
     mockFindMergedPRsSinceLastRelease.mockResolvedValue([123]);
-    mockFetchPRLabels.mockResolvedValue(['bump:patch', 'release:stable']);
+    mockFetchPRLabels.mockResolvedValue(['bump:patch', 'channel:stable']);
 
     const result = await runGate();
 
     expect(result.shouldRelease).toBe(true);
-    // release:stable causes detectBumpFromLabels to return undefined (auto-detect from commits)
+    // channel:stable causes detectBumpFromLabels to return undefined (auto-detect from commits)
     expect(result.bump).toBeUndefined();
     expect(result.stable).toBe(true);
   });
 
-  it('should return stable: false when release:stable and release:prerelease conflict', async () => {
+  it('should return stable: false when channel:stable and channel:prerelease conflict', async () => {
     mockFindMergedPRsSinceLastRelease.mockResolvedValue([123]);
-    mockFetchPRLabels.mockResolvedValue(['release:stable', 'release:prerelease']);
+    mockFetchPRLabels.mockResolvedValue(['channel:stable', 'channel:prerelease']);
 
     const result = await runGate();
 
@@ -372,8 +372,8 @@ describe('Gate', () => {
           major: 'bump:major',
           minor: 'bump:minor',
           patch: 'bump:patch',
-          stable: 'release:stable',
-          prerelease: 'release:prerelease',
+          stable: 'channel:stable',
+          prerelease: 'channel:prerelease',
           skip: 'release:skip',
         },
         scopeLabels: {
@@ -396,7 +396,7 @@ describe('Gate', () => {
   });
 
   describe('per-PR evaluation — wdio-desktop-mobile #225 + #224 regression', () => {
-    // PR #225 merged with `release:prerelease` + `scope:tauri` (no bump:*) — gate must block.
+    // PR #225 merged with `channel:prerelease` + `scope:tauri` (no bump:*) — gate must block.
     // PR #224 merged later with `bump:minor` + `scope:utils` — gate must release #224 alone.
     // Before this fix: gate unioned the labels and produced `preminor` for `@wdio/native-utils`.
     // After: per-PR evaluation, #225's labels are ignored, #224 wins cleanly with `minor`.
@@ -407,8 +407,8 @@ describe('Gate', () => {
           major: 'bump:major',
           minor: 'bump:minor',
           patch: 'bump:patch',
-          stable: 'release:stable',
-          prerelease: 'release:prerelease',
+          stable: 'channel:stable',
+          prerelease: 'channel:prerelease',
           skip: 'release:skip',
         },
         scopeLabels: {
@@ -424,7 +424,7 @@ describe('Gate', () => {
       mockFindMergedPRsSinceLastRelease.mockResolvedValue([224, 225]);
       mockFetchPRLabels
         .mockResolvedValueOnce(['bump:minor', 'scope:utils']) // #224
-        .mockResolvedValueOnce(['release:prerelease', 'scope:tauri']); // #225
+        .mockResolvedValueOnce(['channel:prerelease', 'scope:tauri']); // #225
 
       const result = await runGate({ notify: false });
 
@@ -434,7 +434,7 @@ describe('Gate', () => {
       expect(result.target).toBe('@wdio/native-utils');
       expect(result.scope).toBe('utils');
       // #225's prerelease label must not contaminate the verdict.
-      expect(result.labels).not.toContain('release:prerelease');
+      expect(result.labels).not.toContain('channel:prerelease');
       expect(result.labels).not.toContain('scope:tauri');
     });
 
@@ -443,7 +443,7 @@ describe('Gate', () => {
       mockFindMergedPRsSinceLastRelease.mockResolvedValue([224, 225]);
       mockFetchPRLabels
         .mockResolvedValueOnce(['bump:minor', 'scope:utils'])
-        .mockResolvedValueOnce(['release:prerelease', 'scope:tauri']);
+        .mockResolvedValueOnce(['channel:prerelease', 'scope:tauri']);
 
       const result = await runGate({ notify: false });
 
@@ -452,7 +452,7 @@ describe('Gate', () => {
       const skipped = result.evaluations?.find((e) => e.prNumber === 225);
       expect(winning?.shouldRelease).toBe(true);
       expect(skipped?.shouldRelease).toBe(false);
-      expect(skipped?.reason).toContain('release:prerelease');
+      expect(skipped?.reason).toContain('channel:prerelease');
       expect(skipped?.hasReleaseIntent).toBe(true);
     });
 
@@ -461,7 +461,7 @@ describe('Gate', () => {
       mockFindMergedPRsSinceLastRelease.mockResolvedValue([224, 225]);
       mockFetchPRLabels
         .mockResolvedValueOnce(['bump:minor', 'scope:utils'])
-        .mockResolvedValueOnce(['release:prerelease', 'scope:tauri']);
+        .mockResolvedValueOnce(['channel:prerelease', 'scope:tauri']);
 
       await runGate(); // notify defaults to true
 
@@ -473,7 +473,7 @@ describe('Gate', () => {
       expect(repo).toBe('repo');
       expect(prNumber).toBe(225);
       expect(body).toContain('did not trigger a release');
-      expect(body).toContain('release:prerelease');
+      expect(body).toContain('channel:prerelease');
       expect(marker).toBe('<!-- releasekit-gate-notify -->');
     });
 
@@ -482,7 +482,7 @@ describe('Gate', () => {
       mockFindMergedPRsSinceLastRelease.mockResolvedValue([224, 225]);
       mockFetchPRLabels
         .mockResolvedValueOnce(['bump:minor', 'scope:utils'])
-        .mockResolvedValueOnce(['release:prerelease', 'scope:tauri']);
+        .mockResolvedValueOnce(['channel:prerelease', 'scope:tauri']);
 
       await runGate({ notify: false });
 
@@ -526,8 +526,8 @@ describe('Gate', () => {
             major: 'bump:major',
             minor: 'bump:minor',
             patch: 'bump:patch',
-            stable: 'release:stable',
-            prerelease: 'release:prerelease',
+            stable: 'channel:stable',
+            prerelease: 'channel:prerelease',
             skip: 'release:skip',
           },
         },

--- a/packages/release/test/unit/gate.spec.ts
+++ b/packages/release/test/unit/gate.spec.ts
@@ -70,6 +70,7 @@ describe('Gate', () => {
           stable: 'channel:stable',
           prerelease: 'channel:prerelease',
           skip: 'release:skip',
+          immediate: 'release:immediate',
         },
       },
     });
@@ -112,6 +113,7 @@ describe('Gate', () => {
           minor: 'bump:minor',
           patch: 'bump:patch',
           skip: 'release:skip',
+          immediate: 'release:immediate',
         },
       },
     });
@@ -142,6 +144,7 @@ describe('Gate', () => {
           minor: 'bump:minor',
           patch: 'bump:patch',
           skip: 'release:skip',
+          immediate: 'release:immediate',
         },
       },
     });
@@ -375,6 +378,7 @@ describe('Gate', () => {
           stable: 'channel:stable',
           prerelease: 'channel:prerelease',
           skip: 'release:skip',
+          immediate: 'release:immediate',
         },
         scopeLabels: {
           'scope:electron': '@wdio/electron-*',
@@ -410,6 +414,7 @@ describe('Gate', () => {
           stable: 'channel:stable',
           prerelease: 'channel:prerelease',
           skip: 'release:skip',
+          immediate: 'release:immediate',
         },
         scopeLabels: {
           'scope:utils': '@wdio/native-utils',
@@ -529,6 +534,7 @@ describe('Gate', () => {
             stable: 'channel:stable',
             prerelease: 'channel:prerelease',
             skip: 'release:skip',
+            immediate: 'release:immediate',
           },
         },
       });

--- a/packages/release/test/unit/preview-format.spec.ts
+++ b/packages/release/test/unit/preview-format.spec.ts
@@ -105,10 +105,10 @@ describe('formatPreviewComment', () => {
     expect(result).toContain('<summary><b>Release Preview</b> — my-lib 1.0.0</summary>');
   });
 
-  it('should include package table', () => {
+  it('should not include package table', () => {
     const result = formatPreviewComment(releaseOutput);
-    expect(result).toContain('| `@releasekit/version` | 0.3.1 |');
-    expect(result).toContain('| `@releasekit/notes` | 0.3.1 |');
+    expect(result).not.toContain('### Packages');
+    expect(result).not.toContain('| `@releasekit/version` | 0.3.1 |');
   });
 
   it('should include changelog with entry grouping by type', () => {
@@ -129,10 +129,10 @@ describe('formatPreviewComment', () => {
     expect(result).toContain('</details>');
   });
 
-  it('should include tags', () => {
+  it('should not include tags section', () => {
     const result = formatPreviewComment(releaseOutput);
-    expect(result).toContain('- `@releasekit/version@v0.3.1`');
-    expect(result).toContain('- `@releasekit/notes@v0.3.1`');
+    expect(result).not.toContain('### Tags');
+    expect(result).not.toContain('- `@releasekit/version@v0.3.1`');
   });
 
   describe('shared entries rendering', () => {
@@ -552,7 +552,7 @@ describe('formatPreviewComment', () => {
       expect(result).toContain('**Warning:**');
       expect(result).toContain('This PR is marked to skip release.');
       // Still shows the preview content underneath
-      expect(result).toContain('### Packages');
+      expect(result).toContain('### Changelog');
     });
 
     it('should show major override banner in commit mode', () => {
@@ -601,7 +601,7 @@ describe('formatPreviewComment', () => {
         labelContext: { trigger: 'label', skip: false, bumpLabel: 'minor', noBumpLabel: false },
       });
       expect(result).toContain('labeled for a **minor** release');
-      expect(result).toContain('### Packages');
+      expect(result).toContain('### Changelog');
     });
 
     it('should show patch label banner in label mode', () => {
@@ -623,7 +623,7 @@ describe('formatPreviewComment', () => {
         labelContext: { trigger: 'label', skip: false, noBumpLabel: false, prerelease: false, stable: true },
       });
       expect(result).toContain('labeled for a **stable** release (graduation from prerelease)');
-      expect(result).toContain('### Packages');
+      expect(result).not.toContain('### Packages');
     });
 
     it('should show prerelease-only banner in label mode (conventional commits driven)', () => {
@@ -631,7 +631,7 @@ describe('formatPreviewComment', () => {
         labelContext: { trigger: 'label', skip: false, noBumpLabel: false, prerelease: true, stable: false },
       });
       expect(result).toContain('labeled for a **prerelease** release (bump from conventional commits)');
-      expect(result).toContain('### Packages');
+      expect(result).not.toContain('### Packages');
     });
   });
 
@@ -647,9 +647,9 @@ describe('formatPreviewComment', () => {
     };
 
     const result = formatPreviewComment(output);
-    expect(result).toContain('| `my-lib` | 1.0.0 |');
+    expect(result).not.toContain('### Packages');
     expect(result).not.toContain('### Changelog');
-    expect(result).toContain('- `v1.0.0`');
+    expect(result).not.toContain('### Tags');
   });
 
   it('should handle entries with unknown types', () => {

--- a/packages/release/test/unit/preview-format.spec.ts
+++ b/packages/release/test/unit/preview-format.spec.ts
@@ -307,7 +307,7 @@ describe('formatPreviewComment', () => {
   // --- Standing PR snapshot + merge table ---
 
   describe('standing PR snapshot', () => {
-    it('renders the snapshot block in the no-release branch when strategy is standing-pr', () => {
+    it('should render the snapshot block in the no-release branch when strategy is standing-pr', () => {
       const snapshot = snapshotFor([{ name: '@a/notes', version: '0.5.0' }]);
       const result = formatPreviewComment(null, { strategy: 'standing-pr', standingPrSnapshot: snapshot });
       expect(result).toContain('**Standing release PR:**');
@@ -316,7 +316,7 @@ describe('formatPreviewComment', () => {
       expect(result).toContain('✅ ready to merge');
     });
 
-    it('renders the snapshot block after the package list in the has-release branch', () => {
+    it('should render the snapshot one-liner above the collapsible details so it is always visible', () => {
       const snapshot = snapshotFor([
         { name: '@a/notes', version: '0.5.0' },
         { name: '@a/version', version: '0.3.2' },
@@ -324,14 +324,14 @@ describe('formatPreviewComment', () => {
       const result = formatPreviewComment(releaseOutput, { strategy: 'standing-pr', standingPrSnapshot: snapshot });
       expect(result).toContain('**Standing release PR:**');
       expect(result).toContain('2 packages queued');
-      // The snapshot block should appear after the package table
-      const tableIdx = result.indexOf('| `@releasekit/version` | 0.3.1 |');
+      // The snapshot must precede the <details> open tag (rendered outside, always visible).
+      const detailsIdx = result.indexOf('<details>');
       const snapshotIdx = result.indexOf('**Standing release PR:**');
-      expect(tableIdx).toBeGreaterThan(-1);
-      expect(snapshotIdx).toBeGreaterThan(tableIdx);
+      expect(snapshotIdx).toBeGreaterThan(-1);
+      expect(detailsIdx).toBeGreaterThan(snapshotIdx);
     });
 
-    it('shows the pending gate badge with countdown when gateState is pending', () => {
+    it('should show the pending gate badge with countdown when gateState is pending', () => {
       const snapshot = snapshotFor([{ name: '@a/notes', version: '0.5.0' }], {
         gateState: 'pending',
         gateReason: 'Waiting 4h 20m for minAge',
@@ -341,13 +341,13 @@ describe('formatPreviewComment', () => {
       expect(result).not.toContain('✅ ready to merge');
     });
 
-    it('omits the snapshot when strategy is not standing-pr (defensive)', () => {
+    it('should omit the snapshot when strategy is not standing-pr (defensive)', () => {
       const snapshot = snapshotFor([{ name: '@a/notes', version: '0.5.0' }]);
       const result = formatPreviewComment(releaseOutput, { strategy: 'direct', standingPrSnapshot: snapshot });
       expect(result).not.toContain('**Standing release PR:**');
     });
 
-    it('renders the merge table with escalation, new, and unchanged annotations', () => {
+    it('should render the merge table with escalation, new, and unchanged annotations', () => {
       const snapshot = snapshotFor([{ name: '@a/notes', version: '0.5.0' }]);
       const mergedRows: MergedRow[] = [
         {
@@ -387,16 +387,62 @@ describe('formatPreviewComment', () => {
       expect(result).toContain('| `@a/version` | 0.3.2 | 0.3.2 | 0.3.2 |');
     });
 
-    it('omits the merge table when no rows are provided', () => {
+    it('should omit the merge table when no rows are provided', () => {
       const snapshot = snapshotFor([{ name: '@a/notes', version: '0.5.0' }]);
       const result = formatPreviewComment(releaseOutput, { strategy: 'standing-pr', standingPrSnapshot: snapshot });
       expect(result).not.toContain('### After merge');
     });
 
-    it('does not change output when no snapshot is provided (regression guard)', () => {
+    it('should not change output when no snapshot is provided (regression guard)', () => {
       const withoutSnapshot = formatPreviewComment(releaseOutput, { strategy: 'standing-pr' });
       expect(withoutSnapshot).not.toContain('**Standing release PR:**');
       expect(withoutSnapshot).not.toContain('### After merge');
+    });
+
+    it('should use "this PR contributes no changes" summary when snapshot is present and no result', () => {
+      const snapshot = snapshotFor([{ name: '@a/notes', version: '0.5.0' }]);
+      const result = formatPreviewComment(null, { strategy: 'standing-pr', standingPrSnapshot: snapshot });
+      expect(result).toContain('<summary><b>Release Preview</b> — this PR contributes no changes</summary>');
+      expect(result).not.toContain('— no release</summary>');
+    });
+
+    it('should keep "no release" summary when snapshot is absent', () => {
+      const result = formatPreviewComment(null, { strategy: 'standing-pr' });
+      expect(result).toContain('<summary><b>Release Preview</b> — no release</summary>');
+    });
+
+    it('should render a queued-for-release table inside the details when no result and snapshot has changelogs', () => {
+      const snapshot = snapshotFor([{ name: '@a/notes', version: '0.5.0' }]);
+      snapshot.manifest.versionOutput.changelogs = [
+        {
+          packageName: '@a/notes',
+          version: '0.5.0',
+          previousVersion: '0.4.2',
+          revisionRange: 'v0.4.2..HEAD',
+          repoUrl: null,
+          entries: [{ type: 'feat', description: 'queued change' }],
+        },
+        {
+          packageName: '@a/version',
+          version: '0.3.2',
+          previousVersion: '0.3.1',
+          revisionRange: 'v0.3.1..HEAD',
+          repoUrl: null,
+          entries: [{ type: 'fix', description: 'queued fix' }],
+        },
+      ];
+      const result = formatPreviewComment(null, { strategy: 'standing-pr', standingPrSnapshot: snapshot });
+      expect(result).toContain('### Currently queued for release');
+      expect(result).toContain('| Package | Current | Next |');
+      expect(result).toContain('| `@a/notes` | 0.4.2 | 0.5.0 |');
+      expect(result).toContain('| `@a/version` | 0.3.1 | 0.3.2 |');
+    });
+
+    it('should omit the queued table when snapshot has no changelogs with entries', () => {
+      const snapshot = snapshotFor([{ name: '@a/notes', version: '0.5.0' }]);
+      // changelogs is empty by default in snapshotFor
+      const result = formatPreviewComment(null, { strategy: 'standing-pr', standingPrSnapshot: snapshot });
+      expect(result).not.toContain('### Currently queued for release');
     });
   });
 

--- a/packages/release/test/unit/preview-format.spec.ts
+++ b/packages/release/test/unit/preview-format.spec.ts
@@ -420,7 +420,7 @@ describe('formatPreviewComment', () => {
         mergedRows: allUnchanged,
       });
       expect(result).toContain('### After merge — predicted release');
-      expect(result).toContain('No version changes');
+      expect(result).toContain('No version escalation');
       expect(result).not.toContain('| Package | Standing PR | This PR | After merge |');
       expect(result).not.toContain('Approximate. The standing PR rebuilds');
     });

--- a/packages/release/test/unit/preview-format.spec.ts
+++ b/packages/release/test/unit/preview-format.spec.ts
@@ -483,7 +483,7 @@ describe('formatPreviewComment', () => {
       expect(result).not.toContain('### Currently queued for release');
     });
 
-    it('renders the immediate banner when labelContext.immediate is set', () => {
+    it('should render the immediate banner when labelContext.immediate is set', () => {
       const result = formatPreviewComment(releaseOutput, {
         strategy: 'standing-pr',
         labelContext: {
@@ -506,7 +506,7 @@ describe('formatPreviewComment', () => {
       expect(result).toContain('bypassing the standing PR for a direct release');
     });
 
-    it('suppresses the standing-PR snapshot when immediate label is set', () => {
+    it('should suppress the standing-PR snapshot when immediate label is set', () => {
       const snapshot = snapshotFor([{ name: '@a/notes', version: '0.5.0' }]);
       const result = formatPreviewComment(releaseOutput, {
         strategy: 'standing-pr',
@@ -522,7 +522,21 @@ describe('formatPreviewComment', () => {
       expect(result).not.toContain('### After merge');
     });
 
-    it('renders the advisory banner in standing-pr mode without immediate', () => {
+    it('should use direct-release intro message when immediate label is set', () => {
+      const result = formatPreviewComment(releaseOutput, {
+        strategy: 'standing-pr',
+        labelContext: {
+          trigger: 'commit',
+          skip: false,
+          noBumpLabel: false,
+          immediate: true,
+        },
+      });
+      expect(result).toContain('This PR will trigger the following release when merged:');
+      expect(result).not.toContain('release PR');
+    });
+
+    it('should render the advisory banner in standing-pr mode without immediate', () => {
       const result = formatPreviewComment(null, {
         strategy: 'standing-pr',
         labelContext: {
@@ -549,7 +563,7 @@ describe('formatPreviewComment', () => {
       expect(result).toContain('override by editing labels on the standing PR itself');
     });
 
-    it('advisory banner suppresses the regular trigger-mode banners', () => {
+    it('should suppress the regular trigger-mode banners', () => {
       // With advisoryInStandingPr, the "no bump label detected" banner should NOT render.
       const result = formatPreviewComment(null, {
         strategy: 'standing-pr',

--- a/packages/release/test/unit/preview-format.spec.ts
+++ b/packages/release/test/unit/preview-format.spec.ts
@@ -348,6 +348,15 @@ describe('formatPreviewComment', () => {
       expect(result).not.toContain('✅ ready to merge');
     });
 
+    it('should render all conflict reasons joined in the gate badge', () => {
+      const snapshot = snapshotFor([{ name: '@a/notes', version: '0.5.0' }], {
+        gateState: 'pending',
+        gateReason: 'Conflicting bump labels; Conflicting channel labels',
+      });
+      const result = formatPreviewComment(null, { strategy: 'standing-pr', standingPrSnapshot: snapshot });
+      expect(result).toContain('⏳ Conflicting bump labels; Conflicting channel labels');
+    });
+
     it('should omit the snapshot when strategy is not standing-pr (defensive)', () => {
       const snapshot = snapshotFor([{ name: '@a/notes', version: '0.5.0' }]);
       const result = formatPreviewComment(releaseOutput, { strategy: 'direct', standingPrSnapshot: snapshot });

--- a/packages/release/test/unit/preview-format.spec.ts
+++ b/packages/release/test/unit/preview-format.spec.ts
@@ -6,7 +6,7 @@ import type { StandingPRSnapshot } from '../../src/standing-pr/standing-pr.js';
 import type { ReleaseOutput } from '../../src/types.js';
 
 function snapshotFor(
-  updates: Array<{ name: string; version: string }>,
+  updates: Array<{ name: string; version: string; previousVersion?: string }>,
   overrides: Partial<StandingPRSnapshot> = {},
 ): StandingPRSnapshot {
   return {
@@ -23,7 +23,14 @@ function snapshotFor(
           newVersion: u.version,
           filePath: `packages/${u.name}/package.json`,
         })),
-        changelogs: [],
+        changelogs: updates.map((u) => ({
+          packageName: u.name,
+          version: u.version,
+          previousVersion: u.previousVersion ?? '0.4.0',
+          revisionRange: `v${u.previousVersion ?? '0.4.0'}..HEAD`,
+          repoUrl: null,
+          entries: [],
+        })),
         tags: [],
       },
       releaseNotes: {},
@@ -438,9 +445,9 @@ describe('formatPreviewComment', () => {
       expect(result).toContain('| `@a/version` | 0.3.1 | 0.3.2 |');
     });
 
-    it('should omit the queued table when snapshot has no changelogs with entries', () => {
-      const snapshot = snapshotFor([{ name: '@a/notes', version: '0.5.0' }]);
-      // changelogs is empty by default in snapshotFor
+    it('should omit the queued table when snapshot has no packages being released', () => {
+      // version === previousVersion means the package is not being released
+      const snapshot = snapshotFor([{ name: '@a/notes', version: '0.5.0', previousVersion: '0.5.0' }]);
       const result = formatPreviewComment(null, { strategy: 'standing-pr', standingPrSnapshot: snapshot });
       expect(result).not.toContain('### Currently queued for release');
     });

--- a/packages/release/test/unit/preview-format.spec.ts
+++ b/packages/release/test/unit/preview-format.spec.ts
@@ -437,7 +437,7 @@ describe('formatPreviewComment', () => {
       expect(result).not.toContain('Approximate. The standing PR rebuilds');
     });
 
-    it('should show no-escalation prose when all merged rows are standing-only (current PR out of scope)', () => {
+    it('should show outside-scope prose when all merged rows are standing-only (current PR out of scope)', () => {
       const snapshot = snapshotFor([{ name: '@a/notes', version: '0.5.0' }]);
       const standingOnlyRows: MergedRow[] = [
         {
@@ -454,7 +454,9 @@ describe('formatPreviewComment', () => {
         mergedRows: standingOnlyRows,
       });
       expect(result).toContain('### After merge — predicted release');
-      expect(result).toContain('No version escalation');
+      // packages outside standing scope — different message from allUnchanged
+      expect(result).toContain("outside the standing PR's current scope");
+      expect(result).not.toContain('No version escalation');
       expect(result).toContain('| `@a/notes` | 0.5.0 | — | 0.5.0 |');
       expect(result).not.toContain('Approximate. The standing PR rebuilds');
     });

--- a/packages/release/test/unit/preview-format.spec.ts
+++ b/packages/release/test/unit/preview-format.spec.ts
@@ -444,6 +444,95 @@ describe('formatPreviewComment', () => {
       const result = formatPreviewComment(null, { strategy: 'standing-pr', standingPrSnapshot: snapshot });
       expect(result).not.toContain('### Currently queued for release');
     });
+
+    it('renders the immediate banner when labelContext.immediate is set', () => {
+      const result = formatPreviewComment(releaseOutput, {
+        strategy: 'standing-pr',
+        labelContext: {
+          trigger: 'commit',
+          skip: false,
+          noBumpLabel: false,
+          immediate: true,
+          labels: {
+            stable: 'channel:stable',
+            prerelease: 'channel:prerelease',
+            skip: 'release:skip',
+            immediate: 'release:immediate',
+            major: 'bump:major',
+            minor: 'bump:minor',
+            patch: 'bump:patch',
+          },
+        },
+      });
+      expect(result).toContain('`release:immediate`');
+      expect(result).toContain('bypassing the standing PR for a direct release');
+    });
+
+    it('suppresses the standing-PR snapshot when immediate label is set', () => {
+      const snapshot = snapshotFor([{ name: '@a/notes', version: '0.5.0' }]);
+      const result = formatPreviewComment(releaseOutput, {
+        strategy: 'standing-pr',
+        standingPrSnapshot: snapshot,
+        labelContext: {
+          trigger: 'commit',
+          skip: false,
+          noBumpLabel: false,
+          immediate: true,
+        },
+      });
+      expect(result).not.toContain('**Standing release PR:**');
+      expect(result).not.toContain('### After merge');
+    });
+
+    it('renders the advisory banner in standing-pr mode without immediate', () => {
+      const result = formatPreviewComment(null, {
+        strategy: 'standing-pr',
+        labelContext: {
+          trigger: 'label',
+          skip: false,
+          noBumpLabel: false,
+          advisoryInStandingPr: true,
+          bumpLabel: 'patch',
+          scopeLabels: ['scope:all'],
+          labels: {
+            stable: 'channel:stable',
+            prerelease: 'channel:prerelease',
+            skip: 'release:skip',
+            immediate: 'release:immediate',
+            major: 'bump:major',
+            minor: 'bump:minor',
+            patch: 'bump:patch',
+          },
+        },
+      });
+      expect(result).toContain('Labels on this PR are advisory in standing-pr mode');
+      expect(result).toContain('saw: `bump:patch`, `scope:all`');
+      expect(result).toContain('`release:immediate`');
+      expect(result).toContain('override by editing labels on the standing PR itself');
+    });
+
+    it('advisory banner suppresses the regular trigger-mode banners', () => {
+      // With advisoryInStandingPr, the "no bump label detected" banner should NOT render.
+      const result = formatPreviewComment(null, {
+        strategy: 'standing-pr',
+        labelContext: {
+          trigger: 'label',
+          skip: false,
+          noBumpLabel: false,
+          advisoryInStandingPr: true,
+          labels: {
+            stable: 'channel:stable',
+            prerelease: 'channel:prerelease',
+            skip: 'release:skip',
+            immediate: 'release:immediate',
+            major: 'bump:major',
+            minor: 'bump:minor',
+            patch: 'bump:patch',
+          },
+        },
+      });
+      expect(result).not.toContain('No bump label detected');
+    });
   });
 
   // --- Label context banners ---

--- a/packages/release/test/unit/preview-format.spec.ts
+++ b/packages/release/test/unit/preview-format.spec.ts
@@ -394,6 +394,37 @@ describe('formatPreviewComment', () => {
       expect(result).toContain('| `@a/version` | 0.3.2 | 0.3.2 | 0.3.2 |');
     });
 
+    it('should show a one-liner instead of the table when all rows are unchanged', () => {
+      const snapshot = snapshotFor([{ name: '@a/notes', version: '0.5.0' }]);
+      const allUnchanged: MergedRow[] = [
+        {
+          packageName: '@a/notes',
+          baseline: '0.4.0',
+          standing: '0.5.0',
+          current: '0.5.0',
+          afterMerge: '0.5.0',
+          status: 'unchanged',
+        },
+        {
+          packageName: '@a/version',
+          baseline: '0.3.0',
+          standing: '0.4.0',
+          current: '0.4.0',
+          afterMerge: '0.4.0',
+          status: 'unchanged',
+        },
+      ];
+      const result = formatPreviewComment(releaseOutput, {
+        strategy: 'standing-pr',
+        standingPrSnapshot: snapshot,
+        mergedRows: allUnchanged,
+      });
+      expect(result).toContain('### After merge — predicted release');
+      expect(result).toContain('No version changes');
+      expect(result).not.toContain('| Package | Standing PR | This PR | After merge |');
+      expect(result).not.toContain('Approximate. The standing PR rebuilds');
+    });
+
     it('should omit the merge table when no rows are provided', () => {
       const snapshot = snapshotFor([{ name: '@a/notes', version: '0.5.0' }]);
       const result = formatPreviewComment(releaseOutput, { strategy: 'standing-pr', standingPrSnapshot: snapshot });

--- a/packages/release/test/unit/preview-format.spec.ts
+++ b/packages/release/test/unit/preview-format.spec.ts
@@ -1,7 +1,40 @@
 import type { VersionOutput } from '@releasekit/core';
 import { describe, expect, it } from 'vitest';
 import { formatPreviewComment } from '../../src/preview/format.js';
+import type { MergedRow } from '../../src/preview/merge.js';
+import type { StandingPRSnapshot } from '../../src/standing-pr/standing-pr.js';
 import type { ReleaseOutput } from '../../src/types.js';
+
+function snapshotFor(
+  updates: Array<{ name: string; version: string }>,
+  overrides: Partial<StandingPRSnapshot> = {},
+): StandingPRSnapshot {
+  return {
+    number: 42,
+    url: 'https://github.com/owner/repo/pull/42',
+    openedAt: new Date(Date.now() - 2 * 3_600_000).toISOString(), // 2h ago
+    gateState: 'success',
+    manifest: {
+      schemaVersion: 2,
+      versionOutput: {
+        dryRun: false,
+        updates: updates.map((u) => ({
+          packageName: u.name,
+          newVersion: u.version,
+          filePath: `packages/${u.name}/package.json`,
+        })),
+        changelogs: [],
+        tags: [],
+      },
+      releaseNotes: {},
+      notesFiles: [],
+      createdAt: new Date(Date.now() - 2 * 3_600_000).toISOString(),
+      baseSha: 'abc',
+      firstUpdatedAt: new Date(Date.now() - 2 * 3_600_000).toISOString(),
+    },
+    ...overrides,
+  };
+}
 
 const versionOutput: VersionOutput = {
   dryRun: true,
@@ -268,6 +301,102 @@ describe('formatPreviewComment', () => {
     it('should show scheduled no-changes message', () => {
       const result = formatPreviewComment(null, { strategy: 'scheduled' });
       expect(result).toContain('will not be included in the next scheduled release');
+    });
+  });
+
+  // --- Standing PR snapshot + merge table ---
+
+  describe('standing PR snapshot', () => {
+    it('renders the snapshot block in the no-release branch when strategy is standing-pr', () => {
+      const snapshot = snapshotFor([{ name: '@a/notes', version: '0.5.0' }]);
+      const result = formatPreviewComment(null, { strategy: 'standing-pr', standingPrSnapshot: snapshot });
+      expect(result).toContain('**Standing release PR:**');
+      expect(result).toContain('[#42](https://github.com/owner/repo/pull/42)');
+      expect(result).toContain('1 package queued');
+      expect(result).toContain('✅ ready to merge');
+    });
+
+    it('renders the snapshot block after the package list in the has-release branch', () => {
+      const snapshot = snapshotFor([
+        { name: '@a/notes', version: '0.5.0' },
+        { name: '@a/version', version: '0.3.2' },
+      ]);
+      const result = formatPreviewComment(releaseOutput, { strategy: 'standing-pr', standingPrSnapshot: snapshot });
+      expect(result).toContain('**Standing release PR:**');
+      expect(result).toContain('2 packages queued');
+      // The snapshot block should appear after the package table
+      const tableIdx = result.indexOf('| `@releasekit/version` | 0.3.1 |');
+      const snapshotIdx = result.indexOf('**Standing release PR:**');
+      expect(tableIdx).toBeGreaterThan(-1);
+      expect(snapshotIdx).toBeGreaterThan(tableIdx);
+    });
+
+    it('shows the pending gate badge with countdown when gateState is pending', () => {
+      const snapshot = snapshotFor([{ name: '@a/notes', version: '0.5.0' }], {
+        gateState: 'pending',
+        gateReason: 'Waiting 4h 20m for minAge',
+      });
+      const result = formatPreviewComment(null, { strategy: 'standing-pr', standingPrSnapshot: snapshot });
+      expect(result).toContain('⏳ Waiting 4h 20m for minAge');
+      expect(result).not.toContain('✅ ready to merge');
+    });
+
+    it('omits the snapshot when strategy is not standing-pr (defensive)', () => {
+      const snapshot = snapshotFor([{ name: '@a/notes', version: '0.5.0' }]);
+      const result = formatPreviewComment(releaseOutput, { strategy: 'direct', standingPrSnapshot: snapshot });
+      expect(result).not.toContain('**Standing release PR:**');
+    });
+
+    it('renders the merge table with escalation, new, and unchanged annotations', () => {
+      const snapshot = snapshotFor([{ name: '@a/notes', version: '0.5.0' }]);
+      const mergedRows: MergedRow[] = [
+        {
+          packageName: '@a/notes',
+          baseline: '0.4.0',
+          standing: '0.4.1',
+          current: '0.5.0',
+          afterMerge: '0.5.0',
+          status: 'escalated',
+        },
+        {
+          packageName: '@a/publish',
+          baseline: '0.2.0',
+          current: '0.2.1',
+          afterMerge: '0.2.1',
+          status: 'new-from-pr',
+        },
+        {
+          packageName: '@a/version',
+          baseline: '0.3.1',
+          standing: '0.3.2',
+          current: '0.3.2',
+          afterMerge: '0.3.2',
+          status: 'unchanged',
+        },
+      ];
+      const result = formatPreviewComment(releaseOutput, {
+        strategy: 'standing-pr',
+        standingPrSnapshot: snapshot,
+        mergedRows,
+      });
+      expect(result).toContain('### After merge — predicted release');
+      expect(result).toContain('Approximate. The standing PR rebuilds against `main`');
+      expect(result).toContain('| Package | Standing PR | This PR | After merge |');
+      expect(result).toContain('| `@a/notes` | 0.4.1 | 0.5.0 | 0.5.0 ⚠ escalated from 0.4.1 |');
+      expect(result).toContain('| `@a/publish` | — | 0.2.1 | 0.2.1 (new) |');
+      expect(result).toContain('| `@a/version` | 0.3.2 | 0.3.2 | 0.3.2 |');
+    });
+
+    it('omits the merge table when no rows are provided', () => {
+      const snapshot = snapshotFor([{ name: '@a/notes', version: '0.5.0' }]);
+      const result = formatPreviewComment(releaseOutput, { strategy: 'standing-pr', standingPrSnapshot: snapshot });
+      expect(result).not.toContain('### After merge');
+    });
+
+    it('does not change output when no snapshot is provided (regression guard)', () => {
+      const withoutSnapshot = formatPreviewComment(releaseOutput, { strategy: 'standing-pr' });
+      expect(withoutSnapshot).not.toContain('**Standing release PR:**');
+      expect(withoutSnapshot).not.toContain('### After merge');
     });
   });
 

--- a/packages/release/test/unit/preview-format.spec.ts
+++ b/packages/release/test/unit/preview-format.spec.ts
@@ -403,7 +403,7 @@ describe('formatPreviewComment', () => {
       expect(result).toContain('| `@a/version` | 0.3.2 | 0.3.2 | 0.3.2 |');
     });
 
-    it('should show a one-liner instead of the table when all rows are unchanged', () => {
+    it('should show no-escalation prose and a table with all rows when all rows are unchanged', () => {
       const snapshot = snapshotFor([{ name: '@a/notes', version: '0.5.0' }]);
       const allUnchanged: MergedRow[] = [
         {
@@ -430,7 +430,10 @@ describe('formatPreviewComment', () => {
       });
       expect(result).toContain('### After merge — predicted release');
       expect(result).toContain('No version escalation');
-      expect(result).not.toContain('| Package | Standing PR | This PR | After merge |');
+      // Participating rows are shown so reviewers can see what's already queued
+      expect(result).toContain('| Package | Standing PR | This PR | After merge |');
+      expect(result).toContain('| `@a/notes` | 0.5.0 | 0.5.0 | 0.5.0 |');
+      expect(result).toContain('| `@a/version` | 0.4.0 | 0.4.0 | 0.4.0 |');
       expect(result).not.toContain('Approximate. The standing PR rebuilds');
     });
 

--- a/packages/release/test/unit/preview-format.spec.ts
+++ b/packages/release/test/unit/preview-format.spec.ts
@@ -437,6 +437,28 @@ describe('formatPreviewComment', () => {
       expect(result).not.toContain('Approximate. The standing PR rebuilds');
     });
 
+    it('should show no-escalation prose when all merged rows are standing-only (current PR out of scope)', () => {
+      const snapshot = snapshotFor([{ name: '@a/notes', version: '0.5.0' }]);
+      const standingOnlyRows: MergedRow[] = [
+        {
+          packageName: '@a/notes',
+          baseline: '0.4.0',
+          standing: '0.5.0',
+          afterMerge: '0.5.0',
+          status: 'standing-only',
+        },
+      ];
+      const result = formatPreviewComment(releaseOutput, {
+        strategy: 'standing-pr',
+        standingPrSnapshot: snapshot,
+        mergedRows: standingOnlyRows,
+      });
+      expect(result).toContain('### After merge — predicted release');
+      expect(result).toContain('No version escalation');
+      expect(result).toContain('| `@a/notes` | 0.5.0 | — | 0.5.0 |');
+      expect(result).not.toContain('Approximate. The standing PR rebuilds');
+    });
+
     it('should omit the merge table when no rows are provided', () => {
       const snapshot = snapshotFor([{ name: '@a/notes', version: '0.5.0' }]);
       const result = formatPreviewComment(releaseOutput, { strategy: 'standing-pr', standingPrSnapshot: snapshot });

--- a/packages/release/test/unit/preview-format.spec.ts
+++ b/packages/release/test/unit/preview-format.spec.ts
@@ -709,8 +709,11 @@ describe('formatPreviewComment', () => {
 
     const result = formatPreviewComment(output);
     expect(result).not.toContain('### Packages');
-    expect(result).not.toContain('### Changelog');
     expect(result).not.toContain('### Tags');
+    // Sync-bumped packages with no entries should still appear under ### Changelog
+    expect(result).toContain('### Changelog');
+    expect(result).toContain('`my-lib` → 1.0.0');
+    expect(result).toContain('sync versioning');
   });
 
   it('should handle entries with unknown types', () => {

--- a/packages/release/test/unit/preview-github.spec.ts
+++ b/packages/release/test/unit/preview-github.spec.ts
@@ -185,21 +185,21 @@ describe('fetchPRLabels', () => {
   it('should return label names from PR', async () => {
     const { octokit, mocks } = createMockOctokit();
     mocks.getIssue.mockResolvedValue({
-      data: { labels: [{ name: 'release:stable' }, { name: 'bug' }] },
+      data: { labels: [{ name: 'channel:stable' }, { name: 'bug' }] },
     });
 
     const labels = await fetchPRLabels(octokit, 'owner', 'repo', 1);
-    expect(labels).toEqual(['release:stable', 'bug']);
+    expect(labels).toEqual(['channel:stable', 'bug']);
   });
 
   it('should handle string labels', async () => {
     const { octokit, mocks } = createMockOctokit();
     mocks.getIssue.mockResolvedValue({
-      data: { labels: ['release:stable', 'enhancement'] },
+      data: { labels: ['channel:stable', 'enhancement'] },
     });
 
     const labels = await fetchPRLabels(octokit, 'owner', 'repo', 1);
-    expect(labels).toEqual(['release:stable', 'enhancement']);
+    expect(labels).toEqual(['channel:stable', 'enhancement']);
   });
 
   it('should return empty array when no labels', async () => {

--- a/packages/release/test/unit/preview-merge.spec.ts
+++ b/packages/release/test/unit/preview-merge.spec.ts
@@ -126,4 +126,18 @@ describe('mergeForPreview', () => {
     const rows = mergeForPreview([unchanged], []);
     expect(rows).toEqual([]);
   });
+
+  it('should use current PR version as afterMerge when standing version is invalid semver', () => {
+    const standingCl: VersionPackageChangelog = {
+      ...changelog('@a/notes', '1.0.0', 'not-a-semver'),
+    };
+    const currentCl = changelog('@a/notes', '1.0.0', '1.1.0');
+    const rows = mergeForPreview([standingCl], [currentCl]);
+    expect(rows[0]).toMatchObject({
+      status: 'unchanged',
+      standing: 'not-a-semver',
+      current: '1.1.0',
+      afterMerge: '1.1.0',
+    });
+  });
 });

--- a/packages/release/test/unit/preview-merge.spec.ts
+++ b/packages/release/test/unit/preview-merge.spec.ts
@@ -114,9 +114,16 @@ describe('mergeForPreview', () => {
     expect(rows[0]).toMatchObject({ status: 'escalated', afterMerge: '2.0.0' });
   });
 
-  it('should skip changelogs with no entries', () => {
-    const empty: VersionPackageChangelog = { ...changelog('@a/notes', '1.0.0', '1.1.0'), entries: [] };
-    const rows = mergeForPreview([empty], []);
+  it('should include sync-bumped packages (no entries but version changed)', () => {
+    const synced: VersionPackageChangelog = { ...changelog('@a/notes', '1.0.0', '1.1.0'), entries: [] };
+    const rows = mergeForPreview([synced], []);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ packageName: '@a/notes', standing: '1.1.0', status: 'standing-only' });
+  });
+
+  it('should skip packages with no entries and no version change', () => {
+    const unchanged: VersionPackageChangelog = { ...changelog('@a/notes', '1.0.0', '1.0.0'), entries: [] };
+    const rows = mergeForPreview([unchanged], []);
     expect(rows).toEqual([]);
   });
 });

--- a/packages/release/test/unit/preview-merge.spec.ts
+++ b/packages/release/test/unit/preview-merge.spec.ts
@@ -1,0 +1,122 @@
+import type { VersionPackageChangelog } from '@releasekit/core';
+import { describe, expect, it } from 'vitest';
+import { mergeForPreview } from '../../src/preview/merge.js';
+
+function changelog(
+  packageName: string,
+  previousVersion: string | null,
+  version: string,
+  options: { entries?: number } = {},
+): VersionPackageChangelog {
+  return {
+    packageName,
+    version,
+    previousVersion,
+    revisionRange: `v${previousVersion ?? '0.0.0'}..HEAD`,
+    repoUrl: null,
+    entries: Array.from({ length: options.entries ?? 1 }, (_, i) => ({
+      type: 'feat',
+      description: `entry ${i + 1}`,
+    })),
+  };
+}
+
+describe('mergeForPreview', () => {
+  it('returns empty array when both sides are empty', () => {
+    expect(mergeForPreview([], [])).toEqual([]);
+  });
+
+  it('renders standing-only packages', () => {
+    const rows = mergeForPreview([changelog('@a/notes', '1.0.0', '1.1.0')], []);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      packageName: '@a/notes',
+      baseline: '1.0.0',
+      standing: '1.1.0',
+      afterMerge: '1.1.0',
+      status: 'standing-only',
+    });
+    expect(rows[0]?.current).toBeUndefined();
+  });
+
+  it('renders pr-only packages', () => {
+    const rows = mergeForPreview([], [changelog('@a/notes', '1.0.0', '1.0.1')]);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      packageName: '@a/notes',
+      current: '1.0.1',
+      afterMerge: '1.0.1',
+      status: 'new-from-pr',
+    });
+    expect(rows[0]?.standing).toBeUndefined();
+  });
+
+  it('marks unchanged when versions are equal on both sides', () => {
+    const rows = mergeForPreview([changelog('@a/notes', '1.0.0', '1.1.0')], [changelog('@a/notes', '1.0.0', '1.1.0')]);
+    expect(rows[0]?.status).toBe('unchanged');
+    expect(rows[0]?.afterMerge).toBe('1.1.0');
+  });
+
+  it('escalates when current PR has a higher bump than the standing PR', () => {
+    const rows = mergeForPreview(
+      [changelog('@a/notes', '1.0.0', '1.0.1')], // standing: patch
+      [changelog('@a/notes', '1.0.0', '1.1.0')], // PR: minor
+    );
+    expect(rows[0]).toMatchObject({
+      status: 'escalated',
+      standing: '1.0.1',
+      current: '1.1.0',
+      afterMerge: '1.1.0',
+    });
+  });
+
+  it('keeps standing version when standing has higher bump than current PR', () => {
+    const rows = mergeForPreview(
+      [changelog('@a/notes', '1.0.0', '1.1.0')], // standing: minor
+      [changelog('@a/notes', '1.0.0', '1.0.1')], // PR: patch
+    );
+    expect(rows[0]).toMatchObject({
+      status: 'unchanged',
+      standing: '1.1.0',
+      current: '1.0.1',
+      afterMerge: '1.1.0',
+    });
+  });
+
+  it('handles a mix of overlap, escalation, and pr-only', () => {
+    const rows = mergeForPreview(
+      [changelog('@a/notes', '1.0.0', '1.1.0'), changelog('@a/version', '0.3.1', '0.3.2')],
+      [changelog('@a/version', '0.3.1', '0.4.0'), changelog('@a/publish', '0.2.0', '0.2.1')],
+    );
+
+    expect(rows.map((r) => r.packageName)).toEqual(['@a/notes', '@a/publish', '@a/version']);
+
+    const notes = rows.find((r) => r.packageName === '@a/notes');
+    expect(notes).toMatchObject({ status: 'standing-only', afterMerge: '1.1.0' });
+
+    const publish = rows.find((r) => r.packageName === '@a/publish');
+    expect(publish).toMatchObject({ status: 'new-from-pr', afterMerge: '0.2.1' });
+
+    const version = rows.find((r) => r.packageName === '@a/version');
+    expect(version).toMatchObject({ status: 'escalated', afterMerge: '0.4.0', standing: '0.3.2' });
+  });
+
+  it('treats a stable version as higher than a prerelease of the same target', () => {
+    const rows = mergeForPreview(
+      [changelog('@a/notes', '1.0.0', '1.5.0-beta.1')],
+      [changelog('@a/notes', '1.0.0', '1.5.0')],
+    );
+    expect(rows[0]).toMatchObject({ status: 'escalated', afterMerge: '1.5.0' });
+  });
+
+  it('treats a major bump as higher than a minor bump', () => {
+    const rows = mergeForPreview([changelog('@a/notes', '1.0.0', '1.1.0')], [changelog('@a/notes', '1.0.0', '2.0.0')]);
+    expect(rows[0]).toMatchObject({ status: 'escalated', afterMerge: '2.0.0' });
+  });
+
+  it('skips changelogs with no entries', () => {
+    const empty: VersionPackageChangelog = { ...changelog('@a/notes', '1.0.0', '1.1.0'), entries: [] };
+    const rows = mergeForPreview([empty], []);
+    expect(rows).toEqual([]);
+  });
+});

--- a/packages/release/test/unit/preview-merge.spec.ts
+++ b/packages/release/test/unit/preview-merge.spec.ts
@@ -127,6 +127,19 @@ describe('mergeForPreview', () => {
     expect(rows).toEqual([]);
   });
 
+  it('should not set current when the current PR version is invalid semver', () => {
+    const standingCl = changelog('@a/notes', '1.0.0', '1.1.0');
+    const currentCl: VersionPackageChangelog = { ...changelog('@a/notes', '1.0.0', 'not-a-semver') };
+    const rows = mergeForPreview([standingCl], [currentCl]);
+    expect(rows[0]).toMatchObject({
+      status: 'unchanged',
+      standing: '1.1.0',
+      afterMerge: '1.1.0',
+    });
+    // current must not be set to the garbled string — it should be absent so the table shows '—'
+    expect(rows[0]?.current).toBeUndefined();
+  });
+
   it('should use current PR version as afterMerge when standing version is invalid semver', () => {
     const standingCl: VersionPackageChangelog = {
       ...changelog('@a/notes', '1.0.0', 'not-a-semver'),

--- a/packages/release/test/unit/preview-merge.spec.ts
+++ b/packages/release/test/unit/preview-merge.spec.ts
@@ -22,11 +22,11 @@ function changelog(
 }
 
 describe('mergeForPreview', () => {
-  it('returns empty array when both sides are empty', () => {
+  it('should return empty array when both sides are empty', () => {
     expect(mergeForPreview([], [])).toEqual([]);
   });
 
-  it('renders standing-only packages', () => {
+  it('should render standing-only packages', () => {
     const rows = mergeForPreview([changelog('@a/notes', '1.0.0', '1.1.0')], []);
     expect(rows).toHaveLength(1);
     expect(rows[0]).toMatchObject({
@@ -39,7 +39,7 @@ describe('mergeForPreview', () => {
     expect(rows[0]?.current).toBeUndefined();
   });
 
-  it('renders pr-only packages', () => {
+  it('should render pr-only packages', () => {
     const rows = mergeForPreview([], [changelog('@a/notes', '1.0.0', '1.0.1')]);
     expect(rows).toHaveLength(1);
     expect(rows[0]).toMatchObject({
@@ -51,13 +51,13 @@ describe('mergeForPreview', () => {
     expect(rows[0]?.standing).toBeUndefined();
   });
 
-  it('marks unchanged when versions are equal on both sides', () => {
+  it('should mark unchanged when versions are equal on both sides', () => {
     const rows = mergeForPreview([changelog('@a/notes', '1.0.0', '1.1.0')], [changelog('@a/notes', '1.0.0', '1.1.0')]);
     expect(rows[0]?.status).toBe('unchanged');
     expect(rows[0]?.afterMerge).toBe('1.1.0');
   });
 
-  it('escalates when current PR has a higher bump than the standing PR', () => {
+  it('should escalate when current PR has a higher bump than the standing PR', () => {
     const rows = mergeForPreview(
       [changelog('@a/notes', '1.0.0', '1.0.1')], // standing: patch
       [changelog('@a/notes', '1.0.0', '1.1.0')], // PR: minor
@@ -70,7 +70,7 @@ describe('mergeForPreview', () => {
     });
   });
 
-  it('keeps standing version when standing has higher bump than current PR', () => {
+  it('should keep standing version when standing has higher bump than current PR', () => {
     const rows = mergeForPreview(
       [changelog('@a/notes', '1.0.0', '1.1.0')], // standing: minor
       [changelog('@a/notes', '1.0.0', '1.0.1')], // PR: patch
@@ -83,7 +83,7 @@ describe('mergeForPreview', () => {
     });
   });
 
-  it('handles a mix of overlap, escalation, and pr-only', () => {
+  it('should handle a mix of overlap, escalation, and pr-only', () => {
     const rows = mergeForPreview(
       [changelog('@a/notes', '1.0.0', '1.1.0'), changelog('@a/version', '0.3.1', '0.3.2')],
       [changelog('@a/version', '0.3.1', '0.4.0'), changelog('@a/publish', '0.2.0', '0.2.1')],
@@ -101,7 +101,7 @@ describe('mergeForPreview', () => {
     expect(version).toMatchObject({ status: 'escalated', afterMerge: '0.4.0', standing: '0.3.2' });
   });
 
-  it('treats a stable version as higher than a prerelease of the same target', () => {
+  it('should treat a stable version as higher than a prerelease of the same target', () => {
     const rows = mergeForPreview(
       [changelog('@a/notes', '1.0.0', '1.5.0-beta.1')],
       [changelog('@a/notes', '1.0.0', '1.5.0')],
@@ -109,12 +109,12 @@ describe('mergeForPreview', () => {
     expect(rows[0]).toMatchObject({ status: 'escalated', afterMerge: '1.5.0' });
   });
 
-  it('treats a major bump as higher than a minor bump', () => {
+  it('should treat a major bump as higher than a minor bump', () => {
     const rows = mergeForPreview([changelog('@a/notes', '1.0.0', '1.1.0')], [changelog('@a/notes', '1.0.0', '2.0.0')]);
     expect(rows[0]).toMatchObject({ status: 'escalated', afterMerge: '2.0.0' });
   });
 
-  it('skips changelogs with no entries', () => {
+  it('should skip changelogs with no entries', () => {
     const empty: VersionPackageChangelog = { ...changelog('@a/notes', '1.0.0', '1.1.0'), entries: [] };
     const rows = mergeForPreview([empty], []);
     expect(rows).toEqual([]);

--- a/packages/release/test/unit/preview.spec.ts
+++ b/packages/release/test/unit/preview.spec.ts
@@ -784,6 +784,26 @@ describe('runPreview', () => {
 
       await expect(runPreview({ projectDir: '/test', dryRun: false })).rejects.toThrow('No scope specified');
     });
+
+    it('should not throw when release:immediate is set with a bump label but no scope label and no target', async () => {
+      mockLoadCIConfig.mockReturnValue({
+        releaseStrategy: 'standing-pr',
+        releaseTrigger: 'label',
+        scopeLabels: { 'scope:all': '@releasekit/*' },
+        labels: {
+          stable: 'channel:stable',
+          prerelease: 'channel:prerelease',
+          skip: 'release:skip',
+          immediate: 'release:immediate',
+          major: 'bump:major',
+          minor: 'bump:minor',
+          patch: 'bump:patch',
+        },
+      });
+      mockFetchPRLabels.mockResolvedValue(['release:immediate', 'bump:patch']);
+
+      await expect(runPreview({ projectDir: '/test', dryRun: false })).resolves.toBeUndefined();
+    });
   });
 
   describe('label fetching', () => {

--- a/packages/release/test/unit/preview.spec.ts
+++ b/packages/release/test/unit/preview.spec.ts
@@ -1,7 +1,19 @@
 import type { VersionOutput } from '@releasekit/core';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // --- Mocks ---
+
+const mockFsExistsSync = vi.fn().mockReturnValue(false);
+const mockFsReadFileSync = vi.fn();
+
+vi.mock('node:fs', () => ({
+  default: {
+    existsSync: (...args: unknown[]) => mockFsExistsSync(...args),
+    readFileSync: (...args: unknown[]) => mockFsReadFileSync(...args),
+  },
+  existsSync: (...args: unknown[]) => mockFsExistsSync(...args),
+  readFileSync: (...args: unknown[]) => mockFsReadFileSync(...args),
+}));
 
 const mockLoadCIConfig = vi.fn();
 const mockLoadConfig = vi.fn();
@@ -992,6 +1004,84 @@ describe('runPreview', () => {
 
       const callArg = mockRunRelease.mock.calls[0]?.[0] as { bump?: string };
       expect(callArg?.bump).toBe('major');
+    });
+
+    describe('prBaseSha extraction from event payload', () => {
+      const originalEnv = { ...process.env };
+
+      afterEach(() => {
+        process.env = { ...originalEnv };
+        mockFsExistsSync.mockReturnValue(false);
+      });
+
+      it('should pass prBaseSha as baseRef to runRelease in advisory mode', async () => {
+        mockLoadCIConfig.mockReturnValue(ciWithLabels());
+        mockFetchPRLabels.mockResolvedValue([]); // no bump label — advisory mode
+
+        process.env.GITHUB_EVENT_PATH = '/tmp/event.json';
+        mockFsExistsSync.mockReturnValue(true);
+        mockFsReadFileSync.mockReturnValue(JSON.stringify({ pull_request: { base: { sha: 'pr-base-sha-abc' } } }));
+
+        await runPreview({ projectDir: '/test', dryRun: false, target: '@test/package' });
+
+        const callArg = mockRunRelease.mock.calls[0]?.[0] as { baseRef?: string } | undefined;
+        expect(callArg?.baseRef).toBe('pr-base-sha-abc');
+      });
+
+      it('should NOT extract prBaseSha when release:immediate is set (not advisory mode)', async () => {
+        mockLoadCIConfig.mockReturnValue(ciWithLabels());
+        mockFetchPRLabels.mockResolvedValue(['release:immediate', 'bump:patch']);
+
+        process.env.GITHUB_EVENT_PATH = '/tmp/event.json';
+        mockFsExistsSync.mockReturnValue(true);
+        mockFsReadFileSync.mockReturnValue(JSON.stringify({ pull_request: { base: { sha: 'should-not-be-used' } } }));
+
+        await runPreview({ projectDir: '/test', dryRun: false, target: '@test/package' });
+
+        // fs.existsSync/readFileSync should not have been called because immediate mode is not advisory
+        const callArg = mockRunRelease.mock.calls[0]?.[0] as { baseRef?: string } | undefined;
+        expect(callArg?.baseRef).toBeUndefined();
+      });
+
+      it('should not set baseRef when GITHUB_EVENT_PATH is not set', async () => {
+        mockLoadCIConfig.mockReturnValue(ciWithLabels());
+        mockFetchPRLabels.mockResolvedValue([]);
+
+        delete process.env.GITHUB_EVENT_PATH;
+
+        await runPreview({ projectDir: '/test', dryRun: false, target: '@test/package' });
+
+        const callArg = mockRunRelease.mock.calls[0]?.[0] as { baseRef?: string } | undefined;
+        expect(callArg?.baseRef).toBeUndefined();
+      });
+
+      it('should not set baseRef when event file does not exist', async () => {
+        mockLoadCIConfig.mockReturnValue(ciWithLabels());
+        mockFetchPRLabels.mockResolvedValue([]);
+
+        process.env.GITHUB_EVENT_PATH = '/tmp/nonexistent-event.json';
+        mockFsExistsSync.mockReturnValue(false);
+
+        await runPreview({ projectDir: '/test', dryRun: false, target: '@test/package' });
+
+        const callArg = mockRunRelease.mock.calls[0]?.[0] as { baseRef?: string } | undefined;
+        expect(callArg?.baseRef).toBeUndefined();
+      });
+
+      it('should gracefully handle malformed event JSON without throwing', async () => {
+        mockLoadCIConfig.mockReturnValue(ciWithLabels());
+        mockFetchPRLabels.mockResolvedValue([]);
+
+        process.env.GITHUB_EVENT_PATH = '/tmp/event.json';
+        mockFsExistsSync.mockReturnValue(true);
+        mockFsReadFileSync.mockReturnValue('not valid json {{{{');
+
+        await expect(
+          runPreview({ projectDir: '/test', dryRun: false, target: '@test/package' }),
+        ).resolves.toBeUndefined();
+
+        expect(mockPostOrUpdateComment).toHaveBeenCalled();
+      });
     });
   });
 });

--- a/packages/release/test/unit/preview.spec.ts
+++ b/packages/release/test/unit/preview.spec.ts
@@ -699,12 +699,14 @@ describe('runPreview', () => {
 
       await runPreview({ projectDir: '/test', dryRun: false, target: '@test/package' });
 
+      // Banner shows the LABEL NAME (what the author can recognise on the PR), not the
+      // configured glob pattern. result.target still uses the pattern.
       expect(mockPostOrUpdateComment).toHaveBeenCalledWith(
         expect.anything(),
         'owner',
         'repo',
         1,
-        expect.stringContaining('**Scope:** @wdio/native-*'),
+        expect.stringContaining('**Scope:** scope:shared'),
       );
     });
 

--- a/packages/release/test/unit/preview.spec.ts
+++ b/packages/release/test/unit/preview.spec.ts
@@ -838,7 +838,7 @@ describe('runPreview', () => {
       };
     }
 
-    it('fetches the snapshot and threads it into the comment when strategy is standing-pr', async () => {
+    it('should fetch the snapshot and thread it into the comment when strategy is standing-pr', async () => {
       mockLoadCIConfig.mockReturnValue({ releaseStrategy: 'standing-pr', releaseTrigger: 'commit' });
       mockFetchStandingPRSnapshot.mockResolvedValue(makeSnapshot());
 
@@ -851,7 +851,7 @@ describe('runPreview', () => {
       expect(body).toContain('### After merge — predicted release');
     });
 
-    it('renders snapshot only (no merge table) when this PR has no releasable changes', async () => {
+    it('should render snapshot only (no merge table) when this PR has no releasable changes', async () => {
       mockLoadCIConfig.mockReturnValue({ releaseStrategy: 'standing-pr', releaseTrigger: 'commit' });
       mockFetchStandingPRSnapshot.mockResolvedValue(makeSnapshot());
       mockRunRelease.mockResolvedValue(null);
@@ -863,7 +863,7 @@ describe('runPreview', () => {
       expect(body).not.toContain('### After merge');
     });
 
-    it('omits the snapshot when no standing PR is found', async () => {
+    it('should omit the snapshot when no standing PR is found', async () => {
       mockLoadCIConfig.mockReturnValue({ releaseStrategy: 'standing-pr', releaseTrigger: 'commit' });
       mockFetchStandingPRSnapshot.mockResolvedValue(null);
 
@@ -873,7 +873,7 @@ describe('runPreview', () => {
       expect(body).not.toContain('**Standing release PR:**');
     });
 
-    it('treats fetch failure as non-fatal (preview still posts)', async () => {
+    it('should treat fetch failure as non-fatal (preview still posts)', async () => {
       mockLoadCIConfig.mockReturnValue({ releaseStrategy: 'standing-pr', releaseTrigger: 'commit' });
       mockFetchStandingPRSnapshot.mockRejectedValue(new Error('boom'));
 
@@ -884,7 +884,7 @@ describe('runPreview', () => {
       expect(body).not.toContain('**Standing release PR:**');
     });
 
-    it('does not fetch the snapshot when strategy is not standing-pr', async () => {
+    it('should not fetch the snapshot when strategy is not standing-pr', async () => {
       mockLoadCIConfig.mockReturnValue({ releaseStrategy: 'direct', releaseTrigger: 'commit' });
 
       await runPreview({ projectDir: '/test', dryRun: false, target: '@test/package' });
@@ -911,7 +911,7 @@ describe('runPreview', () => {
       };
     }
 
-    it('does NOT propagate bump label to runRelease in standing-pr advisory mode', async () => {
+    it('should NOT propagate bump label to runRelease in standing-pr advisory mode', async () => {
       mockLoadCIConfig.mockReturnValue(ciWithLabels());
       mockFetchPRLabels.mockResolvedValue(['bump:patch']);
 
@@ -923,7 +923,7 @@ describe('runPreview', () => {
       expect(callArg?.bump).toBeUndefined();
     });
 
-    it('does NOT throw "No scope specified" in standing-pr advisory mode', async () => {
+    it('should NOT throw "No scope specified" in standing-pr advisory mode', async () => {
       mockLoadCIConfig.mockReturnValue(ciWithLabels({ scopeLabels: { 'scope:foo': '@scope/foo' } }));
       mockFetchPRLabels.mockResolvedValue(['bump:patch']); // no scope label, no --target
       // Without the advisory bypass this would throw "No scope specified"
@@ -931,7 +931,7 @@ describe('runPreview', () => {
       expect(mockPostOrUpdateComment).toHaveBeenCalled();
     });
 
-    it('propagates bump label to runRelease when release:immediate is also set', async () => {
+    it('should propagate bump label to runRelease when release:immediate is also set', async () => {
       mockLoadCIConfig.mockReturnValue(ciWithLabels());
       mockFetchPRLabels.mockResolvedValue(['release:immediate', 'bump:minor']);
 
@@ -941,7 +941,7 @@ describe('runPreview', () => {
       expect(callArg?.bump).toBe('minor');
     });
 
-    it('skips standing-PR snapshot fetch when release:immediate is set', async () => {
+    it('should skip standing-PR snapshot fetch when release:immediate is set', async () => {
       mockLoadCIConfig.mockReturnValue(ciWithLabels());
       mockFetchPRLabels.mockResolvedValue(['release:immediate', 'bump:patch']);
 
@@ -950,7 +950,7 @@ describe('runPreview', () => {
       expect(mockFetchStandingPRSnapshot).not.toHaveBeenCalled();
     });
 
-    it('still propagates bump label in direct strategy mode (no change)', async () => {
+    it('should still propagate bump label in direct strategy mode (no change)', async () => {
       mockLoadCIConfig.mockReturnValue({
         releaseStrategy: 'direct',
         releaseTrigger: 'label',

--- a/packages/release/test/unit/preview.spec.ts
+++ b/packages/release/test/unit/preview.spec.ts
@@ -53,6 +53,12 @@ vi.mock('../../src/preview/detect.js', () => ({
   detectPrerelease: (...args: unknown[]) => mockDetectPrerelease(...args),
 }));
 
+const mockFetchStandingPRSnapshot = vi.fn();
+
+vi.mock('../../src/standing-pr/standing-pr.js', () => ({
+  fetchStandingPRSnapshot: (...args: unknown[]) => mockFetchStandingPRSnapshot(...args),
+}));
+
 // --- Fixtures ---
 
 const versionOutputWithChanges: VersionOutput = {
@@ -98,6 +104,7 @@ describe('runPreview', () => {
     mockCreateOctokit.mockReturnValue({});
     mockFetchPRLabels.mockResolvedValue([]);
     mockPostOrUpdateComment.mockResolvedValue(undefined);
+    mockFetchStandingPRSnapshot.mockResolvedValue(null);
 
     const mod = await import('../../src/preview/preview.js');
     runPreview = mod.runPreview;
@@ -795,6 +802,94 @@ describe('runPreview', () => {
 
       expect(mockRunRelease).toHaveBeenCalled();
       expect(mockPostOrUpdateComment).toHaveBeenCalled();
+    });
+  });
+
+  describe('standing PR snapshot', () => {
+    function makeSnapshot() {
+      return {
+        number: 42,
+        url: 'https://github.com/owner/repo/pull/42',
+        openedAt: new Date().toISOString(),
+        gateState: 'success' as const,
+        manifest: {
+          schemaVersion: 2 as const,
+          versionOutput: {
+            dryRun: false,
+            updates: [{ packageName: 'queued-pkg', newVersion: '0.5.0', filePath: 'package.json' }],
+            changelogs: [
+              {
+                packageName: 'queued-pkg',
+                version: '0.5.0',
+                previousVersion: '0.4.0',
+                revisionRange: 'v0.4.0..HEAD',
+                repoUrl: null,
+                entries: [{ type: 'feat', description: 'queued change' }],
+              },
+            ],
+            tags: [],
+          },
+          releaseNotes: {},
+          notesFiles: [],
+          createdAt: new Date().toISOString(),
+          baseSha: 'abc',
+          firstUpdatedAt: new Date().toISOString(),
+        },
+      };
+    }
+
+    it('fetches the snapshot and threads it into the comment when strategy is standing-pr', async () => {
+      mockLoadCIConfig.mockReturnValue({ releaseStrategy: 'standing-pr', releaseTrigger: 'commit' });
+      mockFetchStandingPRSnapshot.mockResolvedValue(makeSnapshot());
+
+      await runPreview({ projectDir: '/test', dryRun: false, target: '@test/package' });
+
+      expect(mockFetchStandingPRSnapshot).toHaveBeenCalledTimes(1);
+      const body = mockPostOrUpdateComment.mock.calls[0]?.[4] as string;
+      expect(body).toContain('**Standing release PR:**');
+      expect(body).toContain('[#42]');
+      expect(body).toContain('### After merge — predicted release');
+    });
+
+    it('renders snapshot only (no merge table) when this PR has no releasable changes', async () => {
+      mockLoadCIConfig.mockReturnValue({ releaseStrategy: 'standing-pr', releaseTrigger: 'commit' });
+      mockFetchStandingPRSnapshot.mockResolvedValue(makeSnapshot());
+      mockRunRelease.mockResolvedValue(null);
+
+      await runPreview({ projectDir: '/test', dryRun: false, target: '@test/package' });
+
+      const body = mockPostOrUpdateComment.mock.calls[0]?.[4] as string;
+      expect(body).toContain('**Standing release PR:**');
+      expect(body).not.toContain('### After merge');
+    });
+
+    it('omits the snapshot when no standing PR is found', async () => {
+      mockLoadCIConfig.mockReturnValue({ releaseStrategy: 'standing-pr', releaseTrigger: 'commit' });
+      mockFetchStandingPRSnapshot.mockResolvedValue(null);
+
+      await runPreview({ projectDir: '/test', dryRun: false, target: '@test/package' });
+
+      const body = mockPostOrUpdateComment.mock.calls[0]?.[4] as string;
+      expect(body).not.toContain('**Standing release PR:**');
+    });
+
+    it('treats fetch failure as non-fatal (preview still posts)', async () => {
+      mockLoadCIConfig.mockReturnValue({ releaseStrategy: 'standing-pr', releaseTrigger: 'commit' });
+      mockFetchStandingPRSnapshot.mockRejectedValue(new Error('boom'));
+
+      await runPreview({ projectDir: '/test', dryRun: false, target: '@test/package' });
+
+      expect(mockPostOrUpdateComment).toHaveBeenCalled();
+      const body = mockPostOrUpdateComment.mock.calls[0]?.[4] as string;
+      expect(body).not.toContain('**Standing release PR:**');
+    });
+
+    it('does not fetch the snapshot when strategy is not standing-pr', async () => {
+      mockLoadCIConfig.mockReturnValue({ releaseStrategy: 'direct', releaseTrigger: 'commit' });
+
+      await runPreview({ projectDir: '/test', dryRun: false, target: '@test/package' });
+
+      expect(mockFetchStandingPRSnapshot).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/release/test/unit/preview.spec.ts
+++ b/packages/release/test/unit/preview.spec.ts
@@ -925,6 +925,54 @@ describe('runPreview', () => {
 
       expect(mockFetchStandingPRSnapshot).not.toHaveBeenCalled();
     });
+
+    it('should exclude packages outside standing PR scope from the merge prediction table', async () => {
+      // The standing PR only knows about 'queued-pkg'. This PR's runRelease result includes
+      // 'test-pkg' (outside standing scope). After the fix, 'test-pkg' must not appear as
+      // a new-from-pr row in the After-merge table.
+      mockLoadCIConfig.mockReturnValue({ releaseStrategy: 'standing-pr', releaseTrigger: 'commit' });
+      mockFetchStandingPRSnapshot.mockResolvedValue(makeSnapshot());
+      // runRelease returns test-pkg (not in standing PR scope) and queued-pkg (is in scope)
+      mockRunRelease.mockResolvedValue({
+        versionOutput: {
+          dryRun: true,
+          updates: [
+            { packageName: 'test-pkg', newVersion: '1.1.0', filePath: 'package.json' },
+            { packageName: 'queued-pkg', newVersion: '0.6.0', filePath: 'package.json' },
+          ],
+          changelogs: [
+            {
+              packageName: 'test-pkg',
+              version: '1.1.0',
+              previousVersion: '1.0.0',
+              revisionRange: 'HEAD',
+              repoUrl: null,
+              entries: [{ type: 'feat', description: 'outside standing scope' }],
+            },
+            {
+              packageName: 'queued-pkg',
+              version: '0.6.0',
+              previousVersion: '0.5.0',
+              revisionRange: 'HEAD',
+              repoUrl: null,
+              entries: [{ type: 'feat', description: 'escalates standing PR' }],
+            },
+          ],
+          tags: [],
+        },
+        notesGenerated: false,
+      });
+
+      await runPreview({ projectDir: '/test', dryRun: false, target: '@test/package' });
+
+      const body = mockPostOrUpdateComment.mock.calls[0]?.[4] as string;
+      // queued-pkg is in the standing PR scope — must appear as a table row (escalated)
+      expect(body).toContain('| `queued-pkg`');
+      // test-pkg is outside standing PR scope — must NOT appear as a merge-table row
+      // (it still appears in the changelog section as <b>test-pkg</b>, which is correct)
+      expect(body).not.toContain('| `test-pkg`');
+      expect(body).toContain('<b>test-pkg</b>');
+    });
   });
 
   describe('label semantics in standing-pr mode', () => {

--- a/packages/release/test/unit/preview.spec.ts
+++ b/packages/release/test/unit/preview.spec.ts
@@ -222,7 +222,7 @@ describe('runPreview', () => {
       });
 
       it('should take priority over prerelease PR label', async () => {
-        mockFetchPRLabels.mockResolvedValue(['release:prerelease']);
+        mockFetchPRLabels.mockResolvedValue(['channel:prerelease']);
         mockDetectPrerelease.mockReturnValue({ isPrerelease: false });
 
         await runPreview({ projectDir: '/test', dryRun: false, stable: true, target: '@test/package' });
@@ -241,7 +241,7 @@ describe('runPreview', () => {
       });
 
       it('should take priority over stable PR label', async () => {
-        mockFetchPRLabels.mockResolvedValue(['release:stable']);
+        mockFetchPRLabels.mockResolvedValue(['channel:stable']);
 
         await runPreview({ projectDir: '/test', dryRun: false, prerelease: 'beta', target: '@test/package' });
 
@@ -353,7 +353,7 @@ describe('runPreview', () => {
 
       it('should compose major and prerelease labels', async () => {
         mockDetectPrerelease.mockReturnValue({ isPrerelease: false });
-        mockFetchPRLabels.mockResolvedValue(['bump:major', 'release:prerelease']);
+        mockFetchPRLabels.mockResolvedValue(['bump:major', 'channel:prerelease']);
 
         await runPreview({ projectDir: '/test', dryRun: false, target: '@test/package' });
 
@@ -408,7 +408,7 @@ describe('runPreview', () => {
       it('should compose bump label and prerelease label', async () => {
         mockLoadCIConfig.mockReturnValue({ releaseTrigger: 'label' });
         mockDetectPrerelease.mockReturnValue({ isPrerelease: false });
-        mockFetchPRLabels.mockResolvedValue(['bump:minor', 'release:prerelease']);
+        mockFetchPRLabels.mockResolvedValue(['bump:minor', 'channel:prerelease']);
 
         await runPreview({ projectDir: '/test', dryRun: false, target: '@test/package' });
 
@@ -497,8 +497,8 @@ describe('runPreview', () => {
     });
 
     describe('stable/prerelease conflicts', () => {
-      it('should block release when release:stable and release:prerelease both present', async () => {
-        mockFetchPRLabels.mockResolvedValue(['release:stable', 'release:prerelease', 'bump:minor']);
+      it('should block release when channel:stable and channel:prerelease both present', async () => {
+        mockFetchPRLabels.mockResolvedValue(['channel:stable', 'channel:prerelease', 'bump:minor']);
         mockLoadCIConfig.mockReturnValue({ releaseTrigger: 'label' });
 
         await runPreview({ projectDir: '/test', dryRun: false, target: '@test/package' });
@@ -517,8 +517,8 @@ describe('runPreview', () => {
 
   describe('stable/prerelease defaults', () => {
     describe('prerelease label', () => {
-      it('should not trigger release when release:prerelease label is present alone', async () => {
-        mockFetchPRLabels.mockResolvedValue(['release:prerelease']);
+      it('should not trigger release when channel:prerelease label is present alone', async () => {
+        mockFetchPRLabels.mockResolvedValue(['channel:prerelease']);
         mockLoadCIConfig.mockReturnValue({ releaseTrigger: 'label' });
 
         await runPreview({ projectDir: '/test', dryRun: false, target: '@test/package' });
@@ -533,15 +533,15 @@ describe('runPreview', () => {
         );
       });
 
-      it('should surface the gate reason in the banner when release:prerelease + scope but no bump (honest preview)', async () => {
-        // Reproduces the wdio-desktop-mobile #225 scenario: release:prerelease + scope:tauri.
+      it('should surface the gate reason in the banner when channel:prerelease + scope but no bump (honest preview)', async () => {
+        // Reproduces the wdio-desktop-mobile #225 scenario: channel:prerelease + scope:tauri.
         // The OLD preview lied — it showed a version bump table because scope was present.
         // The NEW preview matches the gate's verdict: this PR will NOT trigger a release.
         mockLoadCIConfig.mockReturnValue({
           releaseTrigger: 'label',
           scopeLabels: { 'scope:tauri': '@wdio/tauri-*' },
         });
-        mockFetchPRLabels.mockResolvedValue(['release:prerelease', 'scope:tauri']);
+        mockFetchPRLabels.mockResolvedValue(['channel:prerelease', 'scope:tauri']);
 
         await runPreview({ projectDir: '/test', dryRun: false });
 
@@ -551,13 +551,13 @@ describe('runPreview', () => {
         const body = mockPostOrUpdateComment.mock.calls[0][4] as string;
         expect(body).toContain('No bump label detected');
         // The gate reason — surfaced via labelContext.gateReason — explains exactly why.
-        expect(body).toContain('release:prerelease');
+        expect(body).toContain('channel:prerelease');
         // No version bump table is rendered.
         expect(body).not.toContain('### Packages');
       });
 
       it('should use minor bump when prerelease and bump:minor labels present', async () => {
-        mockFetchPRLabels.mockResolvedValue(['release:prerelease', 'bump:minor']);
+        mockFetchPRLabels.mockResolvedValue(['channel:prerelease', 'bump:minor']);
         mockLoadCIConfig.mockReturnValue({ releaseTrigger: 'label' });
 
         await runPreview({ projectDir: '/test', dryRun: false, target: '@test/package' });
@@ -568,21 +568,21 @@ describe('runPreview', () => {
 
     describe('stable label', () => {
       it('should graduate prerelease to stable when stable label is present', async () => {
-        mockFetchPRLabels.mockResolvedValue(['release:stable', 'bump:minor']);
+        mockFetchPRLabels.mockResolvedValue(['channel:stable', 'bump:minor']);
         mockLoadCIConfig.mockReturnValue({ releaseTrigger: 'label' });
         mockDetectPrerelease.mockReturnValue({ isPrerelease: true, identifier: 'beta' });
 
         await runPreview({ projectDir: '/test', dryRun: false, target: '@test/package' });
 
         const callArgs = mockRunRelease.mock.calls[0][0];
-        // Per gate semantics: release:stable causes bump to be auto-detected from commits.
+        // Per gate semantics: channel:stable causes bump to be auto-detected from commits.
         // bump label magnitude is not propagated when graduation is the primary intent.
         expect(callArgs.bump).toBeUndefined();
         expect(callArgs.stable).toBe(true);
       });
 
       it('should run release analysis but not set bump when stable label present without bump label', async () => {
-        mockFetchPRLabels.mockResolvedValue(['release:stable']);
+        mockFetchPRLabels.mockResolvedValue(['channel:stable']);
         mockLoadCIConfig.mockReturnValue({ releaseTrigger: 'label' });
         mockDetectPrerelease.mockReturnValue({ isPrerelease: true, identifier: 'beta' });
 
@@ -673,7 +673,7 @@ describe('runPreview', () => {
 
     it('should NOT release in label mode for scope-only PR — gate requires bump or stable label', async () => {
       // Aligned with gate semantics: in label trigger mode, scope alone does not trigger
-      // a release. The user must add bump:* or release:stable. Conventional-commits-driven
+      // a release. The user must add bump:* or channel:stable. Conventional-commits-driven
       // bumps are only supported in commit trigger mode.
       mockLoadCIConfig.mockReturnValue({
         releaseTrigger: 'label',
@@ -890,6 +890,86 @@ describe('runPreview', () => {
       await runPreview({ projectDir: '/test', dryRun: false, target: '@test/package' });
 
       expect(mockFetchStandingPRSnapshot).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('label semantics in standing-pr mode', () => {
+    function ciWithLabels(extras: Record<string, unknown> = {}) {
+      return {
+        releaseStrategy: 'standing-pr',
+        releaseTrigger: 'label',
+        labels: {
+          stable: 'channel:stable',
+          prerelease: 'channel:prerelease',
+          skip: 'release:skip',
+          immediate: 'release:immediate',
+          major: 'bump:major',
+          minor: 'bump:minor',
+          patch: 'bump:patch',
+        },
+        ...extras,
+      };
+    }
+
+    it('does NOT propagate bump label to runRelease in standing-pr advisory mode', async () => {
+      mockLoadCIConfig.mockReturnValue(ciWithLabels());
+      mockFetchPRLabels.mockResolvedValue(['bump:patch']);
+
+      await runPreview({ projectDir: '/test', dryRun: false, target: '@test/package' });
+
+      // runRelease should be called WITHOUT bump derived from the label
+      expect(mockRunRelease).toHaveBeenCalled();
+      const callArg = mockRunRelease.mock.calls[0]?.[0] as { bump?: string };
+      expect(callArg?.bump).toBeUndefined();
+    });
+
+    it('does NOT throw "No scope specified" in standing-pr advisory mode', async () => {
+      mockLoadCIConfig.mockReturnValue(ciWithLabels({ scopeLabels: { 'scope:foo': '@scope/foo' } }));
+      mockFetchPRLabels.mockResolvedValue(['bump:patch']); // no scope label, no --target
+      // Without the advisory bypass this would throw "No scope specified"
+      await runPreview({ projectDir: '/test', dryRun: false });
+      expect(mockPostOrUpdateComment).toHaveBeenCalled();
+    });
+
+    it('propagates bump label to runRelease when release:immediate is also set', async () => {
+      mockLoadCIConfig.mockReturnValue(ciWithLabels());
+      mockFetchPRLabels.mockResolvedValue(['release:immediate', 'bump:minor']);
+
+      await runPreview({ projectDir: '/test', dryRun: false, target: '@test/package' });
+
+      const callArg = mockRunRelease.mock.calls[0]?.[0] as { bump?: string };
+      expect(callArg?.bump).toBe('minor');
+    });
+
+    it('skips standing-PR snapshot fetch when release:immediate is set', async () => {
+      mockLoadCIConfig.mockReturnValue(ciWithLabels());
+      mockFetchPRLabels.mockResolvedValue(['release:immediate', 'bump:patch']);
+
+      await runPreview({ projectDir: '/test', dryRun: false, target: '@test/package' });
+
+      expect(mockFetchStandingPRSnapshot).not.toHaveBeenCalled();
+    });
+
+    it('still propagates bump label in direct strategy mode (no change)', async () => {
+      mockLoadCIConfig.mockReturnValue({
+        releaseStrategy: 'direct',
+        releaseTrigger: 'label',
+        labels: {
+          stable: 'channel:stable',
+          prerelease: 'channel:prerelease',
+          skip: 'release:skip',
+          immediate: 'release:immediate',
+          major: 'bump:major',
+          minor: 'bump:minor',
+          patch: 'bump:patch',
+        },
+      });
+      mockFetchPRLabels.mockResolvedValue(['bump:major']);
+
+      await runPreview({ projectDir: '/test', dryRun: false, target: '@test/package' });
+
+      const callArg = mockRunRelease.mock.calls[0]?.[0] as { bump?: string };
+      expect(callArg?.bump).toBe('major');
     });
   });
 });

--- a/packages/release/test/unit/release-gate.spec.ts
+++ b/packages/release/test/unit/release-gate.spec.ts
@@ -6,14 +6,14 @@ const labelMode = { releaseTrigger: 'label' as const };
 const commitMode = { releaseTrigger: 'commit' as const };
 
 describe('evaluatePR — label mode', () => {
-  it('returns shouldRelease=false with reason when only release:prerelease is present', () => {
-    const result = evaluatePR(225, ['release:prerelease', 'scope:tauri'], DEFAULT_LABELS, {
+  it('returns shouldRelease=false with reason when only channel:prerelease is present', () => {
+    const result = evaluatePR(225, ['channel:prerelease', 'scope:tauri'], DEFAULT_LABELS, {
       ...labelMode,
       scopeLabels: { 'scope:tauri': '@wdio/tauri-*' },
     });
     expect(result.shouldRelease).toBe(false);
     expect(result.blocked).toBeUndefined();
-    expect(result.reason).toContain('release:prerelease');
+    expect(result.reason).toContain('channel:prerelease');
     expect(result.reason).toContain('bump');
     expect(result.hasReleaseIntent).toBe(true);
   });
@@ -37,25 +37,25 @@ describe('evaluatePR — label mode', () => {
     expect(result.bump).toBe('major');
   });
 
-  it('returns shouldRelease=true with bump=preminor for bump:minor + release:prerelease', () => {
-    const result = evaluatePR(1, ['bump:minor', 'release:prerelease'], DEFAULT_LABELS, labelMode);
+  it('returns shouldRelease=true with bump=preminor for bump:minor + channel:prerelease', () => {
+    const result = evaluatePR(1, ['bump:minor', 'channel:prerelease'], DEFAULT_LABELS, labelMode);
     expect(result.shouldRelease).toBe(true);
     expect(result.bump).toBe('preminor');
     expect(result.stable).toBe(false);
   });
 
-  it('returns shouldRelease=true with bump=premajor for bump:major + release:prerelease', () => {
-    const result = evaluatePR(1, ['bump:major', 'release:prerelease'], DEFAULT_LABELS, labelMode);
+  it('returns shouldRelease=true with bump=premajor for bump:major + channel:prerelease', () => {
+    const result = evaluatePR(1, ['bump:major', 'channel:prerelease'], DEFAULT_LABELS, labelMode);
     expect(result.bump).toBe('premajor');
   });
 
-  it('returns shouldRelease=true with bump=prepatch for bump:patch + release:prerelease', () => {
-    const result = evaluatePR(1, ['bump:patch', 'release:prerelease'], DEFAULT_LABELS, labelMode);
+  it('returns shouldRelease=true with bump=prepatch for bump:patch + channel:prerelease', () => {
+    const result = evaluatePR(1, ['bump:patch', 'channel:prerelease'], DEFAULT_LABELS, labelMode);
     expect(result.bump).toBe('prepatch');
   });
 
-  it('returns shouldRelease=true with stable=true and bump=undefined for release:stable alone', () => {
-    const result = evaluatePR(1, ['release:stable'], DEFAULT_LABELS, labelMode);
+  it('returns shouldRelease=true with stable=true and bump=undefined for channel:stable alone', () => {
+    const result = evaluatePR(1, ['channel:stable'], DEFAULT_LABELS, labelMode);
     expect(result.shouldRelease).toBe(true);
     expect(result.stable).toBe(true);
     // Stable graduation auto-detects magnitude from commits — bump intentionally undefined.
@@ -70,12 +70,12 @@ describe('evaluatePR — label mode', () => {
     expect(result.reason).toContain('minor');
   });
 
-  it('returns blocked=true for release:stable + release:prerelease on the same PR', () => {
-    const result = evaluatePR(1, ['release:stable', 'release:prerelease'], DEFAULT_LABELS, labelMode);
+  it('returns blocked=true for channel:stable + channel:prerelease on the same PR', () => {
+    const result = evaluatePR(1, ['channel:stable', 'channel:prerelease'], DEFAULT_LABELS, labelMode);
     expect(result.blocked).toBe(true);
     expect(result.shouldRelease).toBe(false);
-    expect(result.reason).toContain('release:stable');
-    expect(result.reason).toContain('release:prerelease');
+    expect(result.reason).toContain('channel:stable');
+    expect(result.reason).toContain('channel:prerelease');
   });
 
   it('returns shouldRelease=false (not releasable) for scope-only PR — scope label is not a trigger', () => {
@@ -86,7 +86,7 @@ describe('evaluatePR — label mode', () => {
     expect(result.shouldRelease).toBe(false);
     // Scope label still counts as release intent — user gets a notify comment.
     expect(result.hasReleaseIntent).toBe(true);
-    expect(result.reason).toMatch(/no release labels|need bump|release:stable/i);
+    expect(result.reason).toMatch(/no release labels|need bump|channel:stable/i);
   });
 
   it('returns hasReleaseIntent=false when no release-related labels present', () => {
@@ -141,8 +141,8 @@ describe('evaluatePR — commit mode', () => {
     expect(result.shouldRelease).toBe(true);
   });
 
-  it('blocks on release:stable + release:prerelease conflict in commit mode', () => {
-    const result = evaluatePR(1, ['release:stable', 'release:prerelease'], DEFAULT_LABELS, commitMode);
+  it('blocks on channel:stable + channel:prerelease conflict in commit mode', () => {
+    const result = evaluatePR(1, ['channel:stable', 'channel:prerelease'], DEFAULT_LABELS, commitMode);
     expect(result.blocked).toBe(true);
   });
 });

--- a/packages/release/test/unit/release-gate.spec.ts
+++ b/packages/release/test/unit/release-gate.spec.ts
@@ -6,7 +6,7 @@ const labelMode = { releaseTrigger: 'label' as const };
 const commitMode = { releaseTrigger: 'commit' as const };
 
 describe('evaluatePR — label mode', () => {
-  it('returns shouldRelease=false with reason when only channel:prerelease is present', () => {
+  it('should return shouldRelease=false with reason when only channel:prerelease is present', () => {
     const result = evaluatePR(225, ['channel:prerelease', 'scope:tauri'], DEFAULT_LABELS, {
       ...labelMode,
       scopeLabels: { 'scope:tauri': '@wdio/tauri-*' },
@@ -18,43 +18,43 @@ describe('evaluatePR — label mode', () => {
     expect(result.hasReleaseIntent).toBe(true);
   });
 
-  it('returns shouldRelease=true with bump=patch for bump:patch alone', () => {
+  it('should return shouldRelease=true with bump=patch for bump:patch alone', () => {
     const result = evaluatePR(1, ['bump:patch'], DEFAULT_LABELS, labelMode);
     expect(result.shouldRelease).toBe(true);
     expect(result.bump).toBe('patch');
     expect(result.stable).toBe(false);
   });
 
-  it('returns shouldRelease=true with bump=minor for bump:minor alone', () => {
+  it('should return shouldRelease=true with bump=minor for bump:minor alone', () => {
     const result = evaluatePR(1, ['bump:minor'], DEFAULT_LABELS, labelMode);
     expect(result.shouldRelease).toBe(true);
     expect(result.bump).toBe('minor');
   });
 
-  it('returns shouldRelease=true with bump=major for bump:major alone', () => {
+  it('should return shouldRelease=true with bump=major for bump:major alone', () => {
     const result = evaluatePR(1, ['bump:major'], DEFAULT_LABELS, labelMode);
     expect(result.shouldRelease).toBe(true);
     expect(result.bump).toBe('major');
   });
 
-  it('returns shouldRelease=true with bump=preminor for bump:minor + channel:prerelease', () => {
+  it('should return shouldRelease=true with bump=preminor for bump:minor + channel:prerelease', () => {
     const result = evaluatePR(1, ['bump:minor', 'channel:prerelease'], DEFAULT_LABELS, labelMode);
     expect(result.shouldRelease).toBe(true);
     expect(result.bump).toBe('preminor');
     expect(result.stable).toBe(false);
   });
 
-  it('returns shouldRelease=true with bump=premajor for bump:major + channel:prerelease', () => {
+  it('should return shouldRelease=true with bump=premajor for bump:major + channel:prerelease', () => {
     const result = evaluatePR(1, ['bump:major', 'channel:prerelease'], DEFAULT_LABELS, labelMode);
     expect(result.bump).toBe('premajor');
   });
 
-  it('returns shouldRelease=true with bump=prepatch for bump:patch + channel:prerelease', () => {
+  it('should return shouldRelease=true with bump=prepatch for bump:patch + channel:prerelease', () => {
     const result = evaluatePR(1, ['bump:patch', 'channel:prerelease'], DEFAULT_LABELS, labelMode);
     expect(result.bump).toBe('prepatch');
   });
 
-  it('returns shouldRelease=true with stable=true and bump=undefined for channel:stable alone', () => {
+  it('should return shouldRelease=true with stable=true and bump=undefined for channel:stable alone', () => {
     const result = evaluatePR(1, ['channel:stable'], DEFAULT_LABELS, labelMode);
     expect(result.shouldRelease).toBe(true);
     expect(result.stable).toBe(true);
@@ -62,7 +62,7 @@ describe('evaluatePR — label mode', () => {
     expect(result.bump).toBeUndefined();
   });
 
-  it('returns blocked=true for conflicting bump labels on the same PR', () => {
+  it('should return blocked=true for conflicting bump labels on the same PR', () => {
     const result = evaluatePR(1, ['bump:major', 'bump:minor'], DEFAULT_LABELS, labelMode);
     expect(result.blocked).toBe(true);
     expect(result.shouldRelease).toBe(false);
@@ -70,7 +70,7 @@ describe('evaluatePR — label mode', () => {
     expect(result.reason).toContain('minor');
   });
 
-  it('returns blocked=true for channel:stable + channel:prerelease on the same PR', () => {
+  it('should return blocked=true for channel:stable + channel:prerelease on the same PR', () => {
     const result = evaluatePR(1, ['channel:stable', 'channel:prerelease'], DEFAULT_LABELS, labelMode);
     expect(result.blocked).toBe(true);
     expect(result.shouldRelease).toBe(false);
@@ -78,7 +78,7 @@ describe('evaluatePR — label mode', () => {
     expect(result.reason).toContain('channel:prerelease');
   });
 
-  it('returns shouldRelease=false (not releasable) for scope-only PR — scope label is not a trigger', () => {
+  it('should return shouldRelease=false (not releasable) for scope-only PR — scope label is not a trigger', () => {
     const result = evaluatePR(1, ['scope:utils'], DEFAULT_LABELS, {
       ...labelMode,
       scopeLabels: { 'scope:utils': '@wdio/native-utils' },
@@ -89,13 +89,13 @@ describe('evaluatePR — label mode', () => {
     expect(result.reason).toMatch(/no release labels|need bump|channel:stable/i);
   });
 
-  it('returns hasReleaseIntent=false when no release-related labels present', () => {
+  it('should return hasReleaseIntent=false when no release-related labels present', () => {
     const result = evaluatePR(1, ['enhancement', 'documentation'], DEFAULT_LABELS, labelMode);
     expect(result.shouldRelease).toBe(false);
     expect(result.hasReleaseIntent).toBe(false);
   });
 
-  it('resolves scope and target from THIS PR labels only', () => {
+  it('should resolve scope and target from THIS PR labels only', () => {
     const result = evaluatePR(1, ['bump:minor', 'scope:utils'], DEFAULT_LABELS, {
       ...labelMode,
       scopeLabels: {
@@ -107,7 +107,7 @@ describe('evaluatePR — label mode', () => {
     expect(result.target).toBe('@wdio/native-utils');
   });
 
-  it('returns first matching scope when multiple scope labels present (no union)', () => {
+  it('should return first matching scope when multiple scope labels present (no union)', () => {
     // The order in `labels` determines first-match. Per-PR evaluation does NOT join targets.
     const result = evaluatePR(1, ['bump:minor', 'scope:utils', 'scope:tauri'], DEFAULT_LABELS, {
       ...labelMode,
@@ -122,20 +122,20 @@ describe('evaluatePR — label mode', () => {
 });
 
 describe('evaluatePR — commit mode', () => {
-  it('returns shouldRelease=true when no skip label present', () => {
+  it('should return shouldRelease=true when no skip label present', () => {
     const result = evaluatePR(1, ['feat'], DEFAULT_LABELS, commitMode);
     expect(result.shouldRelease).toBe(true);
     expect(result.hasReleaseIntent).toBe(false);
   });
 
-  it('returns shouldRelease=false when release:skip label present', () => {
+  it('should return shouldRelease=false when release:skip label present', () => {
     const result = evaluatePR(1, ['release:skip'], DEFAULT_LABELS, commitMode);
     expect(result.shouldRelease).toBe(false);
     expect(result.reason).toContain('release:skip');
     expect(result.hasReleaseIntent).toBe(false);
   });
 
-  it('does NOT block on conflicting bump labels in commit mode (bump:* not authoritative)', () => {
+  it('should NOT block on conflicting bump labels in commit mode (bump:* not authoritative)', () => {
     const result = evaluatePR(1, ['bump:major', 'bump:minor'], DEFAULT_LABELS, commitMode);
     expect(result.blocked).toBeUndefined();
     expect(result.shouldRelease).toBe(true);

--- a/packages/release/test/unit/release.spec.ts
+++ b/packages/release/test/unit/release.spec.ts
@@ -745,7 +745,7 @@ describe('runRelease', () => {
     it('should block release when prerelease + stable conflict detected without scopeLabels', async () => {
       mockLoadCIConfig.mockReturnValue({});
       mockFindMergedPRsForCommit.mockResolvedValue([123]);
-      mockFetchPRLabels.mockResolvedValue(['release:stable', 'release:prerelease']);
+      mockFetchPRLabels.mockResolvedValue(['channel:stable', 'channel:prerelease']);
 
       const { runRelease } = await import('../../src/release.js');
       const result = await runRelease(defaultOptions);
@@ -760,7 +760,7 @@ describe('runRelease', () => {
         },
       });
       mockFindMergedPRsForCommit.mockResolvedValue([123]);
-      mockFetchPRLabels.mockResolvedValue(['scope:shared', 'release:stable', 'release:prerelease']);
+      mockFetchPRLabels.mockResolvedValue(['scope:shared', 'channel:stable', 'channel:prerelease']);
 
       const { runRelease } = await import('../../src/release.js');
       const result = await runRelease(defaultOptions);
@@ -831,7 +831,7 @@ describe('runRelease', () => {
         },
       });
       mockFindMergedPRsForCommit.mockResolvedValue([123]);
-      mockFetchPRLabels.mockResolvedValue(['release:stable', 'release:prerelease']);
+      mockFetchPRLabels.mockResolvedValue(['channel:stable', 'channel:prerelease']);
 
       const { runRelease } = await import('../../src/release.js');
       const result = await runRelease({ ...defaultOptions, dryRun: true });

--- a/packages/release/test/unit/standing-pr.spec.ts
+++ b/packages/release/test/unit/standing-pr.spec.ts
@@ -191,6 +191,7 @@ describe('runStandingPRUpdate', () => {
         stable: 'channel:stable',
         prerelease: 'channel:prerelease',
         skip: 'release:skip',
+        immediate: 'release:immediate',
         major: 'bump:major',
         minor: 'bump:minor',
         patch: 'bump:patch',
@@ -1066,6 +1067,7 @@ describe('runStandingPRUpdate — editableNotes', () => {
         stable: 'channel:stable',
         prerelease: 'channel:prerelease',
         skip: 'release:skip',
+        immediate: 'release:immediate',
         major: 'bump:major',
         minor: 'bump:minor',
         patch: 'bump:patch',
@@ -1084,7 +1086,7 @@ describe('runStandingPRUpdate — editableNotes', () => {
     vi.mocked(loadConfig).mockReturnValue(editableConfig as ReturnType<typeof loadConfig>);
 
     const { execSync } = await import('node:child_process');
-    vi.mocked(execSync).mockReturnValue(Buffer.from('abc123\n'));
+    vi.mocked(execSync).mockReturnValue('abc123\n');
   });
 
   afterEach(() => {

--- a/packages/release/test/unit/standing-pr.spec.ts
+++ b/packages/release/test/unit/standing-pr.spec.ts
@@ -673,6 +673,23 @@ describe('runStandingPRUpdate', () => {
       expect(lastStatus?.description).toMatch(/Conflicting bump labels/);
     });
 
+    it('should show conflict description when both a label conflict and a pending minAge exist', async () => {
+      const { loadConfig } = await import('@releasekit/config');
+      vi.mocked(loadConfig).mockReturnValue({
+        ...defaultConfig,
+        ci: { ...defaultConfig.ci, standingPr: { ...defaultConfig.ci.standingPr, minAge: '6h' } },
+      } as ReturnType<typeof loadConfig>);
+
+      const { mocks } = await setupWithStandingPRLabels(['release', 'bump:patch', 'bump:major']);
+
+      await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
+
+      const lastStatus = mocks.createCommitStatus.mock.calls.at(-1)?.[0];
+      expect(lastStatus?.state).toBe('pending');
+      expect(lastStatus?.description).toMatch(/Conflicting bump labels/);
+      expect(lastStatus?.description).not.toMatch(/minAge/);
+    });
+
     it('should preserve maintainer-added labels in setLabels (union with configured labels)', async () => {
       const { mocks } = await setupWithStandingPRLabels(['release', 'bump:major']);
 

--- a/packages/release/test/unit/standing-pr.spec.ts
+++ b/packages/release/test/unit/standing-pr.spec.ts
@@ -704,7 +704,20 @@ describe('runStandingPRUpdate', () => {
       expect(lastSetLabels?.labels).toContain('bump:major');
     });
 
-    it('should inherit sync from version config (defaults true) instead of forcing false', async () => {
+    it('should default sync to false when not set in config (preserves per-package versioning)', async () => {
+      const { runVersionStepMock } = await setupWithStandingPRLabels([]);
+
+      await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
+
+      expect(runVersionStepMock.mock.calls[0]?.[0]).toMatchObject({ sync: false });
+    });
+
+    it('should inherit sync: true from version config when explicitly set', async () => {
+      const { loadConfig } = await import('@releasekit/config');
+      vi.mocked(loadConfig).mockReturnValue({
+        ...defaultConfig,
+        version: { sync: true },
+      } as ReturnType<typeof loadConfig>);
       const { runVersionStepMock } = await setupWithStandingPRLabels([]);
 
       await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });

--- a/packages/release/test/unit/standing-pr.spec.ts
+++ b/packages/release/test/unit/standing-pr.spec.ts
@@ -640,7 +640,7 @@ describe('runStandingPRUpdate', () => {
       return { mocks, octokit, runVersionStepMock: vi.mocked(runVersionStep) };
     }
 
-    it('passes bump:major from standing PR labels into version step', async () => {
+    it('should pass bump:major from standing PR labels into version step', async () => {
       const { runVersionStepMock } = await setupWithStandingPRLabels(['release', 'bump:major']);
 
       await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
@@ -650,7 +650,7 @@ describe('runStandingPRUpdate', () => {
       expect(runVersionStepMock.mock.calls[1]?.[0]).toMatchObject({ bump: 'major' });
     });
 
-    it('passes channel:prerelease from standing PR labels as prerelease override', async () => {
+    it('should pass channel:prerelease from standing PR labels as prerelease override', async () => {
       const { runVersionStepMock } = await setupWithStandingPRLabels(['release', 'channel:prerelease']);
 
       await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
@@ -658,7 +658,7 @@ describe('runStandingPRUpdate', () => {
       expect(runVersionStepMock.mock.calls[0]?.[0]).toMatchObject({ prerelease: true });
     });
 
-    it('drops conflicting bump labels and posts pending status check', async () => {
+    it('should drop conflicting bump labels and posts pending status check', async () => {
       const { mocks, runVersionStepMock } = await setupWithStandingPRLabels(['release', 'bump:patch', 'bump:major']);
 
       await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
@@ -672,7 +672,7 @@ describe('runStandingPRUpdate', () => {
       expect(lastStatus?.description).toMatch(/Conflicting bump labels/);
     });
 
-    it('preserves maintainer-added labels in setLabels (union with configured labels)', async () => {
+    it('should preserve maintainer-added labels in setLabels (union with configured labels)', async () => {
       const { mocks } = await setupWithStandingPRLabels(['release', 'bump:major']);
 
       await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
@@ -683,7 +683,7 @@ describe('runStandingPRUpdate', () => {
       expect(lastSetLabels?.labels).toContain('bump:major');
     });
 
-    it('inherits sync from version config (defaults true) instead of forcing false', async () => {
+    it('should inherit sync from version config (defaults true) instead of forcing false', async () => {
       const { runVersionStepMock } = await setupWithStandingPRLabels([]);
 
       await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
@@ -943,30 +943,30 @@ describe('extractEditableSection', () => {
   const START = '<!-- releasekit-editable-start -->';
   const END = '<!-- releasekit-editable-end -->';
 
-  it('returns the trimmed content between editable markers', () => {
+  it('should return the trimmed content between editable markers', () => {
     const body = `some text\n\n${START}\n### Release Notes\n\n#### pkg — 1.0.0\n\n- note\n${END}\n---`;
     expect(extractEditableSection(body)).toBe('### Release Notes\n\n#### pkg — 1.0.0\n\n- note');
   });
 
-  it('returns null when start marker is absent', () => {
+  it('should return null when start marker is absent', () => {
     expect(extractEditableSection(`### Release Notes\n\n${END}`)).toBeNull();
   });
 
-  it('returns null when end marker is absent', () => {
+  it('should return null when end marker is absent', () => {
     expect(extractEditableSection(`${START}\n### Release Notes`)).toBeNull();
   });
 
-  it('returns null when both markers are absent', () => {
+  it('should return null when both markers are absent', () => {
     expect(extractEditableSection('### Release Notes\n\n- note')).toBeNull();
   });
 
-  it('returns null when end marker precedes start marker', () => {
+  it('should return null when end marker precedes start marker', () => {
     expect(extractEditableSection(`${END}\n${START}`)).toBeNull();
   });
 });
 
 describe('parseEditedNotes', () => {
-  it('parses multiple packages from a section', () => {
+  it('should parse multiple packages from a section', () => {
     const section = [
       '### Release Notes',
       '',
@@ -984,7 +984,7 @@ describe('parseEditedNotes', () => {
     expect(result['@scope/cli']).toBe('- fixed bug');
   });
 
-  it('preserves h4 subheadings within package notes without truncating content', () => {
+  it('should preserve h4 subheadings within package notes without truncating content', () => {
     const section = [
       '### Release Notes',
       '',
@@ -1004,15 +1004,15 @@ describe('parseEditedNotes', () => {
     expect(result['@scope/core']).toContain('- another thing');
   });
 
-  it('returns empty object for a section with no package headings', () => {
+  it('should return empty object for a section with no package headings', () => {
     expect(parseEditedNotes('### Release Notes\n\nsome text')).toEqual({});
   });
 
-  it('returns empty object for an empty string', () => {
+  it('should return empty object for an empty string', () => {
     expect(parseEditedNotes('')).toEqual({});
   });
 
-  it('round-trips the content produced by renderPrBody editable markers', () => {
+  it('should round-trip the content produced by renderPrBody editable markers', () => {
     const versionOutput = createMockVersionOutput([
       { packageName: '@scope/core', newVersion: '1.2.3' },
       { packageName: '@scope/cli', newVersion: '2.0.0' },
@@ -1084,14 +1084,14 @@ describe('runStandingPRUpdate — editableNotes', () => {
     vi.mocked(loadConfig).mockReturnValue(editableConfig as ReturnType<typeof loadConfig>);
 
     const { execSync } = await import('node:child_process');
-    vi.mocked(execSync).mockReturnValue('abc123\n' as unknown as Buffer);
+    vi.mocked(execSync).mockReturnValue(Buffer.from('abc123\n'));
   });
 
   afterEach(() => {
     process.env = { ...originalEnv };
   });
 
-  it('stores notesHash in manifest when editableNotes is enabled and notes exist', async () => {
+  it('should store notesHash in manifest when editableNotes is enabled and notes exist', async () => {
     const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
     const versionOutput = createMockVersionOutput([{ packageName: '@scope/core', newVersion: '1.2.3' }]);
     vi.mocked(runVersionStep)
@@ -1127,7 +1127,7 @@ describe('runStandingPRUpdate — editableNotes', () => {
     expect(typeof parsedManifest.notesHash).toBe('string');
   });
 
-  it('includes editable markers in PR body when editableNotes is enabled', async () => {
+  it('should include editable markers in PR body when editableNotes is enabled', async () => {
     const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
     const versionOutput = createMockVersionOutput([{ packageName: '@scope/core', newVersion: '1.2.3' }]);
     vi.mocked(runVersionStep)
@@ -1158,7 +1158,7 @@ describe('runStandingPRUpdate — editableNotes', () => {
     );
   });
 
-  it('preserves user edits when existing section hash does not match stored notesHash', async () => {
+  it('should preserve user edits when existing section hash does not match stored notesHash', async () => {
     const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
     const versionOutput = createMockVersionOutput([{ packageName: '@scope/core', newVersion: '1.2.3' }]);
     vi.mocked(runVersionStep)
@@ -1210,7 +1210,7 @@ describe('runStandingPRUpdate — editableNotes', () => {
     );
   });
 
-  it('regenerates notes when existing section hash matches stored notesHash (user has not edited)', async () => {
+  it('should regenerate notes when existing section hash matches stored notesHash (user has not edited)', async () => {
     const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
     const versionOutput = createMockVersionOutput([{ packageName: '@scope/core', newVersion: '1.2.3' }]);
     vi.mocked(runVersionStep)
@@ -1294,7 +1294,7 @@ describe('publishFromManifest', () => {
     process.env = { ...originalEnv };
   });
 
-  it('returns null when no GitHub context is available', async () => {
+  it('should return null when no GitHub context is available', async () => {
     delete process.env.GITHUB_REPOSITORY;
     delete process.env.GITHUB_TOKEN;
 
@@ -1308,7 +1308,7 @@ describe('publishFromManifest', () => {
     expect(result).toBeNull();
   });
 
-  it('throws when manifest comment is missing from PR', async () => {
+  it('should throw when manifest comment is missing from PR', async () => {
     const { createOctokit } = await import('../../src/github.js');
     const { octokit } = createMockOctokit();
     vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
@@ -1318,7 +1318,7 @@ describe('publishFromManifest', () => {
     ).rejects.toThrow(/manifest not found/);
   });
 
-  it('publishes using manifest notes when editableNotes is disabled', async () => {
+  it('should publish using manifest notes when editableNotes is disabled', async () => {
     const { createOctokit } = await import('../../src/github.js');
     const { mocks, octokit } = createMockOctokit();
     const manifestBody = serializeManifest(baseManifest);
@@ -1350,7 +1350,7 @@ describe('publishFromManifest', () => {
     );
   });
 
-  it('uses edited notes from PR body when editableNotes is enabled', async () => {
+  it('should use edited notes from PR body when editableNotes is enabled', async () => {
     const { loadConfig } = await import('@releasekit/config');
     vi.mocked(loadConfig).mockReturnValue({
       ci: { standingPr: { branch: 'release/next', deleteBranchOnMerge: true, editableNotes: true } },
@@ -1393,7 +1393,7 @@ describe('publishFromManifest', () => {
     );
   });
 
-  it('falls back to manifest notes for packages missing from edited section', async () => {
+  it('should fall back to manifest notes for packages missing from edited section', async () => {
     const { loadConfig } = await import('@releasekit/config');
     vi.mocked(loadConfig).mockReturnValue({
       ci: { standingPr: { branch: 'release/next', deleteBranchOnMerge: true, editableNotes: true } },

--- a/packages/release/test/unit/standing-pr.spec.ts
+++ b/packages/release/test/unit/standing-pr.spec.ts
@@ -1,8 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { StandingPRManifest } from '../../src/standing-pr/standing-pr.js';
 import {
-  extractEditableSection,
-  parseEditedNotes,
   parseManifest,
   publishFromManifest,
   runStandingPRMerge,
@@ -301,6 +299,45 @@ describe('runStandingPRUpdate', () => {
     expect(result.action).toBe('created');
     expect(result.prNumber).toBe(42);
     expect(mocks.pullsCreate).toHaveBeenCalled();
+  });
+
+  it('should include a ### Changelog section in the PR body with changelog entries', async () => {
+    const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
+    const versionOutput = {
+      ...createMockVersionOutput([{ packageName: '@scope/core', newVersion: '1.2.3' }]),
+      changelogs: [
+        {
+          packageName: '@scope/core',
+          version: '1.2.3',
+          previousVersion: '1.2.2',
+          revisionRange: 'v1.2.2..HEAD',
+          repoUrl: null,
+          entries: [
+            { type: 'feat', description: 'Add new widget' },
+            { type: 'fix', description: 'Fix broken export' },
+          ],
+        },
+      ],
+    };
+    vi.mocked(runVersionStep)
+      .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>)
+      .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>);
+    vi.mocked(runNotesStep).mockResolvedValue({ packageNotes: {}, releaseNotes: {}, files: [] });
+
+    const { createOctokit } = await import('../../src/github.js');
+    const { mocks, octokit } = createMockOctokit();
+    mocks.pullsList.mockResolvedValue({ data: [] });
+    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+
+    await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
+
+    const createCall = mocks.pullsCreate.mock.calls[0]?.[0] as { body?: string } | undefined;
+    expect(createCall?.body).toContain('### Changelog');
+    expect(createCall?.body).toContain('**Added**');
+    expect(createCall?.body).toContain('Add new widget');
+    expect(createCall?.body).toContain('**Fixed**');
+    expect(createCall?.body).toContain('Fix broken export');
+    expect(createCall?.body).toContain('@scope/core — 1.2.2 → 1.2.3');
   });
 
   it('should update existing PR when standing PR already exists', async () => {
@@ -970,339 +1007,6 @@ describe('runStandingPRPublish', () => {
     ).rejects.toThrow(/invalid or incompatible/);
   });
 });
-
-// ─── Editable notes helpers ───────────────────────────────────────────────────
-
-describe('extractEditableSection', () => {
-  const START = '<!-- releasekit-editable-start -->';
-  const END = '<!-- releasekit-editable-end -->';
-
-  it('should return the trimmed content between editable markers', () => {
-    const body = `some text\n\n${START}\n### Release Notes\n\n#### pkg — 1.0.0\n\n- note\n${END}\n---`;
-    expect(extractEditableSection(body)).toBe('### Release Notes\n\n#### pkg — 1.0.0\n\n- note');
-  });
-
-  it('should return null when start marker is absent', () => {
-    expect(extractEditableSection(`### Release Notes\n\n${END}`)).toBeNull();
-  });
-
-  it('should return null when end marker is absent', () => {
-    expect(extractEditableSection(`${START}\n### Release Notes`)).toBeNull();
-  });
-
-  it('should return null when both markers are absent', () => {
-    expect(extractEditableSection('### Release Notes\n\n- note')).toBeNull();
-  });
-
-  it('should return null when end marker precedes start marker', () => {
-    expect(extractEditableSection(`${END}\n${START}`)).toBeNull();
-  });
-});
-
-describe('parseEditedNotes', () => {
-  it('should parse multiple packages from a section', () => {
-    const section = [
-      '### Release Notes',
-      '',
-      '#### @scope/core — 1.2.3',
-      '',
-      '- added feature',
-      '',
-      '#### @scope/cli — 2.0.0',
-      '',
-      '- fixed bug',
-    ].join('\n');
-
-    const result = parseEditedNotes(section);
-    expect(result['@scope/core']).toBe('- added feature');
-    expect(result['@scope/cli']).toBe('- fixed bug');
-  });
-
-  it('should preserve h4 subheadings within package notes without truncating content', () => {
-    const section = [
-      '### Release Notes',
-      '',
-      '#### @scope/core — 1.2.3',
-      '',
-      '#### Breaking Changes',
-      '- something important',
-      '',
-      '#### New Features',
-      '- another thing',
-    ].join('\n');
-
-    const result = parseEditedNotes(section);
-    expect(result['@scope/core']).toContain('#### Breaking Changes');
-    expect(result['@scope/core']).toContain('- something important');
-    expect(result['@scope/core']).toContain('#### New Features');
-    expect(result['@scope/core']).toContain('- another thing');
-  });
-
-  it('should return empty object for a section with no package headings', () => {
-    expect(parseEditedNotes('### Release Notes\n\nsome text')).toEqual({});
-  });
-
-  it('should return empty object for an empty string', () => {
-    expect(parseEditedNotes('')).toEqual({});
-  });
-
-  it('should round-trip the content produced by renderPrBody editable markers', () => {
-    const versionOutput = createMockVersionOutput([
-      { packageName: '@scope/core', newVersion: '1.2.3' },
-      { packageName: '@scope/cli', newVersion: '2.0.0' },
-    ]);
-    const releaseNotes = {
-      '@scope/core': '- added feature',
-      '@scope/cli': '- fixed bug',
-    };
-
-    // Manually reconstruct what renderNotesSection/renderPrBody produces
-    const section = [
-      '### Release Notes',
-      '',
-      '#### @scope/core — 1.2.3',
-      '',
-      '- added feature',
-      '',
-      '#### @scope/cli — 2.0.0',
-      '',
-      '- fixed bug',
-    ].join('\n');
-
-    const parsed = parseEditedNotes(section);
-    expect(parsed).toEqual(releaseNotes);
-    // Suppress unused variable warning
-    void versionOutput;
-  });
-});
-
-// ─── editableNotes in runStandingPRUpdate ─────────────────────────────────────
-
-describe('runStandingPRUpdate — editableNotes', () => {
-  const originalEnv = { ...process.env };
-
-  const editableConfig = {
-    ci: {
-      standingPr: {
-        branch: 'release/next',
-        labels: ['release'],
-        deleteBranchOnMerge: true,
-        title: 'chore: release ${count} package(s)',
-        editableNotes: true,
-      },
-      releaseStrategy: 'standing-pr',
-      releaseTrigger: 'label',
-      prPreview: true,
-      autoRelease: false,
-      skipPatterns: ['chore: release '],
-      minChanges: 1,
-      labels: {
-        stable: 'channel:stable',
-        prerelease: 'channel:prerelease',
-        skip: 'release:skip',
-        immediate: 'release:immediate',
-        major: 'bump:major',
-        minor: 'bump:minor',
-        patch: 'bump:patch',
-      },
-    },
-    git: { branch: 'main', remote: 'origin', pushMethod: 'auto' },
-    release: { ci: { skipPatterns: ['chore: release '] } },
-  };
-
-  beforeEach(async () => {
-    vi.resetAllMocks();
-    process.env.GITHUB_REPOSITORY = 'owner/repo';
-    process.env.GITHUB_TOKEN = 'test-token';
-
-    const { loadConfig } = await import('@releasekit/config');
-    vi.mocked(loadConfig).mockReturnValue(editableConfig as ReturnType<typeof loadConfig>);
-
-    const { execSync } = await import('node:child_process');
-    vi.mocked(execSync).mockReturnValue('abc123\n');
-  });
-
-  afterEach(() => {
-    process.env = { ...originalEnv };
-  });
-
-  it('should store notesHash in manifest when editableNotes is enabled and notes exist', async () => {
-    const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
-    const versionOutput = createMockVersionOutput([{ packageName: '@scope/core', newVersion: '1.2.3' }]);
-    vi.mocked(runVersionStep)
-      .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>)
-      .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>);
-    vi.mocked(runNotesStep).mockResolvedValue({
-      packageNotes: {},
-      releaseNotes: { '@scope/core': '- added feature' },
-      files: [],
-    });
-
-    const { createOctokit } = await import('../../src/github.js');
-    const { mocks, octokit } = createMockOctokit();
-    mocks.pullsList.mockResolvedValue({ data: [] });
-    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
-
-    await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
-
-    // The manifest comment should have been created; verify notesHash is present
-    const createCommentCall = mocks.createComment.mock.calls.find(
-      (c: unknown[]) =>
-        typeof c[0] === 'object' &&
-        c[0] !== null &&
-        'body' in (c[0] as Record<string, unknown>) &&
-        typeof (c[0] as Record<string, unknown>).body === 'string' &&
-        ((c[0] as Record<string, unknown>).body as string).includes('<!-- releasekit-manifest -->'),
-    );
-    expect(createCommentCall).toBeDefined();
-
-    const commentBody = (createCommentCall?.[0] as Record<string, unknown>).body as string;
-    const parsedManifest = parseManifest(commentBody);
-    expect(parsedManifest.notesHash).toBeDefined();
-    expect(typeof parsedManifest.notesHash).toBe('string');
-  });
-
-  it('should include editable markers in PR body when editableNotes is enabled', async () => {
-    const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
-    const versionOutput = createMockVersionOutput([{ packageName: '@scope/core', newVersion: '1.2.3' }]);
-    vi.mocked(runVersionStep)
-      .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>)
-      .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>);
-    vi.mocked(runNotesStep).mockResolvedValue({
-      packageNotes: {},
-      releaseNotes: { '@scope/core': '- added feature' },
-      files: [],
-    });
-
-    const { createOctokit } = await import('../../src/github.js');
-    const { mocks, octokit } = createMockOctokit();
-    mocks.pullsList.mockResolvedValue({ data: [] });
-    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
-
-    await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
-
-    expect(mocks.pullsCreate).toHaveBeenCalledWith(
-      expect.objectContaining({
-        body: expect.stringContaining('<!-- releasekit-editable-start -->'),
-      }),
-    );
-    expect(mocks.pullsCreate).toHaveBeenCalledWith(
-      expect.objectContaining({
-        body: expect.stringContaining('<!-- releasekit-editable-end -->'),
-      }),
-    );
-  });
-
-  it('should preserve user edits when existing section hash does not match stored notesHash', async () => {
-    const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
-    const versionOutput = createMockVersionOutput([{ packageName: '@scope/core', newVersion: '1.2.3' }]);
-    vi.mocked(runVersionStep)
-      .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>)
-      .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>);
-    vi.mocked(runNotesStep).mockResolvedValue({
-      packageNotes: {},
-      releaseNotes: { '@scope/core': '- added feature' },
-      files: [],
-    });
-
-    // Manifest stored with a hash that does NOT match the current PR body section
-    const manifestWithDifferentHash: StandingPRManifest = {
-      ...baseManifest,
-      notesHash: 'aaaaaaaaaaaaaaaa', // intentionally wrong hash
-    };
-
-    const userEditedBody = [
-      '## Release',
-      '',
-      '<!-- releasekit-editable-start -->',
-      '### Release Notes',
-      '',
-      '#### @scope/core — 1.2.3',
-      '',
-      '- user-edited content here',
-      '<!-- releasekit-editable-end -->',
-      '---',
-    ].join('\n');
-
-    const { createOctokit } = await import('../../src/github.js');
-    const { mocks, octokit } = createMockOctokit();
-    mocks.pullsList.mockResolvedValue({ data: [{ number: 99, html_url: 'https://github.com/owner/repo/pull/99' }] });
-    mocks.pullsGet.mockResolvedValue({ data: { body: userEditedBody } });
-    mocks.paginate.iterator.mockReturnValue({
-      async *[Symbol.asyncIterator]() {
-        yield { data: [{ id: 77, body: serializeManifest(manifestWithDifferentHash) }] };
-      },
-    });
-    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
-
-    await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
-
-    // PR body should contain the user's edited content
-    expect(mocks.pullsUpdate).toHaveBeenCalledWith(
-      expect.objectContaining({
-        body: expect.stringContaining('user-edited content here'),
-      }),
-    );
-  });
-
-  it('should regenerate notes when existing section hash matches stored notesHash (user has not edited)', async () => {
-    const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
-    const versionOutput = createMockVersionOutput([{ packageName: '@scope/core', newVersion: '1.2.3' }]);
-    vi.mocked(runVersionStep)
-      .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>)
-      .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>);
-    vi.mocked(runNotesStep).mockResolvedValue({
-      packageNotes: {},
-      releaseNotes: { '@scope/core': '- added feature' },
-      files: [],
-    });
-
-    // Build a body with markers + the exact freshly-generated section, so the hash matches
-    const freshSection = '### Release Notes\n\n#### @scope/core — 1.2.3\n\n- added feature';
-    const { createHash } = await import('node:crypto');
-    const freshHash = createHash('sha256').update(freshSection).digest('hex').slice(0, 16);
-
-    const manifestWithMatchingHash: StandingPRManifest = {
-      ...baseManifest,
-      notesHash: freshHash,
-    };
-
-    const unedited = [
-      '## Release',
-      '',
-      '<!-- releasekit-editable-start -->',
-      freshSection,
-      '<!-- releasekit-editable-end -->',
-      '---',
-    ].join('\n');
-
-    const { createOctokit } = await import('../../src/github.js');
-    const { mocks, octokit } = createMockOctokit();
-    mocks.pullsList.mockResolvedValue({ data: [{ number: 99, html_url: 'https://github.com/owner/repo/pull/99' }] });
-    mocks.pullsGet.mockResolvedValue({ data: { body: unedited } });
-    mocks.paginate.iterator.mockReturnValue({
-      async *[Symbol.asyncIterator]() {
-        yield { data: [{ id: 77, body: serializeManifest(manifestWithMatchingHash) }] };
-      },
-    });
-    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
-
-    await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
-
-    // PR body should contain the freshly generated content (markers present, no user override)
-    expect(mocks.pullsUpdate).toHaveBeenCalledWith(
-      expect.objectContaining({
-        body: expect.stringContaining('<!-- releasekit-editable-start -->'),
-      }),
-    );
-    expect(mocks.pullsUpdate).toHaveBeenCalledWith(
-      expect.objectContaining({
-        body: expect.stringContaining('- added feature'),
-      }),
-    );
-  });
-});
-
 // ─── publishFromManifest ──────────────────────────────────────────────────────
 
 describe('publishFromManifest', () => {
@@ -1316,7 +1020,7 @@ describe('publishFromManifest', () => {
     const { loadConfig } = await import('@releasekit/config');
     vi.mocked(loadConfig).mockReturnValue({
       ci: {
-        standingPr: { branch: 'release/next', mergeMethod: 'merge', deleteBranchOnMerge: true, editableNotes: false },
+        standingPr: { branch: 'release/next', mergeMethod: 'merge', deleteBranchOnMerge: true },
       },
       git: { branch: 'main' },
     } as ReturnType<typeof loadConfig>);
@@ -1351,124 +1055,6 @@ describe('publishFromManifest', () => {
     await expect(
       publishFromManifest(42, { projectDir: '/test', verbose: false, quiet: false, json: false }),
     ).rejects.toThrow(/manifest not found/);
-  });
-
-  it('should publish using manifest notes when editableNotes is disabled', async () => {
-    const { createOctokit } = await import('../../src/github.js');
-    const { mocks, octokit } = createMockOctokit();
-    const manifestBody = serializeManifest(baseManifest);
-    mocks.paginate.iterator.mockReturnValue({
-      async *[Symbol.asyncIterator]() {
-        yield { data: [{ id: 1, body: manifestBody }] };
-      },
-    });
-    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
-
-    const { runPublishStep } = await import('../../src/steps.js');
-    vi.mocked(runPublishStep).mockResolvedValue({ publishSucceeded: true } as unknown as Awaited<
-      ReturnType<typeof runPublishStep>
-    >);
-
-    const result = await publishFromManifest(42, {
-      projectDir: '/test',
-      verbose: false,
-      quiet: false,
-      json: false,
-    });
-
-    expect(result).not.toBeNull();
-    expect(vi.mocked(runPublishStep)).toHaveBeenCalledWith(
-      expect.objectContaining({ updates: baseManifest.versionOutput.updates }),
-      expect.objectContaining({ skipGitCommit: true }),
-      baseManifest.releaseNotes,
-      baseManifest.notesFiles,
-    );
-  });
-
-  it('should use edited notes from PR body when editableNotes is enabled', async () => {
-    const { loadConfig } = await import('@releasekit/config');
-    vi.mocked(loadConfig).mockReturnValue({
-      ci: { standingPr: { branch: 'release/next', deleteBranchOnMerge: true, editableNotes: true } },
-      git: { branch: 'main' },
-    } as ReturnType<typeof loadConfig>);
-
-    const editedBody = [
-      '<!-- releasekit-editable-start -->',
-      '### Release Notes',
-      '',
-      '#### @scope/core — 1.2.3',
-      '',
-      '- hand-crafted release note',
-      '<!-- releasekit-editable-end -->',
-    ].join('\n');
-
-    const { createOctokit } = await import('../../src/github.js');
-    const { mocks, octokit } = createMockOctokit();
-    const manifestBody = serializeManifest(baseManifest);
-    mocks.paginate.iterator.mockReturnValue({
-      async *[Symbol.asyncIterator]() {
-        yield { data: [{ id: 1, body: manifestBody }] };
-      },
-    });
-    mocks.pullsGet.mockResolvedValue({ data: { body: editedBody } });
-    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
-
-    const { runPublishStep } = await import('../../src/steps.js');
-    vi.mocked(runPublishStep).mockResolvedValue({ publishSucceeded: true } as unknown as Awaited<
-      ReturnType<typeof runPublishStep>
-    >);
-
-    await publishFromManifest(42, { projectDir: '/test', verbose: false, quiet: false, json: false });
-
-    expect(vi.mocked(runPublishStep)).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.anything(),
-      expect.objectContaining({ '@scope/core': '- hand-crafted release note' }),
-      expect.anything(),
-    );
-  });
-
-  it('should fall back to manifest notes for packages missing from edited section', async () => {
-    const { loadConfig } = await import('@releasekit/config');
-    vi.mocked(loadConfig).mockReturnValue({
-      ci: { standingPr: { branch: 'release/next', deleteBranchOnMerge: true, editableNotes: true } },
-      git: { branch: 'main' },
-    } as ReturnType<typeof loadConfig>);
-
-    // editedBody has no package headings at all
-    const editedBody = [
-      '<!-- releasekit-editable-start -->',
-      '### Release Notes',
-      '',
-      'Some text without package headings.',
-      '<!-- releasekit-editable-end -->',
-    ].join('\n');
-
-    const { createOctokit } = await import('../../src/github.js');
-    const { mocks, octokit } = createMockOctokit();
-    const manifestBody = serializeManifest(baseManifest);
-    mocks.paginate.iterator.mockReturnValue({
-      async *[Symbol.asyncIterator]() {
-        yield { data: [{ id: 1, body: manifestBody }] };
-      },
-    });
-    mocks.pullsGet.mockResolvedValue({ data: { body: editedBody } });
-    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
-
-    const { runPublishStep } = await import('../../src/steps.js');
-    vi.mocked(runPublishStep).mockResolvedValue({ publishSucceeded: true } as unknown as Awaited<
-      ReturnType<typeof runPublishStep>
-    >);
-
-    await publishFromManifest(42, { projectDir: '/test', verbose: false, quiet: false, json: false });
-
-    // Should still use original manifest notes since edited section has no pkg headings
-    expect(vi.mocked(runPublishStep)).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.anything(),
-      expect.objectContaining({ '@scope/core': baseManifest.releaseNotes['@scope/core'] }),
-      expect.anything(),
-    );
   });
 });
 

--- a/packages/release/test/unit/standing-pr.spec.ts
+++ b/packages/release/test/unit/standing-pr.spec.ts
@@ -63,6 +63,7 @@ function createMockOctokit(overrides: Record<string, unknown> = {}) {
   const pullsGet = vi.fn().mockResolvedValue({ data: { body: '' } });
   const pullsMerge = vi.fn().mockResolvedValue({});
   const issuesSetLabels = vi.fn().mockResolvedValue({});
+  const issuesCreateLabel = vi.fn().mockResolvedValue({});
   const createCommitStatus = vi.fn().mockResolvedValue({});
 
   const paginate = {
@@ -81,6 +82,7 @@ function createMockOctokit(overrides: Record<string, unknown> = {}) {
           listComments: vi.fn(),
           createComment,
           updateComment,
+          createLabel: issuesCreateLabel,
           setLabels: issuesSetLabels,
         },
         pulls: {
@@ -105,6 +107,7 @@ function createMockOctokit(overrides: Record<string, unknown> = {}) {
       pullsGet,
       pullsMerge,
       issuesSetLabels,
+      issuesCreateLabel,
       paginate,
       createCommitStatus,
     },

--- a/packages/release/test/unit/standing-pr.spec.ts
+++ b/packages/release/test/unit/standing-pr.spec.ts
@@ -340,6 +340,28 @@ describe('runStandingPRUpdate', () => {
     expect(createCall?.body).toContain('@scope/core — 1.2.2 → 1.2.3');
   });
 
+  it('should omit the ### Changelog section when all updates are sync-bumped (no entries)', async () => {
+    const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
+    // sync-bumped: updates present but changelogs array is empty
+    const versionOutput = createMockVersionOutput([{ packageName: '@scope/core', newVersion: '1.2.3' }]);
+    vi.mocked(runVersionStep)
+      .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>)
+      .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>);
+    vi.mocked(runNotesStep).mockResolvedValue({ packageNotes: {}, releaseNotes: {}, files: [] });
+
+    const { createOctokit } = await import('../../src/github.js');
+    const { mocks, octokit } = createMockOctokit();
+    mocks.pullsList.mockResolvedValue({ data: [] });
+    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+
+    await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
+
+    const createCall = mocks.pullsCreate.mock.calls[0]?.[0] as { body?: string } | undefined;
+    expect(createCall?.body).not.toContain('### Changelog');
+    expect(createCall?.body).toContain('@scope/core');
+    expect(createCall?.body).toContain('1.2.3');
+  });
+
   it('should update existing PR when standing PR already exists', async () => {
     const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
     const versionOutput = createMockVersionOutput([{ packageName: '@scope/core', newVersion: '1.2.3' }]);

--- a/packages/release/test/unit/standing-pr.spec.ts
+++ b/packages/release/test/unit/standing-pr.spec.ts
@@ -188,8 +188,8 @@ describe('runStandingPRUpdate', () => {
       skipPatterns: ['chore: release '],
       minChanges: 1,
       labels: {
-        stable: 'release:stable',
-        prerelease: 'release:prerelease',
+        stable: 'channel:stable',
+        prerelease: 'channel:prerelease',
         skip: 'release:skip',
         major: 'bump:major',
         minor: 'bump:minor',
@@ -614,6 +614,83 @@ describe('runStandingPRUpdate', () => {
     expect(result.action).toBe('created');
     expect(result.prNumber).toBe(42);
   });
+
+  describe('standing-PR labels as overrides', () => {
+    async function setupWithStandingPRLabels(labelNames: string[]) {
+      const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
+      const versionOutput = createMockVersionOutput([{ packageName: '@scope/core', newVersion: '1.2.3' }]);
+      vi.mocked(runVersionStep)
+        .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>)
+        .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>);
+      vi.mocked(runNotesStep).mockResolvedValue({ packageNotes: {}, releaseNotes: {}, files: [] });
+
+      const { createOctokit } = await import('../../src/github.js');
+      const { mocks, octokit } = createMockOctokit();
+      mocks.pullsList.mockResolvedValue({
+        data: [
+          {
+            number: 99,
+            html_url: 'https://github.com/owner/repo/pull/99',
+            labels: labelNames.map((name) => ({ name })),
+          },
+        ],
+      });
+      vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+
+      return { mocks, octokit, runVersionStepMock: vi.mocked(runVersionStep) };
+    }
+
+    it('passes bump:major from standing PR labels into version step', async () => {
+      const { runVersionStepMock } = await setupWithStandingPRLabels(['release', 'bump:major']);
+
+      await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
+
+      // First call (dry run) and second call (write) should both carry bump: 'major'
+      expect(runVersionStepMock.mock.calls[0]?.[0]).toMatchObject({ bump: 'major' });
+      expect(runVersionStepMock.mock.calls[1]?.[0]).toMatchObject({ bump: 'major' });
+    });
+
+    it('passes channel:prerelease from standing PR labels as prerelease override', async () => {
+      const { runVersionStepMock } = await setupWithStandingPRLabels(['release', 'channel:prerelease']);
+
+      await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
+
+      expect(runVersionStepMock.mock.calls[0]?.[0]).toMatchObject({ prerelease: true });
+    });
+
+    it('drops conflicting bump labels and posts pending status check', async () => {
+      const { mocks, runVersionStepMock } = await setupWithStandingPRLabels(['release', 'bump:patch', 'bump:major']);
+
+      await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
+
+      // Conflict → bump override dropped, version analysis runs commit-driven
+      expect(runVersionStepMock.mock.calls[0]?.[0]).not.toHaveProperty('bump', 'major');
+      expect(runVersionStepMock.mock.calls[0]?.[0]?.bump).toBeUndefined();
+      // Final status check is pending with conflict description
+      const lastStatus = mocks.createCommitStatus.mock.calls.at(-1)?.[0];
+      expect(lastStatus?.state).toBe('pending');
+      expect(lastStatus?.description).toMatch(/Conflicting bump labels/);
+    });
+
+    it('preserves maintainer-added labels in setLabels (union with configured labels)', async () => {
+      const { mocks } = await setupWithStandingPRLabels(['release', 'bump:major']);
+
+      await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
+
+      const lastSetLabels = mocks.issuesSetLabels.mock.calls.at(-1)?.[0];
+      // Should contain BOTH the configured 'release' and the maintainer-added 'bump:major'
+      expect(lastSetLabels?.labels).toContain('release');
+      expect(lastSetLabels?.labels).toContain('bump:major');
+    });
+
+    it('inherits sync from version config (defaults true) instead of forcing false', async () => {
+      const { runVersionStepMock } = await setupWithStandingPRLabels([]);
+
+      await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
+
+      expect(runVersionStepMock.mock.calls[0]?.[0]).toMatchObject({ sync: true });
+    });
+  });
 });
 
 describe('runStandingPRPublish', () => {
@@ -986,8 +1063,8 @@ describe('runStandingPRUpdate — editableNotes', () => {
       skipPatterns: ['chore: release '],
       minChanges: 1,
       labels: {
-        stable: 'release:stable',
-        prerelease: 'release:prerelease',
+        stable: 'channel:stable',
+        prerelease: 'channel:prerelease',
         skip: 'release:skip',
         major: 'bump:major',
         minor: 'bump:minor',

--- a/packages/version/src/core/versionCalculator.ts
+++ b/packages/version/src/core/versionCalculator.ts
@@ -287,6 +287,9 @@ export async function calculateVersion(config: Config, options: VersionOptions):
       log(`Creating bumper with preset: ${preset}`, 'debug');
       const bumper = new Bumper();
       bumper.loadPreset(preset);
+      if (config.baseRef) {
+        bumper.commits({ from: config.baseRef });
+      }
       const recommendedBump = await bumper.bump();
       const releaseTypeFromCommits =
         recommendedBump && 'releaseType' in recommendedBump ? (recommendedBump.releaseType as ReleaseType) : undefined;

--- a/packages/version/src/core/versionCalculator.ts
+++ b/packages/version/src/core/versionCalculator.ts
@@ -152,7 +152,7 @@ export async function calculateVersion(config: Config, options: VersionOptions):
     }
 
     // Handle stableOnly mode: graduate prerelease → stable base; skip already-stable packages.
-    // This is triggered by `release:stable` without a bump label.
+    // This is triggered by `channel:stable` without a bump label.
     log(`Checking stableOnly mode: ${config.stableOnly}`, 'debug');
     if (config.stableOnly) {
       log(`StableOnly mode activated`, 'debug');

--- a/packages/version/src/core/versionEngine.ts
+++ b/packages/version/src/core/versionEngine.ts
@@ -46,6 +46,7 @@ export class VersionEngine {
       }
       if (runOptions.stable) effective.stableOnly = true;
       if (runOptions.targets?.length) this.runtimeTargets = runOptions.targets;
+      if (runOptions.baseRef) effective.baseRef = runOptions.baseRef;
     }
 
     // Default values for required properties

--- a/packages/version/src/core/versionStrategies.ts
+++ b/packages/version/src/core/versionStrategies.ts
@@ -255,22 +255,23 @@ export function createSyncStrategy(config: Config): StrategyFunction {
       let revisionRange = 'HEAD';
 
       try {
-        if (latestTag) {
+        const baseForRange = config.baseRef ?? latestTag;
+        if (baseForRange) {
           try {
-            execSync('git', ['rev-parse', '--verify', latestTag], {
+            execSync('git', ['rev-parse', '--verify', baseForRange], {
               cwd: mainPkgPath,
               stdio: 'ignore',
             });
-            revisionRange = `${latestTag}..HEAD`;
+            revisionRange = `${baseForRange}..HEAD`;
           } catch {
-            if (config.strictReachable) {
+            if (!config.baseRef && config.strictReachable) {
               throw new Error(
-                `Cannot generate changelog: tag '${latestTag}' is not reachable from the current commit. ` +
+                `Cannot generate changelog: tag '${baseForRange}' is not reachable from the current commit. ` +
                   `When strictReachable is enabled, all tags must be reachable. ` +
                   `To allow fallback to all commits, set strictReachable to false.`,
               );
             }
-            log(`Tag ${latestTag} doesn't exist, using all commits for changelog`, 'debug');
+            log(`Ref ${baseForRange} doesn't exist, using all commits for changelog`, 'debug');
             revisionRange = 'HEAD';
           }
         }
@@ -500,32 +501,25 @@ export function createSingleStrategy(config: Config): StrategyFunction {
       let revisionRange = 'HEAD';
 
       try {
-        // Extract entries from commits between the latest tag and HEAD
-
-        // Check if the tag actually exists in the repository
-        if (latestTag) {
+        const baseForRange = config.baseRef ?? latestTag;
+        if (baseForRange) {
           try {
-            execSync('git', ['rev-parse', '--verify', latestTag], {
+            execSync('git', ['rev-parse', '--verify', baseForRange], {
               cwd: pkgPath,
               stdio: 'ignore',
             });
-            // Tag exists, get commits since that tag
-            revisionRange = `${latestTag}..HEAD`;
+            revisionRange = `${baseForRange}..HEAD`;
           } catch {
-            if (config.strictReachable) {
+            if (!config.baseRef && config.strictReachable) {
               throw new Error(
-                `Cannot generate changelog: tag '${latestTag}' is not reachable from the current commit. ` +
+                `Cannot generate changelog: tag '${baseForRange}' is not reachable from the current commit. ` +
                   `When strictReachable is enabled, all tags must be reachable. ` +
                   `To allow fallback to all commits, set strictReachable to false.`,
               );
             }
-            // Tag doesn't exist, get all commits
-            log(`Tag ${latestTag} doesn't exist, using all commits for changelog`, 'debug');
+            log(`Ref ${baseForRange} doesn't exist, using all commits for changelog`, 'debug');
             revisionRange = 'HEAD';
           }
-        } else {
-          // No tag provided, get all commits
-          revisionRange = 'HEAD';
         }
 
         changelogEntries = extractChangelogEntriesFromCommits(pkgPath, revisionRange);

--- a/packages/version/src/git/tagVerification.ts
+++ b/packages/version/src/git/tagVerification.ts
@@ -42,7 +42,7 @@ export function verifyTag(tagName: string, cwd: string): TagVerificationResult {
       return {
         exists: false,
         reachable: false,
-        error: `Tag '${tagName}' not found in repository`,
+        error: `Ref '${tagName}' not found in repository`,
       };
     }
 

--- a/packages/version/src/git/tagVerification.ts
+++ b/packages/version/src/git/tagVerification.ts
@@ -22,14 +22,11 @@ export function verifyTag(tagName: string, cwd: string): TagVerificationResult {
   }
 
   try {
-    // Check if tag exists in the repository
+    // Check if the ref object exists in the repository
     execSync('git', ['rev-parse', '--verify', tagName], {
       cwd,
       stdio: 'ignore',
     });
-
-    // Tag exists and is reachable
-    return { exists: true, reachable: true };
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
 
@@ -51,6 +48,23 @@ export function verifyTag(tagName: string, cwd: string): TagVerificationResult {
       exists: false,
       reachable: false,
       error: `Git error: ${errorMessage}`,
+    };
+  }
+
+  // Ref exists — now confirm it is an ancestor of HEAD so that `<ref>..HEAD` produces a
+  // meaningful range. `rev-parse --verify` only checks object existence, not DAG ancestry;
+  // a SHA from a shallow clone or a squash-merge could be present but not reachable from HEAD.
+  try {
+    execSync('git', ['merge-base', '--is-ancestor', tagName, 'HEAD'], {
+      cwd,
+      stdio: 'ignore',
+    });
+    return { exists: true, reachable: true };
+  } catch {
+    return {
+      exists: true,
+      reachable: false,
+      error: `Ref '${tagName}' exists but is not an ancestor of HEAD`,
     };
   }
 }

--- a/packages/version/src/package/packageProcessor.ts
+++ b/packages/version/src/package/packageProcessor.ts
@@ -193,8 +193,8 @@ export class PackageProcessor {
           } else {
             if (!this.fullConfig.baseRef && this.config.strictReachable) {
               throw new Error(
-                `Cannot generate changelog: tag '${baseForRange}' is not reachable from the current commit. ` +
-                  `When strictReachable is enabled, all tags must be reachable. ` +
+                `Cannot generate changelog: ref '${baseForRange}' is not reachable from the current commit. ` +
+                  `When strictReachable is enabled, all refs must be reachable. ` +
                   `To allow fallback to all commits, set strictReachable to false.`,
               );
             }

--- a/packages/version/src/package/packageProcessor.ts
+++ b/packages/version/src/package/packageProcessor.ts
@@ -182,30 +182,25 @@ export class PackageProcessor {
       let revisionRange = 'HEAD';
 
       try {
-        // Extract entries from commits between the latest tag and HEAD
-        // If latestTag is empty or doesn't exist, we'll extract from HEAD
-
-        // Check if the tag actually exists in the repository using the new verification utility
-        if (latestTag) {
-          const verification = verifyTag(latestTag, pkgPath);
+        // Extract entries from commits between the base ref (or latest tag) and HEAD.
+        // baseRef takes precedence — it's a PR base SHA supplied in advisory standing-pr mode
+        // so the changelog is scoped to only this PR's commits, not all commits since last tag.
+        const baseForRange = this.fullConfig.baseRef ?? latestTag;
+        if (baseForRange) {
+          const verification = verifyTag(baseForRange, pkgPath);
           if (verification.exists && verification.reachable) {
-            // Tag exists and is reachable, get commits since that tag
-            revisionRange = `${latestTag}..HEAD`;
+            revisionRange = `${baseForRange}..HEAD`;
           } else {
-            // Tag doesn't exist or is unreachable
-            if (this.config.strictReachable) {
+            if (!this.fullConfig.baseRef && this.config.strictReachable) {
               throw new Error(
-                `Cannot generate changelog: tag '${latestTag}' is not reachable from the current commit. ` +
+                `Cannot generate changelog: tag '${baseForRange}' is not reachable from the current commit. ` +
                   `When strictReachable is enabled, all tags must be reachable. ` +
                   `To allow fallback to all commits, set strictReachable to false.`,
               );
             }
-            log(`Tag ${latestTag} is unreachable (${verification.error}), using all commits for changelog`, 'debug');
+            log(`Ref ${baseForRange} is unreachable (${verification.error}), using all commits for changelog`, 'debug');
             revisionRange = 'HEAD';
           }
-        } else {
-          // No tag provided, get all commits
-          revisionRange = 'HEAD';
         }
 
         changelogEntries = extractChangelogEntriesFromCommits(pkgPath, revisionRange);

--- a/packages/version/src/types.ts
+++ b/packages/version/src/types.ts
@@ -19,6 +19,12 @@ export interface VersionRunOptions {
   sync?: boolean;
   /** Limit release to these package name patterns (comma-split targets from CLI). */
   targets?: string[];
+  /**
+   * When set, use this commit SHA as the start of the revision range instead of the last release
+   * tag. Scopes both the bump-type calculation and the changelog to commits after this ref.
+   * Useful for preview mode where only a PR's own commits should be analysed.
+   */
+  baseRef?: string;
 }
 
 export interface GitInfo {
@@ -58,6 +64,9 @@ export interface Config extends VersionConfigBase {
   latestTag?: string;
   isPrerelease?: boolean;
   stableOnly?: boolean;
+  /** Runtime override: when set, use this commit SHA as the start of the revision range
+   *  for both bump calculation and changelog extraction. See VersionRunOptions.baseRef. */
+  baseRef?: string;
   mismatchStrategy?: 'error' | 'warn' | 'ignore' | 'prefer-package' | 'prefer-git';
   strictReachable?: boolean;
   cargo?: {

--- a/packages/version/test/unit/core/versionCalculator.spec.ts
+++ b/packages/version/test/unit/core/versionCalculator.spec.ts
@@ -710,6 +710,29 @@ describe('Version Calculator', () => {
   });
 
   describe('Conventional commits analysis', () => {
+    it('should call Bumper.commits with baseRef when config.baseRef is set', async () => {
+      const commitsSpy = vi.spyOn(Bumper.prototype, 'commits').mockReturnThis();
+      vi.spyOn(versionUtils, 'bumpVersion').mockReturnValue('1.0.1');
+
+      const config = { ...defaultConfig, baseRef: 'deadbeef123' } as Config;
+      const options: VersionOptions = { latestTag: 'v1.0.0', versionPrefix: 'v' };
+
+      await calculateVersion(config, options);
+
+      expect(commitsSpy).toHaveBeenCalledWith({ from: 'deadbeef123' });
+    });
+
+    it('should NOT call Bumper.commits when config.baseRef is not set', async () => {
+      const commitsSpy = vi.spyOn(Bumper.prototype, 'commits').mockReturnThis();
+      vi.spyOn(versionUtils, 'bumpVersion').mockReturnValue('1.0.1');
+
+      const options: VersionOptions = { latestTag: 'v1.0.0', versionPrefix: 'v' };
+
+      await calculateVersion(defaultConfig as Config, options);
+
+      expect(commitsSpy).not.toHaveBeenCalled();
+    });
+
     it('should use conventional commits when no type or branch pattern matches', async () => {
       // Setup specific mocks
       vi.spyOn(Bumper.prototype, 'loadPreset').mockImplementation(() => {

--- a/packages/version/test/unit/core/versionCalculator.spec.ts
+++ b/packages/version/test/unit/core/versionCalculator.spec.ts
@@ -1431,7 +1431,7 @@ describe('Version Calculator', () => {
     });
   });
 
-  describe('stableOnly mode (release:stable without bump label)', () => {
+  describe('stableOnly mode (channel:stable without bump label)', () => {
     it('should graduate a prerelease package to its stable base version', async () => {
       const config: Partial<Config> = {
         ...defaultConfig,
@@ -1463,7 +1463,7 @@ describe('Version Calculator', () => {
       const config: Partial<Config> = {
         ...defaultConfig,
         stableOnly: true,
-        // No type — release:stable alone, no bump:* label
+        // No type — channel:stable alone, no bump:* label
       };
 
       const options: VersionOptions = {
@@ -1480,7 +1480,7 @@ describe('Version Calculator', () => {
       expect(versionUtils.bumpVersion).not.toHaveBeenCalled();
     });
 
-    it('should apply bump label to an already-stable package (release:stable + bump:minor)', async () => {
+    it('should apply bump label to an already-stable package (channel:stable + bump:minor)', async () => {
       const config: Partial<Config> = {
         ...defaultConfig,
         stableOnly: true,

--- a/packages/version/test/unit/core/versionEngine.spec.ts
+++ b/packages/version/test/unit/core/versionEngine.spec.ts
@@ -158,6 +158,20 @@ describe('Version Engine', () => {
 
       expect(strategyModule.createStrategyMap).toHaveBeenCalledWith(expect.objectContaining({ stableOnly: true }));
     });
+
+    it('should propagate baseRef from runOptions to effective config', () => {
+      new VersionEngine(defaultConfig as Config, { baseRef: 'abc1234def' });
+
+      expect(strategyModule.createStrategyMap).toHaveBeenCalledWith(expect.objectContaining({ baseRef: 'abc1234def' }));
+    });
+
+    it('should not set baseRef when runOptions does not include it', () => {
+      new VersionEngine(defaultConfig as Config, { bump: 'minor' });
+
+      expect(strategyModule.createStrategyMap).toHaveBeenCalledWith(
+        expect.not.objectContaining({ baseRef: expect.anything() }),
+      );
+    });
   });
 
   describe('getWorkspacePackages', () => {

--- a/packages/version/test/unit/core/versionStrategies.spec.ts
+++ b/packages/version/test/unit/core/versionStrategies.spec.ts
@@ -447,6 +447,40 @@ describe('Version Strategies', () => {
         );
       });
 
+      it('should use baseRef for revision range when config.baseRef is set', async () => {
+        const config: Partial<Config> = {
+          ...defaultConfig,
+          sync: true,
+          baseRef: 'deadbeef1234',
+        };
+
+        const syncStrategy = strategies.createSyncStrategy(config as Config);
+        await syncStrategy(mockPackages);
+
+        expect(commitParser.extractChangelogEntriesFromCommits).toHaveBeenCalledWith(
+          '/test/workspace',
+          'deadbeef1234..HEAD',
+        );
+      });
+
+      it('should fall back to HEAD when baseRef cannot be resolved by git', async () => {
+        // Make the rev-parse --verify call fail for the baseRef
+        vi.mocked(commandExecutor.execSync, { partial: true }).mockImplementationOnce(() => {
+          throw new Error('fatal: bad object nonexistent-sha');
+        });
+
+        const config: Partial<Config> = {
+          ...defaultConfig,
+          sync: true,
+          baseRef: 'nonexistent-sha',
+        };
+
+        const syncStrategy = strategies.createSyncStrategy(config as Config);
+        await syncStrategy(mockPackages);
+
+        expect(commitParser.extractChangelogEntriesFromCommits).toHaveBeenCalledWith('/test/workspace', 'HEAD');
+      });
+
       it('should create one tag per workspace package when packageSpecificTags is true', async () => {
         vi.mocked(formatting.formatTag, { partial: true }).mockImplementation((_version, _prefix, packageName) =>
           packageName ? `${packageName}-v1.1.0` : 'v1.1.0',

--- a/packages/version/test/unit/git/tagVerification.spec.ts
+++ b/packages/version/test/unit/git/tagVerification.spec.ts
@@ -44,7 +44,7 @@ describe('Tag Verification', () => {
       expect(result).toEqual({
         exists: false,
         reachable: false,
-        error: "Tag 'v1.0.0' not found in repository",
+        error: "Ref 'v1.0.0' not found in repository",
       });
     });
 
@@ -59,7 +59,7 @@ describe('Tag Verification', () => {
       expect(result).toEqual({
         exists: false,
         reachable: false,
-        error: "Tag 'v1.0.0' not found in repository",
+        error: "Ref 'v1.0.0' not found in repository",
       });
     });
 
@@ -74,7 +74,7 @@ describe('Tag Verification', () => {
       expect(result).toEqual({
         exists: false,
         reachable: false,
-        error: "Tag 'v1.0.0' not found in repository",
+        error: "Ref 'v1.0.0' not found in repository",
       });
     });
 
@@ -181,7 +181,7 @@ describe('Tag Verification', () => {
         reason: 'Git tag unreachable',
       });
       expect(mockLog).toHaveBeenCalledWith(
-        "Git tag 'v1.0.0' unreachable (Tag 'v1.0.0' not found in repository), using package version: 1.0.0",
+        "Git tag 'v1.0.0' unreachable (Ref 'v1.0.0' not found in repository), using package version: 1.0.0",
         'warning',
       );
     });

--- a/packages/version/test/unit/git/tagVerification.spec.ts
+++ b/packages/version/test/unit/git/tagVerification.spec.ts
@@ -31,6 +31,27 @@ describe('Tag Verification', () => {
         cwd: '/test/path',
         stdio: 'ignore',
       });
+      expect(mockExecSync).toHaveBeenCalledWith('git', ['merge-base', '--is-ancestor', 'v1.0.0', 'HEAD'], {
+        cwd: '/test/path',
+        stdio: 'ignore',
+      });
+    });
+
+    it('should return reachable: false when ref exists but is not an ancestor of HEAD', () => {
+      // First call (rev-parse) succeeds; second call (merge-base --is-ancestor) fails with exit 1
+      mockExecSync
+        .mockImplementationOnce(() => Buffer.from('abc123'))
+        .mockImplementationOnce(() => {
+          throw new Error('exit code 1');
+        });
+
+      const result = verifyTag('deadbeef', '/test/path');
+
+      expect(result).toEqual({
+        exists: true,
+        reachable: false,
+        error: "Ref 'deadbeef' exists but is not an ancestor of HEAD",
+      });
     });
 
     it('should return exists: false when tag does not exist', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -309,6 +309,9 @@ importers:
       minimatch:
         specifier: 'catalog:'
         version: 10.2.5
+      semver:
+        specifier: 'catalog:'
+        version: 7.7.4
       smol-toml:
         specifier: 'catalog:'
         version: 1.6.1

--- a/releasekit.schema.json
+++ b/releasekit.schema.json
@@ -910,11 +910,6 @@
               "default": true,
               "description": "Whether to auto-delete the release branch after the PR is merged."
             },
-            "editableNotes": {
-              "type": "boolean",
-              "default": false,
-              "description": "Allow teams to edit the release notes section in the PR body before publishing. When enabled, the notes section is wrapped in editable markers and preserved across updates if manually changed."
-            },
             "mergeMethod": {
               "type": "string",
               "enum": [

--- a/releasekit.schema.json
+++ b/releasekit.schema.json
@@ -27,7 +27,11 @@
         },
         "pushMethod": {
           "type": "string",
-          "enum": ["auto", "ssh", "https"],
+          "enum": [
+            "auto",
+            "ssh",
+            "https"
+          ],
           "default": "auto",
           "description": "Method for pushing to remote"
         },
@@ -52,7 +56,11 @@
       "properties": {
         "mode": {
           "type": "string",
-          "enum": ["root", "packages", "both"],
+          "enum": [
+            "root",
+            "packages",
+            "both"
+          ],
           "description": "Changelog aggregation mode"
         },
         "rootPath": {
@@ -96,7 +104,9 @@
         },
         "packages": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": {
+            "type": "string"
+          },
           "default": [],
           "description": "Packages to include in versioning"
         },
@@ -106,13 +116,20 @@
         },
         "updateInternalDependencies": {
           "type": "string",
-          "enum": ["major", "minor", "patch", "no-internal-update"],
+          "enum": [
+            "major",
+            "minor",
+            "patch",
+            "no-internal-update"
+          ],
           "default": "minor",
           "description": "How to bump internal dependencies"
         },
         "skip": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": {
+            "type": "string"
+          },
           "description": "Packages to exclude from versioning"
         },
         "commitMessage": {
@@ -121,7 +138,10 @@
         },
         "versionStrategy": {
           "type": "string",
-          "enum": ["branchPattern", "commitMessage"],
+          "enum": [
+            "branchPattern",
+            "commitMessage"
+          ],
           "default": "commitMessage",
           "description": "Strategy for determining version bumps"
         },
@@ -130,24 +150,45 @@
           "items": {
             "type": "object",
             "properties": {
-              "pattern": { "type": "string" },
+              "pattern": {
+                "type": "string"
+              },
               "releaseType": {
                 "type": "string",
-                "enum": ["major", "minor", "patch", "prerelease"]
+                "enum": [
+                  "major",
+                  "minor",
+                  "patch",
+                  "prerelease"
+                ]
               }
             },
-            "required": ["pattern", "releaseType"]
+            "required": [
+              "pattern",
+              "releaseType"
+            ]
           },
           "description": "Branch name patterns for version determination"
         },
         "defaultReleaseType": {
           "type": "string",
-          "enum": ["major", "minor", "patch", "prerelease"],
+          "enum": [
+            "major",
+            "minor",
+            "patch",
+            "prerelease"
+          ],
           "description": "Default release type when no pattern matches"
         },
         "mismatchStrategy": {
           "type": "string",
-          "enum": ["error", "warn", "ignore", "prefer-package", "prefer-git"],
+          "enum": [
+            "error",
+            "warn",
+            "ignore",
+            "prefer-package",
+            "prefer-git"
+          ],
           "default": "warn",
           "description": "How to handle version mismatches"
         },
@@ -181,7 +222,9 @@
             },
             "paths": {
               "type": "array",
-              "items": { "type": "string" },
+              "items": {
+                "type": "string"
+              },
               "description": "Directories to search for Cargo.toml files"
             }
           }
@@ -204,7 +247,11 @@
             },
             "pushMethod": {
               "type": "string",
-              "enum": ["auto", "ssh", "https"],
+              "enum": [
+                "auto",
+                "ssh",
+                "https"
+              ],
               "description": "Push method override"
             },
             "remote": {
@@ -237,7 +284,11 @@
             },
             "auth": {
               "type": "string",
-              "enum": ["auto", "oidc", "token"],
+              "enum": [
+                "auto",
+                "oidc",
+                "token"
+              ],
               "default": "auto",
               "description": "Authentication method"
             },
@@ -248,7 +299,10 @@
             },
             "access": {
               "type": "string",
-              "enum": ["public", "restricted"],
+              "enum": [
+                "public",
+                "restricted"
+              ],
               "default": "public",
               "description": "Package access level"
             },
@@ -259,8 +313,12 @@
             },
             "copyFiles": {
               "type": "array",
-              "items": { "type": "string" },
-              "default": ["LICENSE"],
+              "items": {
+                "type": "string"
+              },
+              "default": [
+                "LICENSE"
+              ],
               "description": "Files to copy to package before publishing"
             },
             "tag": {
@@ -287,7 +345,9 @@
             },
             "publishOrder": {
               "type": "array",
-              "items": { "type": "string" },
+              "items": {
+                "type": "string"
+              },
               "default": [],
               "description": "Order in which to publish packages"
             },
@@ -319,13 +379,29 @@
               "description": "Create separate release per package"
             },
             "prerelease": {
-              "oneOf": [{ "type": "boolean" }, { "type": "string", "enum": ["auto"] }],
+              "oneOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "auto"
+                  ]
+                }
+              ],
               "default": "auto",
               "description": "Mark as prerelease"
             },
             "body": {
               "type": "string",
-              "enum": ["auto", "releaseNotes", "changelog", "generated", "none"],
+              "enum": [
+                "auto",
+                "releaseNotes",
+                "changelog",
+                "generated",
+                "none"
+              ],
               "default": "auto",
               "description": "Source for GitHub release body. 'auto': use release notes if enabled, else changelog, else GitHub auto. 'releaseNotes': use LLM-generated release notes. 'changelog': use changelog entries. 'generated': GitHub auto-generated. 'none': no body."
             },
@@ -410,7 +486,13 @@
       "properties": {
         "changelog": {
           "oneOf": [
-            { "type": "boolean", "enum": [false], "description": "Set to false to disable changelog generation" },
+            {
+              "type": "boolean",
+              "enum": [
+                false
+              ],
+              "description": "Set to false to disable changelog generation"
+            },
             {
               "type": "object",
               "description": "Changelog file configuration",
@@ -418,7 +500,11 @@
               "properties": {
                 "mode": {
                   "type": "string",
-                  "enum": ["root", "packages", "both"],
+                  "enum": [
+                    "root",
+                    "packages",
+                    "both"
+                  ],
                   "description": "Where to write changelog files. root: repo root only. packages: per-package (monorepos). both: repo root and per-package. When omitted entirely (no changelog config), defaults to root."
                 },
                 "file": {
@@ -436,7 +522,11 @@
                     },
                     "engine": {
                       "type": "string",
-                      "enum": ["handlebars", "liquid", "ejs"],
+                      "enum": [
+                        "handlebars",
+                        "liquid",
+                        "ejs"
+                      ],
                       "description": "Template engine"
                     }
                   }
@@ -447,7 +537,13 @@
         },
         "releaseNotes": {
           "oneOf": [
-            { "type": "boolean", "enum": [false], "description": "Set to false to disable release notes" },
+            {
+              "type": "boolean",
+              "enum": [
+                false
+              ],
+              "description": "Set to false to disable release notes"
+            },
             {
               "type": "object",
               "description": "Release notes configuration",
@@ -455,7 +551,11 @@
               "properties": {
                 "mode": {
                   "type": "string",
-                  "enum": ["root", "packages", "both"],
+                  "enum": [
+                    "root",
+                    "packages",
+                    "both"
+                  ],
                   "description": "Where to write release notes file. Omit to skip file output (LLM still runs if configured)."
                 },
                 "file": {
@@ -473,7 +573,11 @@
                     },
                     "engine": {
                       "type": "string",
-                      "enum": ["handlebars", "liquid", "ejs"],
+                      "enum": [
+                        "handlebars",
+                        "liquid",
+                        "ejs"
+                      ],
                       "description": "Template engine"
                     }
                   }
@@ -483,28 +587,65 @@
                   "description": "LLM configuration for release notes",
                   "additionalProperties": false,
                   "properties": {
-                    "provider": { "type": "string", "description": "LLM provider" },
-                    "model": { "type": "string", "description": "Model identifier" },
-                    "baseURL": { "type": "string", "description": "Custom API base URL" },
-                    "apiKey": { "type": "string", "description": "API key" },
+                    "provider": {
+                      "type": "string",
+                      "description": "LLM provider"
+                    },
+                    "model": {
+                      "type": "string",
+                      "description": "Model identifier"
+                    },
+                    "baseURL": {
+                      "type": "string",
+                      "description": "Custom API base URL"
+                    },
+                    "apiKey": {
+                      "type": "string",
+                      "description": "API key"
+                    },
                     "options": {
                       "type": "object",
                       "additionalProperties": false,
                       "properties": {
-                        "timeout": { "type": "integer", "description": "Request timeout in ms" },
-                        "maxTokens": { "type": "integer", "description": "Max tokens to generate" },
-                        "temperature": { "type": "number", "description": "Sampling temperature" }
+                        "timeout": {
+                          "type": "integer",
+                          "description": "Request timeout in ms"
+                        },
+                        "maxTokens": {
+                          "type": "integer",
+                          "description": "Max tokens to generate"
+                        },
+                        "temperature": {
+                          "type": "number",
+                          "description": "Sampling temperature"
+                        }
                       }
                     },
-                    "concurrency": { "type": "integer", "minimum": 1, "description": "Concurrent LLM requests" },
+                    "concurrency": {
+                      "type": "integer",
+                      "minimum": 1,
+                      "description": "Concurrent LLM requests"
+                    },
                     "tasks": {
                       "type": "object",
                       "additionalProperties": false,
                       "properties": {
-                        "summarize": { "type": "boolean", "description": "Enable summarization" },
-                        "enhance": { "type": "boolean", "description": "Enable entry enhancement" },
-                        "categorize": { "type": "boolean", "description": "Enable categorization" },
-                        "releaseNotes": { "type": "boolean", "description": "Enable release note generation" }
+                        "summarize": {
+                          "type": "boolean",
+                          "description": "Enable summarization"
+                        },
+                        "enhance": {
+                          "type": "boolean",
+                          "description": "Enable entry enhancement"
+                        },
+                        "categorize": {
+                          "type": "boolean",
+                          "description": "Enable categorization"
+                        },
+                        "releaseNotes": {
+                          "type": "boolean",
+                          "description": "Enable release note generation"
+                        }
                       }
                     },
                     "categories": {
@@ -513,35 +654,69 @@
                         "type": "object",
                         "additionalProperties": false,
                         "properties": {
-                          "name": { "type": "string" },
-                          "description": { "type": "string" },
-                          "scopes": { "type": "array", "items": { "type": "string" } }
+                          "name": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "type": "string"
+                          },
+                          "scopes": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
                         },
-                        "required": ["name", "description"]
+                        "required": [
+                          "name",
+                          "description"
+                        ]
                       }
                     },
-                    "style": { "type": "string", "description": "Writing style for LLM" },
+                    "style": {
+                      "type": "string",
+                      "description": "Writing style for LLM"
+                    },
                     "scopes": {
                       "type": "object",
                       "additionalProperties": false,
                       "properties": {
                         "mode": {
                           "type": "string",
-                          "enum": ["restricted", "packages", "none", "unrestricted"],
+                          "enum": [
+                            "restricted",
+                            "packages",
+                            "none",
+                            "unrestricted"
+                          ],
                           "default": "unrestricted"
                         },
                         "rules": {
                           "type": "object",
                           "additionalProperties": false,
                           "properties": {
-                            "allowed": { "type": "array", "items": { "type": "string" } },
-                            "caseSensitive": { "type": "boolean", "default": false },
+                            "allowed": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "caseSensitive": {
+                              "type": "boolean",
+                              "default": false
+                            },
                             "invalidScopeAction": {
                               "type": "string",
-                              "enum": ["remove", "keep", "fallback"],
+                              "enum": [
+                                "remove",
+                                "keep",
+                                "fallback"
+                              ],
                               "default": "remove"
                             },
-                            "fallbackScope": { "type": "string" }
+                            "fallbackScope": {
+                              "type": "string"
+                            }
                           }
                         }
                       }
@@ -550,9 +725,21 @@
                       "type": "object",
                       "additionalProperties": false,
                       "properties": {
-                        "maxAttempts": { "type": "integer", "minimum": 1, "description": "Maximum number of attempts" },
-                        "initialDelay": { "type": "integer", "minimum": 0, "description": "Initial delay in ms" },
-                        "maxDelay": { "type": "integer", "minimum": 0, "description": "Maximum delay in ms" },
+                        "maxAttempts": {
+                          "type": "integer",
+                          "minimum": 1,
+                          "description": "Maximum number of attempts"
+                        },
+                        "initialDelay": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "description": "Initial delay in ms"
+                        },
+                        "maxDelay": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "description": "Maximum delay in ms"
+                        },
                         "backoffFactor": {
                           "type": "number",
                           "minimum": 1,
@@ -566,18 +753,25 @@
                       "properties": {
                         "instructions": {
                           "type": "object",
-                          "additionalProperties": { "type": "string" },
+                          "additionalProperties": {
+                            "type": "string"
+                          },
                           "description": "Per-task instruction overrides"
                         },
                         "templates": {
                           "type": "object",
-                          "additionalProperties": { "type": "string" },
+                          "additionalProperties": {
+                            "type": "string"
+                          },
                           "description": "Per-task prompt template overrides"
                         }
                       }
                     }
                   },
-                  "required": ["provider", "model"]
+                  "required": [
+                    "provider",
+                    "model"
+                  ]
                 }
               }
             }
@@ -585,7 +779,10 @@
         },
         "updateStrategy": {
           "type": "string",
-          "enum": ["prepend", "regenerate"],
+          "enum": [
+            "prepend",
+            "regenerate"
+          ],
           "description": "How to update existing changelog files. 'prepend' adds new entries to the top; 'regenerate' rewrites the file from scratch."
         }
       }
@@ -597,13 +794,21 @@
       "properties": {
         "releaseStrategy": {
           "type": "string",
-          "enum": ["manual", "direct", "standing-pr", "scheduled"],
+          "enum": [
+            "manual",
+            "direct",
+            "standing-pr",
+            "scheduled"
+          ],
           "default": "direct",
           "description": "How releases are delivered. 'direct': release on merge to main. 'manual': releases triggered manually (e.g. workflow_dispatch). 'standing-pr': changes accumulate in a release PR. 'scheduled': releases triggered on a schedule."
         },
         "releaseTrigger": {
           "type": "string",
-          "enum": ["commit", "label"],
+          "enum": [
+            "commit",
+            "label"
+          ],
           "default": "label",
           "description": "What triggers a release. 'label': a PR bump label (bump:patch/minor/major) is required. 'commit': conventional commits drive the bump automatically; every merge can trigger a release."
         },
@@ -619,8 +824,12 @@
         },
         "skipPatterns": {
           "type": "array",
-          "items": { "type": "string" },
-          "default": ["chore: release "],
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "chore: release "
+          ],
           "description": "Commit message prefixes that suppress a release. The default matches the release commit template to prevent release loops."
         },
         "minChanges": {
@@ -636,18 +845,23 @@
           "properties": {
             "stable": {
               "type": "string",
-              "default": "release:stable",
+              "default": "channel:stable",
               "description": "Label to graduate a prerelease to stable"
             },
             "prerelease": {
               "type": "string",
-              "default": "release:prerelease",
+              "default": "channel:prerelease",
               "description": "Label to create a prerelease"
             },
             "skip": {
               "type": "string",
               "default": "release:skip",
               "description": "Label to suppress a release on this PR"
+            },
+            "immediate": {
+              "type": "string",
+              "default": "release:immediate",
+              "description": "Label to bypass the standing PR for one merge — triggers a direct release. Standing-pr mode only."
             },
             "major": {
               "type": "string",
@@ -683,8 +897,12 @@
             },
             "labels": {
               "type": "array",
-              "items": { "type": "string" },
-              "default": ["release"],
+              "items": {
+                "type": "string"
+              },
+              "default": [
+                "release"
+              ],
               "description": "Labels to apply to the standing release PR."
             },
             "deleteBranchOnMerge": {
@@ -699,7 +917,11 @@
             },
             "mergeMethod": {
               "type": "string",
-              "enum": ["merge", "squash", "rebase"],
+              "enum": [
+                "merge",
+                "squash",
+                "rebase"
+              ],
               "default": "merge",
               "description": "Merge method to use when merging the standing release PR via CLI."
             },
@@ -725,7 +947,10 @@
           "type": "array",
           "items": {
             "type": "string",
-            "enum": ["notes", "publish"]
+            "enum": [
+              "notes",
+              "publish"
+            ]
           },
           "minItems": 1,
           "description": "Which steps to run by default. Omitting a step is equivalent to --skip-<step>."
@@ -737,7 +962,10 @@
           "properties": {
             "skipPatterns": {
               "type": "array",
-              "items": { "type": "string", "minLength": 1 },
+              "items": {
+                "type": "string",
+                "minLength": 1
+              },
               "description": "Commit message prefixes that prevent a release (e.g. 'chore(deps):', 'ci:')"
             },
             "minChanges": {
@@ -747,12 +975,16 @@
             },
             "githubRelease": {
               "type": "boolean",
-              "enum": [false],
+              "enum": [
+                false
+              ],
               "description": "Set to false to disable GitHub release creation in CI"
             },
             "notes": {
               "type": "boolean",
-              "enum": [false],
+              "enum": [
+                false
+              ],
               "description": "Set to false to disable changelog generation in CI"
             }
           }

--- a/templates/workflows/standing-pr.yml
+++ b/templates/workflows/standing-pr.yml
@@ -63,6 +63,60 @@ jobs:
           # ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           # OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
 
+  immediate-release:
+    # Bypass the standing PR queue and release directly. Triggered when a feeder PR
+    # carrying `release:immediate` (configurable via `ci.labels.immediate`) merges to main.
+    # Honours companion bump:* / scope:* / channel:* labels normally.
+    # The final reconcile step keeps the standing PR fresh — released packages drop out
+    # of the queue with no staleness window.
+    name: Immediate Release (bypass standing PR)
+    if: >
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.merged == true &&
+      contains(github.event.pull_request.labels.*.name, 'release:immediate')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ github.token }}
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - run: pnpm install --frozen-lockfile
+      # Using npm? Replace the line above with: npm ci
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Direct release (bypassing standing PR)
+        run: pnpm exec releasekit release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          # NODE_AUTH_TOKEN unnecessary with OIDC trusted publishing. With token-based
+          # npm auth, uncomment the next line:
+          # NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # Provider key for LLM-enhanced release notes (uncomment your provider):
+          # OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          # ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          # OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
+
+      - name: Reconcile standing PR
+        # The release above tagged new versions. Re-run standing PR update so the queued
+        # release reflects the post-immediate state (released packages drop out of the
+        # queue, anything still queued stays). Zero-staleness reconciliation.
+        run: pnpm exec releasekit standing-pr update
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          # OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          # ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          # OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
+
   publish-release:
     name: Publish Release
     if: >


### PR DESCRIPTION
- Added functionality to fetch and display a snapshot of the current standing PR, including its queued packages and gate state, in the release preview comment.
- Implemented a new `mergeForPreview` function to predict package versions after merging the current PR with the standing PR, providing insights into potential version changes.
- Updated the `formatPreviewComment` function to include the standing PR snapshot and the merge prediction table when the release strategy is set to 'standing-pr'.
- Introduced new types and interfaces for managing the standing PR snapshot and merged rows, improving type safety and clarity in the codebase.
- Added unit tests to ensure the correct rendering of the standing PR snapshot and merge table in various scenarios.