### PR TITLE
feat(release): layered PR resolution for standing-pr publish

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -98,7 +98,7 @@ inputs:
     required: false
 
   pr:
-    description: Pull request number (preview mode)
+    description: Pull request number (preview mode; standing-pr-publish mode when not triggered by a pull_request event)
     required: false
   repo:
     description: Repository in owner/repo format (preview mode)

--- a/docs/action.md
+++ b/docs/action.md
@@ -14,6 +14,9 @@ uses: goosewobbler/releasekit@v0
 
 - `release` (default): runs the full unified release pipeline.
 - `preview`: runs PR preview comment generation.
+- `gate`: evaluates merged-PR labels and emits should-release/bump/scope outputs.
+- `standing-pr-update`: creates or refreshes the standing release PR.
+- `standing-pr-publish`: publishes from a merged standing release PR's manifest. Resolution order for which PR: the `pr` input, then the `pull_request` event payload, then the most recently merged standing PR via the GitHub API. Pass `pr` explicitly in dispatch funnels (e.g. `workflow_dispatch` routing for npm OIDC trusted publishing) — re-runs of a stale dispatch can otherwise infer a newer standing PR.
 
 ## Requirements
 
@@ -45,7 +48,7 @@ uses: goosewobbler/releasekit@v0
 
 | Input | Default | Description |
 |---|---|---|
-| `mode` | `release` | `release` or `preview` |
+| `mode` | `release` | `release`, `preview`, `gate`, `standing-pr-update`, or `standing-pr-publish` |
 | `config` | - | Path to `releasekit.config.json` |
 | `project-dir` | `.` | Project directory |
 | `dry-run` | `false` | Global dry-run toggle |
@@ -73,7 +76,7 @@ uses: goosewobbler/releasekit@v0
 
 | Input | Default | Description |
 |---|---|---|
-| `pr` | - | PR number override |
+| `pr` | - | PR number override (also used by `standing-pr-publish`) |
 | `repo` | - | `owner/repo` override |
 | `preview-prerelease` | - | Force prerelease preview identifier |
 | `preview-stable` | `false` | Force stable preview |
@@ -182,4 +185,3 @@ jobs:
   - moving major alias like `v1`
 - Consumers should reference `@v1`.
 - Breaking changes publish under a new major alias (`v2`).
-

