### PR TITLE
fix(ci): drop unused pull-requests permission from _release.reusable.yml

### DIFF
--- a/.github/workflows/_release.reusable.yml
+++ b/.github/workflows/_release.reusable.yml
@@ -40,7 +40,6 @@ on:
 permissions:
   id-token: write
   contents: write
-  pull-requests: write
 
 env:
   TURBO_TELEMETRY_DISABLED: 1

--- a/.github/workflows/standing-pr.yml
+++ b/.github/workflows/standing-pr.yml
@@ -155,7 +155,6 @@ jobs:
     permissions:
       id-token: write
       contents: write
-      pull-requests: write
     with:
       packages: all
       bump: auto


### PR DESCRIPTION
## Summary
- The follow-up commit on #202 added `pull-requests: write` to `_release.reusable.yml`'s top-level permissions, on the assumption the standing-pr publish path needed it to close or comment on the merged PR. It doesn't — `publishFromManifest` (`packages/release/src/standing-pr/standing-pr.ts:825-951`) only reads the manifest comment via `findManifestComment`, and the merged PR closes naturally when the release branch is deleted (`contents: write`).
- Declaring the permission at the reusable's top level forced every caller job to grant it. `release.yml`'s `release-auto` and `release-manual` only grant `id-token` + `contents`, which broke main with `is requesting 'pull-requests: write', but is only allowed 'pull-requests: none'`.
- Removing the unneeded permission unblocks all four callers (release.yml × 2, standing-pr.yml × 2) without needing to touch them.

## Test plan
- [ ] CI lints `release.yml` and `standing-pr.yml` cleanly after merge.
- [ ] `release.yml` `workflow_dispatch` runs (existing path through `_release.reusable.yml`).
- [ ] After #203 merges, `update-release-pr` regenerates the standing PR; merging it exercises `publish-release` end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)