### PR TITLE
feat(release): enhance standing PR workflow to detect merges from push events

### DIFF
--- a/.github/workflows/standing-pr.yml
+++ b/.github/workflows/standing-pr.yml
@@ -20,9 +20,38 @@ env:
   TURBO_TELEMETRY_DISABLED: 1
 
 jobs:
+  # Runs first on every push to main so the downstream jobs can serialize on its output:
+  # if the push is the merge of a release/* PR, only `publish-release` runs;
+  # otherwise only `update-release-pr` runs. Without this gate, both would run in parallel
+  # and `update-release-pr` could collect the just-released commits as "unreleased" before
+  # `publish-release` finishes tagging.
+  detect-release-merge:
+    name: Detect release merge
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    outputs:
+      pr_number: ${{ steps.detect.outputs.pr_number }}
+    steps:
+      - name: Find PR for merge commit
+        id: detect
+        env:
+          COMMIT_SHA: ${{ github.sha }}
+          REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PRS=$(gh api "repos/$REPO/commits/$COMMIT_SHA/pulls" 2>/dev/null || echo '[]')
+          PR_NUM=$(echo "$PRS" | jq -r '[.[] | select(.head.ref | startswith("release/"))][0].number // empty')
+          if [ -n "$PR_NUM" ]; then
+            echo "pr_number=$PR_NUM" >> "$GITHUB_OUTPUT"
+            echo "Detected standing PR merge: PR #$PR_NUM"
+          else
+            echo "No standing PR merge detected for this push"
+          fi
+
   update-release-pr:
     name: Update Release PR
-    if: github.event_name == 'push'
+    needs: detect-release-merge
+    if: github.event_name == 'push' && needs.detect-release-merge.outputs.pr_number == ''
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -88,32 +117,6 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
 
-  # The pull_request: closed event does not fire when the PR's branch was created by GITHUB_TOKEN
-  # (GitHub suppresses downstream workflow runs to prevent recursion). Detect the standing-PR
-  # merge from the push event instead by looking up the merge commit's PR.
-  detect-release-merge:
-    name: Detect release merge
-    if: github.event_name == 'push'
-    runs-on: ubuntu-latest
-    outputs:
-      pr_number: ${{ steps.detect.outputs.pr_number }}
-    steps:
-      - name: Find PR for merge commit
-        id: detect
-        env:
-          COMMIT_SHA: ${{ github.sha }}
-          REPO: ${{ github.repository }}
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          PRS=$(gh api "repos/$REPO/commits/$COMMIT_SHA/pulls" 2>/dev/null || echo '[]')
-          PR_NUM=$(echo "$PRS" | jq -r '[.[] | select(.head.ref | startswith("release/"))][0].number // empty')
-          if [ -n "$PR_NUM" ]; then
-            echo "pr_number=$PR_NUM" >> "$GITHUB_OUTPUT"
-            echo "Detected standing PR merge: PR #$PR_NUM"
-          else
-            echo "No standing PR merge detected for this push"
-          fi
-
   publish-release:
     name: Publish Release
     needs: detect-release-merge
@@ -138,6 +141,6 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Publish from release PR
-        run: node packages/release/dist/cli.js standing-pr publish --pr ${{ needs.detect-release-merge.outputs.pr_number }}
+        run: node packages/release/dist/cli.js standing-pr publish --pr "${{ needs.detect-release-merge.outputs.pr_number }}"
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/standing-pr.yml
+++ b/.github/workflows/standing-pr.yml
@@ -88,12 +88,36 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
 
+  # The pull_request: closed event does not fire when the PR's branch was created by GITHUB_TOKEN
+  # (GitHub suppresses downstream workflow runs to prevent recursion). Detect the standing-PR
+  # merge from the push event instead by looking up the merge commit's PR.
+  detect-release-merge:
+    name: Detect release merge
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    outputs:
+      pr_number: ${{ steps.detect.outputs.pr_number }}
+    steps:
+      - name: Find PR for merge commit
+        id: detect
+        env:
+          COMMIT_SHA: ${{ github.sha }}
+          REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PRS=$(gh api "repos/$REPO/commits/$COMMIT_SHA/pulls" 2>/dev/null || echo '[]')
+          PR_NUM=$(echo "$PRS" | jq -r '[.[] | select(.head.ref | startswith("release/"))][0].number // empty')
+          if [ -n "$PR_NUM" ]; then
+            echo "pr_number=$PR_NUM" >> "$GITHUB_OUTPUT"
+            echo "Detected standing PR merge: PR #$PR_NUM"
+          else
+            echo "No standing PR merge detected for this push"
+          fi
+
   publish-release:
     name: Publish Release
