### PR TITLE
chore: revert "chore: release 5 package(s) (#212)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "releasekit-monorepo",
-  "version": "0.21.0",
+  "version": "0.20.0",
   "private": true,
   "type": "module",
   "description": "Release tooling for automated versioning and changelog generation",

--- a/packages/notes/package.json
+++ b/packages/notes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@releasekit/notes",
-  "version": "0.21.0",
+  "version": "0.20.0",
   "description": "Release notes and changelog generation with LLM-powered enhancement and flexible templating",
   "type": "module",
   "module": "./dist/index.js",

--- a/packages/publish/package.json
+++ b/packages/publish/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@releasekit/publish",
-  "version": "0.21.0",
+  "version": "0.20.0",
   "description": "Publish packages to npm and crates.io with git tagging and GitHub releases",
   "type": "module",
   "module": "./dist/index.js",

--- a/packages/release/package.json
+++ b/packages/release/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@releasekit/release",
-  "version": "0.21.0",
+  "version": "0.20.0",
   "description": "Unified release pipeline: version, changelog, and publish in a single command",
   "type": "module",
   "module": "./dist/index.js",

--- a/packages/version/package.json
+++ b/packages/version/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@releasekit/version",
-  "version": "0.21.0",
+  "version": "0.20.0",
   "description": "Semantic versioning based on Git history and conventional commits",
   "type": "module",
   "module": "./dist/index.js",


### PR DESCRIPTION
## Summary
- Reverts the version bumps from PR #212 (`def15b7`).
- PR #212 merged but the publish failed with `ENEEDAUTH` again — npm trusted publishing rejects OIDC tokens whose `workflow_ref` is `standing-pr.yml`. Fix in #213 routes the trigger via `release.yml` so the OIDC subject matches the trusted-publisher entry.
- Reverting clears the version bumps so the next standing-PR cycle (after #213 + #214 land) regenerates and publishes cleanly.

## Sequencing
1. Land #213 (route publish via `release.yml workflow_dispatch`) — required for OIDC to match.
2. Land #214 (LLM `invalidScopeAction` honoured; release notes don't fall back to ungrouped).
3. Land this revert.
4. Standing-PR cycle regenerates, gets merged → trigger-publish → release.yml → publish succeeds.

## Test plan
- [ ] After merge, `package.json` files return to pre-#212 versions on main.
- [ ] `update-release-pr` regenerates the standing PR with the same set of pending changes.
- [ ] Next standing-PR merge exercises the new trigger path: `standing-pr.yml` → `gh workflow run release.yml` → `release-standing-pr` (OIDC matches, publish succeeds with provenance) → `build-action-standing-pr` (force-moves the version tag onto dist commit).