### PR TITLE
fix(ci): trigger standing-pr publish via release.yml workflow_dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,10 @@ on:
         description: PR number of a merged standing release PR. When set, runs the manifest-driven publish path instead of the full version+notes+publish flow. Triggered by standing-pr.yml; manual callers should leave blank.
         type: string
         default: ''
+      reconcile_after:
+        description: When true, run a standing-pr update after the release completes. Used by the immediate-release path so the standing PR's queued changes get rebuilt against the new HEAD. Manual callers should leave false.
+        type: boolean
+        default: false
 
 concurrency:
   group: release
@@ -235,3 +239,18 @@ jobs:
       tag: ${{ needs.release-standing-pr.outputs.action_tag }}
     secrets:
       ssh_key: ${{ secrets.DEPLOY_KEY }}
+
+  # After an immediate release, the standing PR's queued changes overlap with what was just
+  # published. Re-running standing-pr update reconciles: closes the standing PR if nothing's
+  # left, otherwise rewrites the release branch against the new HEAD. Triggered by
+  # standing-pr.yml's `trigger-immediate` job via `reconcile_after=true`.
+  reconcile-after-release:
+    name: Reconcile standing PR (after immediate release)
+    needs: release-manual
+    if: github.event_name == 'workflow_dispatch' && inputs.reconcile_after && needs.release-manual.result == 'success' && needs.release-manual.outputs.action_tag != ''
+    uses: ./.github/workflows/_standing-pr-update.reusable.yml
+    permissions:
+      contents: write
+      pull-requests: write
+    secrets:
+      OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -247,6 +247,9 @@ jobs:
   reconcile-after-release:
     name: Reconcile standing PR (after immediate release)
     needs: release-manual
+    # Skip when nothing actually released — under sync mode (the current config), action_tag is
+    # set whenever any package releases. If you switch back to async, this gate becomes too
+    # narrow (it only fires when @releasekit/release itself is bumped) and should be revisited.
     if: github.event_name == 'workflow_dispatch' && inputs.reconcile_after && needs.release-manual.result == 'success' && needs.release-manual.outputs.action_tag != ''
     uses: ./.github/workflows/_standing-pr-update.reusable.yml
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,10 @@ on:
         description: Dry run (no publish, no push)
         type: boolean
         default: true
+      standing_pr_number:
+        description: PR number of a merged standing release PR. When set, runs the manifest-driven publish path instead of the full version+notes+publish flow. Triggered by standing-pr.yml; manual callers should leave blank.
+        type: string
+        default: ''
 
 concurrency:
   group: release
@@ -159,7 +163,7 @@ jobs:
 
   release-manual:
     name: Manual Release
-    if: github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch' && inputs.standing_pr_number == ''
     uses: ./.github/workflows/_release.reusable.yml
     permissions:
       id-token: write
@@ -174,10 +178,32 @@ jobs:
       ssh_key: ${{ secrets.DEPLOY_KEY }}
       OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
 
+  # Standing-PR publish path. Triggered by standing-pr.yml via `gh workflow run` so the OIDC
+  # token's `workflow_ref` claim is `release.yml` — the trusted-publisher entry on npmjs.com is
+  # keyed off the top-level workflow filename, and only one is allowed per package, so all
+  # OIDC publishes have to funnel through here.
+  release-standing-pr:
+    name: Release from Standing PR
+    if: github.event_name == 'workflow_dispatch' && inputs.standing_pr_number != ''
+    uses: ./.github/workflows/_release.reusable.yml
+    permissions:
+      id-token: write
+      contents: write
+    with:
+      packages: all
+      bump: auto
+      sync: true
+      dry_run: false
+      npm_auth: oidc
+      standing_pr_number: ${{ inputs.standing_pr_number }}
+    secrets:
+      ssh_key: ${{ secrets.DEPLOY_KEY }}
+      OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
+
   build-action-manual:
     name: Build and tag action dist
     needs: release-manual
-    if: ${{ github.event_name == 'workflow_dispatch' && needs.release-manual.outputs.action_tag != '' }}
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.standing_pr_number == '' && needs.release-manual.outputs.action_tag != '' }}
     uses: ./.github/workflows/_action-release.reusable.yml
     permissions:
       contents: write
@@ -195,5 +221,17 @@ jobs:
       contents: write
     with:
       tag: ${{ needs.release-auto.outputs.action_tag }}
+    secrets:
+      ssh_key: ${{ secrets.DEPLOY_KEY }}
+
+  build-action-standing-pr:
+    name: Build and tag action dist
+    needs: release-standing-pr
+    if: needs.release-standing-pr.result == 'success' && needs.release-standing-pr.outputs.action_tag != ''
+    uses: ./.github/workflows/_action-release.reusable.yml
+    permissions:
+      contents: write
+    with:
+      tag: ${{ needs.release-standing-pr.outputs.action_tag }}
     secrets:
       ssh_key: ${{ secrets.DEPLOY_KEY }}

