### PR TITLE
chore: revert "chore: release 5 package(s) (#205)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "releasekit-monorepo",
-  "version": "0.21.0",
+  "version": "0.20.0",
   "private": true,
   "type": "module",
   "description": "Release tooling for automated versioning and changelog generation",

--- a/packages/notes/package.json
+++ b/packages/notes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@releasekit/notes",
-  "version": "0.21.0",
+  "version": "0.20.0",
   "description": "Release notes and changelog generation with LLM-powered enhancement and flexible templating",
   "type": "module",
   "module": "./dist/index.js",

--- a/packages/publish/package.json
+++ b/packages/publish/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@releasekit/publish",
-  "version": "0.21.0",
+  "version": "0.20.0",
   "description": "Publish packages to npm and crates.io with git tagging and GitHub releases",
   "type": "module",
   "module": "./dist/index.js",

--- a/packages/release/package.json
+++ b/packages/release/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@releasekit/release",
-  "version": "0.21.0",
+  "version": "0.20.0",
   "description": "Unified release pipeline: version, changelog, and publish in a single command",
   "type": "module",
   "module": "./dist/index.js",

--- a/packages/version/package.json
+++ b/packages/version/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@releasekit/version",
-  "version": "0.21.0",
+  "version": "0.20.0",
   "description": "Semantic versioning based on Git history and conventional commits",
   "type": "module",
   "module": "./dist/index.js",


### PR DESCRIPTION
## Summary
- Reverts the release version bumps from PR #205 (`d79c9ae`).
- PR #205 merged but `publish-release` was skipped due to a GitHub API eventual-consistency race in `detect-release-merge` (see #210). Version bumps landed on `main` without corresponding npm releases.
- The detection bug is fixed in #210; reverting the bumps lets the next standing-PR cycle recompute and merge cleanly through the corrected detection path.

## Sequencing
1. Merge #210 (workflow fix) **first** so the regenerated standing-PR cycle benefits from the fix.
2. Merge this revert. Its commit subject is `Revert "chore: release 5 package(s) (#205)" (#211)` — head ref won't be `release/next`, so `detect-release-merge` correctly falls through to `update-release-pr`, which regenerates the standing PR.
3. Merge the regenerated standing PR. With #210 in place, `publish-release` fires correctly.

## Test plan
- [ ] After merge, package.json files return to pre-#205 versions on main.
- [ ] `update-release-pr` runs and rebuilds the standing PR with the same set of pending changes.
- [ ] Next standing-PR merge exercises the fixed `publish-release` → `build-action-publish` chain end-to-end.