### PR TITLE
Revert "chore: release 4 package(s) (#189)"

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,52 +1,63 @@
-## `@releasekit/version` @ 0.21.0
+
+
+## `@releasekit/version` @ 0.20.0
 
 ### New:
-- Standing PR preview now includes merge prediction.
-
-### Documentation:
-- Documentation has been improved.
-
-**Full Changelog**: https://github.com/goosewobbler/releasekit/compare/releasekit-version-v0.20.0...releasekit-version-v0.21.0
-
----
-
-
-## `@releasekit/notes` @ 0.21.0
+- Publish operations now behave idempotently, allowing safe retries.
 
 ### Fixed:
-- Improved error handling in the fetchPullRequestContext function to better handle failures.
+- **Security**: Fixed shell injection vulnerability in e2e test runner by using execFileSync instead of exec.
 
-### Documentation:
-- Documentation was reviewed and enhanced for clarity.
+### Changed:
+- Updated LLM provider interfaces and improved message handling for better reliability.
 
-### Developer:
-- **Dependencies**: Updated 6 production dependencies to their latest compatible versions.
-
-**Full Changelog**: https://github.com/goosewobbler/releasekit/compare/releasekit-notes-v0.20.0...releasekit-notes-v0.21.0
+**Full Changelog**: https://github.com/goosewobbler/releasekit/compare/releasekit-version-v0.19.3...releasekit-version-v0.20.0
 
 ---
 
 
-## `@releasekit/publish` @ 0.21.0
-
-### Documentation:
-- Improved documentation for better clarity and usability.
-
-**Full Changelog**: https://github.com/goosewobbler/releasekit/compare/releasekit-publish-v0.20.0...releasekit-publish-v0.21.0
-
----
-
-
-## `@releasekit/release` @ 0.21.0
+## `@releasekit/notes` @ 0.20.0
 
 ### New:
-- Enhanced standing PR preview to include merge prediction.
-- Added standing PR command to release program.
+- Made publish operations idempotent, allowing safe retries without duplicate content.
 
-### Removed:
-- Removed the 'scheduled' release strategy.
+### Fixed:
+- **Security**: Switched to execFileSync in e2e test runner to prevent shell injection vulnerabilities.
 
-### Documentation:
-- Improved documentation clarity and coverage.
+### Changed:
+- Updated LLM provider interfaces and improved message handling across the system.
 
-**Full Changelog**: https://github.com/goosewobbler/releasekit/compare/releasekit-release-v0.20.0...releasekit-release-v0.21.0
+**Full Changelog**: https://github.com/goosewobbler/releasekit/compare/releasekit-version-v0.19.3...releasekit-version-v0.20.0
+
+---
+
+
+## `@releasekit/publish` @ 0.20.0
+
+### New:
+- Added idempotent publish behavior to prevent duplicate publications
+
+### Fixed:
+- **Security**: Fixed shell injection vulnerability in e2e test runner by using execFileSync
+
+### Changed:
+- Updated LLM provider interfaces and improved message handling for better reliability
+
+**Full Changelog**: https://github.com/goosewobbler/releasekit/compare/releasekit-version-v0.19.3...releasekit-version-v0.20.0
+
+---
+
+
+## `@releasekit/release` @ 0.20.0
+
+### New:
+- Made publish operation idempotent, allowing safe repeated execution without side effects.
+
+### Fixed:
+- **Security**: Replaced exec with execFileSync in e2e test runner to prevent shell injection vulnerabilities.
+
+### Changed:
+- Updated LLM provider interfaces and improved message handling for better reliability and consistency.
+
+**Full Changelog**: https://github.com/goosewobbler/releasekit/compare/releasekit-version-v0.19.3...releasekit-version-v0.20.0
+

