### PR TITLE
feat(publish): bounded auto-retry for transient registry errors

### DIFF
--- a/docs/rust.md
+++ b/docs/rust.md
@@ -245,4 +245,4 @@ crates.io index propagation can take several minutes. If `publish.verify.cargo` 
 
 **Re-running a partially failed release**
 
-If a release run fails mid-way through a multi-crate workspace, re-running is safe. releasekit checks crates.io before each publish via the API, and also catches the `already exists on crates.io index` error from `cargo publish` itself (to handle sparse index lag). Both paths mark the crate as skipped rather than failing the pipeline.
+If a release run fails mid-way through a multi-crate workspace, re-running is safe. releasekit checks crates.io before each publish via the API, and also catches the `already exists on crates.io index` error from `cargo publish` itself (to handle sparse index lag). Both paths mark the crate as skipped rather than failing the pipeline. Transient registry errors (5xx, timeouts, connection resets, rate limits) are auto-retried per crate up to 2 times before the stage fails, so a brief crates.io blip rarely needs a manual re-run.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -141,6 +141,16 @@ Paths are resolved relative to the project root (the directory containing `relea
 
 ## Publish stage
 
+### Transient registry error during publish (auto-retried)
+
+**Symptom:** The publish logs `Transient publish error for <pkg>@<version> (attempt N/3), retrying in <ms>ms` and then either succeeds or, after the attempts are exhausted, fails the stage with the original registry error.
+
+**Cause:** A short-lived registry or network blip — HTTP 5xx, `ETIMEDOUT`, `ECONNRESET`, `EAI_AGAIN`, or a `429` rate-limit response — interrupted the publish.
+
+**Fix:** No action required when it recovers. releasekit auto-retries transient errors per package up to **2 times** (3 attempts total) with exponential backoff before failing. The attempt count is recorded in the per-package publish result. Permanent errors (auth, missing scope/package, validation) are **not** retried and still fail fast. If the retries are exhausted, the final error shown is the real registry error — check the registry status page, then re-run the release. Re-running is safe: a version that already landed is detected and skipped rather than re-published.
+
+---
+
 ### npm publish failed: ENEEDAUTH
 
 **Symptom:** The publish stage fails with `npm publish failed: ENEEDAUTH` or `code ENEEDAUTH`.

--- a/packages/publish/README.md
+++ b/packages/publish/README.md
@@ -62,6 +62,10 @@ The publish pipeline runs in order:
 
 The pipeline is **fail-fast**: the first package publish failure throws immediately. Git push and GitHub release are skipped, so the version commit and tag remain local until the issue is fixed and the release is retried.
 
+### Auto-retry for transient registry errors
+
+Before failing the stage, the npm and cargo publish steps automatically retry **transient** registry errors — HTTP 5xx, timeouts (`ETIMEDOUT`), connection resets (`ECONNRESET`), DNS hiccups (`EAI_AGAIN`), and rate limits (`429`). Each package is retried up to **2 times** (3 attempts total) with exponential backoff. **Permanent** errors — authentication failures, missing scope/package, and validation errors — fail fast with no retries. The attempt count is recorded in the per-package publish result. Re-running a publish that partially landed is safe: the already-published pre-check (and the conflict detection on the publish error itself) resolves it as a skip rather than a duplicate publish, including on a retry attempt.
+
 ## CLI Reference
 
 | Flag | Description | Default |

--- a/packages/publish/src/stages/cargo-publish.ts
+++ b/packages/publish/src/stages/cargo-publish.ts
@@ -113,7 +113,7 @@ export async function runCargoPublishStage(ctx: PipelineContext): Promise<void> 
       // already-published conflict is surfaced as a non-retryable skip below, so a
       // retry of a "publish landed but the response was lost" case resolves as a
       // skip rather than a duplicate publish.
-      const { attempts } = await withPublishRetry(
+      await withPublishRetry(
         () =>
           execCommand('cargo', publishArgs, {
             cwd,
@@ -127,9 +127,13 @@ export async function runCargoPublishStage(ctx: PipelineContext): Promise<void> 
           // Never retry an already-published conflict — it is handled as a skip below.
           shouldRetry: (error) =>
             !ALREADY_PUBLISHED_PATTERN.test(getExecErrorOutput(error)) && classifyPublishError(error) === 'transient',
+          // Recorded via callback (not the return value) so the failure paths
+          // below — including exhaustion — still carry the attempt count.
+          onAttempt: (attempt) => {
+            result.attempts = attempt;
+          },
         },
       );
-      result.attempts = attempts;
       result.success = true;
       if (!dryRun) {
         success(`Published ${crate.name}@${crate.version} to crates.io`);

--- a/packages/publish/src/stages/cargo-publish.ts
+++ b/packages/publish/src/stages/cargo-publish.ts
@@ -6,8 +6,12 @@ import type { PipelineContext, PublishResult } from '../types.js';
 import { hasCargoAuth } from '../utils/auth.js';
 import { CRATES_IO_API_TIMEOUT_MS, CRATES_IO_USER_AGENT, extractPathDeps, parseCargoToml } from '../utils/cargo.js';
 import { execCommand, execCommandSafe, getExecErrorOutput } from '../utils/exec.js';
+import { classifyPublishError, withPublishRetry } from '../utils/publish-retry.js';
 
 const ALREADY_PUBLISHED_PATTERN = /already exists on crates\.io index|already uploaded/i;
+
+/** Bounded auto-retry for transient registry blips: initial attempt + 2 retries. */
+const PUBLISH_RETRY = { maxAttempts: 3, initialDelay: 1000 } as const;
 
 async function isCratePublished(name: string, version: string): Promise<boolean> {
   try {
@@ -104,12 +108,28 @@ export async function runCargoPublishStage(ctx: PipelineContext): Promise<void> 
     }
 
     try {
-      await execCommand('cargo', publishArgs, {
-        cwd,
-        dryRun,
-        label: `cargo publish ${crate.name}@${crate.version}`,
-        timeout: 30 * 60 * 1000, // 30 minutes timeout
-      });
+      // Transient registry errors (5xx, timeouts, rate limits) are retried with
+      // backoff; permanent errors (auth, validation) fail fast. The
+      // already-published conflict is surfaced as a non-retryable skip below, so a
+      // retry of a "publish landed but the response was lost" case resolves as a
+      // skip rather than a duplicate publish.
+      const { attempts } = await withPublishRetry(
+        () =>
+          execCommand('cargo', publishArgs, {
+            cwd,
+            dryRun,
+            label: `cargo publish ${crate.name}@${crate.version}`,
+            timeout: 30 * 60 * 1000, // 30 minutes timeout
+          }),
+        {
+          ...PUBLISH_RETRY,
+          label: `${crate.name}@${crate.version}`,
+          // Never retry an already-published conflict — it is handled as a skip below.
+          shouldRetry: (error) =>
+            !ALREADY_PUBLISHED_PATTERN.test(getExecErrorOutput(error)) && classifyPublishError(error) === 'transient',
+        },
+      );
+      result.attempts = attempts;
       result.success = true;
       if (!dryRun) {
         success(`Published ${crate.name}@${crate.version} to crates.io`);

--- a/packages/publish/src/stages/npm-publish.ts
+++ b/packages/publish/src/stages/npm-publish.ts
@@ -141,7 +141,7 @@ export async function runNpmPublishStage(ctx: PipelineContext): Promise<void> {
         // already-published conflict is detected inside the retried function and
         // surfaced as a non-retryable skip, so a retry of a "publish landed but the
         // response was lost" case resolves as a skip rather than a duplicate publish.
-        const { attempts } = await withPublishRetry(
+        await withPublishRetry(
           async () => {
             const publishResult = await execCommand(pubFile, pubArgs, {
               cwd: pkgDir, // Always publish from the package directory for reliability
@@ -160,10 +160,14 @@ export async function runNpmPublishStage(ctx: PipelineContext): Promise<void> {
             // Never retry an already-published conflict — it is handled as a skip below.
             shouldRetry: (error) =>
               !ALREADY_PUBLISHED_PATTERN.test(getExecErrorOutput(error)) && classifyPublishError(error) === 'transient',
+            // Recorded via callback (not the return value) so the failure paths
+            // below — including exhaustion — still carry the attempt count.
+            onAttempt: (attempt) => {
+              result.attempts = attempt;
+            },
           },
         );
 
-        result.attempts = attempts;
         result.success = true;
         if (!dryRun) {
           success(`Published ${update.packageName}@${update.newVersion} to npm`);

--- a/packages/publish/src/stages/npm-publish.ts
+++ b/packages/publish/src/stages/npm-publish.ts
@@ -7,9 +7,13 @@ import { detectNpmAuth } from '../utils/auth.js';
 import { execCommand, execCommandSafe, getExecErrorOutput } from '../utils/exec.js';
 import { createNpmSubprocessIsolation } from '../utils/npm-env.js';
 import { buildPublishCommand, buildViewCommand } from '../utils/package-manager.js';
+import { classifyPublishError, withPublishRetry } from '../utils/publish-retry.js';
 import { getDistTag } from '../utils/semver.js';
 
 const ALREADY_PUBLISHED_PATTERN = /EPUBLISHCONFLICT|cannot publish over (?:the )?previously published versions?/i;
+
+/** Bounded auto-retry for transient registry blips: initial attempt + 2 retries. */
+const PUBLISH_RETRY = { maxAttempts: 3, initialDelay: 1000 } as const;
 
 /** Error strategy: FAIL-FAST. First publish failure aborts the stage. */
 export async function runNpmPublishStage(ctx: PipelineContext): Promise<void> {
@@ -111,38 +115,55 @@ export async function runNpmPublishStage(ctx: PipelineContext): Promise<void> {
       debug(`Publish command: ${pubFile} ${pubArgs.join(' ')}`);
       debug(`Working directory: ${pkgDir}`);
 
+      // Debug: Check if dist directory exists before publishing
+      const distExists = fs.existsSync(path.join(pkgDir, 'dist'));
+      debug(`Publishing ${update.packageName}@${update.newVersion} from ${pkgDir}`);
+      debug(`Dist directory exists: ${distExists}`);
+      if (distExists) {
+        const distContents = fs.readdirSync(path.join(pkgDir, 'dist'));
+        debug(`Dist directory contents: ${distContents.join(', ')}`);
+      }
+
+      // Check package manager version
       try {
-        // Debug: Check if dist directory exists before publishing
-        const distExists = fs.existsSync(path.join(pkgDir, 'dist'));
-        debug(`Publishing ${update.packageName}@${update.newVersion} from ${pkgDir}`);
-        debug(`Dist directory exists: ${distExists}`);
-        if (distExists) {
-          const distContents = fs.readdirSync(path.join(pkgDir, 'dist'));
-          debug(`Dist directory contents: ${distContents.join(', ')}`);
-        }
-
-        // Check package manager version
-        try {
-          const versionResult = await execCommand(ctx.packageManager, ['--version'], {
-            cwd,
-            dryRun: false,
-          });
-          debug(`Package manager version (${ctx.packageManager}): ${versionResult.stdout.trim()}`);
-        } catch (error) {
-          debug(`Failed to get package manager version: ${error}`);
-        }
-
-        const publishResult = await execCommand(pubFile, pubArgs, {
-          cwd: pkgDir, // Always publish from the package directory for reliability
-          dryRun,
-          label: `npm publish ${update.packageName}@${update.newVersion}`,
-          env: npmIsolation.env,
+        const versionResult = await execCommand(ctx.packageManager, ['--version'], {
+          cwd,
+          dryRun: false,
         });
+        debug(`Package manager version (${ctx.packageManager}): ${versionResult.stdout.trim()}`);
+      } catch (error) {
+        debug(`Failed to get package manager version: ${error}`);
+      }
 
-        debug(`Publish command completed successfully`);
-        if (publishResult.stdout) debug(`Publish stdout: ${publishResult.stdout}`);
-        if (publishResult.stderr) debug(`Publish stderr: ${publishResult.stderr}`);
+      try {
+        // Transient registry errors (5xx, timeouts, rate limits) are retried with
+        // backoff; permanent errors (auth, validation) fail fast. The
+        // already-published conflict is detected inside the retried function and
+        // surfaced as a non-retryable skip, so a retry of a "publish landed but the
+        // response was lost" case resolves as a skip rather than a duplicate publish.
+        const { attempts } = await withPublishRetry(
+          async () => {
+            const publishResult = await execCommand(pubFile, pubArgs, {
+              cwd: pkgDir, // Always publish from the package directory for reliability
+              dryRun,
+              label: `npm publish ${update.packageName}@${update.newVersion}`,
+              env: npmIsolation.env,
+            });
 
+            debug(`Publish command completed successfully`);
+            if (publishResult.stdout) debug(`Publish stdout: ${publishResult.stdout}`);
+            if (publishResult.stderr) debug(`Publish stderr: ${publishResult.stderr}`);
+          },
+          {
+            ...PUBLISH_RETRY,
+            label: `${update.packageName}@${update.newVersion}`,
+            // Never retry an already-published conflict — it is handled as a skip below.
+            shouldRetry: (error) =>
+              !ALREADY_PUBLISHED_PATTERN.test(getExecErrorOutput(error)) && classifyPublishError(error) === 'transient',
+          },
+        );
+
+        result.attempts = attempts;
         result.success = true;
         if (!dryRun) {
           success(`Published ${update.packageName}@${update.newVersion} to npm`);
@@ -152,7 +173,8 @@ export async function runNpmPublishStage(ctx: PipelineContext): Promise<void> {
         debug(`Publish command failed: ${error}`);
         // If `npm view` and `npm publish` disagreed (rare — usually a transient view
         // failure), treat the conflict as already-published so re-runs of a partially
-        // failed release are idempotent.
+        // failed release are idempotent. This also covers the case where a retried
+        // publish lands but the registry response was lost on the first attempt.
         if (ALREADY_PUBLISHED_PATTERN.test(getExecErrorOutput(error))) {
           result.alreadyPublished = true;
           result.skipped = true;

--- a/packages/publish/src/types.ts
+++ b/packages/publish/src/types.ts
@@ -88,6 +88,13 @@ export interface PublishResult {
   skipped: boolean;
   reason?: string;
   alreadyPublished?: boolean;
+  /**
+   * Number of publish attempts made for this package (1 = succeeded first try,
+   * >1 = transient errors were retried). Recorded so the failure report can
+   * surface retry activity. Absent for packages that were never attempted
+   * (e.g. private/already-published skips).
+   */
+  attempts?: number;
 }
 
 export interface VerificationResult {

--- a/packages/publish/src/utils/publish-retry.ts
+++ b/packages/publish/src/utils/publish-retry.ts
@@ -18,7 +18,9 @@ const PERMANENT_PATTERNS: RegExp[] = [
   /unauthorized|forbidden|authentication failed|not authorized/i,
   /\bE404\b|\b404\b|not found/i, // missing package/scope
   /you do not have permission|requires you to be logged in/i,
-  /invalid|validation|malformed|missing required|illegal|ERR! code E\d{3}.*invalid/i,
+  // A bare `invalid` would also match transient socket errors like
+  // "read ECONNRESET, invalid argument" — require a validation-context noun.
+  /\binvalid\b.*(?:package|tag|name|token|scope|field|format|version|semver)|validation|malformed|missing required|illegal|ERR! code E\d{3}.*invalid/i,
 ];
 
 // Transient failures: worth retrying once the registry recovers.
@@ -67,6 +69,12 @@ export interface PublishRetryOptions {
   shouldRetry?: (error: unknown) => boolean;
   /** Label for the package/operation, used in retry log lines. */
   label?: string;
+  /**
+   * Called at the start of every attempt with the attempt number. The thrown
+   * error carries no attempt count, so callers use this to record attempts on
+   * the per-package result even when all attempts fail.
+   */
+  onAttempt?: (attempt: number) => void;
 }
 
 export interface PublishRetryResult<T> {
@@ -99,6 +107,7 @@ export async function withPublishRetry<T>(
   let delay = options.initialDelay;
 
   for (let attempt = 1; attempt <= options.maxAttempts; attempt++) {
+    options.onAttempt?.(attempt);
     try {
       const value = await fn();
       return { value, attempts: attempt };

--- a/packages/publish/src/utils/publish-retry.ts
+++ b/packages/publish/src/utils/publish-retry.ts
@@ -1,0 +1,122 @@
+import { debug, warn } from '@releasekit/core';
+import { getExecErrorOutput } from './exec.js';
+
+/**
+ * Classification of a registry publish failure.
+ *
+ * - `transient`: a short-lived registry/network blip (5xx, timeout, connection
+ *   reset, DNS hiccup, rate limit) that is likely to succeed if retried.
+ * - `permanent`: a deterministic failure (auth, missing scope/package,
+ *   validation) that will not change on retry, so we fail fast.
+ */
+export type PublishErrorClass = 'transient' | 'permanent';
+
+// Permanent failures: deterministic, retrying will not help. Checked first so an
+// auth/validation error is never misread as transient.
+const PERMANENT_PATTERNS: RegExp[] = [
+  /\bE401\b|\bE403\b|ENEEDAUTH|\b401\b|\b403\b/i, // auth / forbidden
+  /unauthorized|forbidden|authentication failed|not authorized/i,
+  /\bE404\b|\b404\b|not found/i, // missing package/scope
+  /you do not have permission|requires you to be logged in/i,
+  /invalid|validation|malformed|missing required|illegal|ERR! code E\d{3}.*invalid/i,
+];
+
+// Transient failures: worth retrying once the registry recovers.
+const TRANSIENT_PATTERNS: RegExp[] = [
+  /ETIMEDOUT|ECONNRESET|ECONNREFUSED|EAI_AGAIN|ENOTFOUND|EPIPE|ESOCKETTIMEDOUT/i, // network
+  /socket hang up|network timeout|timed out|connection (?:reset|refused|closed)/i,
+  /\b5\d{2}\b/, // HTTP 5xx
+  /internal server error|bad gateway|service unavailable|gateway timeout/i,
+  /\b429\b|too many requests|rate ?limit/i, // rate limiting
+];
+
+/**
+ * Classify a publish failure as transient (retryable) or permanent (fail-fast).
+ *
+ * Permanent patterns are matched first so an auth or validation error that also
+ * happens to mention a status code is never treated as transient. Anything we
+ * cannot positively identify as transient is treated as permanent, preserving
+ * today's fail-fast default for unknown errors.
+ */
+export function classifyPublishError(error: unknown): PublishErrorClass {
+  const output = getExecErrorOutput(error);
+
+  for (const pattern of PERMANENT_PATTERNS) {
+    if (pattern.test(output)) return 'permanent';
+  }
+
+  for (const pattern of TRANSIENT_PATTERNS) {
+    if (pattern.test(output)) return 'transient';
+  }
+
+  return 'permanent';
+}
+
+export interface PublishRetryOptions {
+  /** Total attempts including the first try (e.g. 3 = initial + 2 retries). */
+  maxAttempts: number;
+  /** Base backoff delay in ms; doubled each retry. */
+  initialDelay: number;
+  /** Sleep implementation, injectable so tests don't actually wait. */
+  sleep?: (ms: number) => Promise<void>;
+  /**
+   * Decide whether to keep retrying a given error. Defaults to retrying only
+   * transient failures. Callers can wrap this to short-circuit on outcomes that
+   * should not be retried (e.g. an already-published conflict resolved as skip).
+   */
+  shouldRetry?: (error: unknown) => boolean;
+  /** Label for the package/operation, used in retry log lines. */
+  label?: string;
+}
+
+export interface PublishRetryResult<T> {
+  value: T;
+  /** Number of attempts made before success (1 = succeeded first try). */
+  attempts: number;
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Run a registry publish operation with bounded auto-retry for transient
+ * failures. Transient errors (5xx, timeouts, connection resets, rate limits)
+ * are retried with exponential backoff up to `maxAttempts`; permanent errors
+ * (auth, missing scope/package, validation) throw immediately with zero retries.
+ *
+ * On success it returns the operation result plus the attempt count so the
+ * caller can record it in the per-package publish result. When attempts are
+ * exhausted the final (real) error is rethrown.
+ */
+export async function withPublishRetry<T>(
+  fn: () => Promise<T>,
+  options: PublishRetryOptions,
+): Promise<PublishRetryResult<T>> {
+  const sleep = options.sleep ?? defaultSleep;
+  const shouldRetry = options.shouldRetry ?? ((error) => classifyPublishError(error) === 'transient');
+  const labelSuffix = options.label ? ` for ${options.label}` : '';
+  let delay = options.initialDelay;
+
+  for (let attempt = 1; attempt <= options.maxAttempts; attempt++) {
+    try {
+      const value = await fn();
+      return { value, attempts: attempt };
+    } catch (error) {
+      const isLastAttempt = attempt >= options.maxAttempts;
+
+      if (isLastAttempt || !shouldRetry(error)) {
+        throw error;
+      }
+
+      const reason = error instanceof Error ? error.message : String(error);
+      warn(`Transient publish error${labelSuffix} (attempt ${attempt}/${options.maxAttempts}), retrying in ${delay}ms`);
+      debug(`Retry reason${labelSuffix}: ${reason}`);
+      await sleep(delay);
+      delay *= 2;
+    }
+  }
+
+  // Unreachable: the loop either returns on success or throws on the last attempt.
+  throw new Error('withPublishRetry: exhausted attempts without throwing');
+}

--- a/packages/publish/test/unit/stages/cargo-publish.spec.ts
+++ b/packages/publish/test/unit/stages/cargo-publish.spec.ts
@@ -186,6 +186,111 @@ describe('cargo-publish stage', () => {
     await expect(runCargoPublishStage(ctx)).rejects.toThrow();
   });
 
+  it('should fail fast (zero retries) on an unrelated cargo publish failure', async () => {
+    const { execCommand } = await import('../../../src/utils/exec.js');
+    let publishCalls = 0;
+    vi.mocked(execCommand).mockImplementation(async (cmd, args) => {
+      if (cmd === 'cargo' && (args as string[])[0] === 'publish') {
+        publishCalls++;
+        throw Object.assign(new Error('Command failed: cargo publish ...'), {
+          stdout: '',
+          stderr: 'error: failed to verify package tarball',
+          exitCode: 101,
+        });
+      }
+      return { stdout: '', stderr: '', exitCode: 0 };
+    });
+
+    const dir = createTmpDir();
+    const crateDir = path.join(dir, 'crates', 'my-crate');
+    fs.mkdirSync(crateDir, { recursive: true });
+    fs.writeFileSync(path.join(crateDir, 'Cargo.toml'), '[package]\nname = "my-crate"\nversion = "0.5.0"\n');
+
+    const ctx = createContext(dir);
+    await expect(runCargoPublishStage(ctx)).rejects.toThrow();
+    expect(publishCalls).toBe(1); // permanent error, no retries
+  });
+
+  it('should retry a transient cargo publish error and succeed, recording attempts', async () => {
+    vi.useFakeTimers();
+    try {
+      const { execCommand } = await import('../../../src/utils/exec.js');
+      let publishCalls = 0;
+      vi.mocked(execCommand).mockImplementation(async (cmd, args) => {
+        if (cmd === 'cargo' && (args as string[])[0] === 'publish') {
+          publishCalls++;
+          if (publishCalls === 1) {
+            throw Object.assign(new Error('Command failed: cargo publish ...'), {
+              stdout: '',
+              stderr: 'error: failed to get a 200 OK response, got 503 Service Unavailable',
+              exitCode: 101,
+            });
+          }
+        }
+        return { stdout: '', stderr: '', exitCode: 0 };
+      });
+
+      const dir = createTmpDir();
+      const crateDir = path.join(dir, 'crates', 'my-crate');
+      fs.mkdirSync(crateDir, { recursive: true });
+      fs.writeFileSync(path.join(crateDir, 'Cargo.toml'), '[package]\nname = "my-crate"\nversion = "0.5.0"\n');
+
+      const ctx = createContext(dir);
+      const promise = runCargoPublishStage(ctx);
+      await vi.runAllTimersAsync();
+      await promise;
+
+      expect(publishCalls).toBe(2);
+      expect(ctx.output.cargo[0]?.success).toBe(true);
+      expect(ctx.output.cargo[0]?.attempts).toBe(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('should resolve a retried cargo publish as already-published (no duplicate)', async () => {
+    vi.useFakeTimers();
+    try {
+      const { execCommand } = await import('../../../src/utils/exec.js');
+      let publishCalls = 0;
+      vi.mocked(execCommand).mockImplementation(async (cmd, args) => {
+        if (cmd === 'cargo' && (args as string[])[0] === 'publish') {
+          publishCalls++;
+          if (publishCalls === 1) {
+            throw Object.assign(new Error('Command failed: cargo publish ...'), {
+              stdout: '',
+              stderr: 'error: failed to get a 200 OK response, got 503 Service Unavailable',
+              exitCode: 101,
+            });
+          }
+          throw Object.assign(new Error('Command failed: cargo publish ...'), {
+            stdout: '',
+            stderr: 'error: crate my-crate@0.5.0 already exists on crates.io index',
+            exitCode: 101,
+          });
+        }
+        return { stdout: '', stderr: '', exitCode: 0 };
+      });
+
+      const dir = createTmpDir();
+      const crateDir = path.join(dir, 'crates', 'my-crate');
+      fs.mkdirSync(crateDir, { recursive: true });
+      fs.writeFileSync(path.join(crateDir, 'Cargo.toml'), '[package]\nname = "my-crate"\nversion = "0.5.0"\n');
+
+      const ctx = createContext(dir);
+      const promise = runCargoPublishStage(ctx);
+      await vi.runAllTimersAsync();
+      await expect(promise).resolves.toBeUndefined();
+
+      expect(publishCalls).toBe(2); // already-exists is not retried further
+      expect(ctx.output.cargo[0]?.alreadyPublished).toBe(true);
+      expect(ctx.output.cargo[0]?.skipped).toBe(true);
+      expect(ctx.output.cargo[0]?.success).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('should pass --no-verify when configured', async () => {
     const { execCommand } = await import('../../../src/utils/exec.js');
     const dir = createTmpDir();

--- a/packages/publish/test/unit/stages/npm-publish.spec.ts
+++ b/packages/publish/test/unit/stages/npm-publish.spec.ts
@@ -375,6 +375,8 @@ describe('npm-publish stage', () => {
       expect(String(error)).toContain('503');
       expect(publishCalls).toBe(3); // initial + 2 retries
       expect(ctx.output.npm[0]?.success).toBe(false);
+      // The failed result still records how many attempts were made.
+      expect(ctx.output.npm[0]?.attempts).toBe(3);
     } finally {
       vi.useRealTimers();
     }

--- a/packages/publish/test/unit/stages/npm-publish.spec.ts
+++ b/packages/publish/test/unit/stages/npm-publish.spec.ts
@@ -281,6 +281,151 @@ describe('npm-publish stage', () => {
     expect(ctx.output.npm[0]?.success).toBe(false);
   });
 
+  it('should fail fast (zero retries) on a permanent auth error', async () => {
+    const { execCommand } = await import('../../../src/utils/exec.js');
+    let publishCalls = 0;
+    vi.mocked(execCommand).mockImplementation(async (_file, args) => {
+      if ((args as string[])?.includes('publish')) {
+        publishCalls++;
+        throw Object.assign(new Error('Command failed'), {
+          stdout: '',
+          stderr: 'npm ERR! code ENEEDAUTH\nnpm ERR! 401 Unauthorized',
+          exitCode: 1,
+        });
+      }
+      return { stdout: '', stderr: '', exitCode: 0 };
+    });
+
+    const dir = createTmpDir();
+    const pkgDir = path.join(dir, 'packages', 'pkg');
+    fs.mkdirSync(pkgDir, { recursive: true });
+    fs.writeFileSync(path.join(pkgDir, 'package.json'), JSON.stringify({ name: '@test/pkg', version: '1.0.0' }));
+
+    const ctx = createContext(dir);
+    await expect(runNpmPublishStage(ctx)).rejects.toThrow();
+    expect(publishCalls).toBe(1); // no retries
+    expect(ctx.output.npm[0]?.success).toBe(false);
+  });
+
+  it('should retry a transient registry error and succeed, recording attempts', async () => {
+    vi.useFakeTimers();
+    try {
+      const { execCommand } = await import('../../../src/utils/exec.js');
+      let publishCalls = 0;
+      vi.mocked(execCommand).mockImplementation(async (_file, args) => {
+        if ((args as string[])?.includes('publish')) {
+          publishCalls++;
+          if (publishCalls === 1) {
+            throw Object.assign(new Error('Command failed'), {
+              stdout: '',
+              stderr: 'npm ERR! 503 Service Unavailable',
+              exitCode: 1,
+            });
+          }
+        }
+        return { stdout: '', stderr: '', exitCode: 0 };
+      });
+
+      const dir = createTmpDir();
+      const pkgDir = path.join(dir, 'packages', 'pkg');
+      fs.mkdirSync(pkgDir, { recursive: true });
+      fs.writeFileSync(path.join(pkgDir, 'package.json'), JSON.stringify({ name: '@test/pkg', version: '1.0.0' }));
+
+      const ctx = createContext(dir);
+      const promise = runNpmPublishStage(ctx);
+      await vi.runAllTimersAsync();
+      await promise;
+
+      expect(publishCalls).toBe(2); // one failure + one success
+      expect(ctx.output.npm[0]?.success).toBe(true);
+      expect(ctx.output.npm[0]?.attempts).toBe(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('should exhaust retries on a persistent transient error and throw the real error', async () => {
+    vi.useFakeTimers();
+    try {
+      const { execCommand } = await import('../../../src/utils/exec.js');
+      let publishCalls = 0;
+      vi.mocked(execCommand).mockImplementation(async (_file, args) => {
+        if ((args as string[])?.includes('publish')) {
+          publishCalls++;
+          throw Object.assign(new Error('npm ERR! 503 Service Unavailable'), {
+            stdout: '',
+            stderr: 'npm ERR! 503 Service Unavailable',
+            exitCode: 1,
+          });
+        }
+        return { stdout: '', stderr: '', exitCode: 0 };
+      });
+
+      const dir = createTmpDir();
+      const pkgDir = path.join(dir, 'packages', 'pkg');
+      fs.mkdirSync(pkgDir, { recursive: true });
+      fs.writeFileSync(path.join(pkgDir, 'package.json'), JSON.stringify({ name: '@test/pkg', version: '1.0.0' }));
+
+      const ctx = createContext(dir);
+      const promise = runNpmPublishStage(ctx).catch((e) => e);
+      await vi.runAllTimersAsync();
+      const error = await promise;
+
+      // The final (real) error is surfaced, not a synthetic one.
+      expect(String(error)).toContain('503');
+      expect(publishCalls).toBe(3); // initial + 2 retries
+      expect(ctx.output.npm[0]?.success).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('should resolve a retried publish as already-published when the conflict surfaces (no duplicate)', async () => {
+    vi.useFakeTimers();
+    try {
+      const { execCommand } = await import('../../../src/utils/exec.js');
+      let publishCalls = 0;
+      vi.mocked(execCommand).mockImplementation(async (_file, args) => {
+        if ((args as string[])?.includes('publish')) {
+          publishCalls++;
+          if (publishCalls === 1) {
+            // First attempt: transient blip after the publish may have landed.
+            throw Object.assign(new Error('Command failed'), {
+              stdout: '',
+              stderr: 'npm ERR! 503 Service Unavailable',
+              exitCode: 1,
+            });
+          }
+          // Retry sees the version is now present.
+          throw Object.assign(new Error('Command failed'), {
+            stdout: '',
+            stderr:
+              'npm ERR! code EPUBLISHCONFLICT\nnpm ERR! 403 You cannot publish over the previously published versions: 1.0.0.',
+            exitCode: 1,
+          });
+        }
+        return { stdout: '', stderr: '', exitCode: 0 };
+      });
+
+      const dir = createTmpDir();
+      const pkgDir = path.join(dir, 'packages', 'pkg');
+      fs.mkdirSync(pkgDir, { recursive: true });
+      fs.writeFileSync(path.join(pkgDir, 'package.json'), JSON.stringify({ name: '@test/pkg', version: '1.0.0' }));
+
+      const ctx = createContext(dir);
+      const promise = runNpmPublishStage(ctx);
+      await vi.runAllTimersAsync();
+      await expect(promise).resolves.toBeUndefined();
+
+      expect(publishCalls).toBe(2); // EPUBLISHCONFLICT is not retried further
+      expect(ctx.output.npm[0]?.alreadyPublished).toBe(true);
+      expect(ctx.output.npm[0]?.skipped).toBe(true);
+      expect(ctx.output.npm[0]?.success).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('should skip when npm disabled', async () => {
     const { execCommand } = await import('../../../src/utils/exec.js');
     const config = getDefaultConfig();

--- a/packages/publish/test/unit/utils/publish-retry.spec.ts
+++ b/packages/publish/test/unit/utils/publish-retry.spec.ts
@@ -52,6 +52,18 @@ describe('classifyPublishError', () => {
       // 403 is a status code, but auth failures must not be retried.
       expect(classifyPublishError(new Error('npm ERR! 403 Forbidden - authentication failed'))).toBe('permanent');
     });
+
+    it('does not treat "invalid" inside raw socket errors as permanent', () => {
+      // Node can phrase transient socket failures with the word "invalid" —
+      // these must remain transient or retries would be suppressed.
+      expect(classifyPublishError(new Error('read ECONNRESET, invalid argument'))).toBe('transient');
+      expect(classifyPublishError(new Error('write EPIPE, invalid argument'))).toBe('transient');
+    });
+
+    it('still classifies validation-context "invalid" messages as permanent', () => {
+      expect(classifyPublishError(new Error('npm ERR! Invalid tag name "latest@"'))).toBe('permanent');
+      expect(classifyPublishError(new Error('Invalid version: "1.0.0.0" is not valid semver'))).toBe('permanent');
+    });
   });
 });
 
@@ -99,6 +111,16 @@ describe('withPublishRetry', () => {
 
     expect(fn).toHaveBeenCalledTimes(1);
     expect(noSleep).not.toHaveBeenCalled();
+  });
+
+  it('reports every attempt via onAttempt, including when all attempts fail', async () => {
+    const fn = vi.fn().mockRejectedValue(new Error('ETIMEDOUT'));
+    const onAttempt = vi.fn();
+
+    await expect(withPublishRetry(fn, { ...opts, onAttempt })).rejects.toThrow('ETIMEDOUT');
+
+    // The thrown error carries no count — onAttempt is how callers record it.
+    expect(onAttempt.mock.calls.map(([n]) => n)).toEqual([1, 2, 3]);
   });
 
   it('uses exponential backoff between retries', async () => {

--- a/packages/publish/test/unit/utils/publish-retry.spec.ts
+++ b/packages/publish/test/unit/utils/publish-retry.spec.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { classifyPublishError, withPublishRetry } from '../../../src/utils/publish-retry.js';
+
+describe('classifyPublishError', () => {
+  describe('transient errors', () => {
+    const transient: Array<[string, string]> = [
+      ['HTTP 500', 'npm ERR! 500 Internal Server Error - PUT https://registry.npmjs.org/pkg'],
+      ['HTTP 502', 'received 502 Bad Gateway from registry'],
+      ['HTTP 503', '503 Service Unavailable'],
+      ['HTTP 504', 'Gateway Timeout (504)'],
+      ['ETIMEDOUT', 'npm ERR! network request to https://registry.npmjs.org failed, reason: ETIMEDOUT'],
+      ['ECONNRESET', 'Error: socket hang up\ncode ECONNRESET'],
+      ['EAI_AGAIN', 'getaddrinfo EAI_AGAIN registry.npmjs.org'],
+      ['rate limit 429', 'npm ERR! 429 Too Many Requests'],
+      ['rate limit text', 'error: rate limit exceeded, please slow down'],
+      ['socket hang up', 'request to crates.io failed: socket hang up'],
+    ];
+
+    it.each(transient)('classifies %s as transient', (_label, message) => {
+      expect(classifyPublishError(new Error(message))).toBe('transient');
+    });
+
+    it('reads stdout/stderr from exec-style errors', () => {
+      const error = Object.assign(new Error('Command failed: npm publish'), {
+        stdout: '',
+        stderr: 'npm ERR! 503 Service Unavailable',
+        exitCode: 1,
+      });
+      expect(classifyPublishError(error)).toBe('transient');
+    });
+  });
+
+  describe('permanent errors', () => {
+    const permanent: Array<[string, string]> = [
+      ['ENEEDAUTH', 'npm ERR! code ENEEDAUTH\nThis command requires you to be logged in'],
+      ['E401', 'npm ERR! code E401\nnpm ERR! 401 Unauthorized'],
+      ['E403', 'npm ERR! code E403\nyou do not have permission to publish'],
+      ['E404 missing', 'npm ERR! 404 Not Found - GET https://registry.npmjs.org/@scope%2fpkg'],
+      ['cargo auth', 'error: failed to get a 200 OK response, got 403 Forbidden'],
+      ['validation', 'npm ERR! Invalid package name'],
+    ];
+
+    it.each(permanent)('classifies %s as permanent', (_label, message) => {
+      expect(classifyPublishError(new Error(message))).toBe('permanent');
+    });
+
+    it('treats unknown errors as permanent (fail-fast default)', () => {
+      expect(classifyPublishError(new Error('failed to verify package tarball'))).toBe('permanent');
+    });
+
+    it('prefers permanent when an auth error also mentions a status code', () => {
+      // 403 is a status code, but auth failures must not be retried.
+      expect(classifyPublishError(new Error('npm ERR! 403 Forbidden - authentication failed'))).toBe('permanent');
+    });
+  });
+});
+
+describe('withPublishRetry', () => {
+  const noSleep = vi.fn().mockResolvedValue(undefined);
+  const opts = { maxAttempts: 3, initialDelay: 1000, sleep: noSleep };
+
+  beforeEach(() => {
+    noSleep.mockClear();
+  });
+
+  it('returns the result and attempts=1 on first success', async () => {
+    const fn = vi.fn().mockResolvedValue('ok');
+
+    const result = await withPublishRetry(fn, opts);
+
+    expect(result).toEqual({ value: 'ok', attempts: 1 });
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(noSleep).not.toHaveBeenCalled();
+  });
+
+  it('retries a transient failure and succeeds, reporting attempt count', async () => {
+    const fn = vi.fn().mockRejectedValueOnce(new Error('503 Service Unavailable')).mockResolvedValue('recovered');
+
+    const result = await withPublishRetry(fn, opts);
+
+    expect(result).toEqual({ value: 'recovered', attempts: 2 });
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('exhausts retries on persistent transient failure and rethrows the real error', async () => {
+    const realError = new Error('ETIMEDOUT');
+    const fn = vi.fn().mockRejectedValue(realError);
+
+    await expect(withPublishRetry(fn, opts)).rejects.toThrow('ETIMEDOUT');
+    await expect(withPublishRetry(fn, opts)).rejects.toBe(realError);
+    // 3 attempts per call, 2 calls.
+    expect(fn).toHaveBeenCalledTimes(6);
+  });
+
+  it('does not retry a permanent failure (fail-fast, zero retries)', async () => {
+    const fn = vi.fn().mockRejectedValue(new Error('npm ERR! code ENEEDAUTH'));
+
+    await expect(withPublishRetry(fn, opts)).rejects.toThrow('ENEEDAUTH');
+
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(noSleep).not.toHaveBeenCalled();
+  });
+
+  it('uses exponential backoff between retries', async () => {
+    const sleep = vi.fn().mockResolvedValue(undefined);
+    const fn = vi.fn().mockRejectedValue(new Error('ECONNRESET'));
+
+    await expect(withPublishRetry(fn, { maxAttempts: 3, initialDelay: 1000, sleep })).rejects.toThrow('ECONNRESET');
+
+    // Two backoffs between three attempts: 1000ms then 2000ms.
+    expect(sleep.mock.calls).toEqual([[1000], [2000]]);
+  });
+
+  it('honours a custom shouldRetry predicate', async () => {
+    const fn = vi.fn().mockRejectedValue(new Error('503 Service Unavailable'));
+    const shouldRetry = vi.fn().mockReturnValue(false);
+
+    await expect(
+      withPublishRetry(fn, { maxAttempts: 3, initialDelay: 1, sleep: noSleep, shouldRetry }),
+    ).rejects.toThrow('503');
+
+    // Transient by classification, but the predicate vetoes the retry.
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(shouldRetry).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Problem

Most publish failures are transient — registry 5xx, timeouts, connection resets, rate limits. The npm/cargo stages failed fast on the first error, turning a retryable blip into a human-intervention event.

## Design

New shared utility `publish-retry.ts` in `@releasekit/publish`:

- `classifyPublishError(error)` → `transient | permanent`. Permanent patterns checked **first**, so an auth error mentioning a status code is never misread as transient. Transient = HTTP 5xx, `ETIMEDOUT`/`ECONNRESET`/`ECONNREFUSED`/`EAI_AGAIN`/socket hang-up, 429/rate-limit. Anything not positively transient is permanent — fail-fast preserved for unknowns.
- `withPublishRetry(fn, opts)` → bounded retry loop (3 attempts total, exponential backoff, injectable sleep for tests), logs each retry, returns the attempt count.

Wired into both `npm-publish` and `cargo-publish` stages. The `shouldRetry` predicate excludes already-published conflict patterns, so a "publish landed but the response was lost" retry resolves as a **skip, not a duplicate publish**. `PublishResult` gains an optional `attempts` field (recorded for #243's failure report to surface).

Kept separate from the existing config-driven `withRetry` used by the verify stage — the publish transient/permanent semantics shouldn't couple into the generic retry.

## Tests

- Classification table + retry-loop behavior (backoff sequence, `shouldRetry` veto)
- Stage-level: transient retry-then-succeed (asserts `attempts`), exhaustion surfaces the real error, permanent error zero-retry, already-published-on-retry resolves as skip — fake timers throughout

Full `pnpm turbo run lint typecheck test`: 24/24 tasks pass.

Docs: publish README retry subsection, troubleshooting entry, note in rust.md.

Closes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces bounded auto-retry for transient registry errors in both the npm and cargo publish stages. A shared `publish-retry.ts` utility provides `classifyPublishError` (permanent-first pattern matching) and `withPublishRetry` (exponential backoff, injectable sleep, `onAttempt` callback so exhausted-retry paths still record attempt counts).

- **New utility** `packages/publish/src/utils/publish-retry.ts`: classifies errors as `transient` or `permanent` and wraps the publish operation with up to 3 attempts (initial + 2 retries) and exponential backoff.
- **Both stage files** (`npm-publish.ts`, `cargo-publish.ts`) now call `withPublishRetry`, with a `shouldRetry` predicate that vetoes already-published conflict errors so they fall through to the existing skip logic — preventing duplicate publishes on retry.
- **`PublishResult`** gains an optional `attempts` field populated via the `onAttempt` callback on every attempt, including failed exhaustion paths.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the retry logic is well-bounded, the permanent-first classification prevents retrying auth/validation failures, and the already-published veto in shouldRetry ensures idempotency on duplicate-publish scenarios.

The implementation is thorough: permanent patterns are checked before transient ones, the onAttempt callback ensures attempt counts are recorded even when all retries are exhausted, and the already-published conflict is correctly wired to the existing skip handler via a shouldRetry veto. Previous review concerns about the invalid broad-match and lost attempt counts on failure paths have both been addressed. Stage-level tests cover the critical paths with fake timers throughout.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/publish/src/utils/publish-retry.ts | New shared retry utility: permanent-first classification, bounded exponential backoff, onAttempt callback ensures attempt count is recorded on both success and exhaustion paths. Previously flagged invalid broad-match issue is resolved with a validation-context noun requirement. |
| packages/publish/src/stages/cargo-publish.ts | Wraps execCommand in withPublishRetry with a shouldRetry predicate that vetoes already-published conflicts, ensuring they fall through to the existing skip handler rather than being re-tried as a duplicate publish. |
| packages/publish/src/stages/npm-publish.ts | Adopts withPublishRetry for the npm publish operation; debug pre-flight checks are correctly extracted outside the inner retry try-block. Already-published conflict handling is preserved in the outer catch. |
| packages/publish/test/unit/utils/publish-retry.spec.ts | Comprehensive unit tests: classification table, backoff sequence, shouldRetry veto, onAttempt exhaustion coverage, real-error rethrow. Injectable noSleep keeps tests fast. |
| packages/publish/test/unit/stages/npm-publish.spec.ts | Four new stage-level tests: permanent fail-fast, transient retry-then-succeed (verifies attempts), exhaustion surfaces real error, already-published-on-retry resolves as skip. Fake timers used throughout. |
| packages/publish/test/unit/stages/cargo-publish.spec.ts | Three new stage-level tests covering permanent fail-fast, transient retry-then-succeed, and already-published conflict on retry. |
| packages/publish/src/types.ts | Adds optional attempts field to PublishResult with clear JSDoc; absent for never-attempted skips. |
| docs/troubleshooting.md | New troubleshooting entry accurately describes the retry symptom, cause, and recovery steps. |
| packages/publish/README.md | New auto-retry subsection is clear and matches the implementation behavior. |
| docs/rust.md | Minor amendment noting auto-retry behavior — accurate and consistent with the implementation. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(publish): address review findings on..."](https://github.com/goosewobbler/releasekit/commit/a25cdc5e510678c317420a75d61f4be2f633692b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35617057)</sub>

<!-- /greptile_comment -->