-    if: >
-      github.event_name == 'pull_request' &&
-      github.event.pull_request.merged == true &&
-      startsWith(github.event.pull_request.head.ref, 'release/')
+    needs: detect-release-merge
+    if: needs.detect-release-merge.outputs.pr_number != ''
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -114,6 +138,6 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Publish from release PR
-        run: node packages/release/dist/cli.js standing-pr publish
+        run: node packages/release/dist/cli.js standing-pr publish --pr ${{ needs.detect-release-merge.outputs.pr_number }}
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/standing-pr.yml
+++ b/.github/workflows/standing-pr.yml
@@ -49,10 +49,27 @@ jobs:
         run: |
           set -euo pipefail
           STANDING_PR_BRANCH=$(jq -r '.ci.standingPr.branch // "release/next"' releasekit.config.json)
-          # Let gh api fail loudly: a transient API error here would otherwise look identical to
-          # "no PR for this commit", silently routing a release-PR merge to update-release-pr
-          # instead of publish-release and skipping the actual publish.
-          PRS=$(gh api "repos/$REPO/commits/$COMMIT_SHA/pulls")
+
+          # Retry transient API errors (rate limits, 5xx, network blips) before giving up. The
+          # API call distinguishes "no PR for this commit" (returns []) from real failures, so
+          # silent fall-through to update-release-pr is only safe when we got a successful
+          # response. On persistent failure we fail the job loudly — both downstream jobs will
+          # be skipped, but the next push retries the workflow.
+          PRS=""
+          for attempt in 1 2 3; do
+            if PRS=$(gh api "repos/$REPO/commits/$COMMIT_SHA/pulls" 2>&1); then
+              break
+            fi
+            if [ "$attempt" -lt 3 ]; then
+              echo "::warning::gh api failed (attempt $attempt/3): $PRS — retrying after ${attempt}s"
+              sleep "$attempt"
+              PRS=""
+            else
+              echo "::error::gh api failed after 3 attempts: $PRS"
+              exit 1
+            fi
+          done
+
           PR_NUM=$(echo "$PRS" | jq --arg branch "$STANDING_PR_BRANCH" -r \
             '[.[] | select(.head.ref == $branch)][0].number // empty')
           if [ -n "$PR_NUM" ]; then

--- a/.github/workflows/standing-pr.yml
+++ b/.github/workflows/standing-pr.yml
@@ -32,17 +32,23 @@ jobs:
     outputs:
       pr_number: ${{ steps.detect.outputs.pr_number }}
     steps:
+      # Sparse checkout of just the config file — avoids cloning the whole repo while letting
+      # the branch name come from a single source of truth (ci.standingPr.branch).
+      - name: Checkout config
+        uses: actions/checkout@v6.0.2
+        with:
+          sparse-checkout: releasekit.config.json
+          sparse-checkout-cone-mode: false
+
       - name: Find PR for merge commit
         id: detect
         env:
           COMMIT_SHA: ${{ github.sha }}
           REPO: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}
-          # Must match ci.standingPr.branch in releasekit.config.json. Hardcoded here so this job
-          # doesn't need a checkout — keep in sync if you customize the standing-PR branch.
-          STANDING_PR_BRANCH: release/next
         run: |
           set -euo pipefail
+          STANDING_PR_BRANCH=$(jq -r '.ci.standingPr.branch // "release/next"' releasekit.config.json)
           # Let gh api fail loudly: a transient API error here would otherwise look identical to
           # "no PR for this commit", silently routing a release-PR merge to update-release-pr
           # instead of publish-release and skipping the actual publish.
@@ -53,7 +59,7 @@ jobs:
             echo "pr_number=$PR_NUM" >> "$GITHUB_OUTPUT"
             echo "Detected standing PR merge: PR #$PR_NUM (head: $STANDING_PR_BRANCH)"
           else
