### PR TITLE
feat(workflows): enhance immediate release and reconcile standing PR process

### DIFF
--- a/.github/workflows/_action-release.reusable.yml
+++ b/.github/workflows/_action-release.reusable.yml
@@ -47,16 +47,15 @@ jobs:
           git add -f packages/release/dist/
           git commit --no-verify -m "chore: build action dist for ${RELEASE_TAG} [skip ci]"
 
-          # Extract semver from tag: releasekit-release-v1.2.3 -> 1.2.3
-          VERSION="${RELEASE_TAG#releasekit-release-v}"
+          # Extract semver from the sync-mode shared tag, e.g. `v1.2.3` -> `1.2.3`.
+          VERSION="${RELEASE_TAG#v}"
           MAJOR="${VERSION%%.*}"
 
-          # Immutable patch tag — skip if it already exists (idempotent re-runs)
-          if git rev-parse "v${VERSION}" >/dev/null 2>&1; then
-            echo "Tag v${VERSION} already exists, skipping"
+          # The release tag itself is already `v${VERSION}` in sync mode, so the version tag
+          # exists. Just ensure the GitHub Release exists (idempotent for re-runs).
+          if gh release view "v${VERSION}" >/dev/null 2>&1; then
+            echo "Release v${VERSION} already exists, skipping"
           else
-            git tag "v${VERSION}"
-            git push origin "v${VERSION}"
             if [[ "${VERSION}" != *"-"* ]]; then
               gh release create "v${VERSION}" --title "v${VERSION}" --generate-notes
             else

--- a/.github/workflows/_action-release.reusable.yml
+++ b/.github/workflows/_action-release.reusable.yml
@@ -63,6 +63,11 @@ jobs:
             fi
           fi
 
+          # Force-move the exact version tag to the dist commit so consumers
+          # pinning `uses: goosewobbler/releasekit@v1.2.3` get the built dist.
+          git tag -f "v${VERSION}"
+          git push origin -f "v${VERSION}"
+
           # Moving major alias — only update for stable releases
           if [[ "${VERSION}" != *"-"* ]]; then
             git tag -f "v${MAJOR}"

--- a/.github/workflows/_release.reusable.yml
+++ b/.github/workflows/_release.reusable.yml
@@ -173,9 +173,12 @@ jobs:
         id: extract-tag
         if: ${{ !inputs.dry_run }}
         run: |
+          # Sync-mode produces a single shared tag like `v0.21.0`. Pick the first one matching
+          # the version-prefix pattern as the action_tag (used to trigger _action-release for the
+          # GitHub Action build, and to gate reconcile-standing-pr in standing-pr.yml).
           ACTION_TAG=""
           if [ -f release-output.json ]; then
-            ACTION_TAG=$(jq -r '.versionOutput.tags[] | select(startswith("releasekit-release-v"))' release-output.json 2>/dev/null | head -1)
+            ACTION_TAG=$(jq -r '.versionOutput.tags[] | select(test("^v[0-9]+\\."))' release-output.json 2>/dev/null | head -1)
           fi
           echo "action_tag=${ACTION_TAG}" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/standing-pr.yml
+++ b/.github/workflows/standing-pr.yml
@@ -134,6 +134,18 @@ jobs:
       ssh_key: ${{ secrets.DEPLOY_KEY }}
       OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
 
+  build-action-immediate:
+    name: Build and tag action dist
+    needs: immediate-release
+    if: needs.immediate-release.result == 'success' && needs.immediate-release.outputs.action_tag != ''
+    uses: ./.github/workflows/_action-release.reusable.yml
+    permissions:
+      contents: write
+    with:
+      tag: ${{ needs.immediate-release.outputs.action_tag }}
+    secrets:
+      ssh_key: ${{ secrets.DEPLOY_KEY }}
+
   # After an immediate release, the standing PR's queued changes overlap with what was just
   # published. Re-running standing-pr update reconciles: closes the standing PR if nothing's
   # left, otherwise rewrites the release branch against the new HEAD.

--- a/.github/workflows/standing-pr.yml
+++ b/.github/workflows/standing-pr.yml
@@ -140,7 +140,10 @@ jobs:
   reconcile-standing-pr:
     name: Reconcile standing PR (after immediate release)
     needs: immediate-release
-    if: needs.immediate-release.result == 'success'
+    # Skip when nothing actually released — under sync mode (the current config), action_tag is
+    # set whenever any package releases. If you switch back to async, this gate becomes too
+    # narrow (it only fires when @releasekit/release itself is bumped) and should be revisited.
+    if: needs.immediate-release.result == 'success' && needs.immediate-release.outputs.action_tag != ''
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -164,6 +167,9 @@ jobs:
         run: node packages/release/dist/cli.js standing-pr update
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          # Uncomment the env var matching your notes.releaseNotes.llm.provider.
+          # OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          # ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
 
   publish-release:

--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -88,7 +88,11 @@ function commitAndForcePush(branch: string, cwd: string): void {
   // Check if there's anything to commit
   const status = execSync('git status --porcelain', { encoding: 'utf-8', cwd }).trim();
   if (status) {
-    execSync('git commit -m "chore: release preparation [skip ci]"', { encoding: 'utf-8', cwd, stdio: 'pipe' });
+    // Subject must match `release.ci.skipPatterns` (default 'chore: release ') so a future
+    // standing-pr update on this branch noops correctly. Do NOT add `[skip ci]` — when the PR
+    // is squash-merged with this single-commit history, the squash inherits this message and
+    // suppresses ALL workflow runs on main, including the publish job.
+    execSync('git commit -m "chore: release preparation"', { encoding: 'utf-8', cwd, stdio: 'pipe' });
   }
 
   execSync(`git push --force-with-lease origin "${branch}"`, { encoding: 'utf-8', cwd, stdio: 'pipe' });


### PR DESCRIPTION
- Introduced an 'immediate-release' job to the standing PR workflow, allowing direct releases when a pull request with the 'release:immediate' label is merged.
- Added a 'reconcile-standing-pr' job to manage queued changes after an immediate release, ensuring the standing PR is updated or closed as necessary.
- Updated permissions and environment variables for the new jobs to ensure proper execution and access to required secrets.