### PR TITLE
fix(release): add --reconcile to bypass standing-pr skip-pattern guard

### DIFF
--- a/.github/workflows/_standing-pr-update.reusable.yml
+++ b/.github/workflows/_standing-pr-update.reusable.yml
@@ -6,6 +6,12 @@ name: Standing PR Update
 
 on:
   workflow_call:
+    inputs:
+      reconcile:
+        description: "Bypass the skip-pattern guard (set for the post-release reconcile run, where HEAD is a release commit)"
+        type: boolean
+        required: false
+        default: false
     secrets:
       OLLAMA_API_KEY:
         required: false
@@ -40,7 +46,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Update standing release PR
-        run: node packages/release/dist/cli.js standing-pr update
+        run: node packages/release/dist/cli.js standing-pr update ${{ inputs.reconcile && '--reconcile' || '' }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
           # Uncomment the env var matching your notes.releaseNotes.llm.provider.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -252,6 +252,11 @@ jobs:
     # narrow (it only fires when @releasekit/release itself is bumped) and should be revisited.
     if: github.event_name == 'workflow_dispatch' && inputs.reconcile_after && needs.release-manual.result == 'success' && needs.release-manual.outputs.action_tag != ''
     uses: ./.github/workflows/_standing-pr-update.reusable.yml
+    # HEAD is the just-pushed release commit (matches the skip pattern), so the reconcile run must
+    # bypass the skip-pattern guard or it would no-op and leave the standing PR holding the
+    # just-published versions.
+    with:
+      reconcile: true
     permissions:
       contents: write
       pull-requests: write

--- a/action.yml
+++ b/action.yml
@@ -97,6 +97,11 @@ inputs:
     description: SSH deploy key for git push (enables SSH checkout when not dry-run)
     required: false
 
+  reconcile:
+    description: "Bypass the skip-pattern guard in standing-pr-update mode (for post-release reconcile runs, where HEAD is a release commit)"
+    required: false
+    default: "false"
+
   pr:
     description: Pull request number (preview mode; standing-pr-publish mode when not triggered by a pull_request event)
     required: false
@@ -285,6 +290,7 @@ runs:
         INPUT_SKIP_GIT: ${{ inputs.skip-git }}
         INPUT_SKIP_GITHUB_RELEASE: ${{ inputs.skip-github-release }}
         INPUT_SKIP_VERIFICATION: ${{ inputs.skip-verification }}
+        INPUT_RECONCILE: ${{ inputs.reconcile }}
         INPUT_PR: ${{ inputs.pr }}
         INPUT_REPO: ${{ inputs.repo }}
         INPUT_PREVIEW_PRERELEASE: ${{ inputs.preview-prerelease }}

--- a/docs/action.md
+++ b/docs/action.md
@@ -83,6 +83,13 @@ uses: goosewobbler/releasekit@v0
 | `preview-dry-run` | `false` | Print markdown instead of posting |
 | `preview-target` | - | Comma-separated package targets |
 
+### Standing PR mode inputs
+
+| Input | Default | Description |
+|---|---|---|
+| `pr` | - | Merged standing PR number (`standing-pr-publish`, when not triggered by a `pull_request` event) |
+| `reconcile` | `false` | `standing-pr-update` only: bypass the skip-pattern guard. Set this for a post-release reconcile run, where HEAD is the just-pushed release commit (which matches the skip pattern). Without it the reconcile run no-ops and the standing PR keeps holding the just-published versions. |
+
 ## Outputs
 
 | Output | Description |

--- a/packages/release/src/commands/standing-pr-command.ts
+++ b/packages/release/src/commands/standing-pr-command.ts
@@ -20,7 +20,12 @@ export function createStandingPRCommand(): Command {
   sharedOptions(
     cmd
       .command('update')
-      .description('Calculate versions, commit to release branch, and create/update the standing PR'),
+      .description('Calculate versions, commit to release branch, and create/update the standing PR')
+      .option(
+        '--reconcile',
+        'Bypass the skip-pattern guard so a post-release reconcile run still updates the standing PR (HEAD is a release commit at that point)',
+        false,
+      ),
   ).action(async (opts) => {
     const options: StandingPROptions = {
       config: opts.config,
@@ -29,6 +34,7 @@ export function createStandingPRCommand(): Command {
       json: opts.json,
       verbose: opts.verbose,
       quiet: opts.quiet,
+      reconcile: opts.reconcile,
     };
 
     try {

--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -25,6 +25,14 @@ export interface StandingPROptions {
   quiet: boolean;
   json: boolean;
   npmAuth?: string;
+  /**
+   * Bypass ONLY the skip-pattern guard at the top of `runStandingPRUpdate`. The guard exists to
+   * stop push-triggered runs reacting to a release's own commits, but the post-release reconcile
+   * flow deliberately runs `standing-pr update` right after a release — when HEAD is, by
+   * definition, a release commit that matches the skip pattern. Reconcile callers explicitly
+   * intend an update, so they opt out via this flag. All other guards/behaviour are unchanged.
+   */
+  reconcile?: boolean;
 }
 
 export interface StandingPRResult {
@@ -604,11 +612,18 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
   const base = releaseKitConfig.git?.branch ?? 'main';
   const skipPatterns = releaseKitConfig.release?.ci?.skipPatterns ?? ['chore: release '];
 
-  // Skip-pattern guard
-  const headSubject = getHeadCommitMessage(cwd);
-  if (headSubject && matchesSkipPattern(headSubject, skipPatterns)) {
-    info(`Skipping standing PR update: commit matches skip pattern`);
-    return { action: 'noop' };
+  // Skip-pattern guard. The reconcile flag bypasses it: reconcile runs deliberately right after
+  // a release (HEAD is a release commit that matches the skip pattern by design), so the
+  // push-event noise rejection this guard provides would otherwise turn every reconcile into a
+  // no-op and leave the standing PR holding just-published versions.
+  if (options.reconcile) {
+    info('Reconcile mode: bypassing skip-pattern guard');
+  } else {
+    const headSubject = getHeadCommitMessage(cwd);
+    if (headSubject && matchesSkipPattern(headSubject, skipPatterns)) {
+      info(`Skipping standing PR update: commit matches skip pattern`);
+      return { action: 'noop' };
+    }
   }
 
   const githubContext = getGitHubContext();
@@ -747,9 +762,9 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
   const countableUpdates = publishableUpdates(versionOutput);
   const count = countableUpdates.length;
   const firstUpdate = countableUpdates[0];
+  const isSync = versionOutput.strategy === 'sync';
   /* biome-ignore lint/suspicious/noTemplateCurlyInString: template string uses config variable */
-  const defaultTitle =
-    versionOutput.strategy === 'sync' ? 'chore: release ${tag}' : 'chore: release ${count} package(s)';
+  const defaultTitle = isSync ? 'chore: release ${tag}' : 'chore: release ${count} package(s)';
   const titleTemplate = standingPrConfig?.title ?? defaultTitle;
   const title = titleTemplate
     .replace(/\$\{count\}/g, String(count))

--- a/packages/release/test/unit/standing-pr-command.spec.ts
+++ b/packages/release/test/unit/standing-pr-command.spec.ts
@@ -84,4 +84,16 @@ describe('createStandingPRCommand', () => {
     await parseCommand(['update', '--config', '/path/to/config.json']);
     expect(runStandingPRUpdate).toHaveBeenCalledWith(expect.objectContaining({ config: '/path/to/config.json' }));
   });
+
+  it('should pass --reconcile through as reconcile: true', async () => {
+    const { runStandingPRUpdate } = await import('../../src/standing-pr/standing-pr.js');
+    await parseCommand(['update', '--reconcile']);
+    expect(runStandingPRUpdate).toHaveBeenCalledWith(expect.objectContaining({ reconcile: true }));
+  });
+
+  it('should default reconcile to false when --reconcile is omitted', async () => {
+    const { runStandingPRUpdate } = await import('../../src/standing-pr/standing-pr.js');
+    await parseCommand(['update']);
+    expect(runStandingPRUpdate).toHaveBeenCalledWith(expect.objectContaining({ reconcile: false }));
+  });
 });

--- a/packages/release/test/unit/standing-pr.spec.ts
+++ b/packages/release/test/unit/standing-pr.spec.ts
@@ -340,6 +340,36 @@ describe('runStandingPRUpdate', () => {
     expect(result.action).toBe('noop');
   });
 
+  it('should bypass the skip-pattern guard when reconcile is set', async () => {
+    // HEAD is a release commit (matches the skip pattern) — the post-release reconcile scenario.
+    // Without reconcile this would noop; with reconcile it must proceed and create the PR.
+    const { execSync } = await import('node:child_process');
+    vi.mocked(execSync).mockReturnValue('chore: release @scope/core v1.2.3');
+
+    const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
+    const versionOutput = createMockVersionOutput([{ packageName: '@scope/core', newVersion: '1.2.3' }]);
+    vi.mocked(runVersionStep)
+      .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>)
+      .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>);
+    vi.mocked(runNotesStep).mockResolvedValue({ packageNotes: {}, releaseNotes: {}, files: [] });
+
+    const { createOctokit } = await import('../../src/github.js');
+    const { mocks, octokit } = createMockOctokit();
+    mocks.pullsList.mockResolvedValue({ data: [] });
+    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+
+    const result = await runStandingPRUpdate({
+      projectDir: '/test',
+      verbose: false,
+      quiet: false,
+      json: false,
+      reconcile: true,
+    });
+
+    expect(result.action).toBe('created');
+    expect(mocks.pullsCreate).toHaveBeenCalled();
+  });
+
   it('should return noop when no releasable changes found and no existing PR', async () => {
     const { runVersionStep } = await import('../../src/steps.js');
     vi.mocked(runVersionStep).mockResolvedValue(

--- a/scripts/run-action.d.mts
+++ b/scripts/run-action.d.mts
@@ -19,6 +19,7 @@ export interface ActionInputs {
   skipGit?: string;
   skipGithubRelease?: string;
   skipVerification?: string;
+  reconcile?: string;
   pr?: string;
   repo?: string;
   previewPrerelease?: string;

--- a/scripts/run-action.mjs
+++ b/scripts/run-action.mjs
@@ -86,6 +86,7 @@ export function buildStandingPRUpdateArgs(input) {
   pushOptionalArg(args, '--config', input.config);
   pushOptionalArg(args, '--project-dir', input.projectDir);
   pushOptionalArg(args, '--npm-auth', input.npmAuth);
+  pushBooleanFlag(args, '--reconcile', input.reconcile);
   pushBooleanFlag(args, '--verbose', input.verbose);
   pushBooleanFlag(args, '--quiet', input.quiet);
 
@@ -189,6 +190,7 @@ export function parseInputs(env = process.env) {
     skipGithubRelease: env.INPUT_SKIP_GITHUB_RELEASE,
     skipVerification: env.INPUT_SKIP_VERIFICATION,
 
+    reconcile: env.INPUT_RECONCILE,
     pr: normalizeString(env.INPUT_PR),
     repo: normalizeString(env.INPUT_REPO),
     previewPrerelease: normalizeString(env.INPUT_PREVIEW_PRERELEASE),

--- a/test/integration/action-runner.spec.ts
+++ b/test/integration/action-runner.spec.ts
@@ -9,6 +9,7 @@ import {
   buildReleaseArgs,
   buildReleaseSummary,
   buildStandingPRPublishArgs,
+  buildStandingPRUpdateArgs,
   parseInputs,
   parseReleaseOutput,
   runAction,
@@ -182,6 +183,33 @@ describe('action runner', () => {
 
     expect(args).not.toContain('--pr');
     expect(args).toEqual(expect.arrayContaining(['standing-pr', 'publish', '--json']));
+  });
+
+  it('should build standing-pr update args with --reconcile when reconcile is true', () => {
+    const args = buildStandingPRUpdateArgs({
+      projectDir: '.',
+      reconcile: 'true',
+    });
+
+    expect(args).toEqual(expect.arrayContaining(['standing-pr', 'update', '--json', '--reconcile']));
+  });
+
+  it('should omit --reconcile from standing-pr update args when reconcile is not set', () => {
+    const args = buildStandingPRUpdateArgs({
+      projectDir: '.',
+    });
+
+    expect(args).not.toContain('--reconcile');
+    expect(args).toEqual(expect.arrayContaining(['standing-pr', 'update', '--json']));
+  });
+
+  it('should parse INPUT_RECONCILE into the reconcile input', () => {
+    const parsed = parseInputs({
+      INPUT_MODE: 'standing-pr-update',
+      INPUT_RECONCILE: 'true',
+    });
+
+    expect(parsed.reconcile).toBe('true');
   });
 
   it('should parse action env inputs', () => {


### PR DESCRIPTION
## Problem

The skip-pattern guard at the top of `runStandingPRUpdate` noops when HEAD matches `release.ci.skipPatterns`. Correct for push-triggered runs — but the post-release reconcile flow runs `standing-pr update` deliberately *right after* a release, when HEAD is by definition a release commit. Every reconcile run tripped the guard and nooped, leaving the standing PR holding already-published versions until the next regular merge.

## Fix

An explicit `reconcile` opt-out that bypasses **only** the skip-pattern guard (all other guards and behavior unchanged), logged clearly when active. Wired end to end:

- `StandingPROptions.reconcile` + `--reconcile` on `standing-pr update` (CLI)
- `reconcile` input on the action → `INPUT_RECONCILE` → `--reconcile` (`run-action.mjs`)
- `reconcile` input on `_standing-pr-update.reusable.yml`; the dogfood `reconcile-after-release` job in `release.yml` now passes `reconcile: true`. The push-triggered `update-release-pr` job is unchanged and defaults to `false`, so the guard is preserved for routine runs.
- Documented in `docs/action.md` (new standing-pr mode inputs table)

Explicit flag over implicit `workflow_dispatch` detection, per the issue's preference — keeps local/manual runs predictable.

## Tests

- Guard still noops on push-triggered runs (existing spec unchanged and passing)
- `reconcile: true` with a release-commit HEAD proceeds to create the PR
- CLI flag mapping and default
- Action input parsing and arg building

Full `pnpm turbo run lint typecheck test`: 24/24 tasks pass.

Closes #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a long-standing bug where the post-release reconcile run of `standing-pr update` always no-oped because HEAD was a release commit that matched the skip-pattern guard — the very guard designed to suppress push-triggered noise. The fix introduces an explicit `--reconcile` flag that bypasses only that one guard, wired end-to-end from the CLI through the action inputs, reusable workflow, and release workflow.

- `StandingPROptions.reconcile` and `--reconcile` CLI flag added; `runStandingPRUpdate` skips the skip-pattern check only when the flag is set, leaving all other guards intact.
- `action.yml` gains a `reconcile` string input mapped to `INPUT_RECONCILE`; `run-action.mjs` converts it to `--reconcile` via the existing `pushBooleanFlag` helper; the reusable workflow appends `--reconcile` via a boolean ternary expression.
- The `reconcile-after-release` job in `release.yml` now passes `reconcile: true`; the routine `update-release-pr` push-triggered job is unchanged.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is surgical, well-tested, and leaves all other guards in runStandingPRUpdate untouched.

The bypass is limited to exactly one guard, the flag defaults to false everywhere it is declared (CLI, action input, reusable workflow), and the routine push-triggered job in release.yml is not modified. Tests cover the bypass path, the default-off path, CLI flag mapping, and action input parsing. The normalizeBoolean helper correctly handles the string-to-boolean conversion from the action env. No guards are weakened for the routine workflow path.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/release/src/standing-pr/standing-pr.ts | Adds reconcile bypass for the skip-pattern guard in runStandingPRUpdate; also extracts isSync local variable. Logic is correct — only the one guard is bypassed. |
| packages/release/src/commands/standing-pr-command.ts | Adds --reconcile CLI flag with default false and threads it through to StandingPROptions. Straightforward and correct. |
| scripts/run-action.mjs | Adds reconcile to parseInputs and pushBooleanFlag in buildStandingPRUpdateArgs. Consistent with how other boolean flags are handled throughout the file. |
| .github/workflows/_standing-pr-update.reusable.yml | Adds typed boolean reconcile workflow input; appends --reconcile to the CLI command via a GitHub Actions ternary expression when the input is true. |
| .github/workflows/release.yml | Passes reconcile: true to the reusable workflow only for the reconcile-after-release job; the push-triggered job is unmodified. |
| action.yml | Adds reconcile string input (default false) and wires it through INPUT_RECONCILE env var to run-action.mjs. |
| scripts/run-action.d.mts | Adds reconcile?: string to ActionInputs interface, keeping the type definition in sync with the implementation. |
| packages/release/test/unit/standing-pr.spec.ts | Adds a test verifying reconcile: true bypasses the skip-pattern guard and proceeds to create the PR even when HEAD matches the skip pattern. |
| packages/release/test/unit/standing-pr-command.spec.ts | Adds two tests: --reconcile maps to reconcile: true, and omitting it defaults to reconcile: false. |
| test/integration/action-runner.spec.ts | Adds integration tests for buildStandingPRUpdateArgs and parseInputs covering the reconcile input. |
| docs/action.md | New Standing PR mode inputs table documents both pr and reconcile inputs with clear descriptions. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant ReleaseYml as release.yml
    participant ReusableWf as _standing-pr-update.reusable.yml
    participant CLI as cli.js standing-pr update
    participant StandingPR as runStandingPRUpdate()

    ReleaseYml->>ReusableWf: "reconcile-after-release job with reconcile=true"
    ReusableWf->>CLI: node cli.js standing-pr update --reconcile
    CLI->>StandingPR: "options.reconcile = true"

    alt "reconcile = true"
        StandingPR->>StandingPR: log Reconcile mode: bypassing skip-pattern guard
        StandingPR->>StandingPR: skip getHeadCommitMessage / matchesSkipPattern
        StandingPR-->>CLI: proceeds to created / updated / noop
    else "reconcile = false (routine push run)"
        StandingPR->>StandingPR: getHeadCommitMessage()
        alt HEAD matches skip pattern
            StandingPR-->>CLI: action: noop
        else HEAD does not match
            StandingPR-->>CLI: proceeds to created / updated / noop
        end
    end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(release): add --reconcile to bypass ..."](https://github.com/goosewobbler/releasekit/commit/2b51460a8a1ca10d5942cd6cb419f5b76e8fe819) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35616949)</sub>

<!-- /greptile_comment -->