### PR TITLE
fix(standing-pr): create release tags locally before pushing

### DIFF
--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -170,7 +170,7 @@ function commitNotesFiles(files: string[], versionOutput: VersionOutput, cwd: st
  * commit we warn and skip rather than rewriting history. Errors here don't propagate — the
  * publish pipeline's `--tags` push will publish whatever tags we managed to create.
  */
-function createReleaseTags(tags: string[], cwd: string): void {
+export function createReleaseTags(tags: string[], cwd: string): void {
   if (tags.length === 0) return;
   const headSha = execSync('git rev-parse HEAD', { cwd, encoding: 'utf-8' }).trim();
 

--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -172,11 +172,23 @@ function commitNotesFiles(files: string[], versionOutput: VersionOutput, cwd: st
  */
 export function createReleaseTags(tags: string[], cwd: string): void {
   if (tags.length === 0) return;
-  const headSha = execSync('git rev-parse HEAD', { cwd, encoding: 'utf-8' }).trim();
+
+  // Wrapped per the function contract — errors here must not propagate. A corrupt repo state or
+  // permission error reading HEAD shouldn't abort the publish pipeline before tag creation runs.
+  let headSha: string;
+  try {
+    headSha = execFileSync('git', ['rev-parse', 'HEAD'], { cwd, encoding: 'utf-8' }).trim();
+  } catch (err) {
+    warn(`Failed to resolve HEAD for tag creation: ${err instanceof Error ? err.message : String(err)}`);
+    return;
+  }
 
   for (const tag of tags) {
     try {
-      const existing = execSync(`git rev-parse -q --verify "refs/tags/${tag}^{}"`, {
+      // execFileSync (not execSync) — `refs/tags/${tag}^{}` is a git argument, not a shell
+      // expression. The array form avoids shell parsing entirely if tag names ever contain
+      // metacharacters.
+      const existing = execFileSync('git', ['rev-parse', '-q', '--verify', `refs/tags/${tag}^{}`], {
         cwd,
         encoding: 'utf-8',
         stdio: ['ignore', 'pipe', 'ignore'],

--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -158,6 +158,48 @@ function commitNotesFiles(files: string[], versionOutput: VersionOutput, cwd: st
   }
 }
 
+/**
+ * Create the release tags locally at HEAD.
+ *
+ * The publish pipeline's `runGitCommitStage` is what normally creates tags, but the standing-PR
+ * publish flow sets `skipGitCommit: true` to avoid duplicating the squash-merge commit, which
+ * also skips tag creation. The pipeline's `git push --tags` then has nothing to push.
+ *
+ * Mirrors the idempotency check in `runGitCommitStage` (packages/publish/src/stages/git-commit.ts):
+ * if the tag already points at HEAD it's a no-op (re-runs are safe); if it points at a different
+ * commit we warn and skip rather than rewriting history. Errors here don't propagate — the
+ * publish pipeline's `--tags` push will publish whatever tags we managed to create.
+ */
+function createReleaseTags(tags: string[], cwd: string): void {
+  if (tags.length === 0) return;
+  const headSha = execSync('git rev-parse HEAD', { cwd, encoding: 'utf-8' }).trim();
+
+  for (const tag of tags) {
+    try {
+      const existing = execSync(`git rev-parse -q --verify "refs/tags/${tag}^{}"`, {
+        cwd,
+        encoding: 'utf-8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+      }).trim();
+      if (existing === headSha) {
+        info(`Tag ${tag} already exists at HEAD, skipping`);
+        continue;
+      }
+      warn(`Tag ${tag} exists at ${existing} but HEAD is ${headSha} — skipping (re-tag manually if intended)`);
+      continue;
+    } catch {
+      // Tag doesn't exist; create it below.
+    }
+
+    try {
+      execFileSync('git', ['tag', '-a', tag, '-m', `Release ${tag}`], { cwd, stdio: 'pipe' });
+      success(`Created tag: ${tag}`);
+    } catch (err) {
+      warn(`Failed to create tag ${tag}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+}
+
 // Renders the release notes section content (without editable markers).
 const CHANGELOG_TYPE_LABELS: Record<string, string> = {
   feat: 'Added',
@@ -916,8 +958,8 @@ export async function publishFromManifest(prNumber: number, options: StandingPRO
     notesFiles = [...notesFiles, ...newFiles];
 
     // Commit the new RELEASE_NOTES.md so main reflects what's in the GitHub release body.
-    // Tags created next by the publish step land on this commit (which is fine — the tag
-    // captures the full release state including notes).
+    // Tags created next land on this commit (which is fine — the tag captures the full release
+    // state including notes).
     if (newFiles.length > 0) {
       commitNotesFiles(newFiles, manifest.versionOutput, cwd);
     }
@@ -925,6 +967,11 @@ export async function publishFromManifest(prNumber: number, options: StandingPRO
     warn(`Release notes generation failed: ${err instanceof Error ? err.message : String(err)}`);
     warn('Publish will proceed with empty release notes; GitHub release will use auto-generated notes.');
   }
+
+  // Create the release tags at HEAD before invoking the publish pipeline. The pipeline's
+  // git-commit stage (where tag creation normally lives) is skipped via skipGitCommit below,
+  // so without this the pipeline's `git push --tags` would have nothing to push.
+  createReleaseTags(manifest.versionOutput.tags, cwd);
 
   const publishOptions: ReleaseOptions = {
     config: options.config,

--- a/packages/release/test/unit/standing-pr.spec.ts
+++ b/packages/release/test/unit/standing-pr.spec.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { StandingPRManifest } from '../../src/standing-pr/standing-pr.js';
 import {
+  createReleaseTags,
   parseManifest,
   publishFromManifest,
   runStandingPRMerge,
@@ -11,6 +12,7 @@ import {
 
 vi.mock('node:child_process', () => ({
   execSync: vi.fn().mockReturnValue(''),
+  execFileSync: vi.fn().mockReturnValue(''),
 }));
 
 vi.mock('node:fs', () => ({
@@ -120,6 +122,94 @@ const baseManifest: StandingPRManifest = {
   createdAt: '2024-01-01T00:00:00.000Z',
   baseSha: 'abc123',
 };
+
+describe('createReleaseTags', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('is a no-op for an empty tag list', async () => {
+    const { execSync, execFileSync } = await import('node:child_process');
+    createReleaseTags([], '/tmp/test');
+    expect(execSync).not.toHaveBeenCalled();
+    expect(execFileSync).not.toHaveBeenCalled();
+  });
+
+  it('creates a tag when none exists', async () => {
+    const { execSync, execFileSync } = await import('node:child_process');
+    // git rev-parse HEAD
+    vi.mocked(execSync).mockReturnValueOnce('headsha\n');
+    // git rev-parse --verify (doesn't exist) — throws
+    vi.mocked(execSync).mockImplementationOnce(() => {
+      throw new Error('not found');
+    });
+
+    createReleaseTags(['v1.2.3'], '/tmp/test');
+
+    expect(execFileSync).toHaveBeenCalledWith(
+      'git',
+      ['tag', '-a', 'v1.2.3', '-m', 'Release v1.2.3'],
+      expect.anything(),
+    );
+  });
+
+  it('skips creation when the tag already points at HEAD', async () => {
+    const { execSync, execFileSync } = await import('node:child_process');
+    // git rev-parse HEAD
+    vi.mocked(execSync).mockReturnValueOnce('headsha\n');
+    // git rev-parse refs/tags/v1.2.3^{} — same sha as HEAD
+    vi.mocked(execSync).mockReturnValueOnce('headsha\n');
+
+    createReleaseTags(['v1.2.3'], '/tmp/test');
+
+    expect(execFileSync).not.toHaveBeenCalled();
+  });
+
+  it('does not recreate a tag that points at a different commit', async () => {
+    const { execSync, execFileSync } = await import('node:child_process');
+    vi.mocked(execSync).mockReturnValueOnce('headsha\n');
+    // tag exists at a different sha
+    vi.mocked(execSync).mockReturnValueOnce('othersha\n');
+
+    createReleaseTags(['v1.2.3'], '/tmp/test');
+
+    expect(execFileSync).not.toHaveBeenCalled();
+  });
+
+  it('processes multiple tags independently', async () => {
+    const { execSync, execFileSync } = await import('node:child_process');
+    // git rev-parse HEAD (once for the whole call)
+    vi.mocked(execSync).mockReturnValueOnce('headsha\n');
+    // tag 1: doesn't exist
+    vi.mocked(execSync).mockImplementationOnce(() => {
+      throw new Error('not found');
+    });
+    // tag 2: exists at HEAD
+    vi.mocked(execSync).mockReturnValueOnce('headsha\n');
+
+    createReleaseTags(['v1.2.3', '@scope/pkg@v1.2.3'], '/tmp/test');
+
+    expect(execFileSync).toHaveBeenCalledTimes(1);
+    expect(execFileSync).toHaveBeenCalledWith(
+      'git',
+      ['tag', '-a', 'v1.2.3', '-m', 'Release v1.2.3'],
+      expect.anything(),
+    );
+  });
+
+  it('does not throw when tag creation fails', async () => {
+    const { execSync, execFileSync } = await import('node:child_process');
+    vi.mocked(execSync).mockReturnValueOnce('headsha\n');
+    vi.mocked(execSync).mockImplementationOnce(() => {
+      throw new Error('not found');
+    });
+    vi.mocked(execFileSync).mockImplementationOnce(() => {
+      throw new Error('git tag failed');
+    });
+
+    expect(() => createReleaseTags(['v1.2.3'], '/tmp/test')).not.toThrow();
+  });
+});
 
 describe('serializeManifest / parseManifest', () => {
   it('should round-trip a manifest through serialize/parse', () => {

--- a/packages/release/test/unit/standing-pr.spec.ts
+++ b/packages/release/test/unit/standing-pr.spec.ts
@@ -136,17 +136,19 @@ describe('createReleaseTags', () => {
   });
 
   it('creates a tag when none exists', async () => {
-    const { execSync, execFileSync } = await import('node:child_process');
+    const { execFileSync } = await import('node:child_process');
     // git rev-parse HEAD
-    vi.mocked(execSync).mockReturnValueOnce('headsha\n');
+    vi.mocked(execFileSync).mockReturnValueOnce('headsha\n');
     // git rev-parse --verify (doesn't exist) — throws
-    vi.mocked(execSync).mockImplementationOnce(() => {
+    vi.mocked(execFileSync).mockImplementationOnce(() => {
       throw new Error('not found');
     });
+    // git tag -a (succeeds)
+    vi.mocked(execFileSync).mockReturnValueOnce('');
 
     createReleaseTags(['v1.2.3'], '/tmp/test');
 
-    expect(execFileSync).toHaveBeenCalledWith(
+    expect(execFileSync).toHaveBeenLastCalledWith(
       'git',
       ['tag', '-a', 'v1.2.3', '-m', 'Release v1.2.3'],
       expect.anything(),
@@ -154,53 +156,57 @@ describe('createReleaseTags', () => {
   });
 
   it('skips creation when the tag already points at HEAD', async () => {
-    const { execSync, execFileSync } = await import('node:child_process');
-    // git rev-parse HEAD
-    vi.mocked(execSync).mockReturnValueOnce('headsha\n');
-    // git rev-parse refs/tags/v1.2.3^{} — same sha as HEAD
-    vi.mocked(execSync).mockReturnValueOnce('headsha\n');
+    const { execFileSync } = await import('node:child_process');
+    vi.mocked(execFileSync).mockReturnValueOnce('headsha\n');
+    // tag exists at HEAD
+    vi.mocked(execFileSync).mockReturnValueOnce('headsha\n');
 
     createReleaseTags(['v1.2.3'], '/tmp/test');
 
-    expect(execFileSync).not.toHaveBeenCalled();
+    // Two calls only: rev-parse HEAD, rev-parse refs/tags/...^{}. No `git tag -a`.
+    expect(execFileSync).toHaveBeenCalledTimes(2);
+    expect(execFileSync).not.toHaveBeenCalledWith('git', expect.arrayContaining(['tag', '-a']), expect.anything());
   });
 
   it('does not recreate a tag that points at a different commit', async () => {
-    const { execSync, execFileSync } = await import('node:child_process');
-    vi.mocked(execSync).mockReturnValueOnce('headsha\n');
-    // tag exists at a different sha
-    vi.mocked(execSync).mockReturnValueOnce('othersha\n');
+    const { execFileSync } = await import('node:child_process');
+    vi.mocked(execFileSync).mockReturnValueOnce('headsha\n');
+    vi.mocked(execFileSync).mockReturnValueOnce('othersha\n');
 
     createReleaseTags(['v1.2.3'], '/tmp/test');
 
-    expect(execFileSync).not.toHaveBeenCalled();
+    expect(execFileSync).not.toHaveBeenCalledWith('git', expect.arrayContaining(['tag', '-a']), expect.anything());
   });
 
   it('processes multiple tags independently', async () => {
-    const { execSync, execFileSync } = await import('node:child_process');
-    // git rev-parse HEAD (once for the whole call)
-    vi.mocked(execSync).mockReturnValueOnce('headsha\n');
+    const { execFileSync } = await import('node:child_process');
+    // git rev-parse HEAD
+    vi.mocked(execFileSync).mockReturnValueOnce('headsha\n');
     // tag 1: doesn't exist
-    vi.mocked(execSync).mockImplementationOnce(() => {
+    vi.mocked(execFileSync).mockImplementationOnce(() => {
       throw new Error('not found');
     });
+    // tag 1: git tag -a (succeeds)
+    vi.mocked(execFileSync).mockReturnValueOnce('');
     // tag 2: exists at HEAD
-    vi.mocked(execSync).mockReturnValueOnce('headsha\n');
+    vi.mocked(execFileSync).mockReturnValueOnce('headsha\n');
 
     createReleaseTags(['v1.2.3', '@scope/pkg@v1.2.3'], '/tmp/test');
 
-    expect(execFileSync).toHaveBeenCalledTimes(1);
     expect(execFileSync).toHaveBeenCalledWith(
       'git',
       ['tag', '-a', 'v1.2.3', '-m', 'Release v1.2.3'],
       expect.anything(),
     );
+    // Exactly one `git tag -a` invocation — the second tag was already at HEAD.
+    const tagCalls = vi.mocked(execFileSync).mock.calls.filter((c) => c[1]?.[0] === 'tag');
+    expect(tagCalls).toHaveLength(1);
   });
 
   it('does not throw when tag creation fails', async () => {
-    const { execSync, execFileSync } = await import('node:child_process');
-    vi.mocked(execSync).mockReturnValueOnce('headsha\n');
-    vi.mocked(execSync).mockImplementationOnce(() => {
+    const { execFileSync } = await import('node:child_process');
+    vi.mocked(execFileSync).mockReturnValueOnce('headsha\n');
+    vi.mocked(execFileSync).mockImplementationOnce(() => {
       throw new Error('not found');
     });
     vi.mocked(execFileSync).mockImplementationOnce(() => {
@@ -208,6 +214,17 @@ describe('createReleaseTags', () => {
     });
 
     expect(() => createReleaseTags(['v1.2.3'], '/tmp/test')).not.toThrow();
+  });
+
+  it('does not throw when HEAD lookup fails', async () => {
+    const { execFileSync } = await import('node:child_process');
+    vi.mocked(execFileSync).mockImplementationOnce(() => {
+      throw new Error('fatal: not a git repository');
+    });
+
+    expect(() => createReleaseTags(['v1.2.3'], '/tmp/test')).not.toThrow();
+    // Bails at HEAD lookup — only one call.
+    expect(execFileSync).toHaveBeenCalledTimes(1);
   });
 });
 


### PR DESCRIPTION
## Summary
The 0.21.0 publish run got far enough to push to npm but no version tags landed on git. Root cause: `publishFromManifest` in `packages/release/src/standing-pr/standing-pr.ts` sets `skipGitCommit: true` to avoid duplicating the standing-PR squash-merge commit, but the publish pipeline's `runGitCommitStage` is also the only place `git tag -a` actually runs. Skipping it leaves zero local tags; the pipeline's `git push --tags` is then a no-op.

The pipeline contract says (`packages/publish/src/pipeline/index.ts:67-72`):

> "When skipGitCommit is set, the caller already created the commit and tags."

`publishFromManifest` was honouring the commit half (squash merge + optional notes commit) but skipping the tag half.

## Fix
Add `createReleaseTags()` next to `commitNotesFiles()` and call it in `publishFromManifest` right after the notes commit. Idempotency mirrors `runGitCommitStage`:
- If the tag already points at HEAD → log and skip (re-run safety).
- If the tag exists at a different commit → warn and skip (no destructive rewrite).
- Errors don't propagate; the publish pipeline's `git push --tags` will push whatever tags we managed to create.

## Visible-symptom recap
- npm publish: works (no git-tag dependency).
- branch push: works (the standing PR's commit + the notes commit).
- tag push: silently does nothing.
- `_action-release.reusable.yml` checkout at `vX.Y.Z`: fails with `A branch or tag with the name 'vX.Y.Z' could not be found`.
- Consumers pinning `uses: goosewobbler/releasekit@vX.Y.Z` get a 404.

## Test plan
- [x] `pnpm --filter @releasekit/release typecheck` clean.
- [x] `pnpm --filter @releasekit/release test:unit` — 430 tests pass.
- [ ] After merge: the next standing-PR publish creates `vX.Y.Z` (and any per-package tags from `versionOutput.tags`) at HEAD, pushes them, and `build-action-standing-pr` finds the tag at checkout time.

## Recovery for v0.21.0
Separate from this PR — push the missing `v0.21.0` tag at the existing notes commit on main (`f85b863`) so consumers pinning `@v0.21.0` resolve. Major-alias `v0` move stays a manual one-off too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)