### PR TITLE
feat(release): gate as immediate-release evaluator under standing-pr

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -71,8 +71,8 @@ Array of objects with the following properties:
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `pattern` | string | — |  |
-| `releaseType` | `"major"` \| `"minor"` \| `"patch"` \| `"prerelease"` | — |  |
+| `pattern` | string | — | |
+| `releaseType` | `"major"` \| `"minor"` \| `"patch"` \| `"prerelease"` | — | |
 
 ### `version.cargo`
 
@@ -246,9 +246,9 @@ Array of category objects used for commit categorization. Each item has:
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `name` | string | — |  |
-| `description` | string | — |  |
-| `scopes` | `string[]` | — |  |
+| `name` | string | — | |
+| `description` | string | — | |
+| `scopes` | `string[]` | — | |
 
 #### `notes.releaseNotes.llm.scopes`
 
@@ -256,16 +256,16 @@ Scope validation configuration.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `mode` | `"restricted"` \| `"packages"` \| `"none"` \| `"unrestricted"` | `"unrestricted"` |  |
+| `mode` | `"restricted"` \| `"packages"` \| `"none"` \| `"unrestricted"` | `"unrestricted"` | |
 
 **`notes.releaseNotes.llm.scopes.rules`**
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `allowed` | `string[]` | — |  |
-| `caseSensitive` | boolean | `false` |  |
-| `invalidScopeAction` | `"remove"` \| `"keep"` \| `"fallback"` | `"remove"` |  |
-| `fallbackScope` | string | — |  |
+| `allowed` | `string[]` | — | |
+| `caseSensitive` | boolean | `false` | |
+| `invalidScopeAction` | `"remove"` \| `"keep"` \| `"fallback"` | `"remove"` | |
+| `fallbackScope` | string | — | |
 
 #### `notes.releaseNotes.llm.retry`
 
@@ -296,7 +296,7 @@ CI automation configuration for release triggers, PR previews, and label managem
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `releaseStrategy` | `"manual"` \| `"direct"` \| `"standing-pr"` | `"direct"` | How releases are delivered. 'direct': release on merge to main. 'manual': releases triggered manually (e.g. workflow_dispatch). 'standing-pr': changes accumulate in a release PR. |
+| `releaseStrategy` | `"manual"` \| `"direct"` \| `"standing-pr"` | `"direct"` | How releases are delivered. 'direct': release on merge to main. 'manual': releases triggered manually (e.g. workflow_dispatch). 'standing-pr': changes accumulate in a release PR; gate mode acts as the immediate-release evaluator, firing only for merges labelled with the immediate label. |
 | `releaseTrigger` | `"commit"` \| `"label"` | `"label"` | What triggers a release. 'label': a PR bump label (bump:patch/minor/major) is required. 'commit': conventional commits drive the bump automatically; every merge can trigger a release. |
 | `prPreview` | boolean | `true` | Enable PR preview comments showing what would be released if the PR is merged. Set to false to disable. |
 | `autoRelease` | boolean | `false` | Automatically trigger a release when CI conditions are met, without manual intervention. |

--- a/packages/release/src/gate/evaluate-pr.ts
+++ b/packages/release/src/gate/evaluate-pr.ts
@@ -39,6 +39,12 @@ export interface PREvaluation {
  *  - `release:skip` ⇒ no release
  *  - otherwise ⇒ release
  *
+ * Under the `standing-pr` release strategy (either trigger mode), the gate is the
+ * immediate-release evaluator:
+ *  - no `release:immediate` label ⇒ neutral (changes accumulate in the standing release PR;
+ *    no conflict checks, no notify comment — feeder-PR labels are advisory there)
+ *  - `release:immediate` present ⇒ evaluated against the rules above
+ *
  * Scope/target are resolved from THIS PR's labels only — no cross-PR union.
  */
 export function evaluatePR(
@@ -56,6 +62,7 @@ export function evaluatePR(
     labelConfig.patch,
     labelConfig.stable,
     labelConfig.prerelease,
+    labelConfig.immediate,
   ]);
   const hasScopeLabel = labels.some((l) => Boolean(scopeLabels[l]));
   const hasReleaseIntent = labels.some((l) => releaseLabelNames.has(l)) || hasScopeLabel;
@@ -69,6 +76,23 @@ export function evaluatePR(
       target = scopeLabels[label];
       break;
     }
+  }
+
+  // Standing-pr strategy: merges accumulate in the standing release PR, so a PR without the
+  // immediate label is neutral — not blocked, not notified. Its bump/scope labels are advisory
+  // overrides for the standing PR, not errors, so conflict detection is skipped too.
+  const releaseStrategy = ciConfig?.releaseStrategy ?? 'direct';
+  if (releaseStrategy === 'standing-pr' && !labels.includes(labelConfig.immediate)) {
+    return {
+      prNumber,
+      labels,
+      shouldRelease: false,
+      scope,
+      target,
+      stable: false,
+      reason: `standing-pr strategy: no ${labelConfig.immediate} label — changes accumulate in the standing release PR`,
+      hasReleaseIntent: false,
+    };
   }
 
   const conflict = detectLabelConflicts(labels, labelConfig);

