### PR TITLE
feat(workflows): add standing PR publish and update workflows

### DIFF
--- a/.github/workflows/_release.reusable.yml
+++ b/.github/workflows/_release.reusable.yml
@@ -186,7 +186,12 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
           STANDING_PR_NUMBER: ${{ inputs.standing_pr_number }}
+          INPUT_NPM_AUTH: ${{ inputs.npm_auth }}
         run: |
+          if [ "${INPUT_NPM_AUTH:-oidc}" != "oidc" ]; then
+            echo "::error::standing-pr publish only supports npm_auth=oidc (got: '${INPUT_NPM_AUTH}')"
+            exit 1
+          fi
           set +e
           RELEASE_OUTPUT=$(node packages/release/dist/cli.js standing-pr publish \
             --pr "$STANDING_PR_NUMBER" \

--- a/.github/workflows/_release.reusable.yml
+++ b/.github/workflows/_release.reusable.yml
@@ -22,6 +22,11 @@ on:
         required: false
         type: boolean
         default: false
+      standing_pr_number:
+        description: When set, run `standing-pr publish` against this PR number instead of the full release flow. Routes the standing-PR publish path through this trusted-publisher workflow so npm OIDC authenticates correctly.
+        required: false
+        type: string
+        default: ''
     secrets:
       ssh_key:
         required: false
@@ -80,6 +85,7 @@ jobs:
 
       - name: Run releasekit
         id: release
+        if: inputs.standing_pr_number == ''
         env:
           GITHUB_TOKEN: ${{ github.token }}
           OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
@@ -169,6 +175,38 @@ jobs:
             echo "has_changes=false" >> "$GITHUB_OUTPUT"
           fi
 
+      # Standing-PR publish path. Routed through this reusable so the OIDC `job_workflow_ref`
+      # matches the npm trusted-publisher entry — npm only allows one trusted-publisher
+      # workflow path per package, and that path is this file.
+      - name: Run releasekit (standing-pr publish)
+        id: release-standing-pr
+        if: inputs.standing_pr_number != ''
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
+          STANDING_PR_NUMBER: ${{ inputs.standing_pr_number }}
+        run: |
+          set +e
+          RELEASE_OUTPUT=$(node packages/release/dist/cli.js standing-pr publish \
+            --pr "$STANDING_PR_NUMBER" \
+            --npm-auth oidc \
+            --json \
+            2> >(tee /tmp/release_stderr >&2))
+          EXIT_CODE=$?
+          set -e
+
+          if [ $EXIT_CODE -ne 0 ]; then
+            echo "::error::standing-pr publish failed with exit code $EXIT_CODE"
+            exit $EXIT_CODE
+          fi
+
+          if echo "$RELEASE_OUTPUT" | jq -e '.versionOutput' > /dev/null 2>&1; then
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+            echo "$RELEASE_OUTPUT" > release-output.json
+          else
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Extract action tag
         id: extract-tag
         if: ${{ !inputs.dry_run }}
@@ -189,7 +227,7 @@ jobs:
           INPUT_DRY_RUN: ${{ inputs.dry_run }}
           INPUT_NPM_AUTH: ${{ inputs.npm_auth }}
           INPUT_SYNC: ${{ inputs.sync }}
-          HAS_CHANGES: ${{ steps.release.outputs.has_changes }}
+          HAS_CHANGES: ${{ steps.release.outputs.has_changes || steps.release-standing-pr.outputs.has_changes }}
         run: |
           echo "## Release" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/_release.reusable.yml
+++ b/.github/workflows/_release.reusable.yml
@@ -40,6 +40,7 @@ on:
 permissions:
   id-token: write
   contents: write
+  pull-requests: write
 
 env:
   TURBO_TELEMETRY_DISABLED: 1

--- a/.github/workflows/_standing-pr-update.reusable.yml
+++ b/.github/workflows/_standing-pr-update.reusable.yml
@@ -1,0 +1,49 @@
+name: Standing PR Update
+
+# Wraps `cli.js standing-pr update` for both the routine update job and the post-immediate-release
+# reconcile job. No npm publish, no SSH push — uses the default GITHUB_TOKEN to push the release
+# branch and create/update the standing PR.
+
+on:
+  workflow_call:
+    secrets:
+      OLLAMA_API_KEY:
+        required: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  TURBO_TELEMETRY_DISABLED: 1
+
+jobs:
+  update:
+    name: Update standing PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
+          token: ${{ github.token }}
+
+      - name: Setup workspace
+        uses: ./.github/workflows/actions/setup-workspace
+
+      - name: Build packages
+        run: pnpm build
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Update standing release PR
+        run: node packages/release/dist/cli.js standing-pr update
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          # Uncomment the env var matching your notes.releaseNotes.llm.provider.
+          # OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          # ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}

--- a/.github/workflows/standing-pr.yml
+++ b/.github/workflows/standing-pr.yml
@@ -84,33 +84,12 @@ jobs:
     name: Update Release PR
     needs: detect-release-merge
     if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && needs.detect-release-merge.outputs.pr_number == ''
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6.0.2
-        with:
-          fetch-depth: 0
-          token: ${{ github.token }}
-
-      - name: Setup workspace
-        uses: ./.github/workflows/actions/setup-workspace
-
-      - name: Build packages
-        run: pnpm build
-
-      - name: Configure git
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-      - name: Update standing release PR
-        run: node packages/release/dist/cli.js standing-pr update
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-          # Uncomment the env var matching your notes.releaseNotes.llm.provider.
-          # OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          # ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
+    uses: ./.github/workflows/_standing-pr-update.reusable.yml
+    permissions:
+      contents: write
+      pull-requests: write
+    secrets:
+      OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
 
   # Delegates to the same reusable release workflow used by `release.yml` so npm OIDC auth and
   # SSH-based git push are configured identically — running the CLI inline previously skipped
@@ -157,58 +136,44 @@ jobs:
     # set whenever any package releases. If you switch back to async, this gate becomes too
     # narrow (it only fires when @releasekit/release itself is bumped) and should be revisited.
     if: needs.immediate-release.result == 'success' && needs.immediate-release.outputs.action_tag != ''
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6.0.2
-        with:
-          fetch-depth: 0
-          token: ${{ github.token }}
+    uses: ./.github/workflows/_standing-pr-update.reusable.yml
+    permissions:
+      contents: write
+      pull-requests: write
+    secrets:
+      OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
 
-      - name: Setup workspace
-        uses: ./.github/workflows/actions/setup-workspace
-
-      - name: Build packages
-        run: pnpm build
-
-      - name: Configure git
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-      - name: Reconcile standing PR
-        run: node packages/release/dist/cli.js standing-pr update
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-          # Uncomment the env var matching your notes.releaseNotes.llm.provider.
-          # OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          # ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
-
+  # Routed through `_release.reusable.yml` so the OIDC `job_workflow_ref` matches the npm
+  # trusted-publisher entry (npm only allows one trusted-publisher workflow path per package).
+  # The reusable's `standing_pr_number` input switches it from the version+notes+publish flow
+  # to the manifest-driven standing-pr publish flow, while keeping SSH/auth setup identical.
   publish-release:
     name: Publish Release
     needs: detect-release-merge
     if: needs.detect-release-merge.outputs.pr_number != ''
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6.0.2
-        with:
-          fetch-depth: 0
-          token: ${{ github.token }}
+    uses: ./.github/workflows/_release.reusable.yml
+    permissions:
+      id-token: write
+      contents: write
+    with:
+      packages: all
+      bump: auto
+      sync: true
+      dry_run: false
+      npm_auth: oidc
+      standing_pr_number: ${{ needs.detect-release-merge.outputs.pr_number }}
+    secrets:
+      ssh_key: ${{ secrets.DEPLOY_KEY }}
+      OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
 
-      - name: Setup workspace
-        uses: ./.github/workflows/actions/setup-workspace
-
-      - name: Build packages
-        run: pnpm build
-
-      - name: Configure git
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-      - name: Publish from release PR
-        run: node packages/release/dist/cli.js standing-pr publish --pr "${{ needs.detect-release-merge.outputs.pr_number }}"
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
+  build-action-publish:
+    name: Build and tag action dist
+    needs: publish-release
+    if: needs.publish-release.result == 'success' && needs.publish-release.outputs.action_tag != ''
+    uses: ./.github/workflows/_action-release.reusable.yml
+    permissions:
+      contents: write
+    with:
+      tag: ${{ needs.publish-release.outputs.action_tag }}
+    secrets:
+      ssh_key: ${{ secrets.DEPLOY_KEY }}

--- a/.github/workflows/standing-pr.yml
+++ b/.github/workflows/standing-pr.yml
@@ -155,6 +155,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
+      pull-requests: write
     with:
       packages: all
       bump: auto


### PR DESCRIPTION
- Introduced a new reusable workflow for standing PR updates, allowing for streamlined updates without npm publish or SSH push.
- Enhanced the existing release workflow to support a `standing_pr_number` input, enabling targeted publishing for standing PRs.
- Updated the standing PR job in the main workflow to utilize the new reusable update workflow, improving maintainability and reducing redundancy.
- Adjusted conditions for release steps to accommodate both standard and standing PR publishing paths, ensuring proper execution based on input parameters.
