### PR TITLE
feat: enhance notes generation for standing PRs

### DIFF
--- a/packages/notes/src/core/pipeline.ts
+++ b/packages/notes/src/core/pipeline.ts
@@ -330,7 +330,28 @@ export interface PipelineResult {
   releaseNotes?: Record<string, string>;
 }
 
-export async function runPipeline(input: ChangelogInput, config: Config, dryRun: boolean): Promise<PipelineResult> {
+export interface PipelineOptions {
+  /**
+   * Skip the LLM pass and the release-notes file write (RELEASE_NOTES.md).
+   * Per-package CHANGELOG.md is unaffected. Use during standing-PR update so the
+   * standing-PR workflow doesn't depend on LLM availability and doesn't pay for
+   * an LLM call on every push to main.
+   */
+  skipReleaseNotes?: boolean;
+  /**
+   * Skip the changelog file writes (CHANGELOG.md). LLM + release-notes generation
+   * are unaffected. Use during publish from manifest to regenerate only the
+   * release notes against an already-bumped tree.
+   */
+  skipChangelogs?: boolean;
+}
+
+export async function runPipeline(
+  input: ChangelogInput,
+  config: Config,
+  dryRun: boolean,
+  pipelineOptions?: PipelineOptions,
+): Promise<PipelineResult> {
   debug(`Processing ${input.packages.length} package(s)`);
 
   let contexts = input.packages.map(createTemplateContext);
@@ -349,7 +370,10 @@ export async function runPipeline(input: ChangelogInput, config: Config, dryRun:
         : config.releaseNotes;
 
   const llmConfig = releaseNotesConfig?.llm;
-  if (llmConfig && !process.env.CHANGELOG_NO_LLM) {
+  // The LLM pass is part of release-notes generation: enhanced text only flows into the
+  // release-notes output (and the per-package map returned to callers). When release notes
+  // are skipped, the LLM call is wasted compute, so gate them together.
+  if (llmConfig && !process.env.CHANGELOG_NO_LLM && !pipelineOptions?.skipReleaseNotes) {
     info('Processing with LLM enhancement');
 
     const examplesCount = llmConfig.examples ?? 3;
@@ -421,7 +445,7 @@ export async function runPipeline(input: ChangelogInput, config: Config, dryRun:
     links: releaseNotesConfig?.links,
   };
 
-  if (changelogConfig !== false && changelogConfig.mode) {
+  if (!pipelineOptions?.skipChangelogs && changelogConfig !== false && changelogConfig.mode) {
     const fileName = changelogConfig.file ?? 'CHANGELOG.md';
     const mode = changelogConfig.mode;
 
@@ -452,7 +476,7 @@ export async function runPipeline(input: ChangelogInput, config: Config, dryRun:
     }
   }
 
-  if (releaseNotesConfig?.mode) {
+  if (!pipelineOptions?.skipReleaseNotes && releaseNotesConfig?.mode) {
     const fileName = releaseNotesConfig.file ?? 'RELEASE_NOTES.md';
     const mode = releaseNotesConfig.mode;
 
@@ -492,6 +516,11 @@ export async function runPipeline(input: ChangelogInput, config: Config, dryRun:
   const releaseNotesResult: Record<string, string> = {};
   for (const ctx of contexts) {
     packageNotes[ctx.packageName] = formatVersion(ctx);
+    if (pipelineOptions?.skipReleaseNotes) {
+      // Caller asked to skip release notes — don't populate the per-package map either,
+      // otherwise the callsite will treat it as "available" content and propagate it.
+      continue;
+    }
     if (ctx.enhanced?.releaseNotes) {
       releaseNotesResult[ctx.packageName] = ctx.enhanced.releaseNotes;
     } else if (releaseNotesConfig) {
@@ -528,9 +557,14 @@ export async function runPipeline(input: ChangelogInput, config: Config, dryRun:
   };
 }
 
-export async function processInput(inputJson: string, config: Config, dryRun: boolean): Promise<PipelineResult> {
+export async function processInput(
+  inputJson: string,
+  config: Config,
+  dryRun: boolean,
+  pipelineOptions?: PipelineOptions,
+): Promise<PipelineResult> {
   const input = parseVersionOutput(inputJson);
-  return runPipeline(input, config, dryRun);
+  return runPipeline(input, config, dryRun, pipelineOptions);
 }
 
 async function writeMonorepoFiles(

--- a/packages/notes/src/index.ts
+++ b/packages/notes/src/index.ts
@@ -1,6 +1,6 @@
 export { createNotesCommand } from './command.js';
 export { getDefaultConfig, loadAuth, loadConfig, saveAuth } from './core/config.js';
-export type { PipelineResult } from './core/pipeline.js';
+export type { PipelineOptions, PipelineResult } from './core/pipeline.js';
 export { createTemplateContext, processInput, runPipeline } from './core/pipeline.js';
 export * from './core/types.js';
 export * from './errors/index.js';

--- a/packages/notes/test/integration/pipeline-config.spec.ts
+++ b/packages/notes/test/integration/pipeline-config.spec.ts
@@ -255,3 +255,59 @@ describe('Pipeline: file-only config defaults mode to root', () => {
     expect(result.releaseNotes).toBeUndefined();
   });
 });
+
+describe('Pipeline: skipReleaseNotes / skipChangelogs flags', () => {
+  beforeEach(() => {
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+    vi.mocked(fs.mkdirSync).mockReturnValue(undefined as never);
+    vi.mocked(fs.writeFileSync).mockReturnValue(undefined);
+  });
+
+  it('skipReleaseNotes:true should not write RELEASE_NOTES.md and should not invoke the LLM', async () => {
+    const { createProvider } = await import('../../src/llm/index.js');
+    vi.mocked(createProvider).mockClear();
+
+    const { runPipeline } = await import('../../src/core/pipeline.js');
+    const config: Config = {
+      changelog: { mode: 'root', file: 'CHANGELOG.md' },
+      releaseNotes: {
+        mode: 'root',
+        file: 'RELEASE_NOTES.md',
+        llm: { provider: 'openai-compatible', model: 'gpt-4o', tasks: { releaseNotes: true } },
+      },
+    };
+    const result = await runPipeline(sampleInput, config, false, { skipReleaseNotes: true });
+
+    expect(createProvider).not.toHaveBeenCalled();
+    expect(result.files).toContain('CHANGELOG.md');
+    expect(result.files).not.toContain('RELEASE_NOTES.md');
+    expect(result.releaseNotes).toBeUndefined();
+  });
+
+  it('skipChangelogs:true should skip CHANGELOG.md but still write RELEASE_NOTES.md', async () => {
+    const { createProvider } = await import('../../src/llm/index.js');
+    vi.mocked(createProvider).mockClear();
+
+    const { runPipeline } = await import('../../src/core/pipeline.js');
+    const config: Config = {
+      changelog: { mode: 'root', file: 'CHANGELOG.md' },
+      releaseNotes: { mode: 'root', file: 'RELEASE_NOTES.md' },
+    };
+    const result = await runPipeline(sampleInput, config, false, { skipChangelogs: true });
+
+    expect(result.files).not.toContain('CHANGELOG.md');
+    expect(result.files).toContain('RELEASE_NOTES.md');
+  });
+
+  it('both flags omitted preserves existing behaviour (changelog + release notes both written)', async () => {
+    const { runPipeline } = await import('../../src/core/pipeline.js');
+    const config: Config = {
+      changelog: { mode: 'root', file: 'CHANGELOG.md' },
+      releaseNotes: { mode: 'root', file: 'RELEASE_NOTES.md' },
+    };
+    const result = await runPipeline(sampleInput, config, false);
+
+    expect(result.files).toContain('CHANGELOG.md');
+    expect(result.files).toContain('RELEASE_NOTES.md');
+  });
+});

--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -98,6 +98,42 @@ function commitAndForcePush(branch: string, cwd: string): void {
   execSync(`git push --force-with-lease origin "${branch}"`, { encoding: 'utf-8', cwd, stdio: 'pipe' });
 }
 
+/**
+ * Stage and commit the LLM-enhanced release notes files generated at publish time. Tags created
+ * by the subsequent publish stage land on this commit (which captures the full release state
+ * including the polished notes).
+ */
+function commitNotesFiles(files: string[], versionOutput: VersionOutput, cwd: string): void {
+  if (files.length === 0) return;
+
+  for (const file of files) {
+    try {
+      execSync(`git add "${file}"`, { encoding: 'utf-8', cwd, stdio: 'pipe' });
+    } catch (err) {
+      warn(`Failed to stage ${file}: ${err instanceof Error ? err.message : String(err)}`);
+      return;
+    }
+  }
+
+  // Nothing to commit — the LLM produced output identical to what's already on disk.
+  const status = execSync('git status --porcelain', { encoding: 'utf-8', cwd }).trim();
+  if (!status) {
+    info('Release notes already match the on-disk content, skipping commit');
+    return;
+  }
+
+  // Use the first update's version for the commit subject. In sync mode all packages share
+  // a version; in async this picks one representative — fine for an audit-only commit.
+  const version = versionOutput.updates[0]?.newVersion ?? '';
+  const message = version ? `chore: release notes for v${version}` : 'chore: release notes';
+  try {
+    execSync(`git commit -m "${message}"`, { encoding: 'utf-8', cwd, stdio: 'pipe' });
+    success(`Committed release notes (${files.length} file(s))`);
+  } catch (err) {
+    warn(`Failed to commit release notes: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
 // Renders the release notes section content (without editable markers).
 const CHANGELOG_TYPE_LABELS: Record<string, string> = {
   feat: 'Added',
@@ -578,8 +614,11 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
   const writeOptions = buildBaseReleaseOptions(options, false, buildExtras);
   const versionOutput = await runVersionStep(writeOptions);
 
-  info('Generating release notes...');
-  const notesOptions = { ...writeOptions, skipNotes: false };
+  // Generate per-package CHANGELOG.md only — release-notes generation (LLM + RELEASE_NOTES.md)
+  // is deferred to publish time. This decouples standing-PR updates from LLM availability and
+  // avoids paying for an LLM call on every push to main when only the final publish needs it.
+  info('Generating changelog...');
+  const notesOptions = { ...writeOptions, skipNotes: false, skipReleaseNotes: true };
   const notesResult = await runNotesStep(versionOutput, notesOptions);
 
   // Commit and force-push the release branch
@@ -696,11 +735,13 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
     }
   }
 
-  // Store manifest as a bot comment
+  // Store manifest as a bot comment. `releaseNotes` is intentionally omitted — publishFromManifest
+  // regenerates LLM-enhanced release notes against the merged commit set, so caching them here
+  // would waste LLM calls and risk drift if the standing PR sits open while new commits land.
   const manifest: StandingPRManifest = {
     schemaVersion: 2,
     versionOutput,
-    releaseNotes: notesResult.releaseNotes ?? {},
+    releaseNotes: {},
     notesFiles: notesResult.files,
     createdAt: new Date().toISOString(),
     baseSha,
@@ -805,6 +846,51 @@ export async function publishFromManifest(prNumber: number, options: StandingPRO
 
   info(`Publishing from manifest: ${manifest.versionOutput.updates.length} package(s)`);
 
+  // Regenerate LLM-enhanced release notes against the merged commit set. The standing-PR update
+  // intentionally skipped this so the standing-PR workflow doesn't depend on LLM availability.
+  // On failure we proceed with empty release notes — the publish stage falls back to GitHub's
+  // --generate-notes for the release body.
+  const notesGenerationOptions: ReleaseOptions = {
+    config: options.config,
+    dryRun: false,
+    sync: false,
+    skipNotes: false,
+    skipChangelogs: true,
+    skipReleaseNotes: false,
+    skipPublish: true,
+    skipGit: true,
+    skipGithubRelease: true,
+    skipVerification: true,
+    json: options.json,
+    verbose: options.verbose,
+    quiet: options.quiet,
+    projectDir: cwd,
+  };
+
+  let releaseNotes: Record<string, string> = {};
+  let notesFiles: string[] = [...manifest.notesFiles];
+  try {
+    info('Generating release notes (with LLM enhancement)...');
+    const notesResult = await runNotesStep(manifest.versionOutput, notesGenerationOptions);
+    releaseNotes = notesResult.releaseNotes ?? {};
+    // Add any newly written files (RELEASE_NOTES.md) to the notesFiles list. Don't dedupe
+    // against manifest.notesFiles by string equality alone — paths may differ — but the
+    // changelog files were already on main from the merge so we don't need them in the
+    // publish commit anyway. Just track the new ones.
+    const newFiles = notesResult.files.filter((f) => !manifest.notesFiles.includes(f));
+    notesFiles = [...notesFiles, ...newFiles];
+
+    // Commit the new RELEASE_NOTES.md so main reflects what's in the GitHub release body.
+    // Tags created next by the publish step land on this commit (which is fine — the tag
+    // captures the full release state including notes).
+    if (newFiles.length > 0) {
+      commitNotesFiles(newFiles, manifest.versionOutput, cwd);
+    }
+  } catch (err) {
+    warn(`Release notes generation failed: ${err instanceof Error ? err.message : String(err)}`);
+    warn('Publish will proceed with empty release notes; GitHub release will use auto-generated notes.');
+  }
+
   const publishOptions: ReleaseOptions = {
     config: options.config,
     dryRun: false,
@@ -822,12 +908,7 @@ export async function publishFromManifest(prNumber: number, options: StandingPRO
     npmAuth: (options.npmAuth as ReleaseOptions['npmAuth']) ?? 'auto',
   };
 
-  const publishOutput = await runPublishStep(
-    manifest.versionOutput,
-    publishOptions,
-    manifest.releaseNotes,
-    manifest.notesFiles,
-  );
+  const publishOutput = await runPublishStep(manifest.versionOutput, publishOptions, releaseNotes, notesFiles);
 
   success('Publish complete');
 
@@ -838,8 +919,8 @@ export async function publishFromManifest(prNumber: number, options: StandingPRO
 
   return {
     versionOutput: manifest.versionOutput,
-    notesGenerated: false,
-    releaseNotes: manifest.releaseNotes,
+    notesGenerated: true,
+    releaseNotes,
     publishOutput,
   };
 }

--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -109,17 +109,17 @@ function commitAndForcePush(branch: string, cwd: string): void {
 function commitNotesFiles(files: string[], versionOutput: VersionOutput, cwd: string): void {
   if (files.length === 0) return;
 
-  // Probe whether ANY of the target paths actually differs from HEAD before touching the index.
-  // `git diff --quiet -- <paths>` exits 0 when no diff, 1 when there is a diff. Scoping to
-  // explicit paths avoids picking up unrelated repo-wide dirty state.
-  let hasChanges = false;
-  try {
-    execFileSync('git', ['diff', '--quiet', 'HEAD', '--', ...files], { cwd, stdio: 'pipe' });
-  } catch {
-    hasChanges = true;
-  }
+  // Probe whether ANY of the target paths has tracked changes OR is untracked. `git status
+  // --porcelain -- <paths>` is scoped to the listed paths (so unrelated repo-wide dirty state
+  // is ignored) AND reports untracked files (`??` prefix) — which `git diff HEAD` misses.
+  // Without the untracked check, a brand-new RELEASE_NOTES.md (first release in a repo) would
+  // be silently skipped and never make it into the publish commit.
+  const statusOut = execFileSync('git', ['status', '--porcelain', '--', ...files], {
+    cwd,
+    encoding: 'utf-8',
+  }).trim();
 
-  if (!hasChanges) {
+  if (!statusOut) {
     info('Release notes already match the on-disk content, skipping commit');
     return;
   }

--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'node:child_process';
+import { execFileSync, execSync } from 'node:child_process';
 
 import * as fs from 'node:fs';
 import { type CIConfig, loadConfig as loadReleaseKitConfig } from '@releasekit/config';
@@ -102,32 +102,46 @@ function commitAndForcePush(branch: string, cwd: string): void {
  * Stage and commit the LLM-enhanced release notes files generated at publish time. Tags created
  * by the subsequent publish stage land on this commit (which captures the full release state
  * including the polished notes).
+ *
+ * Uses execFileSync (no shell) and scopes both the diff probe and the commit to the specific
+ * file paths so unrelated dirty index state can't pollute the notes commit.
  */
 function commitNotesFiles(files: string[], versionOutput: VersionOutput, cwd: string): void {
   if (files.length === 0) return;
 
-  for (const file of files) {
-    try {
-      execSync(`git add "${file}"`, { encoding: 'utf-8', cwd, stdio: 'pipe' });
-    } catch (err) {
-      warn(`Failed to stage ${file}: ${err instanceof Error ? err.message : String(err)}`);
-      return;
-    }
+  // Probe whether ANY of the target paths actually differs from HEAD before touching the index.
+  // `git diff --quiet -- <paths>` exits 0 when no diff, 1 when there is a diff. Scoping to
+  // explicit paths avoids picking up unrelated repo-wide dirty state.
+  let hasChanges = false;
+  try {
+    execFileSync('git', ['diff', '--quiet', 'HEAD', '--', ...files], { cwd, stdio: 'pipe' });
+  } catch {
+    hasChanges = true;
   }
 
-  // Nothing to commit — the LLM produced output identical to what's already on disk.
-  const status = execSync('git status --porcelain', { encoding: 'utf-8', cwd }).trim();
-  if (!status) {
+  if (!hasChanges) {
     info('Release notes already match the on-disk content, skipping commit');
     return;
   }
 
-  // Use the first update's version for the commit subject. In sync mode all packages share
-  // a version; in async this picks one representative — fine for an audit-only commit.
+  // Single atomic git add — either every file is staged or none are, no partial-staging
+  // dirty-index window before the subsequent publish step runs.
+  try {
+    execFileSync('git', ['add', '--', ...files], { cwd, stdio: 'pipe' });
+  } catch (err) {
+    warn(`Failed to stage release notes files: ${err instanceof Error ? err.message : String(err)}`);
+    return;
+  }
+
+  // Commit ONLY the listed paths via `git commit -- <paths>`. This is belt-and-braces against
+  // any unrelated content that may already be staged in the index — git will only write the
+  // explicit paths into the commit even if other paths are staged.
+  // Use the first update's version for the commit subject (sync mode shares a single version;
+  // async picks a representative — fine for an audit-only commit).
   const version = versionOutput.updates[0]?.newVersion ?? '';
   const message = version ? `chore: release notes for v${version}` : 'chore: release notes';
   try {
-    execSync(`git commit -m "${message}"`, { encoding: 'utf-8', cwd, stdio: 'pipe' });
+    execFileSync('git', ['commit', '-m', message, '--', ...files], { cwd, stdio: 'pipe' });
     success(`Committed release notes (${files.length} file(s))`);
   } catch (err) {
     warn(`Failed to commit release notes: ${err instanceof Error ? err.message : String(err)}`);
@@ -919,7 +933,9 @@ export async function publishFromManifest(prNumber: number, options: StandingPRO
 
   return {
     versionOutput: manifest.versionOutput,
-    notesGenerated: true,
+    // Reflect actual success — the LLM call may have failed and left releaseNotes empty,
+    // in which case downstream consumers should know not to display/propagate "generated" notes.
+    notesGenerated: Object.keys(releaseNotes).length > 0,
     releaseNotes,
     publishOutput,
   };

--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -114,10 +114,19 @@ function commitNotesFiles(files: string[], versionOutput: VersionOutput, cwd: st
   // is ignored) AND reports untracked files (`??` prefix) — which `git diff HEAD` misses.
   // Without the untracked check, a brand-new RELEASE_NOTES.md (first release in a repo) would
   // be silently skipped and never make it into the publish commit.
-  const statusOut = execFileSync('git', ['status', '--porcelain', '--', ...files], {
-    cwd,
-    encoding: 'utf-8',
-  }).trim();
+  // The probe is wrapped so the function never propagates — the caller's outer try/catch is
+  // scoped to LLM failures, and a bubbled git error there would emit a misleading "release
+  // notes generation failed" warning even though notes were generated successfully.
+  let statusOut: string;
+  try {
+    statusOut = execFileSync('git', ['status', '--porcelain', '--', ...files], {
+      cwd,
+      encoding: 'utf-8',
+    }).trim();
+  } catch (err) {
+    warn(`Failed to probe release notes status: ${err instanceof Error ? err.message : String(err)}`);
+    return;
+  }
 
   if (!statusOut) {
     info('Release notes already match the on-disk content, skipping commit');

--- a/packages/release/src/steps.ts
+++ b/packages/release/src/steps.ts
@@ -55,7 +55,10 @@ export async function runNotesStep(versionOutput: VersionOutput, options: Releas
   const config = loadConfig(options.projectDir, options.config);
 
   const input = versionOutputToChangelogInput(versionOutput);
-  const result = await runPipeline(input, config, options.dryRun);
+  const result = await runPipeline(input, config, options.dryRun, {
+    skipReleaseNotes: options.skipReleaseNotes,
+    skipChangelogs: options.skipChangelogs,
+  });
 
   return { packageNotes: result.packageNotes, releaseNotes: result.releaseNotes, files: result.files };
 }

--- a/packages/release/src/types.ts
+++ b/packages/release/src/types.ts
@@ -12,6 +12,19 @@ export interface ReleaseOptions {
   scope?: string;
   branch?: string;
   skipNotes: boolean;
+  /**
+   * Skip release-notes generation (LLM + RELEASE_NOTES.md write) inside the notes step.
+   * Per-package CHANGELOG.md is unaffected. Used by the standing-pr update path so the
+   * standing-pr workflow doesn't depend on LLM availability and doesn't re-pay for an
+   * LLM call on every push to main.
+   */
+  skipReleaseNotes?: boolean;
+  /**
+   * Skip changelog file writes (CHANGELOG.md) inside the notes step. LLM + release-notes
+   * generation are unaffected. Used by `publishFromManifest` to regenerate only the
+   * release notes against an already-bumped tree.
+   */
+  skipChangelogs?: boolean;
   skipPublish: boolean;
   skipGit: boolean;
   skipGitCommit?: boolean;

--- a/packages/release/test/unit/release.spec.ts
+++ b/packages/release/test/unit/release.spec.ts
@@ -437,7 +437,7 @@ describe('runRelease', () => {
   it('should pass dryRun to notes pipeline', async () => {
     await runRelease({ ...defaultOptions, dryRun: true });
 
-    expect(mockNotesRunPipeline).toHaveBeenCalledWith(expect.anything(), expect.anything(), true);
+    expect(mockNotesRunPipeline).toHaveBeenCalledWith(expect.anything(), expect.anything(), true, expect.anything());
   });
 
   it('should pass version output to notes directly', async () => {

--- a/packages/release/test/unit/standing-pr.spec.ts
+++ b/packages/release/test/unit/standing-pr.spec.ts
@@ -896,7 +896,15 @@ describe('runStandingPRPublish', () => {
     });
     vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
 
-    const { runPublishStep } = await import('../../src/steps.js');
+    const { runNotesStep, runPublishStep } = await import('../../src/steps.js');
+    // publishFromManifest regenerates LLM-enhanced notes against the merged commit set
+    // — the publish step should receive these regenerated notes, not whatever (now empty)
+    // releaseNotes lives on the manifest.
+    vi.mocked(runNotesStep).mockResolvedValue({
+      packageNotes: {},
+      releaseNotes: { '@scope/core': '- regenerated at publish time' },
+      files: ['RELEASE_NOTES.md'],
+    });
     vi.mocked(runPublishStep).mockResolvedValue({ publishSucceeded: true } as unknown as Awaited<
       ReturnType<typeof runPublishStep>
     >);
@@ -909,11 +917,59 @@ describe('runStandingPRPublish', () => {
     });
 
     expect(result).not.toBeNull();
+    // runNotesStep is called with skipChangelogs:true (LLM-only, against the already-merged
+    // tree) before the publish step runs.
+    expect(vi.mocked(runNotesStep)).toHaveBeenCalledWith(
+      expect.objectContaining({ updates: baseManifest.versionOutput.updates }),
+      expect.objectContaining({ skipChangelogs: true, skipReleaseNotes: false }),
+    );
     expect(vi.mocked(runPublishStep)).toHaveBeenCalledWith(
       expect.objectContaining({ updates: baseManifest.versionOutput.updates }),
       expect.objectContaining({ skipGitCommit: true }),
-      baseManifest.releaseNotes,
-      baseManifest.notesFiles,
+      { '@scope/core': '- regenerated at publish time' },
+      expect.arrayContaining(['RELEASE_NOTES.md', ...baseManifest.notesFiles]),
+    );
+  });
+
+  it('should fall back to empty release notes when LLM regeneration fails', async () => {
+    const { readFileSync } = await import('node:fs');
+    vi.mocked(readFileSync).mockReturnValue(
+      JSON.stringify({
+        pull_request: { head: { ref: 'release/next' }, number: 42, merged: true },
+      }),
+    );
+
+    const { createOctokit } = await import('../../src/github.js');
+    const { octokit } = createMockOctokit();
+    const manifestBody = serializeManifest(baseManifest);
+    (octokit as unknown as { paginate: { iterator: ReturnType<typeof vi.fn> } }).paginate.iterator.mockReturnValue({
+      async *[Symbol.asyncIterator]() {
+        yield { data: [{ id: 1, body: manifestBody }] };
+      },
+    });
+    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+
+    const { runNotesStep, runPublishStep } = await import('../../src/steps.js');
+    vi.mocked(runNotesStep).mockRejectedValue(new Error('LLM provider unavailable'));
+    vi.mocked(runPublishStep).mockResolvedValue({ publishSucceeded: true } as unknown as Awaited<
+      ReturnType<typeof runPublishStep>
+    >);
+
+    const result = await runStandingPRPublish({
+      projectDir: '/test',
+      verbose: false,
+      quiet: false,
+      json: false,
+    });
+
+    expect(result).not.toBeNull();
+    // Publish proceeds with empty releaseNotes — the publish stage falls back to
+    // GitHub's --generate-notes for the release body.
+    expect(vi.mocked(runPublishStep)).toHaveBeenCalledWith(
+      expect.objectContaining({ updates: baseManifest.versionOutput.updates }),
+      expect.objectContaining({ skipGitCommit: true }),
+      {},
+      expect.arrayContaining(baseManifest.notesFiles),
     );
   });
 
@@ -1250,7 +1306,12 @@ describe('runStandingPRMerge', () => {
     });
     vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
 
-    const { runPublishStep } = await import('../../src/steps.js');
+    const { runNotesStep, runPublishStep } = await import('../../src/steps.js');
+    vi.mocked(runNotesStep).mockResolvedValue({
+      packageNotes: {},
+      releaseNotes: { '@scope/core': '- regenerated' },
+      files: ['RELEASE_NOTES.md'],
+    });
     vi.mocked(runPublishStep).mockResolvedValue({ publishSucceeded: true } as unknown as Awaited<
       ReturnType<typeof runPublishStep>
     >);
@@ -1264,8 +1325,8 @@ describe('runStandingPRMerge', () => {
     expect(vi.mocked(runPublishStep)).toHaveBeenCalledWith(
       expect.objectContaining({ updates: baseManifest.versionOutput.updates }),
       expect.objectContaining({ skipGitCommit: true }),
-      baseManifest.releaseNotes,
-      baseManifest.notesFiles,
+      { '@scope/core': '- regenerated' },
+      expect.arrayContaining(['RELEASE_NOTES.md', ...baseManifest.notesFiles]),
     );
   });
 


### PR DESCRIPTION
- Added PipelineOptions interface to allow skipping of release notes and changelog generation during the pipeline execution.
- Updated runPipeline and processInput functions to accept pipelineOptions, enhancing flexibility in managing output files.
- Implemented tests to verify the correct behavior of the new flags, ensuring existing functionality is preserved when both flags are omitted.