--- a/.github/workflows/standing-pr.yml
+++ b/.github/workflows/standing-pr.yml
@@ -112,57 +112,40 @@ jobs:
     secrets:
       OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
 
-  # Delegates to the same reusable release workflow used by `release.yml` so npm OIDC auth and
-  # SSH-based git push are configured identically — running the CLI inline previously skipped
-  # both, causing "ENEEDAUTH" on publish and inconsistent push behaviour.
-  immediate-release:
-    name: Immediate Release (bypass standing PR)
+  # Same architectural constraint as `trigger-publish` below: any OIDC publish triggered from
+  # `standing-pr.yml` would have `workflow_ref = standing-pr.yml`, which doesn't match the
+  # `release.yml` trusted-publisher entry on npmjs.com (only one is allowed per package). So
+  # immediate releases are dispatched to `release.yml workflow_dispatch` too. The
+  # `reconcile_after=true` flag tells release.yml to rebuild the standing PR after the publish
+  # succeeds, replacing what used to be the `reconcile-standing-pr` job here.
+  trigger-immediate:
+    name: Trigger immediate release via release.yml
     if: >
       github.event_name == 'pull_request' &&
       github.event.pull_request.merged == true &&
       contains(github.event.pull_request.labels.*.name, 'release:immediate')
-    uses: ./.github/workflows/_release.reusable.yml
+    runs-on: ubuntu-latest
     permissions:
-      id-token: write
-      contents: write
-    with:
-      packages: all
-      bump: auto
-      sync: true
-      dry_run: false
-      npm_auth: oidc
-    secrets:
-      ssh_key: ${{ secrets.DEPLOY_KEY }}
-      OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
-
-  build-action-immediate:
-    name: Build and tag action dist
-    needs: immediate-release
-    if: needs.immediate-release.result == 'success' && needs.immediate-release.outputs.action_tag != ''
-    uses: ./.github/workflows/_action-release.reusable.yml
-    permissions:
-      contents: write
-    with:
-      tag: ${{ needs.immediate-release.outputs.action_tag }}
-    secrets:
-      ssh_key: ${{ secrets.DEPLOY_KEY }}
-
-  # After an immediate release, the standing PR's queued changes overlap with what was just
-  # published. Re-running standing-pr update reconciles: closes the standing PR if nothing's
-  # left, otherwise rewrites the release branch against the new HEAD.
-  reconcile-standing-pr:
-    name: Reconcile standing PR (after immediate release)
-    needs: immediate-release
-    # Skip when nothing actually released — under sync mode (the current config), action_tag is
-    # set whenever any package releases. If you switch back to async, this gate becomes too
-    # narrow (it only fires when @releasekit/release itself is bumped) and should be revisited.
-    if: needs.immediate-release.result == 'success' && needs.immediate-release.outputs.action_tag != ''
-    uses: ./.github/workflows/_standing-pr-update.reusable.yml
-    permissions:
-      contents: write
-      pull-requests: write
-    secrets:
-      OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
+      actions: write
+    steps:
+      - name: Dispatch release.yml
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          gh workflow run release.yml \
+            --repo "$REPO" \
+            --ref main \
+            --field packages=all \
+            --field bump=auto \
+            --field npm_auth=oidc \
+            --field sync=true \
+            --field dry_run=false \
+            --field reconcile_after=true
+          echo "Dispatched release.yml for immediate release of PR #$PR_NUMBER"
+          echo "Watch publish progress: https://github.com/$REPO/actions/workflows/release.yml"
 
   # Trigger release.yml via workflow_dispatch instead of running the publish here directly.
   # npm trusted publishing matches the OIDC token's top-level `workflow_ref` claim (only one

--- a/.github/workflows/standing-pr.yml
+++ b/.github/workflows/standing-pr.yml
@@ -22,10 +22,10 @@ env:
 
 jobs:
   # Runs first on every push to main so the downstream jobs can serialize on its output:
-  # if the push is the merge of a release/* PR, only `publish-release` runs;
-  # otherwise only `update-release-pr` runs. Without this gate, both would run in parallel
-  # and `update-release-pr` could collect the just-released commits as "unreleased" before
-  # `publish-release` finishes tagging.
+  # if the push is the merge of a release/* PR, only `trigger-publish` runs (which dispatches
+  # release.yml); otherwise only `update-release-pr` runs. Without this gate, both would run
+  # in parallel and `update-release-pr` could collect the just-released commits as "unreleased"
+  # before the dispatched release.yml run finishes tagging.
   detect-release-merge:
     name: Detect release merge
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'

--- a/.github/workflows/standing-pr.yml
+++ b/.github/workflows/standing-pr.yml
@@ -164,37 +164,30 @@ jobs:
     secrets:
       OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
 
