### PR TITLE
chore: point biome $schema at local configuration_schema.json

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.10/schema.json",
+  "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
   "vcs": {
     "enabled": false,
     "clientKind": "git",


### PR DESCRIPTION
## Summary

Replaces the versioned `biomejs.dev` schema URL in `biome.jsonc` with the schema file shipped inside the `@biomejs/biome` package:

```jsonc
"$schema": "./node_modules/@biomejs/biome/configuration_schema.json"
```

## Why

Dependabot bumps `@biomejs/biome` but doesn't touch the `$schema` URL, leaving it pointing at a stale version (e.g. #237 bumped biome to 2.4.16 while the schema stayed at 2.4.10). With the relative path the schema always matches the installed version — no sync step, no drift.

The Biome CLI never reads `$schema` (validation is compiled in), so the only effect of a missing `node_modules` is a soft editor warning on fresh clones until `pnpm install` runs — a window in which the CLI can't run anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Replaces the hard-coded versioned Biome schema URL in `biome.jsonc` with a relative path to the schema bundled inside `node_modules`. This eliminates schema-version drift that occurred when Dependabot bumped `@biomejs/biome` without updating the URL.

- **`biome.jsonc`**: `$schema` now points to the local `configuration_schema.json` inside `node_modules`, which always reflects the installed package version. The Biome CLI ignores `$schema` at runtime, so the only observable side-effect is an editor warning on fresh clones before `pnpm install` has been run.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — single-line config change with no runtime impact on the Biome CLI.

The change swaps a remote versioned URL for a local node_modules path. Biome's CLI ignores $schema entirely (validation is compiled in), so there is zero impact on linting or formatting behaviour. Editors lose schema resolution only on fresh clones before pnpm install, which the PR description explicitly acknowledges.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| biome.jsonc | Replaces the versioned remote schema URL with a local node_modules path, ensuring the schema always tracks the installed Biome version |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Editor opens biome.jsonc] --> B{node_modules present?}
    B -- Yes --> C[Resolves ./node_modules/@biomejs/biome/configuration_schema.json]
    C --> D[Schema version matches installed @biomejs/biome]
    B -- No --> E[Schema file not found → soft editor warning]
    E --> F[Run pnpm install]
    F --> C
    G[Biome CLI] -->|Ignores $schema entirely| H[Compiled-in validation — no drift]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: point biome $schema at local conf..."](https://github.com/goosewobbler/releasekit/commit/7030e89754503a295cbdf98a2b23c1ea88cd5464) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35594590)</sub>

<!-- /greptile_comment -->