### PR TITLE
feat(release): partial-publish failure report on the release-driving PR

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -223,6 +223,58 @@ There is no OIDC equivalent for crates.io at this time.
 
 ---
 
+## Recovering from a failed publish
+
+A publish run can fail partway through: some packages reach the registry, the next one errors, and the run stops. ReleaseKit is built so this state is **recoverable by retrying** — you never have to revert version commits or hand-clean the registry.
+
+### The roll-forward model
+
+Version bumps are committed to `main` (or squash-merged from the standing PR) **before** publishing begins. ReleaseKit never rewrites that history to "undo" a failed publish. Instead, the release rolls **forward**: you retry the same release, or you supersede it with the next one.
+
+Concretely, a partial-publish failure leaves the repository in this state:
+
+- **Versions are already on `main`** — the bumped `package.json` / `Cargo.toml` files and changelogs are committed.
+- **Some packages are on the registry** — every package the pipeline reached before the failure is published at its new version.
+- **No tags, no GitHub releases** — consumer tags and GitHub releases are only created **after** the publish succeeds, so a failed run leaves none of them behind. There is nothing half-created to clean up.
+
+### The failure report
+
+On a partial-publish failure, ReleaseKit posts a **failure report** so the state is visible outside the workflow logs. Where it lands depends on the release mode:
+
+- **Standing-pr mode** — a comment on the merged standing PR whose manifest drove the publish.
+- **Direct / label mode** — a comment on the merged feature PR that triggered the release.
+- **Manual dispatch (no PR)** — the workflow step summary.
+
+The report contains a per-package ledger (✅ published / ⏭ skipped / ❌ failed / ⏸ not attempted), the stage that failed and its error, mode-appropriate recovery instructions, and a note that retrying is safe. The comment is idempotent: a repeated failure updates the same report, and a later successful run flips it to **resolved**.
+
+### Recovery path 1 — retry (reconcile the same release)
+
+Re-run the publish for the failed release. Because the publish path **skips versions already on the registry** and only creates tags / GitHub releases after a clean publish, retrying simply re-publishes the packages that did not land the first time and then creates the tags and releases.
+
+- **Standing-pr mode:** dispatch the release workflow targeting the merged standing PR (`standing-pr publish --pr <number>`). Once the `release:retry` label flow lands (issue #245), adding that label to the merged standing PR will trigger the retry automatically.
+- **Direct / label mode:** use GitHub's **"Re-run failed jobs"** on the failed workflow run.
+
+A successful retry marks the failure report resolved and clears the supersede warning described below.
+
+### Recovery path 2 — supersede (let the next release self-heal)
+
+If you would rather move on, **merge the next standing PR**. In sync mode the release partially self-heals at the new version:
+
+- Every package — including the ones that failed before — publishes at the new version.
+- The failed release's baseline tag was never pushed, so the next changelog correctly spans both releases' commits.
+
+The remaining gap is cosmetic: there is no tag or GitHub release for the **failed** version, and the registry has a version hole for the packages that didn't publish in the failed run. Nothing is broken; the history simply skips a version for those packages.
+
+### The supersede warning on the next standing PR
+
+So a failed publish does not silently fade away, ReleaseKit warns while a partially-published release remains unresolved. The **next** standing PR's body and the release preview include a block such as:
+
+> ⚠️ **Previous release v0.24.0 is partially published** (2/4 packages on the registry; no tags/GitHub release created). Retry it by dispatching the release workflow against the merged standing PR (#42), **or** merging this PR supersedes it — the next release re-publishes everything at the new version.
+
+This gives you an honest choice between the two recovery paths. The warning is keyed off the failure report on the most recently merged standing PR and its resolved status, so it clears automatically once the failed release is retried successfully or superseded by the next release.
+
+---
+
 ## Git stage
 
 ### Failed to push: branch protection rules

--- a/packages/release/src/failure-report/failure-report.ts
+++ b/packages/release/src/failure-report/failure-report.ts
@@ -19,6 +19,20 @@ export const FAILURE_MARKER = '<!-- releasekit-publish-failure -->';
 export type FailureReportStatus = 'unresolved' | 'resolved';
 const STATUS_PREFIX = '<!-- releasekit-publish-failure-status:';
 
+/**
+ * Machine-readable headline data (release label + published/total fraction), encoded as its own
+ * HTML comment so the supersede warning can be rebuilt without parsing the human-facing report
+ * copy — prose edits to the report must not silently break detection.
+ */
+const DATA_PREFIX = '<!-- releasekit-publish-failure-data:';
+
+export interface FailureReportData {
+  /** Release label of the partially-published release, e.g. `v0.24.0`. */
+  label: string;
+  published: number;
+  total: number;
+}
+
 /** Release mode the failed publish ran in — drives the recovery instructions. */
 export type FailureReportMode = 'standing-pr' | 'direct' | 'manual';
 
@@ -182,6 +196,7 @@ export function renderFailureReport(input: FailureReportInput): string {
   const lines: string[] = [
     FAILURE_MARKER,
     `${STATUS_PREFIX} unresolved -->`,
+    `${DATA_PREFIX} ${JSON.stringify({ label, published, total } satisfies FailureReportData)} -->`,
     '',
     `## ❌ Publish of ${label} failed partway through`,
     '',
@@ -249,6 +264,25 @@ export function parseFailureReportStatus(body: string): FailureReportStatus | nu
   if (!body.startsWith(FAILURE_MARKER)) return null;
   const match = body.match(/<!-- releasekit-publish-failure-status:\s*(unresolved|resolved)\s*-->/);
   return (match?.[1] as FailureReportStatus | undefined) ?? 'unresolved';
+}
+
+/**
+ * Read the encoded headline data from a failure-report comment body. Returns null when the body
+ * is not a failure report or the data comment is missing/malformed.
+ */
+export function parseFailureReportData(body: string): FailureReportData | null {
+  if (!body.startsWith(FAILURE_MARKER)) return null;
+  const match = body.match(/<!-- releasekit-publish-failure-data:\s*(\{.*?\})\s*-->/);
+  if (!match?.[1]) return null;
+  try {
+    const parsed = JSON.parse(match[1]) as Partial<FailureReportData>;
+    if (typeof parsed.label !== 'string' || typeof parsed.published !== 'number' || typeof parsed.total !== 'number') {
+      return null;
+    }
+    return { label: parsed.label, published: parsed.published, total: parsed.total };
+  } catch {
+    return null;
+  }
 }
 
 export interface SupersedeWarningInput {

--- a/packages/release/src/failure-report/failure-report.ts
+++ b/packages/release/src/failure-report/failure-report.ts
@@ -1,0 +1,281 @@
+import type { VersionOutput } from '@releasekit/core';
+import type { PublishOutput } from '@releasekit/publish';
+import { ATTRIBUTION_FOOTER } from '../attribution.js';
+import { publishableUpdates, syncVersionDisplay } from '../version-display.js';
+
+/**
+ * Distinct comment marker for the partial-publish failure report. Kept separate from the
+ * preview (`<!-- releasekit-preview -->`) and gate-notify markers so the report manages its
+ * own idempotent comment on the release-driving PR.
+ */
+export const FAILURE_MARKER = '<!-- releasekit-publish-failure -->';
+
+/**
+ * Machine-readable resolution status, encoded as an HTML comment immediately after the marker
+ * so a later run (or the next standing-PR / preview) can detect whether the failure is still
+ * outstanding without re-deriving it from a ledger. `unresolved` while a partial publish has
+ * not been retried or superseded; `resolved` once a retry succeeds or a later release supersedes.
+ */
+export type FailureReportStatus = 'unresolved' | 'resolved';
+const STATUS_PREFIX = '<!-- releasekit-publish-failure-status:';
+
+/** Release mode the failed publish ran in — drives the recovery instructions. */
+export type FailureReportMode = 'standing-pr' | 'direct' | 'manual';
+
+/** Per-package outcome in the publish ledger. */
+export type LedgerStatus = 'published' | 'skipped' | 'failed' | 'not-attempted';
+
+export interface LedgerEntry {
+  packageName: string;
+  version: string;
+  status: LedgerStatus;
+  /** Registry the result came from (npm/cargo), when known. */
+  registry?: 'npm' | 'cargo';
+  /** Human-readable detail — the skip reason or failure reason. */
+  detail?: string;
+}
+
+const STATUS_ICON: Record<LedgerStatus, string> = {
+  published: '✅',
+  skipped: '⏭',
+  failed: '❌',
+  'not-attempted': '⏸',
+};
+
+const STATUS_LABEL: Record<LedgerStatus, string> = {
+  published: 'published',
+  skipped: 'skipped',
+  failed: 'failed',
+  'not-attempted': 'not attempted',
+};
+
+/**
+ * Derive the per-package ledger from the version input and the partial publish output.
+ *
+ * The publish ledger (`PublishOutput.npm` / `.cargo`) only carries entries for packages the
+ * pipeline reached before failing. "Not attempted" packages are derived by diffing the input
+ * updates against the packages that appear in the ledger — a package the pipeline never got to
+ * simply has no result entry.
+ */
+export function buildLedger(versionOutput: VersionOutput, publishOutput: PublishOutput | undefined): LedgerEntry[] {
+  const updates = publishableUpdates(versionOutput);
+  const results = [...(publishOutput?.npm ?? []), ...(publishOutput?.cargo ?? [])];
+
+  // Index results by package name. A package may appear once (single registry) — when it appears
+  // on multiple registries, prefer a failed/published entry over a skipped one so the headline
+  // status reflects the most significant outcome.
+  const byPackage = new Map<string, LedgerEntry>();
+  for (const r of results) {
+    let status: LedgerStatus;
+    let detail: string | undefined;
+    if (!r.success) {
+      status = 'failed';
+      detail = r.reason;
+    } else if (r.skipped || r.alreadyPublished) {
+      status = 'skipped';
+      detail = r.alreadyPublished ? 'already published' : (r.reason ?? 'skipped');
+    } else {
+      status = 'published';
+    }
+
+    const existing = byPackage.get(r.packageName);
+    const entry: LedgerEntry = {
+      packageName: r.packageName,
+      version: r.version,
+      status,
+      registry: r.registry,
+      detail,
+    };
+    // Significance order: failed > published > skipped. Keep the more significant outcome.
+    const significance: Record<LedgerStatus, number> = { failed: 3, published: 2, skipped: 1, 'not-attempted': 0 };
+    if (!existing || significance[status] > significance[existing.status]) {
+      byPackage.set(r.packageName, entry);
+    }
+  }
+
+  return updates.map((u) => {
+    const entry = byPackage.get(u.packageName);
+    if (entry) return entry;
+    return {
+      packageName: u.packageName,
+      version: u.newVersion,
+      status: 'not-attempted' as const,
+    };
+  });
+}
+
+/** A short "2/4 packages on npm" style fraction for the headline and supersede warning. */
+function publishedFraction(ledger: LedgerEntry[]): { published: number; total: number } {
+  const published = ledger.filter((e) => e.status === 'published').length;
+  return { published, total: ledger.length };
+}
+
+/**
+ * Best-effort release label (e.g. `v0.24.0`) for the headline. Sync releases share a single
+ * version; async/single fall back to a representative version.
+ */
+function releaseLabel(versionOutput: VersionOutput): string {
+  if (versionOutput.strategy === 'sync') {
+    const display = syncVersionDisplay(versionOutput);
+    return display.startsWith('v') ? display : `v${display}`;
+  }
+  const first = publishableUpdates(versionOutput)[0];
+  return first ? `v${first.newVersion}` : '';
+}
+
+export interface RecoveryContext {
+  mode: FailureReportMode;
+  /** Standing PR number (standing-pr mode) used to phrase the dispatch/retry instruction. */
+  standingPrNumber?: number;
+  /** Whether the `release:retry` label flow is available yet (issue #245). Off until it lands. */
+  retryLabelAvailable?: boolean;
+}
+
+function renderRecovery(ctx: RecoveryContext): string[] {
+  const lines: string[] = ['### How to recover', ''];
+  if (ctx.mode === 'standing-pr') {
+    const prRef = ctx.standingPrNumber ? `#${ctx.standingPrNumber}` : 'the merged standing PR';
+    lines.push(
+      `Re-run the publish for ${prRef}. Versions are already on \`main\`; retrying re-publishes only the packages that did not land.`,
+      '',
+      `- **Dispatch the release workflow** targeting the merged standing PR (\`--pr ${ctx.standingPrNumber ?? '<number>'}\`).`,
+    );
+    if (ctx.retryLabelAvailable) {
+      lines.push(`- Or add the \`release:retry\` label to ${prRef} to trigger a retry automatically.`);
+    }
+  } else if (ctx.mode === 'direct') {
+    lines.push(
+      'Use GitHub’s **"Re-run failed jobs"** on the failed workflow run. Versions are already on `main`; the re-run re-publishes only the packages that did not land.',
+    );
+  } else {
+    lines.push(
+      'Re-run the release workflow (manual dispatch). Versions are already on `main`; the re-run re-publishes only the packages that did not land.',
+    );
+  }
+  return lines;
+}
+
+const SAFE_RETRY_NOTE =
+  '> **Retrying is safe.** The publish path skips versions that are already on the registry, and tags / GitHub releases are only created after the publish succeeds — so a partial failure never leaves a half-created release to clean up.';
+
+export interface FailureReportInput {
+  versionOutput: VersionOutput;
+  publishOutput: PublishOutput | undefined;
+  /** Stage that failed (e.g. `npm-publish`, `verify`). */
+  failedStage: string;
+  /** Error message from the pipeline failure. */
+  errorMessage: string;
+  recovery: RecoveryContext;
+}
+
+/**
+ * Render the partial-publish failure report comment body (marker-keyed, idempotent).
+ * The status line encodes `unresolved` so the next standing PR / preview can detect the
+ * outstanding failure and surface the supersede warning.
+ */
+export function renderFailureReport(input: FailureReportInput): string {
+  const { versionOutput, publishOutput, failedStage, errorMessage, recovery } = input;
+  const ledger = buildLedger(versionOutput, publishOutput);
+  const { published, total } = publishedFraction(ledger);
+  const label = releaseLabel(versionOutput);
+
+  const lines: string[] = [
+    FAILURE_MARKER,
+    `${STATUS_PREFIX} unresolved -->`,
+    '',
+    `## ❌ Publish of ${label} failed partway through`,
+    '',
+    `**${published}/${total} package(s) published.** Versions are already committed on \`main\` (roll-forward model) and no tags or GitHub releases were created. The release is not finished.`,
+    '',
+    '### Package ledger',
+    '',
+    '| Package | Version | Status | Detail |',
+    '|---------|---------|--------|--------|',
+  ];
+
+  for (const e of ledger) {
+    const status = `${STATUS_ICON[e.status]} ${STATUS_LABEL[e.status]}`;
+    const detail = e.detail ?? '';
+    lines.push(`| \`${e.packageName}\` | ${e.version} | ${status} | ${detail} |`);
+  }
+
+  lines.push(
+    '',
+    '### What failed',
+    '',
+    `Stage **\`${failedStage}\`** failed:`,
+    '',
+    '```',
+    errorMessage,
+    '```',
+    '',
+    ...renderRecovery(recovery),
+    '',
+    SAFE_RETRY_NOTE,
+    '',
+    '---',
+    ATTRIBUTION_FOOTER,
+  );
+
+  return lines.join('\n');
+}
+
+/**
+ * Render the resolved variant of the report — produced when a later publish for the same
+ * release succeeds (retry or supersede). Keeps the marker so it updates the same comment, and
+ * encodes `resolved` so the supersede warning clears.
+ */
+export function renderResolvedReport(versionOutput: VersionOutput): string {
+  const label = releaseLabel(versionOutput);
+  return [
+    FAILURE_MARKER,
+    `${STATUS_PREFIX} resolved -->`,
+    '',
+    `## ✅ Publish of ${label} recovered`,
+    '',
+    'A later publish run completed successfully, so this release is now fully published. No further action is needed.',
+    '',
+    '---',
+    ATTRIBUTION_FOOTER,
+  ].join('\n');
+}
+
+/**
+ * Read the encoded resolution status from a failure-report comment body. Returns null when the
+ * body is not a failure report (no marker). Bodies written before the status line existed are
+ * treated as `unresolved` (the conservative default — surface the warning rather than hide it).
+ */
+export function parseFailureReportStatus(body: string): FailureReportStatus | null {
+  if (!body.startsWith(FAILURE_MARKER)) return null;
+  const match = body.match(/<!-- releasekit-publish-failure-status:\s*(unresolved|resolved)\s*-->/);
+  return (match?.[1] as FailureReportStatus | undefined) ?? 'unresolved';
+}
+
+export interface SupersedeWarningInput {
+  /** Release label of the partially-published prior release, e.g. `v0.24.0`. */
+  previousLabel: string;
+  published: number;
+  total: number;
+  /** Standing PR number carrying the failure report (the retry surface). */
+  standingPrNumber?: number;
+  /** Whether `release:retry` is available yet (issue #245). */
+  retryLabelAvailable?: boolean;
+}
+
+/**
+ * Render the warning block shown on the NEXT standing PR (and the release preview) while a
+ * prior release remains partially published. Gives the maintainer the honest retry-vs-supersede
+ * choice described in the issue.
+ */
+export function renderSupersedeWarning(input: SupersedeWarningInput): string[] {
+  const { previousLabel, published, total, standingPrNumber, retryLabelAvailable } = input;
+  const prRef = standingPrNumber ? `the merged standing PR (#${standingPrNumber})` : 'the merged standing PR';
+  const retryHint = retryLabelAvailable
+    ? `Retry it via \`release:retry\` on ${prRef}`
+    : `Retry it by dispatching the release workflow against ${prRef}`;
+  return [
+    `> ⚠️ **Previous release ${previousLabel} is partially published** (${published}/${total} packages on the registry; no tags/GitHub release created).`,
+    `> ${retryHint}, **or** merging this PR supersedes it — the next release re-publishes everything at the new version.`,
+    '',
+  ];
+}

--- a/packages/release/src/failure-report/post.ts
+++ b/packages/release/src/failure-report/post.ts
@@ -7,6 +7,7 @@ import { findPreviewComment, postOrUpdateComment } from '../github.js';
 import {
   FAILURE_MARKER,
   type FailureReportMode,
+  parseFailureReportData,
   parseFailureReportStatus,
   renderFailureReport,
   renderResolvedReport,
@@ -147,17 +148,16 @@ export async function detectUnresolvedFailure(
 
 /**
  * Recover the headline numbers from a rendered failure report so the supersede warning can be
- * rebuilt without the original pipeline output. Parses the released label from the heading and
- * the published/total fraction from the summary line.
+ * rebuilt without the original pipeline output. Reads the machine-readable data comment the
+ * report embeds — never the human-facing copy, which is free to change.
  */
 function parseReportLedgerSummary(body: string, prNumber: number): UnresolvedFailure | null {
-  const labelMatch = body.match(/Publish of (\S+) failed partway through/);
-  const fractionMatch = body.match(/\*\*(\d+)\/(\d+) package\(s\) published\.\*\*/);
-  if (!labelMatch?.[1] || !fractionMatch?.[1] || !fractionMatch[2]) return null;
+  const data = parseFailureReportData(body);
+  if (!data) return null;
   return {
-    previousLabel: labelMatch[1],
-    published: Number.parseInt(fractionMatch[1], 10),
-    total: Number.parseInt(fractionMatch[2], 10),
+    previousLabel: data.label,
+    published: data.published,
+    total: data.total,
     prNumber,
   };
 }

--- a/packages/release/src/failure-report/post.ts
+++ b/packages/release/src/failure-report/post.ts
@@ -1,0 +1,163 @@
+import * as fs from 'node:fs';
+import type { VersionOutput } from '@releasekit/core';
+import { info, warn } from '@releasekit/core';
+import type { PipelineError } from '@releasekit/publish';
+import type { createOctokit } from '../github.js';
+import { findPreviewComment, postOrUpdateComment } from '../github.js';
+import {
+  FAILURE_MARKER,
+  type FailureReportMode,
+  parseFailureReportStatus,
+  renderFailureReport,
+  renderResolvedReport,
+} from './failure-report.js';
+
+type OctokitInstance = ReturnType<typeof createOctokit>;
+
+export interface PostFailureReportContext {
+  octokit: OctokitInstance;
+  owner: string;
+  repo: string;
+  mode: FailureReportMode;
+  /** PR to comment on. Omit for manual dispatch with no PR — the report goes to the step summary. */
+  prNumber?: number;
+  standingPrNumber?: number;
+  retryLabelAvailable?: boolean;
+}
+
+/**
+ * Post (or update) the partial-publish failure report. When a PR number is available the report
+ * is a marker-keyed comment (idempotent — a repeat failure updates the same comment). With no PR
+ * (manual dispatch) it is appended to the workflow step summary at `$GITHUB_STEP_SUMMARY`.
+ */
+export async function postFailureReport(
+  ctx: PostFailureReportContext,
+  versionOutput: VersionOutput,
+  error: PipelineError,
+): Promise<void> {
+  const body = renderFailureReport({
+    versionOutput,
+    publishOutput: error.partialOutput,
+    failedStage: error.failedStage,
+    errorMessage: error.message,
+    recovery: {
+      mode: ctx.mode,
+      standingPrNumber: ctx.standingPrNumber,
+      retryLabelAvailable: ctx.retryLabelAvailable,
+    },
+  });
+
+  if (ctx.prNumber === undefined) {
+    writeStepSummary(body);
+    return;
+  }
+
+  try {
+    await postOrUpdateComment(ctx.octokit, ctx.owner, ctx.repo, ctx.prNumber, body, FAILURE_MARKER);
+    info(`Posted publish-failure report on PR #${ctx.prNumber}`);
+  } catch (err) {
+    warn(`Failed to post publish-failure report: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+/**
+ * On a successful publish, flip any existing failure report for this release to resolved. This
+ * also clears the supersede warning on the next standing PR / preview. No-op when no report
+ * exists. Safe to call unconditionally after a successful publish.
+ */
+export async function resolveFailureReportIfPresent(
+  octokit: OctokitInstance,
+  owner: string,
+  repo: string,
+  prNumber: number,
+  versionOutput: VersionOutput,
+): Promise<void> {
+  try {
+    const existing = await findPreviewComment(octokit, owner, repo, prNumber, FAILURE_MARKER);
+    if (existing === null) return;
+    await postOrUpdateComment(octokit, owner, repo, prNumber, renderResolvedReport(versionOutput), FAILURE_MARKER);
+    info(`Marked publish-failure report on PR #${prNumber} as resolved`);
+  } catch (err) {
+    warn(`Failed to resolve publish-failure report: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+/** Append a block to the GitHub Actions step summary file, when configured. */
+export function writeStepSummary(body: string): void {
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+  if (!summaryPath) {
+    warn('No PR context and no $GITHUB_STEP_SUMMARY — publish-failure report not surfaced');
+    return;
+  }
+  try {
+    fs.appendFileSync(summaryPath, `${body}\n`);
+    info('Wrote publish-failure report to the workflow step summary');
+  } catch (err) {
+    warn(`Failed to write step summary: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+export interface UnresolvedFailure {
+  /** Release label of the partially-published prior release, e.g. `v0.24.0`. */
+  previousLabel: string;
+  published: number;
+  total: number;
+  /** PR number carrying the failure report (the retry surface). */
+  prNumber: number;
+}
+
+/**
+ * Detect an unresolved partial-publish failure on a given PR by locating the failure-report
+ * comment (marker) and reading its encoded resolution status. Returns null when there is no
+ * report or it is already resolved. The published/total fraction is recovered from the ledger
+ * embedded in the report body so the caller doesn't need the original pipeline output.
+ */
+export async function detectUnresolvedFailure(
+  octokit: OctokitInstance,
+  owner: string,
+  repo: string,
+  prNumber: number,
+): Promise<UnresolvedFailure | null> {
+  let body: string | undefined;
+  try {
+    const iterator = octokit.paginate.iterator(octokit.rest.issues.listComments, {
+      owner,
+      repo,
+      issue_number: prNumber,
+      per_page: 100,
+    });
+    for await (const response of iterator) {
+      for (const comment of response.data) {
+        if (comment.body?.startsWith(FAILURE_MARKER)) {
+          body = comment.body;
+          break;
+        }
+      }
+      if (body) break;
+    }
+  } catch {
+    return null;
+  }
+
+  if (!body) return null;
+  if (parseFailureReportStatus(body) !== 'unresolved') return null;
+
+  return parseReportLedgerSummary(body, prNumber);
+}
+
+/**
+ * Recover the headline numbers from a rendered failure report so the supersede warning can be
+ * rebuilt without the original pipeline output. Parses the released label from the heading and
+ * the published/total fraction from the summary line.
+ */
+function parseReportLedgerSummary(body: string, prNumber: number): UnresolvedFailure | null {
+  const labelMatch = body.match(/Publish of (\S+) failed partway through/);
+  const fractionMatch = body.match(/\*\*(\d+)\/(\d+) package\(s\) published\.\*\*/);
+  if (!labelMatch?.[1] || !fractionMatch?.[1] || !fractionMatch[2]) return null;
+  return {
+    previousLabel: labelMatch[1],
+    published: Number.parseInt(fractionMatch[1], 10),
+    total: Number.parseInt(fractionMatch[2], 10),
+    prNumber,
+  };
+}

--- a/packages/release/src/index.ts
+++ b/packages/release/src/index.ts
@@ -1,3 +1,25 @@
+export type {
+  FailureReportInput,
+  FailureReportMode,
+  FailureReportStatus,
+  LedgerEntry,
+  LedgerStatus,
+  RecoveryContext,
+  SupersedeWarningInput,
+} from './failure-report/failure-report.js';
+export {
+  buildLedger,
+  FAILURE_MARKER,
+  parseFailureReportStatus,
+  renderFailureReport,
+  renderResolvedReport,
+  renderSupersedeWarning,
+} from './failure-report/failure-report.js';
+export {
+  detectUnresolvedFailure,
+  postFailureReport,
+  resolveFailureReportIfPresent,
+} from './failure-report/post.js';
 export type { GateOptions, GateOutput } from './gate/gate.js';
 export { runGate } from './gate/gate.js';
 export type { PreviewOptions } from './preview/preview.js';

--- a/packages/release/src/preview/format.ts
+++ b/packages/release/src/preview/format.ts
@@ -66,6 +66,11 @@ export interface FormatOptions {
   /** Per-package merge rows combining standing PR + this PR's contribution. Populated only when both exist. */
   mergedRows?: MergedRow[];
   labelContext?: LabelContext;
+  /**
+   * Warning block (rendered lines) shown while a prior release is partially published — gives the
+   * maintainer the retry-vs-supersede choice. Populated by runPreview in standing-pr mode.
+   */
+  supersedeWarning?: string[];
 }
 
 function getNoChangesMessage(strategy: ReleaseStrategy): string {
@@ -250,6 +255,12 @@ export function formatPreviewComment(result: ReleaseOutput | null, options?: For
   const standingPrSnapshot = showStandingPrContext ? options?.standingPrSnapshot : undefined;
   const mergedRows = showStandingPrContext ? options?.mergedRows : undefined;
   const lines: string[] = [MARKER, ''];
+
+  // Partial-publish supersede warning lives OUTSIDE the details block (and above the snapshot) so
+  // the maintainer always sees that the prior release is incomplete and what their options are.
+  if (showStandingPrContext && options?.supersedeWarning && options.supersedeWarning.length > 0) {
+    lines.push(...options.supersedeWarning);
+  }
 
   // Standing PR snapshot lives OUTSIDE the collapsible details so reviewers always see what's
   // currently queued for release without having to expand the per-PR analysis.

--- a/packages/release/src/preview/preview.ts
+++ b/packages/release/src/preview/preview.ts
@@ -2,11 +2,17 @@ import * as fs from 'node:fs';
 import type { CIConfig } from '@releasekit/config';
 import { loadCIConfig, loadConfig } from '@releasekit/config';
 import { info, success, warn } from '@releasekit/core';
+import { renderSupersedeWarning } from '../failure-report/failure-report.js';
+import { detectUnresolvedFailure } from '../failure-report/post.js';
 import { evaluatePR } from '../gate/evaluate-pr.js';
 import { createOctokit, fetchPRLabels, postOrUpdateComment } from '../github.js';
 import { DEFAULT_LABELS, detectLabelConflicts } from '../label-utils.js';
 import { runRelease } from '../release.js';
-import { fetchStandingPRSnapshot, type StandingPRSnapshot } from '../standing-pr/standing-pr.js';
+import {
+  fetchStandingPRSnapshot,
+  findLatestMergedStandingPR,
+  type StandingPRSnapshot,
+} from '../standing-pr/standing-pr.js';
 import type { PreviewContext } from './context.js';
 import { resolvePreviewContext } from './context.js';
 import { detectPrerelease } from './detect.js';
@@ -62,11 +68,32 @@ export async function runPreview(options: PreviewOptions): Promise<void> {
   // When `release:immediate` is set, skip the fetch — the preview reflects a direct release,
   // not a queued-state outcome.
   let standingPrSnapshot: StandingPRSnapshot | undefined;
+  let supersedeWarning: string[] | undefined;
   if (strategy === 'standing-pr' && !labelContext.immediate && context && octokit) {
     try {
       standingPrSnapshot = (await fetchStandingPRSnapshot(octokit, context.owner, context.repo, ciConfig)) ?? undefined;
     } catch {
       // Non-fatal: preview still renders without the snapshot
+    }
+
+    // Surface the retry-vs-supersede choice while a prior release is partially published. Keyed
+    // off the failure-report comment on the most recently merged standing PR. Non-fatal.
+    try {
+      const branch = ciConfig?.standingPr?.branch ?? 'release/next';
+      const latestMerged = await findLatestMergedStandingPR(octokit, context.owner, context.repo, branch);
+      if (latestMerged !== null) {
+        const unresolved = await detectUnresolvedFailure(octokit, context.owner, context.repo, latestMerged);
+        if (unresolved) {
+          supersedeWarning = renderSupersedeWarning({
+            previousLabel: unresolved.previousLabel,
+            published: unresolved.published,
+            total: unresolved.total,
+            standingPrNumber: unresolved.prNumber,
+          });
+        }
+      }
+    } catch {
+      // Non-fatal: preview still renders without the warning
     }
   }
 
@@ -142,6 +169,7 @@ export async function runPreview(options: PreviewOptions): Promise<void> {
     standingPrSnapshot,
     mergedRows,
     labelContext,
+    supersedeWarning,
   });
 
   if (!context || !octokit) {

--- a/packages/release/src/release.ts
+++ b/packages/release/src/release.ts
@@ -1,12 +1,71 @@
 import type { CIConfig, ReleaseConfig } from '@releasekit/config';
 import { loadConfig as loadReleaseKitConfig } from '@releasekit/config';
+import type { VersionOutput } from '@releasekit/core';
 import { error, info, setJsonMode, setLogLevel, setQuietMode, success, warn } from '@releasekit/core';
+import { PipelineError } from '@releasekit/publish';
+import { postFailureReport, resolveFailureReportIfPresent } from './failure-report/post.js';
 import { getGitHubContext, getHeadCommitMessage, matchesSkipPattern } from './git.js';
 import { createOctokit, fetchPRLabels, findMergedPRsForCommit } from './github.js';
 import { DEFAULT_LABELS, detectLabelConflicts } from './label-utils.js';
 import { runNotesStep, runPublishStep, runVersionStep } from './steps.js';
 import type { ReleaseOptions, ReleaseOutput } from './types.js';
 import { publishableUpdates } from './version-display.js';
+
+/**
+ * Resolve the release-driving PR + mode for the failure report. Direct/label mode: the merged
+ * feature PR that triggered the release (discovered from the HEAD commit). Manual dispatch (no
+ * PR): mode 'manual' with no PR number — the report goes to the workflow step summary.
+ */
+async function resolveReleaseReportTarget(): Promise<{
+  octokit: ReturnType<typeof createOctokit>;
+  owner: string;
+  repo: string;
+  prNumber?: number;
+  mode: 'direct' | 'manual';
+} | null> {
+  const githubContext = getGitHubContext();
+  if (!githubContext?.token) return null;
+  const octokit = createOctokit(githubContext.token);
+  const { owner, repo, sha } = githubContext;
+
+  const isManualDispatch = process.env.GITHUB_EVENT_NAME === 'workflow_dispatch';
+  let prNumber: number | undefined;
+  if (sha && !isManualDispatch) {
+    const prs = await findMergedPRsForCommit(octokit, owner, repo, sha);
+    prNumber = prs[0];
+  }
+
+  return { octokit, owner, repo, prNumber, mode: prNumber !== undefined ? 'direct' : 'manual' };
+}
+
+/**
+ * Post a partial-publish failure report for a direct/label-mode or manual-dispatch release.
+ * Best-effort: never throws (the caller re-throws the original pipeline error).
+ */
+async function reportReleaseFailure(versionOutput: VersionOutput, err: PipelineError): Promise<void> {
+  try {
+    const target = await resolveReleaseReportTarget();
+    if (!target) {
+      warn('No GitHub context — publish-failure report not surfaced');
+      return;
+    }
+    await postFailureReport(
+      {
+        octokit: target.octokit,
+        owner: target.owner,
+        repo: target.repo,
+        mode: target.mode,
+        prNumber: target.prNumber,
+      },
+      versionOutput,
+      err,
+    );
+  } catch (reportErr) {
+    warn(
+      `Failed to surface publish-failure report: ${reportErr instanceof Error ? reportErr.message : String(reportErr)}`,
+    );
+  }
+}
 
 export function resolveScopeToTarget(scopeName: string, scopeLabels: Record<string, string>): string {
   const prefixed = `scope:${scopeName}`;
@@ -257,8 +316,39 @@ export async function runRelease(inputOptions: ReleaseOptions): Promise<ReleaseO
   let publishOutput: ReleaseOutput['publishOutput'];
   if (!options.skipPublish) {
     info('Publishing...');
-    publishOutput = await runPublishStep(versionOutput, options, releaseNotes, notesFiles);
+    try {
+      publishOutput = await runPublishStep(versionOutput, options, releaseNotes, notesFiles);
+    } catch (err) {
+      // On a partial-publish failure the pipeline throws a PipelineError carrying the per-package
+      // ledger. Surface a failure report on the release-driving PR (or the step summary), then
+      // re-throw so the workflow still fails. Skip in dry-run — no real publish happened.
+      if (err instanceof PipelineError && !options.dryRun) {
+        await reportReleaseFailure(versionOutput, err);
+      }
+      throw err;
+    }
     success('Publish complete');
+
+    // A successful publish clears any prior failure report for this release (resolves it and the
+    // supersede warning). Only meaningful for a direct-mode release with a triggering PR.
+    if (!options.dryRun) {
+      try {
+        const target = await resolveReleaseReportTarget();
+        if (target?.prNumber !== undefined) {
+          await resolveFailureReportIfPresent(
+            target.octokit,
+            target.owner,
+            target.repo,
+            target.prNumber,
+            versionOutput,
+          );
+        }
+      } catch (resolveErr) {
+        warn(
+          `Failed to resolve prior publish-failure report: ${resolveErr instanceof Error ? resolveErr.message : String(resolveErr)}`,
+        );
+      }
+    }
   }
 
   return { versionOutput, notesGenerated, packageNotes, releaseNotes, publishOutput };

--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -1060,20 +1060,27 @@ export async function publishFromManifest(prNumber: number, options: StandingPRO
   } catch (err) {
     // Partial-publish failure: surface the report on the merged standing PR (the PR whose
     // manifest drove this publish). Versions are already on main (roll-forward); the report
-    // explains what landed and how to retry. Best-effort — re-throw so the workflow fails.
+    // explains what landed and how to retry. Best-effort — the guard ensures a reporting
+    // failure never replaces the original pipeline error, which is always re-thrown.
     if (err instanceof PipelineError) {
-      await postFailureReport(
-        {
-          octokit,
-          owner,
-          repo,
-          mode: 'standing-pr',
-          prNumber,
-          standingPrNumber: prNumber,
-        },
-        manifest.versionOutput,
-        err,
-      );
+      try {
+        await postFailureReport(
+          {
+            octokit,
+            owner,
+            repo,
+            mode: 'standing-pr',
+            prNumber,
+            standingPrNumber: prNumber,
+          },
+          manifest.versionOutput,
+          err,
+        );
+      } catch (reportErr) {
+        warn(
+          `Failed to surface publish-failure report: ${reportErr instanceof Error ? reportErr.message : String(reportErr)}`,
+        );
+      }
     }
     throw err;
   }

--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -4,8 +4,11 @@ import * as fs from 'node:fs';
 import { type CIConfig, loadConfig as loadReleaseKitConfig } from '@releasekit/config';
 import type { VersionOutput } from '@releasekit/core';
 import { error, info, success, warn } from '@releasekit/core';
+import { PipelineError } from '@releasekit/publish';
 import { ATTRIBUTION_FOOTER } from '../attribution.js';
 import { formatDuration, parseDuration } from '../duration.js';
+import { renderSupersedeWarning } from '../failure-report/failure-report.js';
+import { detectUnresolvedFailure, postFailureReport, resolveFailureReportIfPresent } from '../failure-report/post.js';
 import { getGitHubContext, getHeadCommitMessage, matchesSkipPattern } from '../git.js';
 import { createOctokit } from '../github.js';
 import { DEFAULT_LABELS } from '../label-utils.js';
@@ -315,8 +318,14 @@ function deleteReleaseBranch(releaseBranch: string, cwd: string): void {
   }
 }
 
-function renderPrBody(versionOutput: VersionOutput): string {
+function renderPrBody(versionOutput: VersionOutput, supersedeWarning?: string[]): string {
   const lines: string[] = ['## Release', ''];
+
+  // While a prior release remains partially published, lead with the supersede warning so the
+  // maintainer sees the retry-vs-supersede choice before the package list.
+  if (supersedeWarning && supersedeWarning.length > 0) {
+    lines.push(...supersedeWarning);
+  }
 
   // The root lockstep bump (sync mode) is never published — keep it out of the package list.
   const updates = publishableUpdates(versionOutput);
@@ -762,7 +771,28 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
   // label override resolution; saves an extra API call.
   const existing = existingStandingPr;
 
-  const body = renderPrBody(versionOutput);
+  // Detect an unresolved partial-publish on the most recently merged standing PR so this PR's
+  // body warns that the prior release is incomplete and offers the retry-vs-supersede choice.
+  // Best-effort — a lookup failure must not block the standing-PR update.
+  let supersedeWarning: string[] | undefined;
+  try {
+    const latestMerged = await findLatestMergedStandingPR(octokit, owner, repo, branch);
+    if (latestMerged !== null) {
+      const unresolved = await detectUnresolvedFailure(octokit, owner, repo, latestMerged);
+      if (unresolved) {
+        supersedeWarning = renderSupersedeWarning({
+          previousLabel: unresolved.previousLabel,
+          published: unresolved.published,
+          total: unresolved.total,
+          standingPrNumber: unresolved.prNumber,
+        });
+      }
+    }
+  } catch (err) {
+    warn(`Could not check for unresolved publish failures: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  const body = renderPrBody(versionOutput, supersedeWarning);
 
   let prNumber: number;
   let prUrl: string;
@@ -1024,9 +1054,35 @@ export async function publishFromManifest(prNumber: number, options: StandingPRO
     npmAuth: (options.npmAuth as ReleaseOptions['npmAuth']) ?? 'auto',
   };
 
-  const publishOutput = await runPublishStep(manifest.versionOutput, publishOptions, releaseNotes, notesFiles);
+  let publishOutput: ReleaseOutput['publishOutput'];
+  try {
+    publishOutput = await runPublishStep(manifest.versionOutput, publishOptions, releaseNotes, notesFiles);
+  } catch (err) {
+    // Partial-publish failure: surface the report on the merged standing PR (the PR whose
+    // manifest drove this publish). Versions are already on main (roll-forward); the report
+    // explains what landed and how to retry. Best-effort — re-throw so the workflow fails.
+    if (err instanceof PipelineError) {
+      await postFailureReport(
+        {
+          octokit,
+          owner,
+          repo,
+          mode: 'standing-pr',
+          prNumber,
+          standingPrNumber: prNumber,
+        },
+        manifest.versionOutput,
+        err,
+      );
+    }
+    throw err;
+  }
 
   success('Publish complete');
+
+  // Publish succeeded — clear any prior failure report on this PR (resolves it and the supersede
+  // warning that would otherwise show on the next standing PR).
+  await resolveFailureReportIfPresent(octokit, owner, repo, prNumber, manifest.versionOutput);
 
   // Cleanup: delete release branch if configured
   if (deleteBranchOnMerge) {

--- a/packages/release/test/unit/failure-report-post.spec.ts
+++ b/packages/release/test/unit/failure-report-post.spec.ts
@@ -127,7 +127,8 @@ describe('postFailureReport', () => {
       expect(written).toContain('1/2 package(s) published');
       fs.unlinkSync(tmp);
     } finally {
-      process.env.GITHUB_STEP_SUMMARY = undefined;
+      // Assigning undefined would coerce to the string "undefined" — delete instead.
+      delete process.env.GITHUB_STEP_SUMMARY;
     }
   });
 });

--- a/packages/release/test/unit/failure-report-post.spec.ts
+++ b/packages/release/test/unit/failure-report-post.spec.ts
@@ -1,0 +1,207 @@
+import type { VersionOutput } from '@releasekit/core';
+import { PipelineError, type PublishOutput, type PublishResult } from '@releasekit/publish';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { FAILURE_MARKER, renderFailureReport, renderResolvedReport } from '../../src/failure-report/failure-report.js';
+import {
+  detectUnresolvedFailure,
+  postFailureReport,
+  resolveFailureReportIfPresent,
+} from '../../src/failure-report/post.js';
+
+function versionOutputFor(packages: Array<{ name: string; version: string }>): VersionOutput {
+  return {
+    dryRun: false,
+    strategy: 'async',
+    updates: packages.map((p) => ({
+      packageName: p.name,
+      newVersion: p.version,
+      filePath: `packages/${p.name}/package.json`,
+    })),
+    changelogs: [],
+    tags: packages.map((p) => `${p.name}@v${p.version}`),
+  };
+}
+
+function publishOutputFor(npm: PublishResult[]): PublishOutput {
+  return {
+    dryRun: false,
+    git: { committed: true, tags: [], pushed: false },
+    npm,
+    cargo: [],
+    verification: [],
+    githubReleases: [],
+    publishSucceeded: false,
+  };
+}
+
+function pipelineErrorFor(versionOutput: VersionOutput): PipelineError {
+  const publishOutput = publishOutputFor([
+    { packageName: '@scope/a', version: '0.24.0', registry: 'npm', success: true, skipped: false },
+    { packageName: '@scope/b', version: '0.24.0', registry: 'npm', success: false, skipped: false, reason: 'npm 403' },
+  ]);
+  void versionOutput;
+  return new PipelineError('Failed to publish to npm: npm 403', 'npm-publish', publishOutput);
+}
+
+function commentsIterator(bodies: Array<{ id: number; body: string }>) {
+  return {
+    iterator: vi.fn().mockReturnValue({
+      async *[Symbol.asyncIterator]() {
+        yield { data: bodies };
+      },
+    }),
+  };
+}
+
+function mockOctokit(comments: Array<{ id: number; body: string }> = []) {
+  const createComment = vi.fn().mockResolvedValue({});
+  const updateComment = vi.fn().mockResolvedValue({});
+  return {
+    octokit: {
+      paginate: commentsIterator(comments),
+      rest: {
+        issues: {
+          listComments: vi.fn(),
+          createComment,
+          updateComment,
+        },
+      },
+    } as never,
+    createComment,
+    updateComment,
+  };
+}
+
+const versionOutput = versionOutputFor([
+  { name: '@scope/a', version: '0.24.0' },
+  { name: '@scope/b', version: '0.24.0' },
+]);
+
+describe('postFailureReport', () => {
+  it('creates a new marker comment when none exists', async () => {
+    const { octokit, createComment } = mockOctokit([]);
+    await postFailureReport(
+      { octokit, owner: 'o', repo: 'r', mode: 'standing-pr', prNumber: 42, standingPrNumber: 42 },
+      versionOutput,
+      pipelineErrorFor(versionOutput),
+    );
+    expect(createComment).toHaveBeenCalledTimes(1);
+    const body = createComment.mock.calls[0]?.[0]?.body as string;
+    expect(body.startsWith(FAILURE_MARKER)).toBe(true);
+    expect(body).toContain('1/2 package(s) published');
+  });
+
+  it('updates the existing report on a repeated failure (idempotent — does not stack)', async () => {
+    const existing = renderFailureReport({
+      versionOutput,
+      publishOutput: publishOutputFor([]),
+      failedStage: 'npm-publish',
+      errorMessage: 'older error',
+      recovery: { mode: 'standing-pr', standingPrNumber: 42 },
+    });
+    const { octokit, createComment, updateComment } = mockOctokit([{ id: 7, body: existing }]);
+    await postFailureReport(
+      { octokit, owner: 'o', repo: 'r', mode: 'standing-pr', prNumber: 42, standingPrNumber: 42 },
+      versionOutput,
+      pipelineErrorFor(versionOutput),
+    );
+    expect(createComment).not.toHaveBeenCalled();
+    expect(updateComment).toHaveBeenCalledTimes(1);
+    expect(updateComment.mock.calls[0]?.[0]?.comment_id).toBe(7);
+  });
+
+  it('writes to the step summary when no PR is available (manual dispatch)', async () => {
+    const tmp = `${process.env.RUNNER_TEMP ?? '/tmp'}/rk-step-summary-${Date.now()}.md`;
+    const fs = await import('node:fs');
+    process.env.GITHUB_STEP_SUMMARY = tmp;
+    try {
+      const { octokit, createComment } = mockOctokit([]);
+      await postFailureReport(
+        { octokit, owner: 'o', repo: 'r', mode: 'manual' },
+        versionOutput,
+        pipelineErrorFor(versionOutput),
+      );
+      expect(createComment).not.toHaveBeenCalled();
+      const written = fs.readFileSync(tmp, 'utf-8');
+      expect(written).toContain(FAILURE_MARKER);
+      expect(written).toContain('1/2 package(s) published');
+      fs.unlinkSync(tmp);
+    } finally {
+      process.env.GITHUB_STEP_SUMMARY = undefined;
+    }
+  });
+});
+
+describe('resolveFailureReportIfPresent', () => {
+  it('flips an existing report to resolved', async () => {
+    const existing = renderFailureReport({
+      versionOutput,
+      publishOutput: publishOutputFor([]),
+      failedStage: 'npm-publish',
+      errorMessage: 'err',
+      recovery: { mode: 'standing-pr', standingPrNumber: 42 },
+    });
+    const { octokit, updateComment } = mockOctokit([{ id: 7, body: existing }]);
+    await resolveFailureReportIfPresent(octokit, 'o', 'r', 42, versionOutput);
+    expect(updateComment).toHaveBeenCalledTimes(1);
+    const body = updateComment.mock.calls[0]?.[0]?.body as string;
+    expect(body).toContain('recovered');
+  });
+
+  it('is a no-op when there is no existing report', async () => {
+    const { octokit, updateComment, createComment } = mockOctokit([]);
+    await resolveFailureReportIfPresent(octokit, 'o', 'r', 42, versionOutput);
+    expect(updateComment).not.toHaveBeenCalled();
+    expect(createComment).not.toHaveBeenCalled();
+  });
+});
+
+describe('detectUnresolvedFailure', () => {
+  it('detects an unresolved failure and recovers the headline numbers', async () => {
+    const report = renderFailureReport({
+      versionOutput,
+      publishOutput: publishOutputFor([
+        { packageName: '@scope/a', version: '0.24.0', registry: 'npm', success: true, skipped: false },
+        {
+          packageName: '@scope/b',
+          version: '0.24.0',
+          registry: 'npm',
+          success: false,
+          skipped: false,
+          reason: 'npm 403',
+        },
+      ]),
+      failedStage: 'npm-publish',
+      errorMessage: 'npm 403',
+      recovery: { mode: 'standing-pr', standingPrNumber: 42 },
+    });
+    const { octokit } = mockOctokit([{ id: 9, body: report }]);
+    const result = await detectUnresolvedFailure(octokit, 'o', 'r', 42);
+    expect(result).toEqual({ previousLabel: 'v0.24.0', published: 1, total: 2, prNumber: 42 });
+  });
+
+  it('returns null once the report is resolved', async () => {
+    const resolved = renderResolvedReport(versionOutput);
+    const { octokit } = mockOctokit([{ id: 9, body: resolved }]);
+    expect(await detectUnresolvedFailure(octokit, 'o', 'r', 42)).toBeNull();
+  });
+
+  it('returns null when there is no failure report', async () => {
+    const { octokit } = mockOctokit([{ id: 1, body: 'unrelated comment' }]);
+    expect(await detectUnresolvedFailure(octokit, 'o', 'r', 42)).toBeNull();
+  });
+});
+
+describe('detectUnresolvedFailure env hygiene', () => {
+  let savedSummary: string | undefined;
+  beforeEach(() => {
+    savedSummary = process.env.GITHUB_STEP_SUMMARY;
+  });
+  afterEach(() => {
+    if (savedSummary === undefined) delete process.env.GITHUB_STEP_SUMMARY;
+    else process.env.GITHUB_STEP_SUMMARY = savedSummary;
+  });
+  it('placeholder to anchor the env reset hooks', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/packages/release/test/unit/failure-report.spec.ts
+++ b/packages/release/test/unit/failure-report.spec.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest';
 import {
   buildLedger,
   FAILURE_MARKER,
+  parseFailureReportData,
   parseFailureReportStatus,
   renderFailureReport,
   renderResolvedReport,
@@ -125,6 +126,27 @@ describe('renderFailureReport', () => {
     });
     expect(body.startsWith(FAILURE_MARKER)).toBe(true);
     expect(parseFailureReportStatus(body)).toBe('unresolved');
+  });
+
+  it('embeds machine-readable headline data that round-trips independent of the prose', () => {
+    const body = renderFailureReport({
+      versionOutput,
+      publishOutput,
+      failedStage: 'npm-publish',
+      errorMessage: 'Failed to publish to npm: npm 403',
+      recovery: { mode: 'standing-pr', standingPrNumber: 42 },
+    });
+    expect(parseFailureReportData(body)).toEqual({ label: 'v0.24.0', published: 1, total: 2 });
+    // Detection must survive copy-edits to the human-facing report text.
+    const copyEdited = body.replace('failed partway through', 'did not complete');
+    expect(parseFailureReportData(copyEdited)).toEqual({ label: 'v0.24.0', published: 1, total: 2 });
+  });
+
+  it('returns null headline data for non-report bodies and malformed data comments', () => {
+    expect(parseFailureReportData('not a report')).toBeNull();
+    expect(
+      parseFailureReportData(`${FAILURE_MARKER}\n<!-- releasekit-publish-failure-data: {bad json} -->`),
+    ).toBeNull();
   });
 
   it('renders the per-package ledger with status icons and the published fraction', () => {

--- a/packages/release/test/unit/failure-report.spec.ts
+++ b/packages/release/test/unit/failure-report.spec.ts
@@ -1,0 +1,235 @@
+import type { VersionOutput } from '@releasekit/core';
+import type { PublishOutput, PublishResult } from '@releasekit/publish';
+import { describe, expect, it } from 'vitest';
+import {
+  buildLedger,
+  FAILURE_MARKER,
+  parseFailureReportStatus,
+  renderFailureReport,
+  renderResolvedReport,
+  renderSupersedeWarning,
+} from '../../src/failure-report/failure-report.js';
+
+function versionOutputFor(
+  packages: Array<{ name: string; version: string }>,
+  overrides: Partial<VersionOutput> = {},
+): VersionOutput {
+  return {
+    dryRun: false,
+    strategy: 'async',
+    updates: packages.map((p) => ({
+      packageName: p.name,
+      newVersion: p.version,
+      filePath: `packages/${p.name}/package.json`,
+    })),
+    changelogs: [],
+    tags: packages.map((p) => `${p.name}@v${p.version}`),
+    ...overrides,
+  };
+}
+
+function npmResult(partial: Partial<PublishResult> & { packageName: string; version: string }): PublishResult {
+  return {
+    registry: 'npm',
+    success: true,
+    skipped: false,
+    ...partial,
+  };
+}
+
+function publishOutputFor(npm: PublishResult[]): PublishOutput {
+  return {
+    dryRun: false,
+    git: { committed: true, tags: [], pushed: false },
+    npm,
+    cargo: [],
+    verification: [],
+    githubReleases: [],
+    publishSucceeded: false,
+  };
+}
+
+describe('buildLedger', () => {
+  it('distinguishes published / skipped / failed / not-attempted', () => {
+    const versionOutput = versionOutputFor([
+      { name: '@scope/a', version: '1.0.0' },
+      { name: '@scope/b', version: '1.0.0' },
+      { name: '@scope/c', version: '1.0.0' },
+      { name: '@scope/d', version: '1.0.0' },
+    ]);
+    const publishOutput = publishOutputFor([
+      npmResult({ packageName: '@scope/a', version: '1.0.0', success: true }),
+      npmResult({ packageName: '@scope/b', version: '1.0.0', success: true, alreadyPublished: true }),
+      npmResult({ packageName: '@scope/c', version: '1.0.0', success: false, reason: 'npm 403 Forbidden' }),
+      // @scope/d has no result entry — the pipeline never reached it.
+    ]);
+
+    const ledger = buildLedger(versionOutput, publishOutput);
+
+    expect(ledger).toEqual([
+      { packageName: '@scope/a', version: '1.0.0', status: 'published', registry: 'npm', detail: undefined },
+      {
+        packageName: '@scope/b',
+        version: '1.0.0',
+        status: 'skipped',
+        registry: 'npm',
+        detail: 'already published',
+      },
+      { packageName: '@scope/c', version: '1.0.0', status: 'failed', registry: 'npm', detail: 'npm 403 Forbidden' },
+      { packageName: '@scope/d', version: '1.0.0', status: 'not-attempted' },
+    ]);
+  });
+
+  it('excludes the root lockstep bump from the ledger', () => {
+    const versionOutput = versionOutputFor([{ name: '@scope/a', version: '2.0.0' }], { strategy: 'sync' });
+    versionOutput.updates.push({
+      packageName: 'root',
+      newVersion: '2.0.0',
+      filePath: 'package.json',
+      isRoot: true,
+    });
+    const ledger = buildLedger(versionOutput, publishOutputFor([]));
+    expect(ledger.map((e) => e.packageName)).toEqual(['@scope/a']);
+  });
+
+  it('keeps the most significant outcome when a package appears on multiple registries', () => {
+    const versionOutput = versionOutputFor([{ name: '@scope/a', version: '1.0.0' }]);
+    const publishOutput = publishOutputFor([
+      npmResult({ packageName: '@scope/a', version: '1.0.0', success: true, alreadyPublished: true }),
+    ]);
+    publishOutput.cargo = [
+      { packageName: '@scope/a', version: '1.0.0', registry: 'cargo', success: false, skipped: false, reason: 'boom' },
+    ];
+    const ledger = buildLedger(versionOutput, publishOutput);
+    expect(ledger[0]?.status).toBe('failed');
+  });
+});
+
+describe('renderFailureReport', () => {
+  const versionOutput = versionOutputFor([
+    { name: '@scope/a', version: '0.24.0' },
+    { name: '@scope/b', version: '0.24.0' },
+  ]);
+  const publishOutput = publishOutputFor([
+    npmResult({ packageName: '@scope/a', version: '0.24.0', success: true }),
+    npmResult({ packageName: '@scope/b', version: '0.24.0', success: false, reason: 'npm 403' }),
+  ]);
+
+  it('starts with the distinct marker and an unresolved status line', () => {
+    const body = renderFailureReport({
+      versionOutput,
+      publishOutput,
+      failedStage: 'npm-publish',
+      errorMessage: 'Failed to publish to npm: npm 403',
+      recovery: { mode: 'standing-pr', standingPrNumber: 42 },
+    });
+    expect(body.startsWith(FAILURE_MARKER)).toBe(true);
+    expect(parseFailureReportStatus(body)).toBe('unresolved');
+  });
+
+  it('renders the per-package ledger with status icons and the published fraction', () => {
+    const body = renderFailureReport({
+      versionOutput,
+      publishOutput,
+      failedStage: 'npm-publish',
+      errorMessage: 'npm 403',
+      recovery: { mode: 'standing-pr', standingPrNumber: 42 },
+    });
+    expect(body).toContain('1/2 package(s) published');
+    expect(body).toContain('| `@scope/a` | 0.24.0 | ✅ published |');
+    expect(body).toContain('| `@scope/b` | 0.24.0 | ❌ failed | npm 403 |');
+  });
+
+  it('includes the failed stage, error message, and the safe-retry note', () => {
+    const body = renderFailureReport({
+      versionOutput,
+      publishOutput,
+      failedStage: 'npm-publish',
+      errorMessage: 'Failed to publish to npm: npm 403',
+      recovery: { mode: 'standing-pr', standingPrNumber: 42 },
+    });
+    expect(body).toContain('`npm-publish`');
+    expect(body).toContain('Failed to publish to npm: npm 403');
+    expect(body).toContain('Retrying is safe');
+  });
+
+  it('gives standing-pr recovery instructions with the PR number', () => {
+    const body = renderFailureReport({
+      versionOutput,
+      publishOutput,
+      failedStage: 'npm-publish',
+      errorMessage: 'npm 403',
+      recovery: { mode: 'standing-pr', standingPrNumber: 42 },
+    });
+    expect(body).toContain('--pr 42');
+    expect(body).not.toContain('Re-run failed jobs');
+  });
+
+  it('mentions the release:retry label only when it is available', () => {
+    const withRetry = renderFailureReport({
+      versionOutput,
+      publishOutput,
+      failedStage: 'npm-publish',
+      errorMessage: 'npm 403',
+      recovery: { mode: 'standing-pr', standingPrNumber: 42, retryLabelAvailable: true },
+    });
+    expect(withRetry).toContain('release:retry');
+
+    const withoutRetry = renderFailureReport({
+      versionOutput,
+      publishOutput,
+      failedStage: 'npm-publish',
+      errorMessage: 'npm 403',
+      recovery: { mode: 'standing-pr', standingPrNumber: 42 },
+    });
+    expect(withoutRetry).not.toContain('release:retry');
+  });
+
+  it('gives direct-mode recovery instructions (re-run failed jobs)', () => {
+    const body = renderFailureReport({
+      versionOutput,
+      publishOutput,
+      failedStage: 'npm-publish',
+      errorMessage: 'npm 403',
+      recovery: { mode: 'direct' },
+    });
+    expect(body).toContain('Re-run failed jobs');
+    expect(body).not.toContain('--pr');
+  });
+});
+
+describe('renderResolvedReport', () => {
+  it('keeps the marker and encodes resolved status', () => {
+    const versionOutput = versionOutputFor([{ name: '@scope/a', version: '0.24.0' }]);
+    const body = renderResolvedReport(versionOutput);
+    expect(body.startsWith(FAILURE_MARKER)).toBe(true);
+    expect(parseFailureReportStatus(body)).toBe('resolved');
+    expect(body).toContain('recovered');
+  });
+});
+
+describe('parseFailureReportStatus', () => {
+  it('returns null for a non-report body', () => {
+    expect(parseFailureReportStatus('just a normal comment')).toBeNull();
+  });
+
+  it('defaults to unresolved when the status line is missing', () => {
+    expect(parseFailureReportStatus(`${FAILURE_MARKER}\n\n## something`)).toBe('unresolved');
+  });
+});
+
+describe('renderSupersedeWarning', () => {
+  it('states the partial-publish fraction and both recovery paths', () => {
+    const lines = renderSupersedeWarning({
+      previousLabel: 'v0.24.0',
+      published: 2,
+      total: 4,
+      standingPrNumber: 42,
+    });
+    const text = lines.join('\n');
+    expect(text).toContain('v0.24.0 is partially published');
+    expect(text).toContain('2/4 packages');
+    expect(text).toContain('#42');
+    expect(text).toContain('supersedes it');
+  });
+});

--- a/packages/release/test/unit/preview-format.spec.ts
+++ b/packages/release/test/unit/preview-format.spec.ts
@@ -1039,4 +1039,42 @@ describe('formatPreviewComment', () => {
       expect(result).toContain('No bump label detected');
     });
   });
+
+  describe('partial-publish supersede warning', () => {
+    const warning = [
+      '> ⚠️ **Previous release v0.24.0 is partially published** (2/4 packages on the registry; no tags/GitHub release created).',
+      '> Retry it by dispatching the release workflow against the merged standing PR (#42), **or** merging this PR supersedes it — the next release re-publishes everything at the new version.',
+      '',
+    ];
+
+    it('renders the warning above the standing PR snapshot when present', () => {
+      const snapshot = snapshotFor([{ name: '@a/notes', version: '0.5.0' }]);
+      const result = formatPreviewComment(releaseOutput, {
+        strategy: 'standing-pr',
+        standingPrSnapshot: snapshot,
+        supersedeWarning: warning,
+      });
+      expect(result).toContain('Previous release v0.24.0 is partially published');
+      expect(result).toContain('2/4 packages');
+      // Warning must sit before the snapshot block.
+      expect(result.indexOf('partially published')).toBeLessThan(result.indexOf('**Standing release PR:**'));
+    });
+
+    it('omits the warning when none is supplied (failure cleared / never occurred)', () => {
+      const snapshot = snapshotFor([{ name: '@a/notes', version: '0.5.0' }]);
+      const result = formatPreviewComment(releaseOutput, {
+        strategy: 'standing-pr',
+        standingPrSnapshot: snapshot,
+      });
+      expect(result).not.toContain('partially published');
+    });
+
+    it('suppresses the warning outside standing-pr strategy (defensive)', () => {
+      const result = formatPreviewComment(releaseOutput, {
+        strategy: 'direct',
+        supersedeWarning: warning,
+      });
+      expect(result).not.toContain('partially published');
+    });
+  });
 });

--- a/packages/release/test/unit/release.spec.ts
+++ b/packages/release/test/unit/release.spec.ts
@@ -22,6 +22,9 @@ vi.mock('../../src/github.js', () => ({
   createOctokit: (...args: unknown[]) => mockCreateOctokit(...args),
   findMergedPRsForCommit: (...args: unknown[]) => mockFindMergedPRsForCommit(...args),
   fetchPRLabels: (...args: unknown[]) => mockFetchPRLabels(...args),
+  // Used by the best-effort failure-report resolve path; a plain stub keeps it quiet.
+  findPreviewComment: vi.fn().mockResolvedValue(null),
+  postOrUpdateComment: vi.fn().mockResolvedValue(undefined),
 }));
 
 const mockEnableJsonOutput = vi.fn();

--- a/packages/release/test/unit/release.spec.ts
+++ b/packages/release/test/unit/release.spec.ts
@@ -69,10 +69,16 @@ vi.mock('@releasekit/notes', () => ({
 const mockPublishRunPipeline = vi.fn();
 const mockPublishLoadConfig = vi.fn();
 
-vi.mock('@releasekit/publish', () => ({
-  runPipeline: (...args: unknown[]) => mockPublishRunPipeline(...args),
-  loadConfig: (...args: unknown[]) => mockPublishLoadConfig(...args),
-}));
+vi.mock('@releasekit/publish', async (importOriginal) => {
+  // Pull the real PipelineError through so release.ts's `instanceof PipelineError` check works;
+  // only runPipeline/loadConfig are stubbed.
+  const actual = await importOriginal<typeof import('@releasekit/publish')>();
+  return {
+    PipelineError: actual.PipelineError,
+    runPipeline: (...args: unknown[]) => mockPublishRunPipeline(...args),
+    loadConfig: (...args: unknown[]) => mockPublishLoadConfig(...args),
+  };
+});
 
 vi.mock('@releasekit/core', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@releasekit/core')>();

--- a/packages/release/test/unit/standing-pr.spec.ts
+++ b/packages/release/test/unit/standing-pr.spec.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderFailureReport, renderResolvedReport } from '../../src/failure-report/failure-report.js';
 import type { StandingPRManifest } from '../../src/standing-pr/standing-pr.js';
 import {
   createReleaseTags,
@@ -536,6 +537,122 @@ describe('runStandingPRUpdate', () => {
     expect(createCall?.body).not.toContain('### Changelog');
     expect(createCall?.body).toContain('@scope/core');
     expect(createCall?.body).toContain('1.2.3');
+  });
+
+  describe('partial-publish supersede warning on the next standing PR', () => {
+    function failureReportBody() {
+      const versionOutput = {
+        ...createMockVersionOutput([
+          { packageName: '@scope/core', newVersion: '0.24.0' },
+          { packageName: '@scope/utils', newVersion: '0.24.0' },
+        ]),
+      } as unknown as Parameters<typeof renderFailureReport>[0]['versionOutput'];
+      return renderFailureReport({
+        versionOutput,
+        publishOutput: {
+          dryRun: false,
+          git: { committed: true, tags: [], pushed: false },
+          npm: [
+            { packageName: '@scope/core', version: '0.24.0', registry: 'npm', success: true, skipped: false },
+            {
+              packageName: '@scope/utils',
+              version: '0.24.0',
+              registry: 'npm',
+              success: false,
+              skipped: false,
+              reason: 'npm 403',
+            },
+          ],
+          cargo: [],
+          verification: [],
+          githubReleases: [],
+          publishSucceeded: false,
+        },
+        failedStage: 'npm-publish',
+        errorMessage: 'npm 403',
+        recovery: { mode: 'standing-pr', standingPrNumber: 7 },
+      });
+    }
+
+    // pullsList is used both for the open standing PR (findStandingPR) and the most recently
+    // merged one (findLatestMergedStandingPR). Branch on the requested state.
+    function listByState(merged: Array<{ number: number; merged_at: string }>) {
+      return (args: { state?: string }) => Promise.resolve({ data: args.state === 'closed' ? merged : [] });
+    }
+
+    it('includes the warning when the latest merged standing PR has an unresolved failure', async () => {
+      const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
+      const versionOutput = createMockVersionOutput([{ packageName: '@scope/core', newVersion: '0.25.0' }]);
+      vi.mocked(runVersionStep)
+        .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>)
+        .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>);
+      vi.mocked(runNotesStep).mockResolvedValue({ packageNotes: {}, releaseNotes: {}, files: [] });
+
+      const { createOctokit } = await import('../../src/github.js');
+      const { mocks, octokit } = createMockOctokit();
+      mocks.pullsList.mockImplementation(listByState([{ number: 7, merged_at: '2026-01-01T00:00:00Z' }]));
+      mocks.paginate.iterator.mockReturnValue({
+        async *[Symbol.asyncIterator]() {
+          yield { data: [{ id: 1, body: failureReportBody() }] };
+        },
+      });
+      vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+
+      await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
+
+      const createCall = mocks.pullsCreate.mock.calls[0]?.[0] as { body?: string } | undefined;
+      expect(createCall?.body).toContain('partially published');
+      expect(createCall?.body).toContain('1/2 packages');
+      expect(createCall?.body).toContain('#7');
+    });
+
+    it('omits the warning when the latest merged standing PR failure is resolved', async () => {
+      const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
+      const versionOutput = createMockVersionOutput([{ packageName: '@scope/core', newVersion: '0.25.0' }]);
+      vi.mocked(runVersionStep)
+        .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>)
+        .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>);
+      vi.mocked(runNotesStep).mockResolvedValue({ packageNotes: {}, releaseNotes: {}, files: [] });
+
+      const { createOctokit } = await import('../../src/github.js');
+      const { mocks, octokit } = createMockOctokit();
+      mocks.pullsList.mockImplementation(listByState([{ number: 7, merged_at: '2026-01-01T00:00:00Z' }]));
+      const resolved = renderResolvedReport(
+        createMockVersionOutput([{ packageName: '@scope/core', newVersion: '0.24.0' }]) as unknown as Parameters<
+          typeof renderResolvedReport
+        >[0],
+      );
+      mocks.paginate.iterator.mockReturnValue({
+        async *[Symbol.asyncIterator]() {
+          yield { data: [{ id: 1, body: resolved }] };
+        },
+      });
+      vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+
+      await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
+
+      const createCall = mocks.pullsCreate.mock.calls[0]?.[0] as { body?: string } | undefined;
+      expect(createCall?.body).not.toContain('partially published');
+    });
+
+    it('omits the warning when there is no merged standing PR', async () => {
+      const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
+      const versionOutput = createMockVersionOutput([{ packageName: '@scope/core', newVersion: '0.25.0' }]);
+      vi.mocked(runVersionStep)
+        .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>)
+        .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>);
+      vi.mocked(runNotesStep).mockResolvedValue({ packageNotes: {}, releaseNotes: {}, files: [] });
+
+      const { createOctokit } = await import('../../src/github.js');
+      const { mocks, octokit } = createMockOctokit();
+      mocks.pullsList.mockImplementation(listByState([]));
+      vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+
+      await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
+
+      const createCall = mocks.pullsCreate.mock.calls[0]?.[0] as { body?: string } | undefined;
+      expect(createCall?.body).not.toContain('partially published');
+    });
   });
 
   it('should update existing PR when standing PR already exists', async () => {


### PR DESCRIPTION
## Problem

A failed publish leaves bumped versions on main (roll-forward model), some packages immutably on the registry, and tags/GitHub releases withheld — but the only record of which packages landed, and how to finish the release, was buried in workflow logs.

## Design

**Rendering (`failure-report/failure-report.ts`)** — pure functions: `buildLedger` derives per-package status (✅ published / ⏭ skipped / ❌ failed / ⏸ not attempted) by diffing the release's input updates against the `PipelineError` output ledger; `renderFailureReport` produces the marker-keyed comment with an encoded resolved/unresolved status line, the failed stage + error, mode-appropriate recovery instructions, and the safe-retry note; `renderSupersedeWarning` renders the next-PR warning.

**Posting (`failure-report/post.ts`)** — `postFailureReport` is idempotent (distinct `<!-- releasekit-publish-failure -->` marker, repeated failures update the same comment); falls back to `$GITHUB_STEP_SUMMARY` when there is no PR (manual dispatch). `resolveFailureReportIfPresent` flips the report to resolved on a later successful publish. `detectUnresolvedFailure` finds the report on the most recently merged standing PR — detection needs no separate state store.

**Wiring** — standing-pr mode: `publishFromManifest` posts/resolves on the merged standing PR; direct/label mode: `runRelease` resolves the triggering merged PR via the existing commit→PR lookup; the next standing PR body and the release preview surface the supersede warning while a failure is unresolved. All report paths are best-effort (non-throwing) and the original `PipelineError` is always re-thrown, so the workflow still fails loudly.

**Docs** — "Recovering from a failed publish" in `docs/troubleshooting.md`: roll-forward model, the report, retry-vs-supersede.

## Note on #245

The `release:retry` label flow is issue #245 (blocked by this PR). Recovery instructions are behind a `retryLabelAvailable` flag (default false) and currently say "dispatch the release workflow"; #245 flips the flag and adds the label workflow.

## Tests

Ledger derivation + rendering, posting idempotency, step-summary fallback, resolve-on-success, unresolved detection, supersede warning presence/absence in both the standing PR body and the preview. Full `pnpm turbo run lint typecheck test`: 24/24 tasks, 492 release unit tests + 32 integration tests.

Closes #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces a partial-publish failure report for ReleaseKit: when a publish run fails mid-flight, a marker-keyed comment is posted on the release-driving PR (or the workflow step summary for manual dispatch) with a per-package ledger, recovery instructions, and a supersede warning on the next standing PR.

- **`failure-report/failure-report.ts`** — pure rendering functions (`buildLedger`, `renderFailureReport`, `renderResolvedReport`, `renderSupersedeWarning`) plus machine-readable HTML-comment encoding for status and headline data, decoupling detection from prose copy.
- **`failure-report/post.ts`** — idempotent posting (`postFailureReport`), resolve-on-success (`resolveFailureReportIfPresent`), unresolved detection (`detectUnresolvedFailure`), and step-summary fallback for no-PR runs.
- **`release.ts` / `standing-pr.ts`** — wires reporting into `runRelease` (direct/label mode) and `publishFromManifest` (standing-PR mode); preview and standing-PR body surface the supersede warning while a failure is outstanding.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge once the two missing dry-run guards in publishFromManifest are added; all other paths are well-structured and best-effort.

release.ts explicitly skips both failure reporting and failure-report resolution in dry-run mode, but publishFromManifest in standing-pr.ts does neither. A dry-run failure would post a spurious failure report on the real PR, and a dry-run success would silently flip an outstanding failure report to resolved before any packages have been re-published.

packages/release/src/standing-pr/standing-pr.ts — the publishFromManifest function needs the same !options.dryRun guards that release.ts already applies to both paths.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/release/src/failure-report/failure-report.ts | New file: pure rendering functions for the failure report. Machine-readable data comment correctly decouples detection from prose copy. No issues found. |
| packages/release/src/failure-report/post.ts | New file: idempotent posting, step-summary fallback, resolve-on-success, and unresolved detection. All external calls are wrapped in try-catch. No issues found. |
| packages/release/src/standing-pr/standing-pr.ts | Two dry-run guards are missing in publishFromManifest: the PipelineError catch posts a failure report without !options.dryRun, and resolveFailureReportIfPresent is called unconditionally on success. release.ts has both guards; this path does not. |
| packages/release/src/release.ts | Adds reportReleaseFailure (best-effort, fully guarded) and the resolve path for direct/label mode. Both paths are correctly gated on !options.dryRun. No issues found. |
| packages/release/src/preview/preview.ts | Adds supersede-warning detection to runPreview in standing-pr mode. Wrapped in a non-fatal try-catch. No issues found. |
| packages/release/test/unit/failure-report-post.spec.ts | New test file covering idempotency, step-summary fallback, resolve-on-success, and detection. Env hygiene correctly uses delete process.env.GITHUB_STEP_SUMMARY. Good coverage. |
| packages/release/test/unit/failure-report.spec.ts | New test file for ledger derivation, rendering, round-trip data parsing, and supersede warning. Covers copy-edit resilience of machine-readable data comments. No issues found. |

</details>

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Frelease%2Fsrc%2Fstanding-pr%2Fstanding-pr.ts%3A1065-1067%0AMissing%20%60dryRun%60%20guard%20before%20posting%20the%20failure%20report.%20In%20%60release.ts%60%20the%20equivalent%20catch%20block%20uses%20%60err%20instanceof%20PipelineError%20%26%26%20!options.dryRun%60%20with%20the%20explicit%20comment%20%22Skip%20in%20dry-run%20%E2%80%94%20no%20real%20publish%20happened.%22%20Without%20that%20guard%20here%2C%20a%20dry-run%20failure%20in%20standing-PR%20mode%20would%20post%20a%20real%20failure%20report%20on%20the%20actual%20PR%2C%20falsely%20claiming%20packages%20failed%20to%20publish%20when%20nothing%20was%20attempted.%20%60options.dryRun%60%20is%20already%20used%20a%20few%20lines%20above%20when%20building%20%60publishOptions%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20if%20%28err%20instanceof%20PipelineError%20%26%26%20!options.dryRun%29%20%7B%0A%20%20%20%20%20%20try%20%7B%0A%20%20%20%20%20%20%20%20await%20postFailureReport%28%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Frelease%2Fsrc%2Fstanding-pr%2Fstanding-pr.ts%3A1090-1092%0AThe%20successful-publish%20path%20resolves%20an%20existing%20failure%20report%20unconditionally.%20%60release.ts%60%20wraps%20the%20equivalent%20call%20in%20%60if%20%28!options.dryRun%29%60.%20Without%20this%20guard%20a%20successful%20dry-run%20would%20flip%20the%20failure%20report%20on%20the%20real%20PR%20to%20%22resolved%22%2C%20silently%20clearing%20the%20warning%20before%20any%20actual%20packages%20have%20been%20re-published.%0A%0A%60%60%60suggestion%0A%20%20%2F%2F%20Publish%20succeeded%20%E2%80%94%20clear%20any%20prior%20failure%20report%20on%20this%20PR%20%28resolves%20it%20and%20the%20supersede%0A%20%20%2F%2F%20warning%20that%20would%20otherwise%20show%20on%20the%20next%20standing%20PR%29.%0A%20%20if%20%28!options.dryRun%29%20%7B%0A%20%20%20%20await%20resolveFailureReportIfPresent%28octokit%2C%20owner%2C%20repo%2C%20prNumber%2C%20manifest.versionOutput%29%3B%0A%20%20%7D%0A%60%60%60%0A%0A&repo=goosewobbler%2Freleasekit&pr=252&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Frelease%2Fsrc%2Fstanding-pr%2Fstanding-pr.ts%3A1065-1067%0AMissing%20%60dryRun%60%20guard%20before%20posting%20the%20failure%20report.%20In%20%60release.ts%60%20the%20equivalent%20catch%20block%20uses%20%60err%20instanceof%20PipelineError%20%26%26%20!options.dryRun%60%20with%20the%20explicit%20comment%20%22Skip%20in%20dry-run%20%E2%80%94%20no%20real%20publish%20happened.%22%20Without%20that%20guard%20here%2C%20a%20dry-run%20failure%20in%20standing-PR%20mode%20would%20post%20a%20real%20failure%20report%20on%20the%20actual%20PR%2C%20falsely%20claiming%20packages%20failed%20to%20publish%20when%20nothing%20was%20attempted.%20%60options.dryRun%60%20is%20already%20used%20a%20few%20lines%20above%20when%20building%20%60publishOptions%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20if%20%28err%20instanceof%20PipelineError%20%26%26%20!options.dryRun%29%20%7B%0A%20%20%20%20%20%20try%20%7B%0A%20%20%20%20%20%20%20%20await%20postFailureReport%28%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Frelease%2Fsrc%2Fstanding-pr%2Fstanding-pr.ts%3A1090-1092%0AThe%20successful-publish%20path%20resolves%20an%20existing%20failure%20report%20unconditionally.%20%60release.ts%60%20wraps%20the%20equivalent%20call%20in%20%60if%20%28!options.dryRun%29%60.%20Without%20this%20guard%20a%20successful%20dry-run%20would%20flip%20the%20failure%20report%20on%20the%20real%20PR%20to%20%22resolved%22%2C%20silently%20clearing%20the%20warning%20before%20any%20actual%20packages%20have%20been%20re-published.%0A%0A%60%60%60suggestion%0A%20%20%2F%2F%20Publish%20succeeded%20%E2%80%94%20clear%20any%20prior%20failure%20report%20on%20this%20PR%20%28resolves%20it%20and%20the%20supersede%0A%20%20%2F%2F%20warning%20that%20would%20otherwise%20show%20on%20the%20next%20standing%20PR%29.%0A%20%20if%20%28!options.dryRun%29%20%7B%0A%20%20%20%20await%20resolveFailureReportIfPresent%28octokit%2C%20owner%2C%20repo%2C%20prNumber%2C%20manifest.versionOutput%29%3B%0A%20%20%7D%0A%60%60%60%0A%0A&pr=252&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["fix(release): address review findings on..."](https://github.com/goosewobbler/releasekit/commit/bad2dd7dafbccd67fe1042391ddba0cb75245c69) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35617675)</sub>

<!-- /greptile_comment -->