-  # Routed through `_release.reusable.yml` so the OIDC `job_workflow_ref` matches the npm
-  # trusted-publisher entry (npm only allows one trusted-publisher workflow path per package).
-  # The reusable's `standing_pr_number` input switches it from the version+notes+publish flow
-  # to the manifest-driven standing-pr publish flow, while keeping SSH/auth setup identical.
-  publish-release:
-    name: Publish Release
+  # Trigger release.yml via workflow_dispatch instead of running the publish here directly.
+  # npm trusted publishing matches the OIDC token's top-level `workflow_ref` claim (only one
+  # trusted-publisher entry per package, currently `release.yml`), so any publish triggered from
+  # `standing-pr.yml` would be rejected with ENEEDAUTH. Routing through `gh workflow run
+  # release.yml` makes the dispatched run's `workflow_ref` resolve to `release.yml`, which
+  # matches the trusted-publisher config and lets OIDC trusted publishing succeed.
+  trigger-publish:
+    name: Trigger publish via release.yml
     needs: detect-release-merge
     if: needs.detect-release-merge.outputs.pr_number != ''
-    uses: ./.github/workflows/_release.reusable.yml
+    runs-on: ubuntu-latest
     permissions:
-      id-token: write
-      contents: write
-    with:
-      packages: all
-      bump: auto
-      sync: true
-      dry_run: false
-      npm_auth: oidc
-      standing_pr_number: ${{ needs.detect-release-merge.outputs.pr_number }}
-    secrets:
-      ssh_key: ${{ secrets.DEPLOY_KEY }}
-      OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
-
-  build-action-publish:
-    name: Build and tag action dist
-    needs: publish-release
-    if: needs.publish-release.result == 'success' && needs.publish-release.outputs.action_tag != ''
-    uses: ./.github/workflows/_action-release.reusable.yml
-    permissions:
-      contents: write
-    with:
-      tag: ${{ needs.publish-release.outputs.action_tag }}
-    secrets:
-      ssh_key: ${{ secrets.DEPLOY_KEY }}
+      actions: write
+    steps:
+      - name: Dispatch release.yml
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ needs.detect-release-merge.outputs.pr_number }}
+        run: |
+          set -euo pipefail
+          gh workflow run release.yml \
+            --repo "$REPO" \
+            --ref main \
+            --field "standing_pr_number=$PR_NUMBER"
+          echo "Dispatched release.yml with standing_pr_number=$PR_NUMBER"
+          echo "Watch publish progress: https://github.com/$REPO/actions/workflows/release.yml"

--- a/.github/workflows/standing-pr.yml
+++ b/.github/workflows/standing-pr.yml
@@ -15,7 +15,6 @@ concurrency:
 permissions:
   contents: write
   pull-requests: write
-  id-token: write
 
 env:
   TURBO_TELEMETRY_DISABLED: 1


### PR DESCRIPTION
## Summary
- npm trusted publishing matches the OIDC token's top-level `workflow_ref` claim, not the reusable's `job_workflow_ref`. Only one trusted publisher is allowed per scoped package, currently configured for `release.yml`. So even though everything routes through `_release.reusable.yml`, an OIDC publish triggered from `standing-pr.yml` has `workflow_ref = standing-pr.yml` and is rejected with `ENEEDAUTH`.
- Fix: standing-pr.yml's `publish-release` job is replaced with a thin `trigger-publish` step that calls `gh workflow run release.yml --field standing_pr_number=N`. The dispatched run's `workflow_ref` becomes `release.yml`, matches the trusted-publisher entry, and OIDC succeeds with provenance intact.

## Architecture changes

### `release.yml`
- New `standing_pr_number` input on `workflow_dispatch` (default `''`).
- New `release-standing-pr` job that fires when the input is set; calls `_release.reusable.yml` with the manifest-driven publish path.
- New `build-action-standing-pr` job chained to the above.
- `release-manual` gated to `inputs.standing_pr_number == ''` so manual releases and standing-pr-triggered releases don't collide.

### `standing-pr.yml`
- Old `publish-release` (job that called `_release.reusable.yml` directly) and `build-action-publish` (chained action-dist build) are removed.
- New `trigger-publish` job: a single-step job that runs `gh workflow run release.yml --field standing_pr_number=N` with `permissions: actions: write`.
- The publish itself runs in a separate `release.yml` workflow run; the trigger job logs a link to the release.yml runs page.

## Tradeoffs
- **Async detachment**: publish progress lives in a different workflow run than the merge detection. Acceptable because npm's single-trusted-publisher constraint forces this; the trigger step's log message points at the release.yml runs page.
- **Failure recovery**: if `gh workflow run` fails, the trigger job fails visibly. If the dispatched release.yml run fails, it can be re-run from its UI or re-triggered via `gh workflow run release.yml --field standing_pr_number=N`.

## Test plan
- [x] `actionlint .github/workflows/release.yml .github/workflows/standing-pr.yml` clean (modulo pre-existing TURBO_TOKEN/shellcheck warnings).
- [ ] After merge: revert PR #205 (still on main from the prior failed publish), let the standing-PR cycle regenerate, merge it. Watch:
  - `standing-pr.yml` `trigger-publish` succeeds and dispatches `release.yml`.
  - `release.yml` `release-standing-pr` succeeds with `--provenance` (no ENEEDAUTH this time).
  - `build-action-standing-pr` rebuilds dist and force-moves the version tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)