--- a/packages/release/src/gate/evaluate-pr.ts
+++ b/packages/release/src/gate/evaluate-pr.ts
@@ -91,6 +91,9 @@ export function evaluatePR(
       target,
       stable: false,
       reason: `standing-pr strategy: no ${labelConfig.immediate} label — changes accumulate in the standing release PR`,
+      // Deliberately forced false even when bump/scope labels are present: this field drives
+      // shouldNotifyPR, and a feeder PR's advisory labels are not release intent here. Don't
+      // read it as "has release labels".
       hasReleaseIntent: false,
     };
   }

--- a/packages/release/src/gate/gate.ts
+++ b/packages/release/src/gate/gate.ts
@@ -49,14 +49,6 @@ export async function runGate(options: GateOptions): Promise<GateOutput> {
   const releaseKitConfig = await loadReleaseKitConfig({ cwd: options.projectDir, configPath: options.config });
   const ciConfig = releaseKitConfig.ci;
 
-  // Strategy guard - gate only works with direct/manual strategies
-  const releaseStrategy = ciConfig?.releaseStrategy ?? 'direct';
-  if (releaseStrategy === 'standing-pr') {
-    throw new Error(
-      "Gate mode is not compatible with releaseStrategy: 'standing-pr'. Use 'releasekit standing-pr update' instead — see docs/ci-setup.md.",
-    );
-  }
-
   // Check GitHub context (sha serves as a proxy for "are we in GitHub Actions?")
   const githubContext = getGitHubContext();
   if (!githubContext?.sha) {

--- a/packages/release/test/unit/gate.spec.ts
+++ b/packages/release/test/unit/gate.spec.ts
@@ -323,12 +323,86 @@ describe('Gate', () => {
     expect(result.reason).toContain('skip pattern');
   });
 
-  it('should throw with clear error when releaseStrategy is standing-pr', async () => {
-    mockLoadReleaseKitConfig.mockReturnValue({
-      ci: { releaseStrategy: 'standing-pr' },
+  describe('standing-pr strategy (immediate-release evaluator)', () => {
+    function standingPrConfig(extra: Record<string, unknown> = {}) {
+      return {
+        ci: {
+          releaseStrategy: 'standing-pr',
+          releaseTrigger: 'label',
+          labels: {
+            major: 'bump:major',
+            minor: 'bump:minor',
+            patch: 'bump:patch',
+            stable: 'channel:stable',
+            prerelease: 'channel:prerelease',
+            skip: 'release:skip',
+            immediate: 'release:immediate',
+          },
+          ...extra,
+        },
+      };
+    }
+
+    it('should stay neutral for a merged PR without the immediate label', async () => {
+      mockLoadReleaseKitConfig.mockReturnValue(standingPrConfig());
+      mockFindMergedPRsSinceLastRelease.mockResolvedValue([123]);
+      mockFetchPRLabels.mockResolvedValue(['bump:minor']);
+
+      const result = await runGate();
+
+      expect(result.shouldRelease).toBe(false);
+      expect(result.blocked).toBeUndefined();
+      expect(result.reason).toContain('standing release PR');
+      // Neutral PRs must not get the "didn't trigger a release" nag comment.
+      expect(mockPostOrUpdateComment).not.toHaveBeenCalled();
     });
 
-    await expect(runGate()).rejects.toThrow('standing-pr');
+    it('should not treat conflicting bump labels as blocking without the immediate label', async () => {
+      mockLoadReleaseKitConfig.mockReturnValue(standingPrConfig());
+      mockFindMergedPRsSinceLastRelease.mockResolvedValue([123]);
+      mockFetchPRLabels.mockResolvedValue(['bump:major', 'bump:minor']);
+
+      const result = await runGate();
+
+      expect(result.shouldRelease).toBe(false);
+      expect(result.blocked).toBeUndefined();
+      expect(mockPostOrUpdateComment).not.toHaveBeenCalled();
+    });
+
+    it('should release with resolved bump and scope when the immediate label is present', async () => {
+      mockLoadReleaseKitConfig.mockReturnValue(standingPrConfig({ scopeLabels: { 'scope:tauri': '@wdio/tauri-*' } }));
+      mockFindMergedPRsSinceLastRelease.mockResolvedValue([123]);
+      mockFetchPRLabels.mockResolvedValue(['release:immediate', 'bump:minor', 'scope:tauri']);
+
+      const result = await runGate();
+
+      expect(result.shouldRelease).toBe(true);
+      expect(result.bump).toBe('minor');
+      expect(result.scope).toBe('tauri');
+      expect(result.target).toBe('@wdio/tauri-*');
+    });
+
+    it('should not release but notify when immediate is present without a bump label', async () => {
+      mockLoadReleaseKitConfig.mockReturnValue(standingPrConfig());
+      mockFindMergedPRsSinceLastRelease.mockResolvedValue([123]);
+      mockFetchPRLabels.mockResolvedValue(['release:immediate']);
+
+      const result = await runGate();
+
+      expect(result.shouldRelease).toBe(false);
+      expect(mockPostOrUpdateComment).toHaveBeenCalled();
+    });
+
+    it('should block on conflicting bump labels when the immediate label is present', async () => {
+      mockLoadReleaseKitConfig.mockReturnValue(standingPrConfig());
+      mockFindMergedPRsSinceLastRelease.mockResolvedValue([123]);
+      mockFetchPRLabels.mockResolvedValue(['release:immediate', 'bump:major', 'bump:minor']);
+
+      const result = await runGate();
+
+      expect(result.shouldRelease).toBe(false);
+      expect(result.blocked).toBe(true);
+    });
   });
 
   it('should return shouldRelease: false with reason when no GitHub context', async () => {

--- a/packages/release/test/unit/gate.spec.ts
+++ b/packages/release/test/unit/gate.spec.ts
@@ -403,6 +403,30 @@ describe('Gate', () => {
       expect(result.shouldRelease).toBe(false);
       expect(result.blocked).toBe(true);
     });
+
+    it('should stay neutral for a feeder PR in commit trigger mode', async () => {
+      mockLoadReleaseKitConfig.mockReturnValue(standingPrConfig({ releaseTrigger: 'commit' }));
+      mockFindMergedPRsSinceLastRelease.mockResolvedValue([123]);
+      mockFetchPRLabels.mockResolvedValue(['enhancement']);
+
+      const result = await runGate();
+
+      // Without the standing-pr guard, commit mode releases every merge — a feeder PR
+      // slipping through here would direct-release on every push.
+      expect(result.shouldRelease).toBe(false);
+      expect(result.reason).toContain('standing release PR');
+      expect(mockPostOrUpdateComment).not.toHaveBeenCalled();
+    });
+
+    it('should release on the immediate label alone in commit trigger mode (no bump label required)', async () => {
+      mockLoadReleaseKitConfig.mockReturnValue(standingPrConfig({ releaseTrigger: 'commit' }));
+      mockFindMergedPRsSinceLastRelease.mockResolvedValue([123]);
+      mockFetchPRLabels.mockResolvedValue(['release:immediate']);
+
+      const result = await runGate();
+
+      expect(result.shouldRelease).toBe(true);
+    });
   });
 
   it('should return shouldRelease: false with reason when no GitHub context', async () => {

--- a/releasekit.schema.json
+++ b/releasekit.schema.json
@@ -805,7 +805,7 @@
             "standing-pr"
           ],
           "default": "direct",
-          "description": "How releases are delivered. 'direct': release on merge to main. 'manual': releases triggered manually (e.g. workflow_dispatch). 'standing-pr': changes accumulate in a release PR."
+          "description": "How releases are delivered. 'direct': release on merge to main. 'manual': releases triggered manually (e.g. workflow_dispatch). 'standing-pr': changes accumulate in a release PR; gate mode acts as the immediate-release evaluator, firing only for merges labelled with the immediate label."
         },
         "releaseTrigger": {
           "type": "string",


### PR DESCRIPTION
## Summary

Gate mode hard-threw under `releaseStrategy: 'standing-pr'`, which forced scoped/multi-channel consumers to re-implement label→bump/scope derivation in workflow bash for the `release:immediate` bypass path — logic the gate already owns (per-PR evaluation, `ci.scopeLabels` resolution, channel handling, conflict blocking).

Under standing-pr the gate now **evaluates immediate-release intent instead of throwing**:

- A merged PR **without** `release:immediate` is neutral: no release, no conflict blocking, no notify comment. Its `bump:*`/`scope:*` labels are advisory overrides for the standing PR, not errors, so conflict detection is skipped for it.
- A merged PR **with** `release:immediate` is evaluated against the normal trigger rules — consumers can dispatch a direct release straight from the gate's existing `bump`/`scope`/`stable` outputs, no consumer-side label parsing.
- `release:immediate` now counts as release intent, so an immediate-labelled PR missing a bump label gets the gate's notify comment telling the author what to add (in any strategy).

Direct/manual strategies are unchanged. The removed error message also referenced `docs/ci-setup.md`, which doesn't exist.

Also updates the `releaseStrategy` schema description (+ regenerated `docs/configuration.md`).

## Testing

- Replaced the strategy-guard throw test with 5 behavior tests: neutral feeder PR (no nag comment), conflicting bumps stay non-blocking without immediate, immediate+bump+scope releases with resolved outputs, immediate-without-bump notifies, immediate+conflicting bumps blocks
- Full monorepo suite green (`@releasekit/release`: 441 passed; all other packages passing)
- `pnpm typecheck` + `pnpm lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR repurposes the gate as an immediate-release evaluator when `releaseStrategy: 'standing-pr'` is configured, replacing a hard throw with nuanced per-PR logic in `evaluatePR`. The removed error also referenced a non-existent `docs/ci-setup.md`.

- **`evaluatePR`**: A new early-return before conflict detection returns a neutral result (no release, no block, `hasReleaseIntent: false`) for any PR without the `release:immediate` label under `standing-pr`, covering both `label` and `commit` trigger modes. PRs carrying the `release:immediate` label fall through to the normal evaluation rules unchanged.
- **`gate.ts`**: The standing-pr strategy-guard throw is removed; no other gate logic is touched.
- **Tests**: The single throw-assertion is replaced by 7 targeted tests — including the previously-flagged commit-mode gap — covering neutral feeder, conflicting-without-immediate, immediate+bump+scope release, immediate-without-bump notification, conflict blocking, and both trigger modes.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge. The early-return guard in evaluatePR is correctly placed before conflict detection, LabelConfig.immediate is a required field so the includes check can never silently match undefined, and the new neutral path's hasReleaseIntent: false correctly prevents the notifier from firing on feeder PRs.

The logic is straightforward: a single guard checks for the immediate label before any conflict or bump evaluation, falling through to the unmodified evaluation chain when it is present. Both trigger modes are exercised. The deliberate hasReleaseIntent override is clearly documented inline, and the schema/docs are consistent with the implementation.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/release/src/gate/evaluate-pr.ts | Adds standing-pr early-return guard before conflict detection; correctly forces hasReleaseIntent: false to silence the notifier, well-documented. LabelConfig.immediate is a required string so the includes check is always safe. |
| packages/release/src/gate/gate.ts | Removes the standing-pr error throw; no other logic changes. The notifier and computeGateResult paths are unaffected and work correctly with the new neutral evaluations produced by evaluatePR. |
| packages/release/test/unit/gate.spec.ts | Replaces the single standing-pr throw test with 7 behavior tests covering both label and commit trigger modes, including the previously-flagged commit-mode gap. standingPrConfig helper correctly spreads extra at the ci level. |
| releasekit.schema.json | Updated releaseStrategy description to reflect gate-as-immediate-evaluator semantics; matches the regenerated docs/configuration.md. |
| docs/configuration.md | Regenerated configuration docs with updated releaseStrategy description and minor whitespace normalisation in empty Description cells. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PR merged → gate triggered] --> B{releaseStrategy = 'standing-pr'?}
    B -- No --> E[Normal direct/manual evaluation]
    B -- Yes --> C{labels includes release:immediate?}
    C -- No --> D[Neutral return: shouldRelease false, hasReleaseIntent false, no notify, no block]
    C -- Yes --> F{releaseTrigger?}
    F -- label --> G{Conflict on this PR?}
    F -- commit --> H{Has release:skip?}
    G -- bump conflict --> I[blocked: true]
    G -- prerelease conflict --> I
    G -- no conflict --> J{Has bump label or stable label?}
    J -- Yes --> K[shouldRelease: true, bump/scope/target resolved]
    J -- No bump has prerelease --> L[shouldRelease: false, hasReleaseIntent: true, notify]
    J -- No labels --> L
    H -- Yes --> M[shouldRelease: false, no notify in commit mode]
    H -- No --> N[shouldRelease: true, bump from commits]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["test(release): Greptile round — commit-t..."](https://github.com/goosewobbler/releasekit/commit/13272bb262fcd7862bee275bb47d0b26cef1171e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35590773)</sub>

<!-- /greptile_comment -->