-            echo "No standing PR merge detected for this push"
+            echo "No standing PR merge detected for this push (looking for head: $STANDING_PR_BRANCH)"
           fi
 
   update-release-pr:

--- a/.github/workflows/standing-pr.yml
+++ b/.github/workflows/standing-pr.yml
@@ -38,12 +38,20 @@ jobs:
           COMMIT_SHA: ${{ github.sha }}
           REPO: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}
+          # Must match ci.standingPr.branch in releasekit.config.json. Hardcoded here so this job
+          # doesn't need a checkout — keep in sync if you customize the standing-PR branch.
+          STANDING_PR_BRANCH: release/next
         run: |
-          PRS=$(gh api "repos/$REPO/commits/$COMMIT_SHA/pulls" 2>/dev/null || echo '[]')
-          PR_NUM=$(echo "$PRS" | jq -r '[.[] | select(.head.ref | startswith("release/"))][0].number // empty')
+          set -euo pipefail
+          # Let gh api fail loudly: a transient API error here would otherwise look identical to
+          # "no PR for this commit", silently routing a release-PR merge to update-release-pr
+          # instead of publish-release and skipping the actual publish.
+          PRS=$(gh api "repos/$REPO/commits/$COMMIT_SHA/pulls")
+          PR_NUM=$(echo "$PRS" | jq --arg branch "$STANDING_PR_BRANCH" -r \
+            '[.[] | select(.head.ref == $branch)][0].number // empty')
           if [ -n "$PR_NUM" ]; then
             echo "pr_number=$PR_NUM" >> "$GITHUB_OUTPUT"
-            echo "Detected standing PR merge: PR #$PR_NUM"
+            echo "Detected standing PR merge: PR #$PR_NUM (head: $STANDING_PR_BRANCH)"
           else
             echo "No standing PR merge detected for this push"
           fi

