### PR TITLE
fix(ci): detect standing-PR merge from commit subject to avoid API race

### DIFF
--- a/.github/workflows/standing-pr.yml
+++ b/.github/workflows/standing-pr.yml
@@ -62,10 +62,9 @@ jobs:
           SUBJECT=$(printf '%s\n' "$COMMIT_MSG" | head -1)
           if [[ "$SUBJECT" =~ \(#([0-9]+)\)[[:space:]]*$ ]]; then
             CANDIDATE="${BASH_REMATCH[1]}"
-            HEAD_REF=$(gh pr view "$CANDIDATE" --json headRefName --jq '.headRefName' 2>/dev/null || echo "")
+            HEAD_REF=$(gh pr view "$CANDIDATE" --repo "$REPO" --json headRefName --jq '.headRefName' 2>/dev/null || echo "")
             if [ "$HEAD_REF" = "$STANDING_PR_BRANCH" ]; then
               PR_NUM="$CANDIDATE"
-              echo "Detected standing PR merge from subject: PR #$PR_NUM (head: $STANDING_PR_BRANCH)"
             else
               echo "Subject references PR #$CANDIDATE but its head ref ('$HEAD_REF') is not '$STANDING_PR_BRANCH' — not a standing-PR merge"
             fi

--- a/.github/workflows/standing-pr.yml
+++ b/.github/workflows/standing-pr.yml
@@ -45,34 +45,56 @@ jobs:
         id: detect
         env:
           COMMIT_SHA: ${{ github.sha }}
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
           REPO: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           STANDING_PR_BRANCH=$(jq -r '.ci.standingPr.branch // "release/next"' releasekit.config.json)
 
-          # Retry transient API errors (rate limits, 5xx, network blips) before giving up. The
-          # API call distinguishes "no PR for this commit" (returns []) from real failures, so
-          # silent fall-through to update-release-pr is only safe when we got a successful
-          # response. On persistent failure we fail the job loudly — both downstream jobs will
-          # be skipped, but the next push retries the workflow.
-          PRS=""
-          for attempt in 1 2 3; do
-            if PRS=$(gh api "repos/$REPO/commits/$COMMIT_SHA/pulls" 2>&1); then
-              break
-            fi
-            if [ "$attempt" -lt 3 ]; then
-              echo "::warning::gh api failed (attempt $attempt/3): $PRS — retrying after ${attempt}s"
-              sleep "$attempt"
-              PRS=""
+          # Primary path: parse the PR number from the squash-merge subject `(#N)` suffix.
+          # GitHub's commits→PRs cross-reference index is eventually consistent and can return
+          # an empty list for ~30s after a merge. Looking up the PR object by number is
+          # immediately stable, so when we know the number from the subject we skip the racy
+          # endpoint entirely. Falls back to the API approach if the subject doesn't match
+          # (merge commit, rebase merge, direct push).
+          PR_NUM=""
+          SUBJECT=$(printf '%s\n' "$COMMIT_MSG" | head -1)
+          if [[ "$SUBJECT" =~ \(#([0-9]+)\)[[:space:]]*$ ]]; then
+            CANDIDATE="${BASH_REMATCH[1]}"
+            HEAD_REF=$(gh pr view "$CANDIDATE" --json headRefName --jq '.headRefName' 2>/dev/null || echo "")
+            if [ "$HEAD_REF" = "$STANDING_PR_BRANCH" ]; then
+              PR_NUM="$CANDIDATE"
+              echo "Detected standing PR merge from subject: PR #$PR_NUM (head: $STANDING_PR_BRANCH)"
             else
-              echo "::error::gh api failed after 3 attempts: $PRS"
-              exit 1
+              echo "Subject references PR #$CANDIDATE but its head ref ('$HEAD_REF') is not '$STANDING_PR_BRANCH' — not a standing-PR merge"
             fi
-          done
+          fi
 
-          PR_NUM=$(echo "$PRS" | jq --arg branch "$STANDING_PR_BRANCH" -r \
-            '[.[] | select(.head.ref == $branch)][0].number // empty')
+          # Fallback path: ask the API for PRs cross-referencing this commit. Used when the
+          # subject doesn't carry a PR number (non-squash merges) or when the candidate's head
+          # ref didn't match. Retry on API errors (rate limits, 5xx, network blips); a
+          # successful empty result means there's no PR for this commit.
+          if [ -z "$PR_NUM" ]; then
+            PRS=""
+            for attempt in 1 2 3; do
+              if PRS=$(gh api "repos/$REPO/commits/$COMMIT_SHA/pulls" 2>&1); then
+                break
+              fi
+              if [ "$attempt" -lt 3 ]; then
+                echo "::warning::gh api failed (attempt $attempt/3): $PRS — retrying after ${attempt}s"
+                sleep "$attempt"
+                PRS=""
+              else
+                echo "::error::gh api failed after 3 attempts: $PRS"
+                exit 1
+              fi
+            done
+
+            PR_NUM=$(echo "$PRS" | jq --arg branch "$STANDING_PR_BRANCH" -r \
+              '[.[] | select(.head.ref == $branch)][0].number // empty')
+          fi
+
           if [ -n "$PR_NUM" ]; then
             echo "pr_number=$PR_NUM" >> "$GITHUB_OUTPUT"
             echo "Detected standing PR merge: PR #$PR_NUM (head: $STANDING_PR_BRANCH)"


### PR DESCRIPTION
## Summary
- PR #205 merged but the publish job was skipped. Root cause: `detect-release-merge` queried `gh api repos/.../commits/$SHA/pulls` ~7s after the merge and got back `[]`. GitHub's commits→PRs cross-reference index is eventually consistent (~30s lag for fresh squash merges); the retry loop only handled API *errors*, not successful empty responses, so the workflow fell through to `update-release-pr` and nothing published.
- Querying the same endpoint hours later returns PR #205 correctly, confirming the race interpretation.
- Fix: parse the PR number from the squash-merge subject's `(#N)` suffix as the primary detection path. PR-by-number lookup (`gh pr view N`) is immediately stable, so the race is gone for the typical squash-merge case. The original API approach is kept as a fallback for non-squash merges (merge commits, rebase merges) where the subject doesn't carry a PR number.

## Workflow run that triggered this
[run 25450283759](https://github.com/goosewobbler/releasekit/actions/runs/25450283759) — log line: `No standing PR merge detected for this push (looking for head: release/next)`.

## Test plan
- [x] Regex tested locally against squash-merge subjects, multi-line subjects (using `head -1`), non-PR direct pushes, and subjects with non-trailing `#N` (e.g. issue references) — only the trailing `(#N)` matches.
- [x] `actionlint .github/workflows/standing-pr.yml` clean.
- [ ] Once main has the fix, verify the next standing-PR merge fires the publish path.

## Follow-up needed
- The version bumps from PR #205 are on main but no npm release happened. After this PR merges, revert PR #205 like we did with #199. The next standing-PR cycle then regenerates and merges cleanly through the fixed detection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)