--- a/packages/release/src/commands/standing-pr-command.ts
+++ b/packages/release/src/commands/standing-pr-command.ts
@@ -48,7 +48,7 @@ export function createStandingPRCommand(): Command {
       .description('Publish packages from a merged standing release PR (reads manifest from PR comment)')
       .option(
         '--pr <number>',
-        'PR number of the merged standing release PR. Use when the workflow runs on a push event (auto-detected from pull_request event when omitted)',
+        'PR number of the merged standing release PR. When omitted, falls back to the pull_request event payload, then to the most recently merged standing PR via the GitHub API',
       ),
   ).action(async (opts) => {
     const options: StandingPROptions = {

--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -1044,8 +1044,13 @@ export async function findLatestMergedStandingPR(
     per_page: 10,
   });
 
-  const merged = prs.find((pr) => pr.merged_at != null);
-  return merged ? merged.number : null;
+  // 'updated' ordering only guarantees the newest merge is in the page (merging touches
+  // updated_at) — late activity on an older merged PR (a comment, a label) can sort it
+  // above a newer merge. Pick by merged_at, not list position.
+  const merged = prs
+    .filter((pr) => pr.merged_at != null)
+    .sort((a, b) => new Date(b.merged_at as string).getTime() - new Date(a.merged_at as string).getTime());
+  return merged[0]?.number ?? null;
 }
 
 export async function runStandingPRPublish(

--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -1023,56 +1023,101 @@ export async function publishFromManifest(prNumber: number, options: StandingPRO
   };
 }
 
+/**
+ * Find the most recently merged PR whose head is the standing release branch.
+ * Inference fallback for dispatch-funnelled publishes — explicit `--pr` is preferred
+ * because a re-run of a stale dispatch can land after a newer standing PR has merged.
+ */
+export async function findLatestMergedStandingPR(
+  octokit: OctokitInstance,
+  owner: string,
+  repo: string,
+  branch: string,
+): Promise<number | null> {
+  const { data: prs } = await octokit.rest.pulls.list({
+    owner,
+    repo,
+    head: `${owner}:${branch}`,
+    state: 'closed',
+    sort: 'updated',
+    direction: 'desc',
+    per_page: 10,
+  });
+
+  const merged = prs.find((pr) => pr.merged_at != null);
+  return merged ? merged.number : null;
+}
+
 export async function runStandingPRPublish(
   options: StandingPROptions,
   explicitPrNumber?: number,
 ): Promise<ReleaseOutput | null> {
-  // Push-event path: caller (workflow) detected the standing-PR merge and passed the PR number.
+  // Resolution order: explicit --pr, then the pull_request event payload, then the most
+  // recently merged standing PR via the API. The API fallback covers dispatch-funnelled
+  // workflows (workflow_dispatch has no pull_request payload).
   if (explicitPrNumber !== undefined) {
     return publishFromManifest(explicitPrNumber, options);
   }
 
   const cwd = options.projectDir;
 
-  // Pull-request-event path: parse the event payload to find the merged PR.
-  const eventPath = process.env.GITHUB_EVENT_PATH;
-  if (!eventPath) {
-    error('GITHUB_EVENT_PATH not set and no --pr provided — cannot determine standing PR to publish');
-    return null;
-  }
-
-  let event: { pull_request?: { head?: { ref?: string }; number?: number; merged?: boolean } };
-  try {
-    event = JSON.parse(fs.readFileSync(eventPath, 'utf-8'));
-  } catch (err) {
-    error(`Failed to read GitHub event: ${err instanceof Error ? err.message : String(err)}`);
-    return null;
-  }
-
   const releaseKitConfig = loadReleaseKitConfig({ cwd, configPath: options.config });
   const standingPrConfig = releaseKitConfig.ci?.standingPr;
   const releaseBranch = standingPrConfig?.branch ?? 'release/next';
 
-  const headRef = event.pull_request?.head?.ref;
-  const merged = event.pull_request?.merged;
-  const prNumber = event.pull_request?.number;
+  // Pull-request-event path: parse the event payload to find the merged PR.
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  let event: { pull_request?: { head?: { ref?: string }; number?: number; merged?: boolean } } | undefined;
+  if (eventPath) {
+    try {
+      event = JSON.parse(fs.readFileSync(eventPath, 'utf-8'));
+    } catch (err) {
+      error(`Failed to read GitHub event: ${err instanceof Error ? err.message : String(err)}`);
+      return null;
+    }
+  }
 
-  if (!headRef || headRef !== releaseBranch) {
-    info(`Skipping: merged PR head ref '${headRef}' does not match release branch '${releaseBranch}'`);
+  if (event?.pull_request) {
+    const headRef = event.pull_request.head?.ref;
+    const merged = event.pull_request.merged;
+    const prNumber = event.pull_request.number;
+
+    if (!headRef || headRef !== releaseBranch) {
+      info(`Skipping: merged PR head ref '${headRef}' does not match release branch '${releaseBranch}'`);
+      return null;
+    }
+
+    if (!merged) {
+      info('Skipping: PR was not merged');
+      return null;
+    }
+
+    if (!prNumber) {
+      error('Could not determine PR number from GitHub event');
+      return null;
+    }
+
+    return publishFromManifest(prNumber, options);
+  }
+
+  // No pull_request context — infer the merged standing PR from the API.
+  const githubContext = getGitHubContext();
+  if (!githubContext?.token) {
+    error('No GitHub context (GITHUB_REPOSITORY or GITHUB_TOKEN) available — pass --pr explicitly');
     return null;
   }
 
-  if (!merged) {
-    info('Skipping: PR was not merged');
+  const octokit = createOctokit(githubContext.token);
+  const inferred = await findLatestMergedStandingPR(octokit, githubContext.owner, githubContext.repo, releaseBranch);
+  if (inferred === null) {
+    error(`No merged standing release PR found for branch '${releaseBranch}' — pass --pr explicitly`);
     return null;
   }
 
-  if (!prNumber) {
-    error('Could not determine PR number from GitHub event');
-    return null;
-  }
-
-  return publishFromManifest(prNumber, options);
+  info(
+    `Inferred standing PR #${inferred} (most recently merged '${releaseBranch}' PR) — pass --pr to target a specific PR`,
+  );
+  return publishFromManifest(inferred, options);
 }
 
 export async function runStandingPRMerge(

--- a/packages/release/test/unit/standing-pr.spec.ts
+++ b/packages/release/test/unit/standing-pr.spec.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { StandingPRManifest } from '../../src/standing-pr/standing-pr.js';
 import {
   createReleaseTags,
+  findLatestMergedStandingPR,
   parseManifest,
   publishFromManifest,
   runStandingPRMerge,
@@ -890,6 +891,46 @@ describe('runStandingPRUpdate', () => {
 
       expect(runVersionStepMock.mock.calls[0]?.[0]).toMatchObject({ sync: true });
     });
+  });
+});
+
+describe('findLatestMergedStandingPR', () => {
+  it('should pick the most recently merged PR even when an older merge was updated more recently', async () => {
+    const { createOctokit } = await import('../../src/github.js');
+    const { octokit, mocks } = createMockOctokit();
+    // List order is the API's 'updated' sort — late activity (a comment, a label) on the
+    // older merged #42 floats it above the newer merge #77.
+    mocks.pullsList.mockResolvedValue({
+      data: [
+        { number: 42, merged_at: '2024-01-01T00:00:00Z' },
+        { number: 80, merged_at: null },
+        { number: 77, merged_at: '2024-01-02T00:00:00Z' },
+      ],
+    });
+
+    const result = await findLatestMergedStandingPR(
+      octokit as unknown as ReturnType<typeof createOctokit>,
+      'owner',
+      'repo',
+      'release/next',
+    );
+
+    expect(result).toBe(77);
+  });
+
+  it('should return null when no closed PR from the branch was merged', async () => {
+    const { createOctokit } = await import('../../src/github.js');
+    const { octokit, mocks } = createMockOctokit();
+    mocks.pullsList.mockResolvedValue({ data: [{ number: 80, merged_at: null }] });
+
+    const result = await findLatestMergedStandingPR(
+      octokit as unknown as ReturnType<typeof createOctokit>,
+      'owner',
+      'repo',
+      'release/next',
+    );
+
+    expect(result).toBeNull();
   });
 });
 

--- a/packages/release/test/unit/standing-pr.spec.ts
+++ b/packages/release/test/unit/standing-pr.spec.ts
@@ -918,8 +918,65 @@ describe('runStandingPRPublish', () => {
     process.env = { ...originalEnv };
   });
 
-  it('should return null when GITHUB_EVENT_PATH is not set', async () => {
+  it('should infer the latest merged standing PR from the API when GITHUB_EVENT_PATH is not set', async () => {
     delete process.env.GITHUB_EVENT_PATH;
+
+    const { createOctokit } = await import('../../src/github.js');
+    const { octokit, mocks } = createMockOctokit();
+    mocks.pullsList.mockResolvedValue({
+      data: [
+        { number: 80, merged_at: null },
+        { number: 77, merged_at: '2024-01-02T00:00:00Z' },
+      ],
+    });
+    // No manifest comment on the inferred PR — the publish attempt throwing proves the
+    // inference resolved #77 and proceeded to publishFromManifest.
+    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+
+    await expect(
+      runStandingPRPublish({ projectDir: '/test', verbose: false, quiet: false, json: false }),
+    ).rejects.toThrow(/manifest not found/);
+
+    expect(mocks.pullsList).toHaveBeenCalledWith(
+      expect.objectContaining({ head: 'owner:release/next', state: 'closed' }),
+    );
+  });
+
+  it('should fall back to API inference when the event payload has no pull_request (workflow_dispatch)', async () => {
+    const { readFileSync } = await import('node:fs');
+    vi.mocked(readFileSync).mockReturnValue(JSON.stringify({ inputs: {} }));
+
+    const { createOctokit } = await import('../../src/github.js');
+    const { octokit, mocks } = createMockOctokit();
+    mocks.pullsList.mockResolvedValue({ data: [{ number: 42, merged_at: '2024-01-02T00:00:00Z' }] });
+    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+
+    await expect(
+      runStandingPRPublish({ projectDir: '/test', verbose: false, quiet: false, json: false }),
+    ).rejects.toThrow(/manifest not found/);
+  });
+
+  it('should return null when API inference finds no merged standing PR', async () => {
+    delete process.env.GITHUB_EVENT_PATH;
+
+    const { createOctokit } = await import('../../src/github.js');
+    const { octokit, mocks } = createMockOctokit();
+    mocks.pullsList.mockResolvedValue({ data: [{ number: 80, merged_at: null }] });
+    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+
+    const result = await runStandingPRPublish({
+      projectDir: '/test',
+      verbose: false,
+      quiet: false,
+      json: false,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('should return null when inference is needed but no GitHub token is available', async () => {
+    delete process.env.GITHUB_EVENT_PATH;
+    delete process.env.GITHUB_TOKEN;
 
     const result = await runStandingPRPublish({
       projectDir: '/test',

--- a/scripts/run-action.mjs
+++ b/scripts/run-action.mjs
@@ -99,6 +99,10 @@ export function buildStandingPRPublishArgs(input) {
   pushOptionalArg(args, '--config', input.config);
   pushOptionalArg(args, '--project-dir', input.projectDir);
   pushOptionalArg(args, '--npm-auth', input.npmAuth);
+  // Dispatch-funnelled publishes (gh workflow run from standing-pr.yml) run on a
+  // workflow_dispatch event with no pull_request payload, so the merged standing PR's
+  // number has to be carried across the dispatch boundary explicitly.
+  pushOptionalArg(args, '--pr', input.pr);
   pushBooleanFlag(args, '--verbose', input.verbose);
   pushBooleanFlag(args, '--quiet', input.quiet);
 

--- a/test/integration/action-runner.spec.ts
+++ b/test/integration/action-runner.spec.ts
@@ -8,6 +8,7 @@ import {
   buildPreviewArgs,
   buildReleaseArgs,
   buildReleaseSummary,
+  buildStandingPRPublishArgs,
   parseInputs,
   parseReleaseOutput,
   runAction,
@@ -147,6 +148,40 @@ describe('action runner', () => {
         '--dry-run',
       ]),
     );
+  });
+
+  it('should build standing-pr publish args with --pr', () => {
+    const args = buildStandingPRPublishArgs({
+      config: 'releasekit.config.json',
+      projectDir: '.',
+      npmAuth: 'oidc',
+      pr: '123',
+    });
+
+    expect(args).toEqual(
+      expect.arrayContaining([
+        'standing-pr',
+        'publish',
+        '--json',
+        '--config',
+        'releasekit.config.json',
+        '--project-dir',
+        '.',
+        '--npm-auth',
+        'oidc',
+        '--pr',
+        '123',
+      ]),
+    );
+  });
+
+  it('should omit --pr from standing-pr publish args when not provided', () => {
+    const args = buildStandingPRPublishArgs({
+      projectDir: '.',
+    });
+
+    expect(args).not.toContain('--pr');
+    expect(args).toEqual(expect.arrayContaining(['standing-pr', 'publish', '--json']));
   });
 
   it('should parse action env inputs', () => {


### PR DESCRIPTION
## Summary

Makes dispatch-funnelled standing-pr publishes work for **action consumers**. The funnel (`gh workflow run release.yml` from `standing-pr.yml`, so npm OIDC trusted publishing sees the right `workflow_ref`) lands the publish on a `workflow_dispatch` event — which has no `pull_request` payload, the only auto-detect path `standing-pr publish` had. The dogfood never hits this because it invokes the local CLI directly with `--pr`; the action wrapper was the only path missing it.

Two layered changes:

- **Action:** `buildStandingPRPublishArgs` now maps the existing `pr` input to `--pr` (preview mode already maps the same input — this was a parity gap, not a new input).
- **CLI:** when neither `--pr` nor a `pull_request` payload is present, `standing-pr publish` infers the most recently merged PR whose head is the standing release branch via the GitHub API (`findLatestMergedStandingPR`), logs the inferred number, and errors cleanly when none is found.

Resolution order: **explicit `--pr` → `pull_request` event payload → API inference.** Explicit stays first-class because a re-run of a stale dispatch can land after a newer standing PR has merged — inference would publish the wrong manifest; `--pr` pins the run to the PR it was dispatched for.

Docs: action.md now lists all five modes (it documented only `release`/`preview`), and the `--pr` option/`pr` input descriptions reflect the resolution order.

## Testing

- 4 new unit tests covering the inference path (API fallback when no event path, `workflow_dispatch` payload fall-through, no-merged-PR error, missing-token error) — `@releasekit/release` suite: 440 passed
- 2 new integration tests for the action args builder (`--pr` mapped / omitted) — integration suite: 32 passed
- `pnpm typecheck` + `pnpm lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a missing `--pr` mapping in the action wrapper for `standing-pr publish` and adds a 3-layer PR-resolution chain (explicit `--pr` → `pull_request` event payload → API inference via `findLatestMergedStandingPR`) so that dispatch-funnelled workflows triggered by `workflow_dispatch` (which carry no `pull_request` payload) can still publish correctly.

- **`scripts/run-action.mjs`**: `buildStandingPRPublishArgs` now passes `--pr` from the `pr` action input, closing a parity gap with `preview` mode.
- **`packages/release/src/standing-pr/standing-pr.ts`**: `runStandingPRPublish` refactored to fall back to API inference when no `pull_request` event context is present; `findLatestMergedStandingPR` fetches the 10 most-recently-updated closed PRs from the release branch and selects the one with the greatest `merged_at` (client-side sort, avoiding the stale-activity ranking hazard).
- **Tests & docs**: 4 new unit tests cover inference, `workflow_dispatch` fallthrough, no-PR, and no-token error paths; 2 new integration tests cover the args-builder gap; `action.md` documents all five modes and the resolution order for `standing-pr-publish`.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is additive (new fallback layer) and the explicit --pr fast-path is unmodified, so existing callers that pass --pr are unaffected.

The 3-layer resolution is implemented correctly: the event-payload branch preserves all prior guard checks (head-ref, merged flag, prNumber), and the new API-inference branch correctly sorts by merged_at client-side rather than relying on API list order. The buildStandingPRPublishArgs fix closes a straightforward parity gap. New unit and integration tests cover inference, workflow_dispatch fallthrough, no-merged-PR, and missing-token paths.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/release/src/standing-pr/standing-pr.ts | Core logic refactor: runStandingPRPublish gains 3-layer resolution and new exported findLatestMergedStandingPR sorts by merged_at client-side to avoid stale-activity ranking bugs. |
| scripts/run-action.mjs | Adds missing --pr flag mapping in buildStandingPRPublishArgs, closing the parity gap with the preview mode builder. |
| packages/release/test/unit/standing-pr.spec.ts | Adds 4 unit tests covering API inference, workflow_dispatch fallthrough, no-merged-PR error, and missing-token error; existing mock pattern is consistent with the rest of the suite. |
| test/integration/action-runner.spec.ts | Two new integration tests verify that --pr is included when provided and omitted when not, directly covering the args-builder fix. |
| docs/action.md | Documents all five modes (previously only release/preview) and explains the PR resolution order for standing-pr-publish. |
| action.yml | Description of the pr input updated to reflect its dual use across preview and standing-pr-publish modes. |
| packages/release/src/commands/standing-pr-command.ts | CLI help text updated to describe the full fallback chain for --pr; no logic changes. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[runStandingPRPublish called] --> B{explicitPrNumber provided?}
    B -- Yes --> C[publishFromManifest explicitPrNumber]
    B -- No --> D[Load releaseKitConfig / get releaseBranch]
    D --> E{GITHUB_EVENT_PATH set?}
    E -- No --> H
    E -- Yes --> F[Read & parse event file]
    F -- parse error --> ERR1[error + return null]
    F -- ok --> G{event.pull_request present?}
    G -- No --> H[getGitHubContext]
    G -- Yes --> G1{headRef matches releaseBranch?}
    G1 -- No --> RN1[info: Skipping + return null]
    G1 -- Yes --> G2{merged?}
    G2 -- No --> RN2[info: Skipping + return null]
    G2 -- Yes --> G3{prNumber present?}
    G3 -- No --> ERR2[error + return null]
    G3 -- Yes --> C2[publishFromManifest prNumber]
    H --> I{token available?}
    I -- No --> ERR3[error + return null]
    I -- Yes --> J[findLatestMergedStandingPR API: closed PRs head=branch]
    J --> K[Client-side sort by merged_at desc]
    K --> L{Found?}
    L -- No --> ERR4[error + return null]
    L -- Yes --> M[info: Inferred PR number]
    M --> C3[publishFromManifest inferred]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(release): pick inferred standing PR ..."](https://github.com/goosewobbler/releasekit/commit/d33257fce524262eb52c8b54fe5adfa9bb2e5035) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35590164)</sub>

<!-- /greptile_comment -->