### PR TITLE
fix(notes): honour invalidScopeAction; stop retrying LLM on scope mismatches

### DIFF
--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -213,6 +213,8 @@ export const LLMCategorySchema = z.object({
 export const ScopeRulesSchema = z.object({
   allowed: z.array(z.string()).optional(),
   caseSensitive: z.boolean().default(false),
+  invalidScopeAction: z.enum(['remove', 'keep', 'fallback']).default('remove'),
+  fallbackScope: z.string().optional(),
 });
 
 export const ScopeConfigSchema = z.object({

--- a/packages/notes/src/core/types.ts
+++ b/packages/notes/src/core/types.ts
@@ -108,6 +108,8 @@ export interface LLMCategory {
 export interface ScopeRules {
   allowed?: string[];
   caseSensitive?: boolean;
+  invalidScopeAction?: 'remove' | 'keep' | 'fallback';
+  fallbackScope?: string;
 }
 
 export interface ScopeConfig {

--- a/packages/notes/src/llm/scopes.ts
+++ b/packages/notes/src/llm/scopes.ts
@@ -1,3 +1,4 @@
+import { warn } from '@releasekit/core';
 import type { ChangelogEntry, LLMCategory, ScopeConfig } from '../core/types.js';
 
 export interface ScopeError {
@@ -7,7 +8,9 @@ export interface ScopeError {
 }
 
 export interface ScopeValidationResult {
-  valid: boolean;
+  // Always `true` — the configured `invalidScopeAction` defines the resolution, so the
+  // validator never signals retry-worthy failure. The literal type encodes the contract.
+  valid: true;
   entries: ChangelogEntry[];
   errors: ScopeError[];
 }
@@ -92,6 +95,19 @@ export function validateEntryScopes(
   const action = scopeConfig?.rules?.invalidScopeAction ?? 'remove';
   const fallback = scopeConfig?.rules?.fallbackScope;
   const errors: ScopeError[] = [];
+
+  // Misconfiguration guard: if `fallback` is set but isn't itself in the allow list, the
+  // substituted scope would still violate the rules. Warn once at the top of the validator
+  // rather than once per entry; this is a config bug, not an LLM bug.
+  if (
+    action === 'fallback' &&
+    fallback !== undefined &&
+    validateScope(fallback, allowedScopes, caseSensitive) === undefined
+  ) {
+    warn(
+      `scopes.rules.fallbackScope "${fallback}" is not in the allowed scope list (${allowedScopes.length ? allowedScopes.join(', ') : '<empty>'}); substituted scopes will violate the allow-list. Add "${fallback}" to the allow list or change invalidScopeAction.`,
+    );
+  }
 
   const validatedEntries = entries.map((entry, index) => {
     const cleaned = validateScope(entry.scope, allowedScopes, caseSensitive);

--- a/packages/notes/src/llm/scopes.ts
+++ b/packages/notes/src/llm/scopes.ts
@@ -73,9 +73,12 @@ export function validateScope(
 }
 
 /**
- * Validate scopes on all entries. Returns cleaned entries (invalid scopes set
- * to undefined) plus structured errors for each violation. Callers can use the
- * errors to build corrective-retry messages rather than silently dropping scopes.
+ * Validate scopes on all entries and apply the configured `invalidScopeAction`
+ * (`remove` | `keep` | `fallback`, default `remove`). Always returns
+ * `valid: true` once the action has been applied — the action defines the
+ * resolution, so callers should not trigger a corrective retry on the LLM.
+ *
+ * `errors` is populated for logging/inspection but does not signal failure.
  */
 export function validateEntryScopes(
   entries: ChangelogEntry[],
@@ -86,6 +89,8 @@ export function validateEntryScopes(
   if (allowedScopes === null) return { valid: true, entries, errors: [] };
 
   const caseSensitive = scopeConfig?.rules?.caseSensitive ?? false;
+  const action = scopeConfig?.rules?.invalidScopeAction ?? 'remove';
+  const fallback = scopeConfig?.rules?.fallbackScope;
   const errors: ScopeError[] = [];
 
   const validatedEntries = entries.map((entry, index) => {
@@ -96,10 +101,11 @@ export function validateEntryScopes(
         providedScope: entry.scope,
         allowedScopes,
       });
-      return { ...entry, scope: undefined };
+      const replacement = action === 'keep' ? entry.scope : action === 'fallback' ? fallback : undefined;
+      return { ...entry, scope: replacement };
     }
     return entry.scope !== cleaned ? { ...entry, scope: cleaned } : entry;
   });
 
-  return { valid: errors.length === 0, entries: validatedEntries, errors };
+  return { valid: true, entries: validatedEntries, errors };
 }

--- a/packages/notes/src/llm/tasks/categorize.ts
+++ b/packages/notes/src/llm/tasks/categorize.ts
@@ -109,16 +109,15 @@ function makeValidator(
       return scope ? { ...entry, scope } : entry;
     });
 
-    // Validate scopes
+    // Validate scopes. The validator applies `invalidScopeAction` (default `remove`) and
+    // returns `valid: true` — scope mismatches don't trigger an LLM retry, since the configured
+    // action defines the resolution. Surface a warning so disallowed scopes stay visible.
     const scopeResult = validateEntryScopes(withScopes, context.scopes, context.categories);
-    if (!scopeResult.valid) {
-      const msg = scopeResult.errors
-        .map(
-          (e) =>
-            `entry ${e.entryIndex} scope "${e.providedScope}" (${e.allowedScopes.length ? `valid: ${e.allowedScopes.join(', ')}` : 'no scopes permitted'})`,
-        )
-        .join('; ');
-      return { valid: false, error: `Invalid scopes: ${msg}` };
+    if (scopeResult.errors.length > 0) {
+      const offenders = [...new Set(scopeResult.errors.map((e) => e.providedScope))];
+      warn(
+        `LLM returned ${scopeResult.errors.length} entries with disallowed scopes (${offenders.join(', ')}); resolved per invalidScopeAction.`,
+      );
     }
 
     return { valid: true, value: groupByCategory(zodResult.data.entries, scopeResult.entries) };

--- a/packages/notes/src/llm/tasks/categorize.ts
+++ b/packages/notes/src/llm/tasks/categorize.ts
@@ -159,7 +159,11 @@ export async function categorizeEntries(
   } catch (error) {
     if (error instanceof LLMError) {
       warn(`categorizeEntries failed after all attempts: ${error.message}. Returning entries under General.`);
-      // Strip LLM-assigned scopes — they were never validated in this path.
+      // Triggered by structural validation failures the LLM couldn't recover from across the
+      // retry budget: malformed JSON, schema-incompatible output, wrong entry count, or
+      // categories outside the configured list. (Disallowed scopes don't reach here — the
+      // configured invalidScopeAction resolves them in-place.) Strip scopes since the LLM
+      // run never produced validated values.
       return [{ category: 'General', entries: entries.map((e) => ({ ...e, scope: undefined })) }];
     }
     throw error;

--- a/packages/notes/src/llm/tasks/enhance-and-categorize.ts
+++ b/packages/notes/src/llm/tasks/enhance-and-categorize.ts
@@ -137,16 +137,16 @@ function makeValidator(
       };
     });
 
-    // Validate scopes
+    // Validate scopes. The validator applies `invalidScopeAction` (default `remove`) and
+    // returns `valid: true` once the action has been applied — we don't retry the LLM for
+    // scope mismatches, since the configured action defines the resolution. We do surface a
+    // warning so users can see which scopes the LLM produced that didn't match the allow list.
     const scopeResult = validateEntryScopes(enhancedEntries, context.scopes, context.categories);
-    if (!scopeResult.valid) {
-      const msg = scopeResult.errors
-        .map(
-          (e) =>
-            `entry ${e.entryIndex} scope "${e.providedScope}" (${e.allowedScopes.length ? `valid: ${e.allowedScopes.join(', ')}` : 'no scopes permitted'})`,
-        )
-        .join('; ');
-      return { valid: false, error: `Invalid scopes: ${msg}` };
+    if (scopeResult.errors.length > 0) {
+      const offenders = [...new Set(scopeResult.errors.map((e) => e.providedScope))];
+      warn(
+        `LLM returned ${scopeResult.errors.length} entries with disallowed scopes (${offenders.join(', ')}); resolved per invalidScopeAction.`,
+      );
     }
 
     const categories = groupByCategory(zodResult.data.entries, scopeResult.entries);

--- a/packages/notes/src/llm/tasks/enhance-and-categorize.ts
+++ b/packages/notes/src/llm/tasks/enhance-and-categorize.ts
@@ -199,7 +199,11 @@ export async function enhanceAndCategorize(
   } catch (error) {
     if (error instanceof LLMError) {
       warn(`enhanceAndCategorize failed after all attempts: ${error.message}. Returning entries ungrouped.`);
-      // Strip LLM-assigned fields — scopes/leadIns were never validated in this path.
+      // Triggered by structural validation failures the LLM couldn't recover from across the
+      // retry budget: malformed JSON, schema-incompatible output, wrong entry count, or
+      // categories outside the configured list. (Disallowed scopes don't reach here — the
+      // configured invalidScopeAction resolves them in-place.) Strip the original entries'
+      // scope/leadIn since the LLM run never produced validated values for either.
       const stripped = entries.map((e) => ({ ...e, scope: undefined, leadIn: undefined }));
       return { enhancedEntries: stripped, categories: [{ category: 'General', entries: stripped }] };
     }

--- a/packages/notes/test/unit/llm.spec.ts
+++ b/packages/notes/test/unit/llm.spec.ts
@@ -219,7 +219,7 @@ describe('categorizeEntries()', () => {
     expect(result[0]?.entries[1]?.scope).toBeUndefined();
   });
 
-  it('should validate scopes and trigger corrective retry on invalid scopes', async () => {
+  it('should apply invalidScopeAction (default remove) without triggering an LLM retry', async () => {
     const entries: ChangelogEntry[] = [
       { type: 'added', description: 'Update CI config' },
       { type: 'fixed', description: 'Fix deps' },
@@ -231,20 +231,10 @@ describe('categorizeEntries()', () => {
       capabilities: { systemRole: true, structuredOutputs: false, toolUse: false },
       async complete(): Promise<CompleteResult> {
         callCount++;
-        if (callCount === 1) {
-          const content = JSON.stringify({
-            entries: [
-              { category: 'Developer', scope: 'CI' },
-              { category: 'Developer', scope: 'InvalidScope' },
-            ],
-          });
-          return { content, structured: JSON.parse(content) };
-        }
-        // Second attempt (corrective): return valid scopes
         const content = JSON.stringify({
           entries: [
             { category: 'Developer', scope: 'CI' },
-            { category: 'Developer', scope: 'Dependencies' },
+            { category: 'Developer', scope: 'InvalidScope' },
           ],
         });
         return { content, structured: JSON.parse(content) };
@@ -259,8 +249,10 @@ describe('categorizeEntries()', () => {
 
     const dev = result.find((c) => c.category === 'Developer');
     expect(dev?.entries[0]?.scope).toBe('CI');
-    expect(dev?.entries[1]?.scope).toBe('Dependencies');
-    expect(callCount).toBe(2);
+    // 'InvalidScope' is dropped per the default invalidScopeAction: 'remove'.
+    expect(dev?.entries[1]?.scope).toBeUndefined();
+    // Only one LLM call — scope mismatches are resolved by the configured action, not retried.
+    expect(callCount).toBe(1);
   });
 
   it('should strip all scopes when scope mode is none', async () => {
@@ -521,7 +513,7 @@ describe('enhanceAndCategorize()', () => {
     await expect(enhanceAndCategorize(provider, sampleEntries, llmContext)).rejects.toThrow();
   });
 
-  it('should validate scopes against restricted scope config', async () => {
+  it('should apply invalidScopeAction to disallowed scopes without retrying the LLM', async () => {
     const response = JSON.stringify({
       entries: [
         { description: 'Updated CI', category: 'Developer', scope: 'CI', breaking: null, leadIn: null },
@@ -536,18 +528,7 @@ describe('enhanceAndCategorize()', () => {
       capabilities: { systemRole: true, structuredOutputs: false, toolUse: false },
       async complete(): Promise<CompleteResult> {
         callCount++;
-        if (callCount === 1) {
-          return { content: response, structured: JSON.parse(response) };
-        }
-        // Corrective: fix invalid scopes
-        const fixed = JSON.stringify({
-          entries: [
-            { description: 'Updated CI', category: 'Developer', scope: 'CI', breaking: null, leadIn: null },
-            { description: 'Fixed bug', category: 'Fixed', scope: null, breaking: null, leadIn: null },
-            { description: 'Refactored', category: 'Developer', scope: 'Dependencies', breaking: null, leadIn: null },
-          ],
-        });
-        return { content: fixed, structured: JSON.parse(fixed) };
+        return { content: response, structured: JSON.parse(response) };
       },
     };
 
@@ -561,8 +542,10 @@ describe('enhanceAndCategorize()', () => {
     });
 
     expect(result.enhancedEntries[0]?.scope).toBe('CI');
-    expect(result.enhancedEntries[2]?.scope).toBe('Dependencies');
-    expect(callCount).toBe(2);
+    // 'InvalidScope' and 'Code Quality' both fall outside the allowed set; default action `remove`.
+    expect(result.enhancedEntries[1]?.scope).toBeUndefined();
+    expect(result.enhancedEntries[2]?.scope).toBeUndefined();
+    expect(callCount).toBe(1);
   });
 
   it('should pass prompt instructions to the provider in the system message', async () => {

--- a/packages/notes/test/unit/scopes.spec.ts
+++ b/packages/notes/test/unit/scopes.spec.ts
@@ -173,23 +173,63 @@ describe('validateEntryScopes()', () => {
     expect(result.errors).toHaveLength(0);
   });
 
-  it('should return invalid result with all scopes stripped for none mode', () => {
+  it('should strip all scopes for none mode (and remain valid — invalidScopeAction defines resolution)', () => {
     const result = validateEntryScopes(entries, { mode: 'none' });
-    expect(result.valid).toBe(false);
+    expect(result.valid).toBe(true);
     expect(result.entries[0]?.scope).toBeUndefined();
     expect(result.entries[1]?.scope).toBeUndefined();
     expect(result.entries[2]?.scope).toBeUndefined();
+    // Errors still surface for logging — both entries with original scopes triggered them
+    expect(result.errors).toHaveLength(2);
   });
 
-  it('should validate scopes and return errors for invalid ones', () => {
+  it('should remove invalid scopes and report errors for logging (default action)', () => {
     const categories: LLMCategory[] = [{ name: 'Developer', description: 'Internal', scopes: ['CI', 'Dependencies'] }];
     const result = validateEntryScopes(entries, { mode: 'restricted' }, categories);
-    expect(result.valid).toBe(false);
-    expect(result.entries[0]?.scope).toBe('CI'); // valid
-    expect(result.entries[1]?.scope).toBeUndefined(); // InvalidScope stripped
+    // Validation passes — `invalidScopeAction` (default `remove`) defines resolution; no retry.
+    expect(result.valid).toBe(true);
+    expect(result.entries[0]?.scope).toBe('CI'); // valid, kept
+    expect(result.entries[1]?.scope).toBeUndefined(); // invalid, removed
     expect(result.errors).toHaveLength(1);
     expect(result.errors[0]?.providedScope).toBe('InvalidScope');
     expect(result.errors[0]?.entryIndex).toBe(1);
+  });
+
+  it('should keep invalid scopes when invalidScopeAction is "keep"', () => {
+    const categories: LLMCategory[] = [{ name: 'Developer', description: 'Internal', scopes: ['CI', 'Dependencies'] }];
+    const result = validateEntryScopes(
+      entries,
+      { mode: 'restricted', rules: { invalidScopeAction: 'keep' } },
+      categories,
+    );
+    expect(result.valid).toBe(true);
+    expect(result.entries[0]?.scope).toBe('CI');
+    expect(result.entries[1]?.scope).toBe('InvalidScope'); // kept as-is
+    expect(result.errors).toHaveLength(1);
+  });
+
+  it('should replace invalid scopes with fallbackScope when invalidScopeAction is "fallback"', () => {
+    const categories: LLMCategory[] = [{ name: 'Developer', description: 'Internal', scopes: ['CI', 'Dependencies'] }];
+    const result = validateEntryScopes(
+      entries,
+      { mode: 'restricted', rules: { invalidScopeAction: 'fallback', fallbackScope: 'Other' } },
+      categories,
+    );
+    expect(result.valid).toBe(true);
+    expect(result.entries[0]?.scope).toBe('CI');
+    expect(result.entries[1]?.scope).toBe('Other'); // replaced with fallback
+    expect(result.errors).toHaveLength(1);
+  });
+
+  it('should set scope to undefined when fallback action is set without fallbackScope', () => {
+    const categories: LLMCategory[] = [{ name: 'Developer', description: 'Internal', scopes: ['CI', 'Dependencies'] }];
+    const result = validateEntryScopes(
+      entries,
+      { mode: 'restricted', rules: { invalidScopeAction: 'fallback' } },
+      categories,
+    );
+    expect(result.valid).toBe(true);
+    expect(result.entries[1]?.scope).toBeUndefined();
   });
 
   it('should return valid result when all scopes are valid', () => {

--- a/packages/notes/test/unit/scopes.spec.ts
+++ b/packages/notes/test/unit/scopes.spec.ts
@@ -232,6 +232,28 @@ describe('validateEntryScopes()', () => {
     expect(result.entries[1]?.scope).toBeUndefined();
   });
 
+  it('should warn when fallbackScope is set but not in the allow list', async () => {
+    // @releasekit/core's `warn` writes to console.error (all log lines go via stderr)
+    const messages: string[] = [];
+    const originalError = console.error;
+    console.error = (...args: unknown[]) => {
+      messages.push(args.map(String).join(' '));
+    };
+    try {
+      const categories: LLMCategory[] = [
+        { name: 'Developer', description: 'Internal', scopes: ['CI', 'Dependencies'] },
+      ];
+      validateEntryScopes(
+        entries,
+        { mode: 'restricted', rules: { invalidScopeAction: 'fallback', fallbackScope: 'NotAllowed' } },
+        categories,
+      );
+    } finally {
+      console.error = originalError;
+    }
+    expect(messages.some((m) => m.includes('fallbackScope') && m.includes('NotAllowed'))).toBe(true);
+  });
+
   it('should return valid result when all scopes are valid', () => {
     const validEntries: ChangelogEntry[] = [
       { type: 'added', description: 'Update CI', scope: 'CI' },


### PR DESCRIPTION
## Summary
The standing-PR publish runs were producing `enhanceAndCategorize failed after all attempts: Structured output validation failed after 3 attempts: Invalid scopes: entry 0 scope \"release\" (valid: Dependencies, CI, Testing, ...). Returning entries ungrouped.` then continuing with no category headings.

Two coupled bugs:

1. **`invalidScopeAction` was defined in the JSON schema but missing from the Zod schema** (`packages/config/src/schema.ts`). The Zod schema strips unknown fields silently, so the user's `invalidScopeAction: \"remove\"` was thrown away — the code never read it.
2. **Even with the field in scope, the validator always flagged invalid scopes as errors** (`scopeResult.valid = false`), and the LLM-task callers turned that into corrective-retry instructions. After 3 retries failed, `enhanceAndCategorize` caught the LLMError and dumped everything ungrouped.

The user's commits use scoped names like `release`, `notes`, `publish`, `version`, `standing-pr`, `action` — none in the `Developer` category's explicit scope list of generic categories (`Dependencies, CI, Testing, ...`). So every run hit the corrective-retry → fallback path.

## Changes
- **@releasekit/config**: extend `ScopeRulesSchema` with `invalidScopeAction` (`remove` | `keep` | `fallback`, default `remove`) and `fallbackScope` (optional string), matching the JSON schema.
- **@releasekit/notes**: mirror the same fields on the parallel `ScopeRules` interface in `src/core/types.ts`.
- **@releasekit/notes/src/llm/scopes.ts**: `validateEntryScopes` now applies the configured action and always returns `valid: true`. Errors are preserved on the result for logging but don't signal failure. `keep` leaves the original scope, `fallback` substitutes `fallbackScope` (or `undefined` if not set), `remove` drops to `undefined`.
- **enhanceAndCategorize / categorize**: replace the \"return `valid: false` on scope errors\" branches with a one-line `warn(...)` listing the offending scopes. No more corrective retries on scope mismatches — the action defines the resolution.
- **Tests**: update existing assertions that expected `valid: false` to expect `valid: true` + the action-applied entries; add coverage for `keep` and `fallback`; rewrite the two LLM end-to-end tests that mocked the corrective-retry path to assert single-call behaviour.

## User-visible behaviour
With the current `releasekit.config.json` (`mode: restricted`, `invalidScopeAction: remove`):
- Disallowed scopes are silently dropped — entries keep their description but lose the scope qualifier.
- LLM enhancement no longer falls back to ungrouped output; categorization works normally.
- A single warn line per task summarises the disallowed scopes the LLM produced.

If you want to preserve scope labels like `release`/`notes`/`publish` in the changelog, switch the config to either:
- `\"invalidScopeAction\": \"keep\"` (leaves them intact even when not in the allow list), or
- `\"mode\": \"unrestricted\"` (disable validation entirely).

## Test plan
- [x] `pnpm test` — all 1716 tests pass across all packages.
- [x] `pnpm --filter @releasekit/notes typecheck` clean.
- [x] `pnpm --filter @releasekit/config typecheck` clean.
- [ ] After merge: next standing-PR publish should generate categorised release notes without the `Returning entries ungrouped.` warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)