--- a/packages/notes/CHANGELOG.md
+++ b/packages/notes/CHANGELOG.md
@@ -89,20 +89,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
-
-## [0.21.0] - 2026-05-05
-
-[Full Changelog](https://github.com/goosewobbler/releasekit/compare/releasekit-notes-v0.20.0...releasekit-notes-v0.21.0)
-
-### Fixed
-- Improved error handling in the fetchPullRequestContext function to better handle failures.
-
-### Documentation
-- Documentation was reviewed and enhanced for clarity.
-
-### Developer
-- **Dependencies**: Updated 6 production dependencies to their latest compatible versions.
-
 ## [0.20.0] - 2026-05-04
 
 [Full Changelog](https://github.com/goosewobbler/releasekit/compare/releasekit-version-v0.19.3...releasekit-version-v0.20.0)

--- a/packages/notes/package.json
+++ b/packages/notes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@releasekit/notes",
-  "version": "0.21.0",
+  "version": "0.20.0",
   "description": "Release notes and changelog generation with LLM-powered enhancement and flexible templating",
   "type": "module",
   "module": "./dist/index.js",

--- a/packages/publish/CHANGELOG.md
+++ b/packages/publish/CHANGELOG.md
@@ -89,14 +89,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
-
-## [0.21.0] - 2026-05-05
-
-[Full Changelog](https://github.com/goosewobbler/releasekit/compare/releasekit-publish-v0.20.0...releasekit-publish-v0.21.0)
-
-### Documentation
-- Improved documentation for better clarity and usability.
-
 ## [0.20.0] - 2026-05-04
 
 [Full Changelog](https://github.com/goosewobbler/releasekit/compare/releasekit-version-v0.19.3...releasekit-version-v0.20.0)

--- a/packages/publish/package.json
+++ b/packages/publish/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@releasekit/publish",
-  "version": "0.21.0",
+  "version": "0.20.0",
   "description": "Publish packages to npm and crates.io with git tagging and GitHub releases",
   "type": "module",
   "module": "./dist/index.js",

--- a/packages/release/CHANGELOG.md
+++ b/packages/release/CHANGELOG.md
@@ -100,21 +100,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
-
-## [0.21.0] - 2026-05-05
-
-[Full Changelog](https://github.com/goosewobbler/releasekit/compare/releasekit-release-v0.20.0...releasekit-release-v0.21.0)
-
-### New
-- **Standing PR preview**: Enhanced standing PR preview to include merge prediction.
-- **Standing PR command**: Added standing PR command to release program.
-
-### Removed
-- Removed the 'scheduled' release strategy.
-
-### Documentation
-- Improved documentation clarity and coverage.
-
 ## [0.20.0] - 2026-05-04
 
 [Full Changelog](https://github.com/goosewobbler/releasekit/compare/releasekit-version-v0.19.3...releasekit-version-v0.20.0)

--- a/packages/release/package.json
+++ b/packages/release/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@releasekit/release",
-  "version": "0.21.0",
+  "version": "0.20.0",
   "description": "Unified release pipeline: version, changelog, and publish in a single command",
   "type": "module",
   "module": "./dist/index.js",

--- a/packages/version/CHANGELOG.md
+++ b/packages/version/CHANGELOG.md
@@ -89,17 +89,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
-
-## [0.21.0] - 2026-05-05
-
-[Full Changelog](https://github.com/goosewobbler/releasekit/compare/releasekit-version-v0.20.0...releasekit-version-v0.21.0)
-
-### New
-- **Standing PR preview**: Standing PR preview now includes merge prediction.
-
-### Documentation
-- Documentation has been improved.
-
 ## [0.20.0] - 2026-05-04
 
 [Full Changelog](https://github.com/goosewobbler/releasekit/compare/releasekit-version-v0.19.3...releasekit-version-v0.20.0)

--- a/packages/version/package.json
+++ b/packages/version/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@releasekit/version",
-  "version": "0.21.0",
+  "version": "0.20.0",
   "description": "Semantic versioning based on Git history and conventional commits",
   "type": "module",
   "module": "./dist/index.js",


### PR DESCRIPTION
## Summary

Reverts the standing PR release commit from #189. The merge landed on main but the publish workflow never ran (the `pull_request: closed` trigger was suppressed because the `release/next` branch had been pushed by `GITHUB_TOKEN`), so main was left with version bumps and changelog entries that don't correspond to any tags or published artifacts.

The trigger bug is fixed in #193 (push-event detection). Once both this revert and #193 are merged, the next standing PR will be regenerated with the same queued bumps and the publish step will fire correctly on merge.

## Test plan

- [ ] Verify CI is green
- [ ] After merge, confirm the standing-PR workflow recreates `release/next` with the expected bumps