### PR TITLE
Revert "chore: release preparation [skip ci]" (#195)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,69 +1,63 @@
-## `@releasekit/version` @ 0.21.0
-
-### Changed:
-- Enhanced standing PR preview to include merge prediction.
-
-### Documentation:
-- Enhanced project documentation.
-
-### Developer:
-- **CI**: Reverted the release of 4 package(s).
-- **CI**: Released 4 package(s).
-
-**Full Changelog**: https://github.com/goosewobbler/releasekit/compare/releasekit-version-v0.20.0...releasekit-version-v0.21.0
-
----
 
 
-## `@releasekit/notes` @ 0.21.0
-
-### Fixed:
-- Improved error handling in the fetchPullRequestContext function for more reliable release note generation.
-
-### Changed:
-- Reverted the previous release of 4 package(s) due to an issue.
-- Released 4 package(s) to production.
-
-### Documentation:
-- Updated project documentation for improved clarity.
-
-### Developer:
-- **Dependencies**: Updated 6 production dependencies in the project.
-
-**Full Changelog**: https://github.com/goosewobbler/releasekit/compare/releasekit-notes-v0.20.0...releasekit-notes-v0.21.0
-
----
-
-
-## `@releasekit/publish` @ 0.21.0
-
-### Documentation:
-- Updated project documentation
-
-### Developer:
-- **Infrastructure**: Reverted the previous package release
-- **Infrastructure**: Released 4 packages
-
-**Full Changelog**: https://github.com/goosewobbler/releasekit/compare/releasekit-publish-v0.20.0...releasekit-publish-v0.21.0
-
----
-
-
-## `@releasekit/release` @ 0.21.0
+## `@releasekit/version` @ 0.20.0
 
 ### New:
-- **Tooling**: Introduced a new standing PR command to the release program for managing standing pull requests.
+- Publish operations now behave idempotently, allowing safe retries.
+
+### Fixed:
+- **Security**: Fixed shell injection vulnerability in e2e test runner by using execFileSync instead of exec.
 
 ### Changed:
-- **CI**: The standing PR workflow now detects merge commits from push events for improved synchronization.
-- Reverted a previous release of 4 package(s) due to an issue.
-- Released 4 package(s) to distribution.
-- **CI**: Standing PR previews now include merge prediction to help anticipate merge outcomes.
+- Updated LLM provider interfaces and improved message handling for better reliability.
 
-### Removed:
-- Removed the scheduled release strategy from available options.
+**Full Changelog**: https://github.com/goosewobbler/releasekit/compare/releasekit-version-v0.19.3...releasekit-version-v0.20.0
 
-### Documentation:
-- Updated documentation for clarity and completeness.
+---
 
-**Full Changelog**: https://github.com/goosewobbler/releasekit/compare/releasekit-release-v0.20.0...releasekit-release-v0.21.0
+
+## `@releasekit/notes` @ 0.20.0
+
+### New:
+- Made publish operations idempotent, allowing safe retries without duplicate content.
+
+### Fixed:
+- **Security**: Switched to execFileSync in e2e test runner to prevent shell injection vulnerabilities.
+
+### Changed:
+- Updated LLM provider interfaces and improved message handling across the system.
+
+**Full Changelog**: https://github.com/goosewobbler/releasekit/compare/releasekit-version-v0.19.3...releasekit-version-v0.20.0
+
+---
+
+
+## `@releasekit/publish` @ 0.20.0
+
+### New:
+- Added idempotent publish behavior to prevent duplicate publications
+
+### Fixed:
+- **Security**: Fixed shell injection vulnerability in e2e test runner by using execFileSync
+
+### Changed:
+- Updated LLM provider interfaces and improved message handling for better reliability
+
+**Full Changelog**: https://github.com/goosewobbler/releasekit/compare/releasekit-version-v0.19.3...releasekit-version-v0.20.0
+
+---
+
+
+## `@releasekit/release` @ 0.20.0
+
+### New:
+- Made publish operation idempotent, allowing safe repeated execution without side effects.
+
+### Fixed:
+- **Security**: Replaced exec with execFileSync in e2e test runner to prevent shell injection vulnerabilities.
+
+### Changed:
+- Updated LLM provider interfaces and improved message handling for better reliability and consistency.
+
+**Full Changelog**: https://github.com/goosewobbler/releasekit/compare/releasekit-version-v0.19.3...releasekit-version-v0.20.0
+

--- a/packages/notes/CHANGELOG.md
+++ b/packages/notes/CHANGELOG.md
@@ -89,24 +89,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
-
-## [0.21.0] - 2026-05-05
-
-[Full Changelog](https://github.com/goosewobbler/releasekit/compare/releasekit-notes-v0.20.0...releasekit-notes-v0.21.0)
-
-### Fixed
-- Improved error handling in the fetchPullRequestContext function for more reliable release note generation.
-
-### Changed
-- Reverted the previous release of 4 package(s) due to an issue.
-- Released 4 package(s) to production.
-
-### Documentation
-- Updated project documentation for improved clarity.
-
-### Developer
-- **Dependencies**: Updated 6 production dependencies in the project.
-
 ## [0.20.0] - 2026-05-04
 
 [Full Changelog](https://github.com/goosewobbler/releasekit/compare/releasekit-version-v0.19.3...releasekit-version-v0.20.0)

--- a/packages/notes/package.json
+++ b/packages/notes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@releasekit/notes",
-  "version": "0.21.0",
+  "version": "0.20.0",
   "description": "Release notes and changelog generation with LLM-powered enhancement and flexible templating",
   "type": "module",
   "module": "./dist/index.js",

--- a/packages/publish/CHANGELOG.md
+++ b/packages/publish/CHANGELOG.md
@@ -89,19 +89,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
-
-## [0.21.0] - 2026-05-05
-
-[Full Changelog](https://github.com/goosewobbler/releasekit/compare/releasekit-publish-v0.20.0...releasekit-publish-v0.21.0)
-
-### Documentation
-- Updated project documentation
-
-### Developer
-**Infrastructure**:
-- Reverted the previous package release
-- Released 4 packages
-
 ## [0.20.0] - 2026-05-04
 
 [Full Changelog](https://github.com/goosewobbler/releasekit/compare/releasekit-version-v0.19.3...releasekit-version-v0.20.0)

--- a/packages/publish/package.json
+++ b/packages/publish/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@releasekit/publish",
-  "version": "0.21.0",
+  "version": "0.20.0",
   "description": "Publish packages to npm and crates.io with git tagging and GitHub releases",
   "type": "module",
   "module": "./dist/index.js",

--- a/packages/release/CHANGELOG.md
+++ b/packages/release/CHANGELOG.md
@@ -100,27 +100,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
-
-## [0.21.0] - 2026-05-05
-
-[Full Changelog](https://github.com/goosewobbler/releasekit/compare/releasekit-release-v0.20.0...releasekit-release-v0.21.0)
-
-### Breaking
-- **BREAKING** Removed the scheduled release strategy from available options.
-
-### New
-- **Standing PR command**: Introduced a new standing PR command to the release program for managing standing pull requests.
-
-### Changed
-**CI**:
-- **Merge detection**: The standing PR workflow now detects merge commits from push events for improved synchronization.
-- **Merge prediction**: Standing PR previews now include merge prediction to help anticipate merge outcomes.
-- Reverted a previous release of 4 package(s) due to an issue.
-- Released 4 package(s) to distribution.
-
-### Documentation
-- Updated documentation for clarity and completeness.
-
 ## [0.20.0] - 2026-05-04
 
 [Full Changelog](https://github.com/goosewobbler/releasekit/compare/releasekit-version-v0.19.3...releasekit-version-v0.20.0)

--- a/packages/release/package.json
+++ b/packages/release/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@releasekit/release",
-  "version": "0.21.0",
+  "version": "0.20.0",
   "description": "Unified release pipeline: version, changelog, and publish in a single command",
   "type": "module",
   "module": "./dist/index.js",

--- a/packages/version/CHANGELOG.md
+++ b/packages/version/CHANGELOG.md
@@ -89,22 +89,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
-
-## [0.21.0] - 2026-05-05
-
-[Full Changelog](https://github.com/goosewobbler/releasekit/compare/releasekit-version-v0.20.0...releasekit-version-v0.21.0)
-
-### Changed
-- Enhanced standing PR preview to include merge prediction.
-
-### Documentation
-- Enhanced project documentation.
-
-### Developer
-**CI**:
-- Reverted the release of 4 package(s).
-- Released 4 package(s).
-
 ## [0.20.0] - 2026-05-04
 
 [Full Changelog](https://github.com/goosewobbler/releasekit/compare/releasekit-version-v0.19.3...releasekit-version-v0.20.0)

--- a/packages/version/package.json
+++ b/packages/version/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@releasekit/version",
-  "version": "0.21.0",
+  "version": "0.20.0",
   "description": "Semantic versioning based on Git history and conventional commits",
   "type": "module",
   "module": "./dist/index.js",


### PR DESCRIPTION
## Summary

Reverts the squash-merge commit from #195. The standing PR was squash-merged with the auto-generated source commit message `chore: release preparation [skip ci]`, which GitHub Actions interprets as "skip all workflows on main" — so the publish job (and every other workflow) was suppressed on the merge push. The version bump commits landed on main but no npm publish or tags happened.

The root cause is fixed in the `chore/fix-publish` branch (removed `[skip ci]` from the auto-generated commit since it was redundant — push workflows already filter to `branches: [main]`). Once both this revert and that fix merge, a fresh standing PR will rebuild and the next merge will publish cleanly.

## Test plan

- [ ] CI green
- [ ] After merge, confirm a new standing PR is generated with the same queued bumps