### PR TITLE
feat(workflows): fix immediate release, switch to sync mode

### DIFF
--- a/.github/workflows/standing-pr.yml
+++ b/.github/workflows/standing-pr.yml
@@ -111,12 +111,36 @@ jobs:
           # ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
 
+  # Delegates to the same reusable release workflow used by `release.yml` so npm OIDC auth and
+  # SSH-based git push are configured identically — running the CLI inline previously skipped
+  # both, causing "ENEEDAUTH" on publish and inconsistent push behaviour.
   immediate-release:
     name: Immediate Release (bypass standing PR)
     if: >
       github.event_name == 'pull_request' &&
       github.event.pull_request.merged == true &&
       contains(github.event.pull_request.labels.*.name, 'release:immediate')
+    uses: ./.github/workflows/_release.reusable.yml
+    permissions:
+      id-token: write
+      contents: write
+    with:
+      packages: all
+      bump: auto
+      sync: true
+      dry_run: false
+      npm_auth: oidc
+    secrets:
+      ssh_key: ${{ secrets.DEPLOY_KEY }}
+      OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
+
+  # After an immediate release, the standing PR's queued changes overlap with what was just
+  # published. Re-running standing-pr update reconciles: closes the standing PR if nothing's
+  # left, otherwise rewrites the release branch against the new HEAD.
+  reconcile-standing-pr:
+    name: Reconcile standing PR (after immediate release)
+    needs: immediate-release
+    if: needs.immediate-release.result == 'success'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -135,12 +159,6 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-
-      - name: Direct release (bypassing standing PR)
-        run: node packages/release/dist/cli.js release
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-          OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
 
       - name: Reconcile standing PR
         run: node packages/release/dist/cli.js standing-pr update

--- a/releasekit.config.json
+++ b/releasekit.config.json
@@ -6,14 +6,17 @@
   },
   "version": {
     "preset": "angular",
-    "sync": false,
+    "sync": true,
     "versionPrefix": "v",
-    "packages": ["packages/version", "packages/notes", "packages/publish", "packages/release"],
+    "packages": [
+      "packages/version",
+      "packages/notes",
+      "packages/publish",
+      "packages/release"
+    ],
     "mismatchStrategy": "prefer-package",
-    "tagTemplate": "${packageName}-${prefix}${version}",
-    "commitMessage": "chore: release ${packageName}@${version} [skip ci]",
-    "prereleaseIdentifier": "next",
-    "packageSpecificTags": true
+    "commitMessage": "chore: release v${version} [skip ci]",
+    "prereleaseIdentifier": "next"
   },
   "notes": {
     "changelog": {
@@ -35,11 +38,26 @@
           "categorize": true
         },
         "categories": [
-          { "name": "New", "description": "New features and additions" },
-          { "name": "Fixed", "description": "Bug fixes including security and performance fixes" },
-          { "name": "Changed", "description": "Changes to existing functionality" },
-          { "name": "Removed", "description": "Features that were removed" },
-          { "name": "Documentation", "description": "Documentation updates" },
+          {
+            "name": "New",
+            "description": "New features and additions"
+          },
+          {
+            "name": "Fixed",
+            "description": "Bug fixes including security and performance fixes"
+          },
+          {
+            "name": "Changed",
+            "description": "Changes to existing functionality"
+          },
+          {
+            "name": "Removed",
+            "description": "Features that were removed"
+          },
+          {
+            "name": "Documentation",
+            "description": "Documentation updates"
+          },
           {
             "name": "Developer",
             "description": "Internal changes",
@@ -74,7 +92,9 @@
   },
   "release": {
     "ci": {
-      "skipPatterns": ["chore: release "]
+      "skipPatterns": [
+        "chore: release "
+      ]
     }
   },
   "ci": {


### PR DESCRIPTION
- Introduced an 'immediate-release' job to the standing PR workflow, allowing direct releases when a pull request with the 'release:immediate' label is merged.
- Added a 'reconcile-standing-pr' job to manage queued changes after an immediate release, ensuring the standing PR is updated or closed as necessary.
- Updated permissions and environment variables for the new jobs to ensure proper execution and access to required secrets.