### PR TITLE
chore(release): clean up biome lint findings

### DIFF
--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -179,8 +179,12 @@ const CHANGELOG_TYPE_LABELS: Record<string, string> = {
 function renderChangelogEntries(entries: VersionOutput['changelogs'][number]['entries']): string[] {
   const grouped = new Map<string, typeof entries>();
   for (const entry of entries) {
-    if (!grouped.has(entry.type)) grouped.set(entry.type, []);
-    grouped.get(entry.type)!.push(entry);
+    let group = grouped.get(entry.type);
+    if (!group) {
+      group = [];
+      grouped.set(entry.type, group);
+    }
+    group.push(entry);
   }
   const lines: string[] = [];
   const renderedTypes = new Set<string>();
@@ -213,15 +217,15 @@ function renderChangelogEntries(entries: VersionOutput['changelogs'][number]['en
 }
 
 function renderChangelogSection(versionOutput: VersionOutput): string {
-  const hasShared = (versionOutput.sharedEntries?.length ?? 0) > 0;
+  const sharedEntries = versionOutput.sharedEntries ?? [];
   const hasPackageEntries = versionOutput.changelogs.some((cl) => cl.entries.length > 0);
-  if (!hasShared && !hasPackageEntries) return '';
+  if (sharedEntries.length === 0 && !hasPackageEntries) return '';
 
   const lines: string[] = ['### Changelog', ''];
 
-  if (hasShared) {
+  if (sharedEntries.length > 0) {
     lines.push('#### Project-wide changes', '');
-    lines.push(...renderChangelogEntries(versionOutput.sharedEntries!));
+    lines.push(...renderChangelogEntries(sharedEntries));
   }
 
   for (const cl of versionOutput.changelogs) {

--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -221,15 +221,13 @@ function renderChangelogSection(versionOutput: VersionOutput): string {
   const hasPackageEntries = versionOutput.changelogs.some((cl) => cl.entries.length > 0);
   if (sharedEntries.length === 0 && !hasPackageEntries) return '';
 
-  const totalEntries =
-    (versionOutput.sharedEntries?.length ?? 0) +
-    versionOutput.changelogs.reduce((acc, cl) => acc + cl.entries.length, 0);
+  const totalEntries = sharedEntries.length + versionOutput.changelogs.reduce((acc, cl) => acc + cl.entries.length, 0);
 
   const inner: string[] = ['### Changelog', ''];
 
   if (sharedEntries.length > 0) {
-    lines.push('#### Project-wide changes', '');
-    lines.push(...renderChangelogEntries(sharedEntries));
+    inner.push('#### Project-wide changes', '');
+    inner.push(...renderChangelogEntries(sharedEntries));
   }
 
   for (const cl of versionOutput.changelogs) {

--- a/packages/release/tsconfig.json
+++ b/packages/release/tsconfig.json
@@ -6,6 +6,12 @@
     "noUncheckedIndexedAccess": true,
     "noImplicitOverride": true
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "test"]
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "test"
+  ]
 }


### PR DESCRIPTION
## Summary
- Refactor two non-null-assertion sites in `standing-pr.ts` into explicit binds. Same behaviour, no `!`.
  - `renderChangelogEntries`: `Map.get(...)!.push` → bind-or-create local.
  - `renderChangelogSection`: `versionOutput.sharedEntries!` → `?? []` defaulted local; the `hasShared` flag becomes redundant once narrowed.
- Reformat `packages/release/tsconfig.json` arrays to match biome's expected multi-line layout.

## Test plan
- [x] `pnpm --filter @releasekit/release lint` clean (was: 1 error + 2 warnings).
- [x] `pnpm --filter @releasekit/release typecheck` clean.
- [x] `pnpm --filter @releasekit/release test:unit` — 430 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)