### PR TITLE
fix(tooling): make lint-staged tolerate unprocessable paths and cover .jsonc

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,11 +49,11 @@
   },
   "lint-staged": {
     "**/*.ts": [
-      "biome check --write",
+      "biome check --write --no-errors-on-unmatched --files-ignore-unknown=true",
       "eslint --fix --cache"
     ],
-    "**/*.{md,json}": [
-      "biome format --write"
+    "**/*.{md,json,jsonc}": [
+      "biome format --write --no-errors-on-unmatched --files-ignore-unknown=true"
     ]
   }
 }


### PR DESCRIPTION
## Problem

The root `package.json` lint-staged config ran `biome format --write` over `**/*.{md,json}`. Biome cannot format markdown, so a commit staging only `docs/*.md` gave biome nothing to process and it exited 1 (`× No files were processed in the specified paths`), failing the pre-commit hook. This stayed latent because doc changes usually co-stage a `.json` file. Separately, `biome.jsonc` matched neither glob (`*.json` does not match `.jsonc`), so the repo's own biome config was silently skipped by the hook.

## Fix

- Pass `--no-errors-on-unmatched --files-ignore-unknown=true` to both the `biome check` and `biome format` lint-staged commands so unmatched/unprocessable paths no longer exit 1.
- Add `jsonc` to the format glob so `biome.jsonc` and future `.jsonc` files are formatted by the hook.

Flag names verified against the installed biome 2.4.16 (`biome format --help`).

## Verification

Ran `pnpm exec lint-staged` directly with files staged:

- Doc-only `.md`: exit 1 on the old config (bug reproduced), exit 0 after the fix
- `.jsonc`: a mis-indented `biome.jsonc` staged → biome reformatted it, exit 0 — proving `.jsonc` is now covered
- `.ts` + `.json` together: unchanged behavior — biome check + eslint on the `.ts`, biome format on the `.json`, exit 0
- `pnpm turbo run lint typecheck test` → 24/24 tasks successful

Closes #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes two related lint-staged pre-commit hook failures: biome exiting with code 1 when no processable files matched (e.g., doc-only commits), and `.jsonc` files being silently excluded from the format pass.

- Adds `--no-errors-on-unmatched --files-ignore-unknown=true` to both the `biome check` (`.ts`) and `biome format` (`.md`, `.json`, `.jsonc`) lint-staged commands so unmatched or unsupported file types no longer fail the hook.
- Extends the format glob from `**/*.{md,json}` to `**/*.{md,json,jsonc}` so `biome.jsonc` and any future `.jsonc` files are covered.
</details>

<h3>Confidence Score: 5/5</h3>

A focused config-only change that makes the pre-commit hook more tolerant; no production code is touched.

Both flags are standard biome CLI options that convert non-fatal 'no matching files' exits into clean exits, exactly matching the failure mode described. The jsonc extension addition closes the silent omission of biome.jsonc. The fix is narrowly scoped to lint-staged config and cannot affect build, test, or runtime behaviour.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| package.json | lint-staged config updated: defensive biome flags added to both command entries and `jsonc` extension added to the format glob; no logic or dependency changes. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(tooling): make lint-staged tolerate ..."](https://github.com/goosewobbler/releasekit/commit/525264468721bf58defc39c830c111701caef5ad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35618264)</sub>

<!-- /greptile_comment -->