### PR TITLE
refactor(version): extract deriveBaselineTagPrefix and displayTag utilities

### DIFF
--- a/packages/version/src/core/versionStrategies.ts
+++ b/packages/version/src/core/versionStrategies.ts
@@ -6,11 +6,7 @@ import fs from 'node:fs';
 import * as path from 'node:path';
 import type { Package } from '@manypkg/get-packages';
 import type { VersionChangelogEntry } from '@releasekit/core';
-import {
-  sanitizePackageName,
-  shouldMatchPackageTargets,
-  shouldProcessPackage as shouldProcessPackageUtil,
-} from '@releasekit/core';
+import { shouldMatchPackageTargets, shouldProcessPackage as shouldProcessPackageUtil } from '@releasekit/core';
 import { extractChangelogEntriesFromCommits } from '../changelog/commitParser.js';
 import { BaseVersionError } from '../errors/baseError.js';
 import { createVersionError, VersionErrorCode } from '../errors/versionError.js';
@@ -19,7 +15,13 @@ import { getLatestTag, getLatestTagForPackage } from '../git/tagsAndBranches.js'
 import { updatePackageVersion } from '../package/packageManagement.js';
 import { PackageProcessor } from '../package/packageProcessor.js';
 import type { Config } from '../types.js';
-import { formatCommitMessage, formatTag, formatVersionPrefix } from '../utils/formatting.js';
+import {
+  deriveBaselineTagPrefix,
+  displayTag,
+  formatCommitMessage,
+  formatTag,
+  formatVersionPrefix,
+} from '../utils/formatting.js';
 import {
   addBaselineTag,
   addChangelogData,
@@ -116,26 +118,10 @@ export function createSyncStrategy(config: Config): StrategyFunction {
       // read a separate "baseline" tag (one that stays on the source branch's history) rather
       // than the consumer-facing `tagTemplate` tag (which a downstream step may force-move
       // off the branch). Resolve the baseline template's leading prefix so getLatestTag's
-      // semver scan filters to the baseline family. `${version}` marks the boundary; anything
-      // before it (after `${prefix}`/`${packageName}` substitution) is the literal prefix.
-      const baselineTagPrefix = config.baselineTagTemplate
-        ? config.baselineTagTemplate
-            .split('${' + 'version}')[0]
-            .replace(/\$\{prefix\}/g, formattedPrefix)
-            .replace(/\$\{packageName\}/g, mainPackage ? sanitizePackageName(mainPackage) : '')
-        : undefined;
+      // semver scan filters to the baseline family.
+      const baselineTagPrefix = deriveBaselineTagPrefix(config.baselineTagTemplate, formattedPrefix, mainPackage);
 
       let latestTag = await getLatestTag(baselineTagPrefix);
-
-      // Display form of latestTag for changelog headers etc. — keeps `latestTag` itself as
-      // the full git ref (needed for `${tag}..HEAD` ranges and git-rev-parse) while showing
-      // users the consumer-facing tag form. With `baselineTagTemplate` set, replace its
-      // prefix with `tagTemplate`'s prefix so `release/v0.22.0` shows as `v0.22.0` in the
-      // preview rather than leaking the internal marker scheme.
-      const displayLatestTag = (tag: string): string => {
-        if (!baselineTagPrefix || !tag.startsWith(baselineTagPrefix)) return tag;
-        return `${formattedPrefix}${tag.slice(baselineTagPrefix.length)}`;
-      };
 
       // Capture the repo root before any mainPackage branch can overwrite mainPkgPath.
       // This is used as commitCheckPath so commit counting always spans the full repo.
@@ -373,7 +359,7 @@ export function createSyncStrategy(config: Config): StrategyFunction {
       // In per-package tag mode, emit one changelog entry per workspace package so the
       // notes pipeline can write a CHANGELOG.md to each package directory and the
       // publish pipeline can match tags to the right release notes.
-      const displayPrevious = latestTag ? displayLatestTag(latestTag) : null;
+      const displayPrevious = latestTag ? displayTag(latestTag, baselineTagPrefix, formattedPrefix) : null;
       if (config.packageSpecificTags && workspaceNames.length > 0) {
         for (const pkgName of workspaceNames) {
           addChangelogData({
@@ -525,6 +511,7 @@ export function createSingleStrategy(config: Config): StrategyFunction {
 
       // At this point, latestTagResult is guaranteed to be a string (possibly empty)
       const latestTag = latestTagResult;
+      const baselineTagPrefix = deriveBaselineTagPrefix(config.baselineTagTemplate, formattedPrefix, packageName);
 
       let nextVersion: string | undefined;
 
@@ -624,7 +611,7 @@ export function createSingleStrategy(config: Config): StrategyFunction {
       addChangelogData({
         packageName,
         version: nextVersion,
-        previousVersion: latestTag || null,
+        previousVersion: latestTag ? displayTag(latestTag, baselineTagPrefix, formattedPrefix) : null,
         revisionRange,
         repoUrl: repoUrl || null,
         entries: changelogEntries,

--- a/packages/version/src/package/packageProcessor.ts
+++ b/packages/version/src/package/packageProcessor.ts
@@ -8,7 +8,13 @@ import { calculateVersion } from '../core/versionCalculator.js';
 import { getLatestTagForPackage } from '../git/tagsAndBranches.js';
 import { verifyTag } from '../git/tagVerification.js';
 import type { Config, VersionConfigBase } from '../types.js';
-import { formatCommitMessage, formatTag, formatVersionPrefix } from '../utils/formatting.js';
+import {
+  deriveBaselineTagPrefix,
+  displayTag,
+  formatCommitMessage,
+  formatTag,
+  formatVersionPrefix,
+} from '../utils/formatting.js';
 import {
   addChangelogData,
   addTag,
@@ -277,11 +283,14 @@ export class PackageProcessor {
         );
       }
 
-      // Track changelog data for JSON output
+      // Track changelog data for JSON output. previousVersion is shown to users in the
+      // changelog header — strip the baseline-tag scheme back to its consumer-facing form
+      // so `release/v0.22.0` appears as `v0.22.0` rather than leaking the internal marker.
+      const baselineTagPrefix = deriveBaselineTagPrefix(this.fullConfig.baselineTagTemplate, formattedPrefix, name);
       addChangelogData({
         packageName: name,
         version: nextVersion,
-        previousVersion: latestTag || null,
+        previousVersion: latestTag ? displayTag(latestTag, baselineTagPrefix, formattedPrefix) : null,
         revisionRange,
         repoUrl: repoUrl || null,
         entries: changelogEntries,

--- a/packages/version/src/utils/formatting.ts
+++ b/packages/version/src/utils/formatting.ts
@@ -158,3 +158,35 @@ export function buildTagStripPatternFromTemplate(template: string, packageName: 
 
   return escapeRegExp(prefixPattern);
 }
+
+/**
+ * Resolve a `baselineTagTemplate` to its literal leading prefix — the substring before the
+ * `${version}` placeholder, with `${prefix}` and `${packageName}` substitutions applied.
+ * Used to filter `getSemverTags`'s scan to the baseline family and to recognise baseline
+ * tags when stripping for display. Returns `undefined` when the template is unset.
+ */
+export function deriveBaselineTagPrefix(
+  template: string | undefined,
+  formattedPrefix: string,
+  packageName?: string,
+): string | undefined {
+  if (!template) return undefined;
+  return template
+    .split('${' + 'version}')[0]
+    .replace(/\$\{prefix\}/g, formattedPrefix)
+    .replace(/\$\{packageName\}/g, packageName ? sanitizePackageName(packageName) : '');
+}
+
+/**
+ * Convert an internal baseline tag (e.g. `release/v1.2.3`) to its consumer-facing display
+ * form (e.g. `v1.2.3`) by swapping the baseline prefix for the consumer prefix. When the
+ * tag isn't a baseline tag — or no baseline prefix is configured — returns it unchanged.
+ *
+ * Used wherever a tag is shown to the user (changelog headers, preview blocks). The
+ * underlying `latestTag` value used for git-rev-parse and `${tag}..HEAD` ranges is left
+ * alone — only the display surfaces are cleaned up.
+ */
+export function displayTag(tag: string, baselineTagPrefix: string | undefined, formattedPrefix: string): string {
+  if (!baselineTagPrefix || !tag.startsWith(baselineTagPrefix)) return tag;
+  return `${formattedPrefix}${tag.slice(baselineTagPrefix.length)}`;
+}

--- a/packages/version/test/unit/core/versionStrategies.spec.ts
+++ b/packages/version/test/unit/core/versionStrategies.spec.ts
@@ -35,9 +35,12 @@ vi.mock('../../../src/utils/formatting.js', () => ({
   formatCommitMessage: vi.fn().mockImplementation((template, version, packageName) => {
     return template.replace(/\$\{version\}/g, version).replace(/\$\{packageName\}/g, packageName || '');
   }),
-  deriveBaselineTagPrefix: vi.fn().mockImplementation((template, formattedPrefix) => {
+  deriveBaselineTagPrefix: vi.fn().mockImplementation((template, formattedPrefix, packageName) => {
     if (!template) return undefined;
-    return template.split('${' + 'version}')[0].replace(/\$\{prefix\}/g, formattedPrefix);
+    return template
+      .split('${' + 'version}')[0]
+      .replace(/\$\{prefix\}/g, formattedPrefix)
+      .replace(/\$\{packageName\}/g, packageName ?? '');
   }),
   displayTag: vi.fn().mockImplementation((tag, baselineTagPrefix, formattedPrefix) => {
     if (!baselineTagPrefix || !tag.startsWith(baselineTagPrefix)) return tag;
@@ -100,10 +103,15 @@ describe('Version Strategies', () => {
     vi.mocked(formatting.formatTag, { partial: true }).mockReturnValue('v1.1.0');
     // Default mock: single-package result used by most tests. Sync tests override this.
     vi.mocked(formatting.formatCommitMessage, { partial: true }).mockReturnValue('chore: release package-a v1.1.0');
-    vi.mocked(formatting.deriveBaselineTagPrefix, { partial: true }).mockImplementation((template, formattedPrefix) => {
-      if (!template) return undefined;
-      return template.split('${' + 'version}')[0].replace(/\$\{prefix\}/g, formattedPrefix);
-    });
+    vi.mocked(formatting.deriveBaselineTagPrefix, { partial: true }).mockImplementation(
+      (template, formattedPrefix, packageName) => {
+        if (!template) return undefined;
+        return template
+          .split('${' + 'version}')[0]
+          .replace(/\$\{prefix\}/g, formattedPrefix)
+          .replace(/\$\{packageName\}/g, packageName ?? '');
+      },
+    );
     vi.mocked(formatting.displayTag, { partial: true }).mockImplementation(
       (tag, baselineTagPrefix, formattedPrefix) => {
         if (!baselineTagPrefix || !tag.startsWith(baselineTagPrefix)) return tag;

--- a/packages/version/test/unit/core/versionStrategies.spec.ts
+++ b/packages/version/test/unit/core/versionStrategies.spec.ts
@@ -35,6 +35,14 @@ vi.mock('../../../src/utils/formatting.js', () => ({
   formatCommitMessage: vi.fn().mockImplementation((template, version, packageName) => {
     return template.replace(/\$\{version\}/g, version).replace(/\$\{packageName\}/g, packageName || '');
   }),
+  deriveBaselineTagPrefix: vi.fn().mockImplementation((template, formattedPrefix) => {
+    if (!template) return undefined;
+    return template.split('${' + 'version}')[0].replace(/\$\{prefix\}/g, formattedPrefix);
+  }),
+  displayTag: vi.fn().mockImplementation((tag, baselineTagPrefix, formattedPrefix) => {
+    if (!baselineTagPrefix || !tag.startsWith(baselineTagPrefix)) return tag;
+    return `${formattedPrefix}${tag.slice(baselineTagPrefix.length)}`;
+  }),
 }));
 vi.mock('../../../src/package/packageProcessor.js');
 vi.mock('node:fs');
@@ -92,6 +100,16 @@ describe('Version Strategies', () => {
     vi.mocked(formatting.formatTag, { partial: true }).mockReturnValue('v1.1.0');
     // Default mock: single-package result used by most tests. Sync tests override this.
     vi.mocked(formatting.formatCommitMessage, { partial: true }).mockReturnValue('chore: release package-a v1.1.0');
+    vi.mocked(formatting.deriveBaselineTagPrefix, { partial: true }).mockImplementation((template, formattedPrefix) => {
+      if (!template) return undefined;
+      return template.split('${' + 'version}')[0].replace(/\$\{prefix\}/g, formattedPrefix);
+    });
+    vi.mocked(formatting.displayTag, { partial: true }).mockImplementation(
+      (tag, baselineTagPrefix, formattedPrefix) => {
+        if (!baselineTagPrefix || !tag.startsWith(baselineTagPrefix)) return tag;
+        return `${formattedPrefix}${tag.slice(baselineTagPrefix.length)}`;
+      },
+    );
     vi.mocked(commitParser.extractChangelogEntriesFromCommits, { partial: true }).mockReturnValue([
       { type: 'added', description: 'New feature' },
     ]);

--- a/packages/version/test/unit/package/packageProcessor.spec.ts
+++ b/packages/version/test/unit/package/packageProcessor.spec.ts
@@ -32,7 +32,10 @@ vi.mock('../../../src/utils/formatting.js', () => ({
   }),
   escapeRegExp: vi.fn().mockImplementation((str) => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')),
   deriveBaselineTagPrefix: vi.fn().mockReturnValue(undefined),
-  displayTag: vi.fn().mockImplementation((tag) => tag),
+  displayTag: vi.fn().mockImplementation((tag, baselineTagPrefix, formattedPrefix) => {
+    if (!baselineTagPrefix || !tag.startsWith(baselineTagPrefix)) return tag;
+    return `${formattedPrefix}${tag.slice(baselineTagPrefix.length)}`;
+  }),
 }));
 vi.mock('../../../src/utils/jsonOutput.js');
 vi.mock('../../../src/utils/manifestHelpers.js', () => ({

--- a/packages/version/test/unit/package/packageProcessor.spec.ts
+++ b/packages/version/test/unit/package/packageProcessor.spec.ts
@@ -374,6 +374,30 @@ describe('Package Processor', () => {
       expect(result.updatedPackages[1].name).toBe('package-b');
     });
 
+    it('should strip baseline tag prefix from previousVersion passed to addChangelogData', async () => {
+      vi.spyOn(gitTags, 'getLatestTagForPackage').mockResolvedValue('release/v1.0.0');
+      vi.spyOn(formatting, 'deriveBaselineTagPrefix').mockReturnValue('release/v');
+      vi.spyOn(formatting, 'displayTag').mockImplementation((tag, baselineTagPrefix, formattedPrefix) => {
+        if (!baselineTagPrefix || !tag.startsWith(baselineTagPrefix)) return tag;
+        return `${formattedPrefix}${tag.slice(baselineTagPrefix.length)}`;
+      });
+
+      const processor = new PackageProcessor({
+        ...defaultOptions,
+        fullConfig: {
+          ...mockConfig,
+          baselineTagTemplate: 'release/${' + 'prefix}${' + 'version}',
+          writeChangelog: false,
+        },
+      });
+
+      await processor.processPackages([mockPackages[0]]);
+
+      const calls = vi.mocked(jsonOutput.addChangelogData).mock.calls;
+      expect(calls.length).toBeGreaterThan(0);
+      expect(calls[0][0]).toMatchObject({ previousVersion: 'v1.0.0' });
+    });
+
     it('should emit repo-level entries as sharedEntries, not in individual package changelogs', async () => {
       const repoLevelEntry = { type: 'chore', description: 'Update CI workflow' };
       const pkgAEntry = { type: 'added', description: 'New feature in pkg-a' };

--- a/packages/version/test/unit/package/packageProcessor.spec.ts
+++ b/packages/version/test/unit/package/packageProcessor.spec.ts
@@ -31,6 +31,8 @@ vi.mock('../../../src/utils/formatting.js', () => ({
     return template.replace('${version}', version);
   }),
   escapeRegExp: vi.fn().mockImplementation((str) => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')),
+  deriveBaselineTagPrefix: vi.fn().mockReturnValue(undefined),
+  displayTag: vi.fn().mockImplementation((tag) => tag),
 }));
 vi.mock('../../../src/utils/jsonOutput.js');
 vi.mock('../../../src/utils/manifestHelpers.js', () => ({

--- a/packages/version/test/unit/utils/formatting.spec.ts
+++ b/packages/version/test/unit/utils/formatting.spec.ts
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   buildTagStripPatternFromTemplate,
+  deriveBaselineTagPrefix,
+  displayTag,
   formatCommitMessage,
   formatTag,
   formatTagPrefix,
@@ -329,6 +331,64 @@ describe('formatting', () => {
         'v',
       );
       expect(result).toBe('release-wdio-native-spy@v');
+    });
+  });
+
+  describe('deriveBaselineTagPrefix', () => {
+    it('should return undefined when template is undefined', () => {
+      expect(deriveBaselineTagPrefix(undefined, 'v')).toBeUndefined();
+    });
+
+    it('should extract the prefix before ${version}', () => {
+      expect(deriveBaselineTagPrefix('release/${' + 'prefix}${' + 'version}', 'v')).toBe('release/v');
+    });
+
+    it('should substitute ${prefix}', () => {
+      expect(deriveBaselineTagPrefix('${' + 'prefix}${' + 'version}', 'v')).toBe('v');
+    });
+
+    it('should substitute ${packageName} with sanitized package name', () => {
+      expect(deriveBaselineTagPrefix('release/${' + 'packageName}/${' + 'prefix}${' + 'version}', 'v', 'my-pkg')).toBe(
+        'release/my-pkg/v',
+      );
+    });
+
+    it('should sanitize scoped package names in ${packageName}', () => {
+      expect(
+        deriveBaselineTagPrefix('release/${' + 'packageName}/${' + 'prefix}${' + 'version}', 'v', '@scope/pkg'),
+      ).toBe('release/scope-pkg/v');
+    });
+
+    it('should replace ${packageName} with empty string when packageName is omitted', () => {
+      expect(deriveBaselineTagPrefix('release/${' + 'packageName}/${' + 'prefix}${' + 'version}', 'v')).toBe(
+        'release//v',
+      );
+    });
+
+    it('should return empty string when template starts with ${version}', () => {
+      expect(deriveBaselineTagPrefix('${' + 'version}', 'v')).toBe('');
+    });
+  });
+
+  describe('displayTag', () => {
+    it('should return the tag unchanged when baselineTagPrefix is undefined', () => {
+      expect(displayTag('release/v1.2.3', undefined, 'v')).toBe('release/v1.2.3');
+    });
+
+    it('should return the tag unchanged when it does not start with the baseline prefix', () => {
+      expect(displayTag('v1.2.3', 'release/v', 'v')).toBe('v1.2.3');
+    });
+
+    it('should replace the baseline prefix with the consumer prefix', () => {
+      expect(displayTag('release/v1.2.3', 'release/v', 'v')).toBe('v1.2.3');
+    });
+
+    it('should handle an empty consumer prefix', () => {
+      expect(displayTag('release/1.2.3', 'release/', '')).toBe('1.2.3');
+    });
+
+    it('should handle baseline prefix equal to the full tag', () => {
+      expect(displayTag('release/v', 'release/v', 'v')).toBe('v');
     });
   });
 });


### PR DESCRIPTION
## Summary

- Extracts the inline baseline-tag prefix derivation and display-form conversion into two shared helpers (`deriveBaselineTagPrefix`, `displayTag`) in `formatting.ts`
- Fixes a bug where `createSingleStrategy` and `PackageProcessor` were missing the baseline-tag display translation, causing internal tags like `release/v0.22.0` to leak into user-facing changelog output instead of showing `v0.22.0`
- Updates mocks in both affected spec files to cover the new utilities

## Test plan

- [ ] Existing unit tests pass (`packages/version` test suite)
- [ ] Verify changelog preview output shows consumer-facing tag form when `baselineTagTemplate` is configured
- [ ] Confirm no regression in `createSyncStrategy` baseline tag display (already had the logic, now delegates to shared util)

🤖 Generated with [Claude Code](https://claude.com/claude-code)