### PR TITLE
chore: revert "chore: release 5 package(s) (#199)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "releasekit-monorepo",
-  "version": "0.21.0",
+  "version": "0.20.0",
   "private": true,
   "type": "module",
   "description": "Release tooling for automated versioning and changelog generation",

--- a/packages/notes/package.json
+++ b/packages/notes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@releasekit/notes",
-  "version": "0.21.0",
+  "version": "0.20.0",
   "description": "Release notes and changelog generation with LLM-powered enhancement and flexible templating",
   "type": "module",
   "module": "./dist/index.js",

--- a/packages/publish/package.json
+++ b/packages/publish/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@releasekit/publish",
-  "version": "0.21.0",
+  "version": "0.20.0",
   "description": "Publish packages to npm and crates.io with git tagging and GitHub releases",
   "type": "module",
   "module": "./dist/index.js",

--- a/packages/release/package.json
+++ b/packages/release/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@releasekit/release",
-  "version": "0.21.0",
+  "version": "0.20.0",
   "description": "Unified release pipeline: version, changelog, and publish in a single command",
   "type": "module",
   "module": "./dist/index.js",

--- a/packages/version/package.json
+++ b/packages/version/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@releasekit/version",
-  "version": "0.21.0",
+  "version": "0.20.0",
   "description": "Semantic versioning based on Git history and conventional commits",
   "type": "module",
   "module": "./dist/index.js",


### PR DESCRIPTION
## Summary
- Reverts the release version bumps from PR #199 (`be84b50`).
- PR #199 merged but the publish job in `standing-pr.yml` failed (missing `OLLAMA_API_KEY`, OIDC subject mismatch, no SSH for tag push), so the version bumps landed on `main` without corresponding npm releases.
- The underlying workflow bug is fixed in #202; reverting the bumps lets the next standing-PR cycle recompute and publish cleanly via the corrected path.

## Test plan
- [ ] Confirm `package.json` files return to pre-#199 versions on merge.
- [ ] After merge, `standing-pr update` runs and rebuilds the standing PR with the same set of pending changes.
- [ ] Next merge of the regenerated standing PR exercises the fixed `publish-release` → `build-action-publish` chain end-to-end (npm publish via OIDC, tags pushed via SSH, action dist tagged).