### PR TITLE
feat(standing-pr): collapse changelog under <details> in PR body

### DIFF
--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -217,21 +217,30 @@ function renderChangelogSection(versionOutput: VersionOutput): string {
   const hasPackageEntries = versionOutput.changelogs.some((cl) => cl.entries.length > 0);
   if (!hasShared && !hasPackageEntries) return '';
 
-  const lines: string[] = ['### Changelog', ''];
+  const totalEntries =
+    (versionOutput.sharedEntries?.length ?? 0) +
+    versionOutput.changelogs.reduce((acc, cl) => acc + cl.entries.length, 0);
+
+  const inner: string[] = ['### Changelog', ''];
 
   if (hasShared) {
-    lines.push('#### Project-wide changes', '');
-    lines.push(...renderChangelogEntries(versionOutput.sharedEntries!));
+    inner.push('#### Project-wide changes', '');
+    inner.push(...renderChangelogEntries(versionOutput.sharedEntries!));
   }
 
   for (const cl of versionOutput.changelogs) {
     if (cl.entries.length === 0) continue;
-    lines.push(`#### ${cl.packageName} — ${cl.previousVersion ?? 'N/A'} → ${cl.version}`, '');
-    lines.push(...renderChangelogEntries(cl.entries));
+    inner.push(`#### ${cl.packageName} — ${cl.previousVersion ?? 'N/A'} → ${cl.version}`, '');
+    inner.push(...renderChangelogEntries(cl.entries));
   }
 
-  if (lines[lines.length - 1] === '') lines.pop();
-  return lines.join('\n');
+  if (inner[inner.length - 1] === '') inner.pop();
+
+  // Wrap in <details> — standing-PR changelogs can run to hundreds of entries across
+  // many packages and dominate the PR body. Collapsed-by-default keeps the package
+  // table immediately visible while still letting reviewers expand to inspect.
+  const summary = `Show changelog (${totalEntries} ${totalEntries === 1 ? 'entry' : 'entries'})`;
+  return ['<details>', `<summary>${summary}</summary>`, '', ...inner, '', '</details>'].join('\n');
 }
 
 function deleteReleaseBranch(releaseBranch: string, cwd: string): void {


### PR DESCRIPTION
## Summary
- Wrap the rendered standing-PR changelog in a `<details>` block (collapsed by default), with the entry count in the `<summary>` line.
- Standing-PR changelogs grow to hundreds of entries on busy repos and dominate the PR body, pushing the package version table off-screen. This keeps the table immediately visible while still letting reviewers expand to inspect.

## Preview

Before:
```
## Release
| Package | Version |
|---------|---------|
...

### Changelog

#### Project-wide changes
**Added**
- Entry 1
- Entry 2
... 200 more entries ...
```

After:
```
## Release
| Package | Version |
|---------|---------|
...

<details>
<summary>Show changelog (203 entries)</summary>

### Changelog

#### Project-wide changes
**Added**
- Entry 1
...
</details>
```

## Test plan
- [x] `pnpm --filter @releasekit/release test:unit` — all 430 tests pass; existing `body.toContain('### Changelog')` assertions still hold (heading lives inside `<details>`).
- [x] `pnpm --filter @releasekit/release typecheck` clean.
- [x] Lint counts unchanged (1 error + 2 warnings, all pre-existing).
- [ ] After merge, next standing-PR cycle renders the collapsed body in GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)