--- a/packages/release/src/commands/standing-pr-command.ts
+++ b/packages/release/src/commands/standing-pr-command.ts
@@ -45,7 +45,11 @@ export function createStandingPRCommand(): Command {
   sharedOptions(
     cmd
       .command('publish')
-      .description('Publish packages from a merged standing release PR (reads manifest from PR comment)'),
+      .description('Publish packages from a merged standing release PR (reads manifest from PR comment)')
+      .option(
+        '--pr <number>',
+        'PR number of the merged standing release PR. Use when the workflow runs on a push event (auto-detected from pull_request event when omitted)',
+      ),
   ).action(async (opts) => {
     const options: StandingPROptions = {
       config: opts.config,
@@ -56,8 +60,17 @@ export function createStandingPRCommand(): Command {
       quiet: opts.quiet,
     };
 
+    let prNumber: number | undefined;
+    if (opts.pr !== undefined) {
+      prNumber = Number.parseInt(opts.pr, 10);
+      if (Number.isNaN(prNumber) || prNumber <= 0) {
+        console.error(`--pr must be a positive integer (got: ${opts.pr})`);
+        process.exit(EXIT_CODES.GENERAL_ERROR);
+      }
+    }
+
     try {
-      const result = await runStandingPRPublish(options);
+      const result = await runStandingPRPublish(options, prNumber);
       if (opts.json && result) {
         console.log(JSON.stringify(result, null, 2));
       }

--- a/packages/release/src/commands/standing-pr-command.ts
+++ b/packages/release/src/commands/standing-pr-command.ts
@@ -62,11 +62,14 @@ export function createStandingPRCommand(): Command {
 
     let prNumber: number | undefined;
     if (opts.pr !== undefined) {
-      prNumber = Number.parseInt(opts.pr, 10);
-      if (Number.isNaN(prNumber) || prNumber <= 0) {
+      // Use a strict regex rather than parseInt — the latter silently accepts trailing
+      // non-digit characters ('123abc' → 123), which would mask genuine input errors.
+      const trimmed = String(opts.pr).trim();
+      if (!/^[1-9]\d*$/.test(trimmed)) {
         console.error(`--pr must be a positive integer (got: ${opts.pr})`);
         process.exit(EXIT_CODES.GENERAL_ERROR);
       }
+      prNumber = Number.parseInt(trimmed, 10);
     }
 
     try {

--- a/packages/release/src/preview/format.ts
+++ b/packages/release/src/preview/format.ts
@@ -100,7 +100,43 @@ function getLabelBanner(labelContext?: LabelContext): string[] {
   // directly, so the standard banners ("labeled for X", "no bump label", scope) would only confuse.
   if (labelContext.immediate) {
     const immediateLabel = labelContext.labels?.immediate ?? 'release:immediate';
-    lines.push(`> **\`${immediateLabel}\`** — bypassing the standing PR for a direct release.`, '');
+
+    // Build the descriptor (bump magnitude + channel) and the source-label list in parallel so
+    // the banner reads "direct **minor prerelease** release (from `bump:minor`, `channel:prerelease`)"
+    // — telling the reader both what will happen and which labels drove the decision.
+    const descriptor: string[] = [];
+    const sources: string[] = [];
+
+    if (
+      labelContext.bumpLabel === 'major' ||
+      labelContext.bumpLabel === 'minor' ||
+      labelContext.bumpLabel === 'patch'
+    ) {
+      descriptor.push(labelContext.bumpLabel);
+      const bumpLabelName = labelContext.labels?.[labelContext.bumpLabel];
+      if (bumpLabelName) sources.push(`\`${bumpLabelName}\``);
+    }
+    if (labelContext.prerelease) {
+      descriptor.push('prerelease');
+      sources.push(`\`${labelContext.labels?.prerelease ?? 'channel:prerelease'}\``);
+    }
+    if (labelContext.stable) {
+      descriptor.push('stable');
+      sources.push(`\`${labelContext.labels?.stable ?? 'channel:stable'}\``);
+    }
+
+    const releasePart = descriptor.length > 0 ? `**${descriptor.join(' ')}** release` : 'release';
+
+    const annotations: string[] = [];
+    annotations.push(sources.length > 0 ? `from ${sources.join(', ')}` : 'bump derived from conventional commits');
+    if (labelContext.scopeLabels && labelContext.scopeLabels.length > 0) {
+      annotations.push(`scope: ${labelContext.scopeLabels.map((s) => `\`${s}\``).join(', ')}`);
+    }
+
+    lines.push(
+      `> **\`${immediateLabel}\`** — bypassing the standing PR for a direct ${releasePart} (${annotations.join('; ')}).`,
+      '',
+    );
     return lines;
   }
 

--- a/packages/release/src/preview/preview.ts
+++ b/packages/release/src/preview/preview.ts
@@ -318,6 +318,44 @@ async function applyLabelOverrides(
     return { options: result, labelContext };
   }
 
+  // `release:immediate` short-circuits label-trigger gating. The user has opted into a direct
+  // release for this PR, so the rule "must have a bump:* label" doesn't apply — commits drive
+  // the bump (matching what merging the standing PR would do). Explicit bump/channel labels are
+  // still honored as overrides when present.
+  if (hasImmediate) {
+    const conflict = detectLabelConflicts(prLabels, labels);
+    if (conflict.bumpConflict) {
+      labelContext.bumpConflict = true;
+      labelContext.noBumpLabel = true;
+      warn(`Conflicting bump labels detected (${conflict.bumpLabelsPresent.join(', ')}) — release blocked`);
+    }
+    if (conflict.prereleaseConflict) {
+      labelContext.prereleaseConflict = true;
+      labelContext.noBumpLabel = true;
+      warn(`Conflicting labels "${labels.stable}" and "${labels.prerelease}" detected — release blocked`);
+    }
+    if (!labelContext.noBumpLabel) {
+      if (prLabels.includes(labels.major)) {
+        labelContext.bumpLabel = 'major';
+        result.bump = 'major';
+      } else if (prLabels.includes(labels.minor)) {
+        labelContext.bumpLabel = 'minor';
+        result.bump = 'minor';
+      } else if (prLabels.includes(labels.patch)) {
+        labelContext.bumpLabel = 'patch';
+        result.bump = 'patch';
+      }
+      if (prLabels.includes(labels.stable)) {
+        labelContext.stable = true;
+        result.stable = true;
+      } else if (prLabels.includes(labels.prerelease)) {
+        labelContext.prerelease = true;
+        result.prerelease = true;
+      }
+    }
+    return { options: result, labelContext };
+  }
+
   if (trigger === 'label') {
     // Single source of truth: the gate's per-PR evaluation. Preview shows exactly the
     // verdict the gate would produce for THIS PR's labels — never lies.

--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -840,13 +840,21 @@ export async function publishFromManifest(prNumber: number, options: StandingPRO
   };
 }
 
-export async function runStandingPRPublish(options: StandingPROptions): Promise<ReleaseOutput | null> {
+export async function runStandingPRPublish(
+  options: StandingPROptions,
+  explicitPrNumber?: number,
+): Promise<ReleaseOutput | null> {
+  // Push-event path: caller (workflow) detected the standing-PR merge and passed the PR number.
+  if (explicitPrNumber !== undefined) {
+    return publishFromManifest(explicitPrNumber, options);
+  }
+
   const cwd = options.projectDir;
 
-  // Guard: verify this is triggered by the release PR being merged
+  // Pull-request-event path: parse the event payload to find the merged PR.
   const eventPath = process.env.GITHUB_EVENT_PATH;
   if (!eventPath) {
-    error('GITHUB_EVENT_PATH not set — standing-pr publish must run in GitHub Actions');
+    error('GITHUB_EVENT_PATH not set and no --pr provided — cannot determine standing PR to publish');
     return null;
   }
 

--- a/packages/release/test/unit/preview-format.spec.ts
+++ b/packages/release/test/unit/preview-format.spec.ts
@@ -530,6 +530,82 @@ describe('formatPreviewComment', () => {
       });
       expect(result).toContain('`release:immediate`');
       expect(result).toContain('bypassing the standing PR for a direct release');
+      expect(result).toContain('bump derived from conventional commits');
+    });
+
+    it('should detail the bump magnitude and source label in the immediate banner', () => {
+      const result = formatPreviewComment(releaseOutput, {
+        strategy: 'standing-pr',
+        labelContext: {
+          trigger: 'label',
+          skip: false,
+          noBumpLabel: false,
+          immediate: true,
+          bumpLabel: 'minor',
+          labels: {
+            stable: 'channel:stable',
+            prerelease: 'channel:prerelease',
+            skip: 'release:skip',
+            immediate: 'release:immediate',
+            major: 'bump:major',
+            minor: 'bump:minor',
+            patch: 'bump:patch',
+          },
+        },
+      });
+      expect(result).toContain('direct **minor** release (from `bump:minor`)');
+      expect(result).not.toContain('bump derived from conventional commits');
+    });
+
+    it('should combine bump + prerelease channel + scope in the immediate banner', () => {
+      const result = formatPreviewComment(releaseOutput, {
+        strategy: 'standing-pr',
+        labelContext: {
+          trigger: 'label',
+          skip: false,
+          noBumpLabel: false,
+          immediate: true,
+          bumpLabel: 'minor',
+          prerelease: true,
+          scopeLabels: ['scope:docs'],
+          labels: {
+            stable: 'channel:stable',
+            prerelease: 'channel:prerelease',
+            skip: 'release:skip',
+            immediate: 'release:immediate',
+            major: 'bump:major',
+            minor: 'bump:minor',
+            patch: 'bump:patch',
+          },
+        },
+      });
+      expect(result).toContain('direct **minor prerelease** release');
+      expect(result).toContain('from `bump:minor`, `channel:prerelease`');
+      expect(result).toContain('scope: `scope:docs`');
+    });
+
+    it('should include scope when immediate is set without a bump label', () => {
+      const result = formatPreviewComment(releaseOutput, {
+        strategy: 'standing-pr',
+        labelContext: {
+          trigger: 'label',
+          skip: false,
+          noBumpLabel: false,
+          immediate: true,
+          scopeLabels: ['scope:all'],
+          labels: {
+            stable: 'channel:stable',
+            prerelease: 'channel:prerelease',
+            skip: 'release:skip',
+            immediate: 'release:immediate',
+            major: 'bump:major',
+            minor: 'bump:minor',
+            patch: 'bump:patch',
+          },
+        },
+      });
+      expect(result).toContain('bump derived from conventional commits');
+      expect(result).toContain('scope: `scope:all`');
     });
 
     it('should suppress the standing-PR snapshot when immediate label is set', () => {

--- a/packages/release/test/unit/preview.spec.ts
+++ b/packages/release/test/unit/preview.spec.ts
@@ -1032,6 +1032,21 @@ describe('runPreview', () => {
       expect(mockFetchStandingPRSnapshot).not.toHaveBeenCalled();
     });
 
+    it('should run version analysis with commit-driven bump when release:immediate is set without a bump label', async () => {
+      // Mirrors the bypass workflow: `releasekit release` with no --bump runs commit-driven.
+      // Previously the preview required a bump:* label and rendered "no release", contradicting
+      // the "bypassing the standing PR for a direct release" banner.
+      mockLoadCIConfig.mockReturnValue(ciWithLabels({ scopeLabels: { 'scope:all': '*' } }));
+      mockFetchPRLabels.mockResolvedValue(['release:immediate', 'scope:all']);
+
+      await runPreview({ projectDir: '/test', dryRun: false });
+
+      expect(mockRunRelease).toHaveBeenCalled();
+      const callArg = mockRunRelease.mock.calls[0]?.[0] as { bump?: string; target?: string };
+      expect(callArg?.bump).toBeUndefined();
+      expect(callArg?.target).toBe('*');
+    });
+
     it('should still propagate bump label in direct strategy mode (no change)', async () => {
       mockLoadCIConfig.mockReturnValue({
         releaseStrategy: 'direct',

--- a/packages/release/test/unit/standing-pr-command.spec.ts
+++ b/packages/release/test/unit/standing-pr-command.spec.ts
@@ -37,7 +37,13 @@ describe('createStandingPRCommand', () => {
   it('should call runStandingPRPublish for publish subcommand', async () => {
     const { runStandingPRPublish } = await import('../../src/standing-pr/standing-pr.js');
     await parseCommand(['publish', '--project-dir', '/test']);
-    expect(runStandingPRPublish).toHaveBeenCalledWith(expect.objectContaining({ projectDir: '/test' }));
+    expect(runStandingPRPublish).toHaveBeenCalledWith(expect.objectContaining({ projectDir: '/test' }), undefined);
+  });
+
+  it('should pass --pr through to runStandingPRPublish as a number', async () => {
+    const { runStandingPRPublish } = await import('../../src/standing-pr/standing-pr.js');
+    await parseCommand(['publish', '--project-dir', '/test', '--pr', '189']);
+    expect(runStandingPRPublish).toHaveBeenCalledWith(expect.objectContaining({ projectDir: '/test' }), 189);
   });
 
   it('should pass --verbose, --quiet, --json flags through', async () => {

--- a/packages/release/test/unit/standing-pr-command.spec.ts
+++ b/packages/release/test/unit/standing-pr-command.spec.ts
@@ -46,6 +46,25 @@ describe('createStandingPRCommand', () => {
     expect(runStandingPRPublish).toHaveBeenCalledWith(expect.objectContaining({ projectDir: '/test' }), 189);
   });
 
+  it('should reject --pr values with trailing non-digit characters', async () => {
+    const { runStandingPRPublish } = await import('../../src/standing-pr/standing-pr.js');
+    vi.mocked(runStandingPRPublish).mockClear();
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit(${code})`);
+    }) as never);
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      await expect(parseCommand(['publish', '--project-dir', '/test', '--pr', '123abc'])).rejects.toThrow(
+        /process\.exit/,
+      );
+      expect(runStandingPRPublish).not.toHaveBeenCalled();
+      expect(errSpy).toHaveBeenCalledWith(expect.stringContaining('positive integer'));
+    } finally {
+      exitSpy.mockRestore();
+      errSpy.mockRestore();
+    }
+  });
+
   it('should pass --verbose, --quiet, --json flags through', async () => {
     const { runStandingPRUpdate } = await import('../../src/standing-pr/standing-pr.js');
     await parseCommand(['update', '--verbose', '--quiet', '--json']);


### PR DESCRIPTION
- Added a new job to detect release merges from push events, allowing the workflow to identify the associated pull request number.
- Updated the publish-release job to utilize the detected PR number when publishing from a release PR.
- Enhanced the standing PR command to accept an optional `--pr` argument for specifying the PR number, improving flexibility in various event contexts.
- Updated unit tests to ensure correct handling of the new PR number functionality.
