### PR TITLE
feat(release): user-invoked publish retry via release:retry label

### DIFF
--- a/.github/workflows/release-retry.yml
+++ b/.github/workflows/release-retry.yml
@@ -18,12 +18,14 @@ on:
   pull_request:
     types: [labeled]
 
-# Only act on the retry label. Other label events (bump:*, scope:*, etc.) are ignored. The label
-# name is the default `release:retry`; the validation step reads the configured name from
-# releasekit.config.json so a custom label still works, but the cheap fast-path guard below avoids
-# spinning up a runner for unrelated label events.
+# Only act on the retry label. Other label events (bump:*, scope:*, etc.) are ignored. The
+# job-level guard is necessarily hardcoded to the default `release:retry` — workflow `if`
+# expressions can't read releasekit.config.json. If you rename the label via ci.labels.retry,
+# update the guard below to match; the validation step re-checks the configured name as the
+# authoritative source either way.
 permissions:
   actions: write
+  contents: read # checkout of the config file below; an explicit permissions block zeroes everything unlisted
   pull-requests: write
 
 jobs:

--- a/.github/workflows/release-retry.yml
+++ b/.github/workflows/release-retry.yml
@@ -1,0 +1,101 @@
+name: Release Retry
+
+# Maintainer-invoked retry for a failed standing-PR publish (issue #245).
+#
+# Applying the `release:retry` label to a MERGED standing PR dispatches the manifest-driven
+# publish path in release.yml for that PR. The publish is idempotent: it skips versions already
+# on the registry and only pushes tags / creates GitHub releases once the publish succeeds, so a
+# retry after a partial failure publishes only the missing packages. A successful retry also
+# resolves the partial-publish failure report (#243), which clears the supersede warning from the
+# next standing PR.
+#
+# Label events fire even on closed (merged) PRs, which is why this listens for `labeled`. The
+# label is removed after each application, so each application is exactly one retry and the label
+# can be re-applied for another. Permission gating comes free — only users with triage rights can
+# apply labels. Applying the label to a non-standing or unmerged PR is a no-op with an explanatory
+# comment.
+on:
+  pull_request:
+    types: [labeled]
+
+# Only act on the retry label. Other label events (bump:*, scope:*, etc.) are ignored. The label
+# name is the default `release:retry`; the validation step reads the configured name from
+# releasekit.config.json so a custom label still works, but the cheap fast-path guard below avoids
+# spinning up a runner for unrelated label events.
+permissions:
+  actions: write
+  pull-requests: write
+
+jobs:
+  retry-publish:
+    name: Retry standing-PR publish
+    if: github.event.label.name == 'release:retry'
+    runs-on: ubuntu-latest
+    steps:
+      # Sparse checkout of just the config file — avoids cloning the whole repo while letting the
+      # branch and label names come from a single source of truth (releasekit.config.json). Pin to
+      # `main`: the standing PR's branch is typically deleted on merge, so the PR head ref may no
+      # longer exist when this runs.
+      - name: Checkout config
+        uses: actions/checkout@v6.0.2
+        with:
+          ref: main
+          sparse-checkout: releasekit.config.json
+          sparse-checkout-cone-mode: false
+
+      - name: Validate, dispatch, and remove the label
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_MERGED: ${{ github.event.pull_request.merged }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          LABEL_NAME: ${{ github.event.label.name }}
+        run: |
+          set -euo pipefail
+
+          STANDING_PR_BRANCH=$(jq -r '.ci.standingPr.branch // "release/next"' releasekit.config.json)
+          RETRY_LABEL=$(jq -r '.ci.labels.retry // "release:retry"' releasekit.config.json)
+
+          # Honour a custom retry label: if the event label isn't the configured one, do nothing.
+          # (The job-level `if` already matched the default; this covers a renamed label.)
+          if [ "$LABEL_NAME" != "$RETRY_LABEL" ]; then
+            echo "Label '$LABEL_NAME' is not the configured retry label '$RETRY_LABEL' — ignoring"
+            exit 0
+          fi
+
+          # Always remove the label so the action is one-shot and re-appliable, regardless of
+          # whether validation passes. Best-effort — removal failure must not mask a dispatch.
+          remove_label() {
+            gh api -X DELETE \
+              "repos/$REPO/issues/$PR_NUMBER/labels/$(jq -rn --arg l "$RETRY_LABEL" '$l|@uri')" \
+              >/dev/null 2>&1 || echo "::warning::Could not remove label '$RETRY_LABEL' from PR #$PR_NUMBER"
+          }
+
+          # Validation: the PR must be a MERGED standing PR (head ref is the configured release
+          # branch). On failure, leave an explanatory comment and remove the label without
+          # dispatching — applying the label to a non-standing or unmerged PR is a clear no-op.
+          if [ "$PR_MERGED" != "true" ]; then
+            echo "PR #$PR_NUMBER is not merged — not retrying"
+            gh pr comment "$PR_NUMBER" --repo "$REPO" --body \
+              "⚠️ \`$RETRY_LABEL\` ignored: this PR is not merged. The retry label only applies to a **merged** standing PR (head \`$STANDING_PR_BRANCH\`). Removing the label."
+            remove_label
+            exit 0
+          fi
+
+          if [ "$PR_HEAD_REF" != "$STANDING_PR_BRANCH" ]; then
+            echo "PR #$PR_NUMBER head ref '$PR_HEAD_REF' is not the standing branch '$STANDING_PR_BRANCH' — not retrying"
+            gh pr comment "$PR_NUMBER" --repo "$REPO" --body \
+              "⚠️ \`$RETRY_LABEL\` ignored: this is not a standing release PR (its head is \`$PR_HEAD_REF\`, not \`$STANDING_PR_BRANCH\`). The retry label only applies to a merged standing PR. Removing the label."
+            remove_label
+            exit 0
+          fi
+
+          # Dispatch the manifest-driven publish for this PR, then remove the label.
+          gh workflow run release.yml \
+            --repo "$REPO" \
+            --ref main \
+            --field "standing_pr_number=$PR_NUMBER"
+          echo "Dispatched release.yml with standing_pr_number=$PR_NUMBER (retry)"
+          echo "Watch publish progress: https://github.com/$REPO/actions/workflows/release.yml"
+          remove_label

--- a/docs/action.md
+++ b/docs/action.md
@@ -125,7 +125,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version: "24"
           registry-url: https://registry.npmjs.org
       - id: rk
         uses: goosewobbler/releasekit@v0

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -325,6 +325,7 @@ PR label names used for release control. Override to match your repository's lab
 | `prerelease` | string | `"channel:prerelease"` | Label to create a prerelease |
 | `skip` | string | `"release:skip"` | Label to suppress a release on this PR |
 | `immediate` | string | `"release:immediate"` | Label to bypass the standing PR for one merge — triggers a direct release. Standing-pr mode only. |
+| `retry` | string | `"release:retry"` | Label to retry a failed publish by re-applying it to a merged standing PR. Standing-pr mode only. |
 | `major` | string | `"bump:major"` | Label to force a major bump |
 | `minor` | string | `"bump:minor"` | Label to force a minor bump |
 | `patch` | string | `"bump:patch"` | Label to force a patch bump |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -171,7 +171,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
       - run: pnpm install --frozen-lockfile
       - run: pnpm exec releasekit release

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -124,6 +124,7 @@ For a monorepo, change `changelog.mode` to `"packages"` and list your packages i
 | "Version Packages" PR | Standing release PR (`ci.releaseStrategy: "standing-pr"`) |
 | `pnpm changeset publish` | Merge the standing PR (publish runs automatically) |
 | Ship one PR urgently without queueing | Add `release:immediate` to the feeder PR |
+| Retry a publish that failed partway | Add `release:retry` to the merged standing PR |
 | `.changeset/config.json` | `releasekit.config.json` |
 | `fixed` packages (move together) | `version.sync: true` |
 | `linked` packages | Not directly supported; use `version.sync` |

--- a/docs/rust.md
+++ b/docs/rust.md
@@ -193,7 +193,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Run releasekit
         uses: goosewobbler/releasekit@v1

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -147,7 +147,7 @@ Paths are resolved relative to the project root (the directory containing `relea
 
 **Cause:** A short-lived registry or network blip — HTTP 5xx, `ETIMEDOUT`, `ECONNRESET`, `EAI_AGAIN`, or a `429` rate-limit response — interrupted the publish.
 
-**Fix:** No action required when it recovers. releasekit auto-retries transient errors per package up to **2 times** (3 attempts total) with exponential backoff before failing. The attempt count is recorded in the per-package publish result. Permanent errors (auth, missing scope/package, validation) are **not** retried and still fail fast. If the retries are exhausted, the final error shown is the real registry error — check the registry status page, then re-run the release. Re-running is safe: a version that already landed is detected and skipped rather than re-published.
+**Fix:** No action required when it recovers. releasekit auto-retries transient errors per package up to **2 times** (3 attempts total) with exponential backoff before failing. The attempt count is recorded in the per-package publish result. Permanent errors (auth, missing scope/package, validation) are **not** retried and still fail fast. If the retries are exhausted, the final error shown is the real registry error — check the registry status page, then re-run the release. Re-running is safe: a version that already landed is detected and skipped rather than re-published. If the failure left a release partially published, see [Recovering from a failed publish](#recovering-from-a-failed-publish).
 
 ---
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -261,7 +261,7 @@ The report contains a per-package ledger (✅ published / ⏭ skipped / ❌ fail
 
 Re-run the publish for the failed release. Because the publish path **skips versions already on the registry** and only creates tags / GitHub releases after a clean publish, retrying simply re-publishes the packages that did not land the first time and then creates the tags and releases.
 
-- **Standing-pr mode:** dispatch the release workflow targeting the merged standing PR (`standing-pr publish --pr <number>`). Once the `release:retry` label flow lands (issue #245), adding that label to the merged standing PR will trigger the retry automatically.
+- **Standing-pr mode:** add the **`release:retry`** label to the merged standing PR. A workflow validates that the PR is a merged standing PR, dispatches the manifest-driven publish for it, and removes the label — so each application is exactly one retry and you can re-apply the label to retry again. (Applying it to a non-standing or unmerged PR is a no-op: the workflow leaves a comment explaining why and removes the label.) Equivalently, dispatch the release workflow yourself targeting the merged standing PR (`standing-pr publish --pr <number>`). The label name is configurable via `ci.labels.retry`.
 - **Direct / label mode:** use GitHub's **"Re-run failed jobs"** on the failed workflow run.
 
 A successful retry marks the failure report resolved and clears the supersede warning described below.
@@ -279,7 +279,7 @@ The remaining gap is cosmetic: there is no tag or GitHub release for the **faile
 
 So a failed publish does not silently fade away, ReleaseKit warns while a partially-published release remains unresolved. The **next** standing PR's body and the release preview include a block such as:
 
-> ⚠️ **Previous release v0.24.0 is partially published** (2/4 packages on the registry; no tags/GitHub release created). Retry it by dispatching the release workflow against the merged standing PR (#42), **or** merging this PR supersedes it — the next release re-publishes everything at the new version.
+> ⚠️ **Previous release v0.24.0 is partially published** (2/4 packages on the registry; no tags/GitHub release created). Retry it via `release:retry` on the merged standing PR (#42), **or** merging this PR supersedes it — the next release re-publishes everything at the new version.
 
 This gives you an honest choice between the two recovery paths. The warning is keyed off the failure report on the most recently merged standing PR and its resolved status, so it clears automatically once the failed release is retried successfully or superseded by the next release.
 

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -316,6 +316,8 @@ export const CILabelsConfigSchema = z.object({
   skip: z.string().default('release:skip'),
   /** Bypass the standing PR for one merge — triggers a direct release. Standing-pr mode only. */
   immediate: z.string().default('release:immediate'),
+  /** Retry a failed publish by re-applying it to a merged standing PR. Standing-pr mode only. */
+  retry: z.string().default('release:retry'),
   major: z.string().default('bump:major'),
   minor: z.string().default('bump:minor'),
   patch: z.string().default('bump:patch'),
@@ -362,6 +364,7 @@ export const CIConfigSchema = z.object({
     prerelease: 'channel:prerelease',
     skip: 'release:skip',
     immediate: 'release:immediate',
+    retry: 'release:retry',
     major: 'bump:major',
     minor: 'bump:minor',
     patch: 'bump:patch',

--- a/packages/config/test/unit/schema.spec.ts
+++ b/packages/config/test/unit/schema.spec.ts
@@ -462,6 +462,7 @@ describe('CIConfigSchema', () => {
       prerelease: 'channel:prerelease',
       skip: 'release:skip',
       immediate: 'release:immediate',
+      retry: 'release:retry',
       major: 'bump:major',
       minor: 'bump:minor',
       patch: 'bump:patch',

--- a/packages/release/docs/ci-setup.md
+++ b/packages/release/docs/ci-setup.md
@@ -458,7 +458,7 @@ Result: the standing PR is up-to-date by the time the workflow exits — no stal
 
 #### Retrying a failed publish
 
-If a standing-PR publish fails partway through (some packages on the registry, no tags/GitHub release), add the **`release:retry`** label to the **merged** standing PR (configurable via `ci.labels.retry`). The `release-retry.yml` workflow:
+If a standing-PR publish fails partway through (some packages on the registry, no tags/GitHub release), add the **`release:retry`** label to the **merged** standing PR (configurable via `ci.labels.retry` — note the workflow's job-level `if` guard hardcodes the default name, so a renamed label requires updating that guard too). The `release-retry.yml` workflow:
 
 1. Validates the PR is a merged standing PR (head is the configured release branch).
 2. Dispatches the manifest-driven publish in `release.yml` for that PR — idempotent, so it re-publishes only the packages that did not land, then pushes tags and creates GitHub releases.

--- a/packages/release/docs/ci-setup.md
+++ b/packages/release/docs/ci-setup.md
@@ -456,6 +456,16 @@ The `immediate-release` job in `standing-pr.yml` handles this:
 
 Result: the standing PR is up-to-date by the time the workflow exits — no staleness window.
 
+#### Retrying a failed publish
+
+If a standing-PR publish fails partway through (some packages on the registry, no tags/GitHub release), add the **`release:retry`** label to the **merged** standing PR (configurable via `ci.labels.retry`). The `release-retry.yml` workflow:
+
+1. Validates the PR is a merged standing PR (head is the configured release branch).
+2. Dispatches the manifest-driven publish in `release.yml` for that PR — idempotent, so it re-publishes only the packages that did not land, then pushes tags and creates GitHub releases.
+3. Removes the label, so each application is exactly one retry; re-apply it to retry again.
+
+Applying the label to a non-standing or unmerged PR is a no-op — the workflow leaves an explanatory comment and removes the label without dispatching. A successful retry resolves the partial-publish failure report and clears the supersede warning from the next standing PR. Full recovery walkthrough: [Recovering from a failed publish](../../../docs/troubleshooting.md#recovering-from-a-failed-publish).
+
 ### Troubleshooting
 
 | Symptom | Cause / fix |
@@ -490,6 +500,7 @@ Standing-pr mode handles both batched and one-off releases through a single work
 | Critical fix that needs to ship now | Add `release:immediate` (optionally `+ bump:patch`) to the PR. |
 | Adjust the standing PR's bump magnitude | Add `bump:major` (etc.) to the standing PR itself; the next update applies it. |
 | Promote accumulated prereleases to stable | Add `channel:stable` to the standing PR and merge it. |
+| Retry a publish that failed partway | Add `release:retry` to the **merged** standing PR. |
 
 ---
 

--- a/packages/release/docs/ci-setup.md
+++ b/packages/release/docs/ci-setup.md
@@ -38,7 +38,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
 
       - run: pnpm install --frozen-lockfile
@@ -114,7 +114,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
 
       - run: pnpm install --frozen-lockfile
@@ -207,7 +207,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
 
       - run: pnpm install --frozen-lockfile
 
@@ -308,7 +308,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    types: [closed]
+    types: [closed, labeled]  # labeled: release:retry on the merged standing PR (fires on closed PRs)
     branches: [main]
   schedule:
     - cron: '0 * * * *'  # Hourly — re-evaluates minAge status check as time passes
@@ -336,7 +336,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
 
       - run: pnpm install --frozen-lockfile
@@ -357,8 +357,11 @@ jobs:
 
   publish-release:
     name: Publish Release
+    # action == 'closed' matters: with `labeled` subscribed above, a label added to the
+    # already-merged standing PR would otherwise re-match this job and publish unvalidated.
     if: >
       github.event_name == 'pull_request' &&
+      github.event.action == 'closed' &&
       github.event.pull_request.merged == true &&
       startsWith(github.event.pull_request.head.ref, 'release/')
     runs-on: ubuntu-latest
@@ -370,7 +373,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
 
       - run: pnpm install --frozen-lockfile
@@ -386,6 +389,51 @@ jobs:
           # With OIDC trusted publishing (recommended) NODE_AUTH_TOKEN is
           # unnecessary. With token-based npm auth, uncomment the next line:
           # NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  # Maintainer-invoked retry after a partial-publish failure: apply `release:retry` to the
+  # MERGED standing PR (label events fire on closed PRs). Publishing is idempotent — versions
+  # already on the registry are skipped, and tags / GitHub releases are only created once the
+  # publish succeeds — so the retry completes exactly what the failed run left unfinished.
+  retry-publish:
+    name: Retry Publish
+    if: >
+      github.event_name == 'pull_request' &&
+      github.event.action == 'labeled' &&
+      github.event.label.name == 'release:retry' &&
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'release/')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ github.token }}
+          ref: main  # the standing PR's branch is deleted on merge; publish from main
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - run: pnpm exec releasekit standing-pr publish --pr ${{ github.event.pull_request.number }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          # Same auth note as publish-release above.
+          # NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # Remove the label so each application is exactly one retry; re-apply to retry again.
+      - name: Remove retry label
+        if: always()
+        run: gh api -X DELETE "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels/release%3Aretry" || true
+        env:
+          GH_TOKEN: ${{ github.token }}
 ```
 
 > **Using npm?** Replace `pnpm install --frozen-lockfile` with `npm ci` and `pnpm exec` with `npx`.
@@ -458,13 +506,13 @@ Result: the standing PR is up-to-date by the time the workflow exits — no stal
 
 #### Retrying a failed publish
 
-If a standing-PR publish fails partway through (some packages on the registry, no tags/GitHub release), add the **`release:retry`** label to the **merged** standing PR (configurable via `ci.labels.retry` — note the workflow's job-level `if` guard hardcodes the default name, so a renamed label requires updating that guard too). The `release-retry.yml` workflow:
+If a standing-PR publish fails partway through (some packages on the registry, no tags/GitHub release), add the **`release:retry`** label to the **merged** standing PR. The `retry-publish` job in the workflow template above:
 
-1. Validates the PR is a merged standing PR (head is the configured release branch).
-2. Dispatches the manifest-driven publish in `release.yml` for that PR — idempotent, so it re-publishes only the packages that did not land, then pushes tags and creates GitHub releases.
+1. Validates via its `if` guard that the PR is a merged standing PR and the label is `release:retry` — note the guard hardcodes the label name (workflow `if` expressions can't read releasekit config), so renaming the label via `ci.labels.retry` requires updating the guard to match.
+2. Re-runs the manifest-driven publish for that PR (`standing-pr publish --pr <n>`) — idempotent, so it re-publishes only the packages that did not land, then pushes tags and creates GitHub releases.
 3. Removes the label, so each application is exactly one retry; re-apply it to retry again.
 
-Applying the label to a non-standing or unmerged PR is a no-op — the workflow leaves an explanatory comment and removes the label without dispatching. A successful retry resolves the partial-publish failure report and clears the supersede warning from the next standing PR. Full recovery walkthrough: [Recovering from a failed publish](../../../docs/troubleshooting.md#recovering-from-a-failed-publish).
+Applying the label to a non-standing or unmerged PR simply doesn't match the job's guard — nothing runs. A successful retry resolves the partial-publish failure report and clears the supersede warning from the next standing PR. Full recovery walkthrough: [Recovering from a failed publish](../../../docs/troubleshooting.md#recovering-from-a-failed-publish). (For reference, releasekit's own repo implements the same flow as a standalone [`release-retry.yml`](../../../.github/workflows/release-retry.yml) that dispatches its release workflow — useful if your publish runs in a separate dispatchable workflow.)
 
 ### Troubleshooting
 
@@ -522,7 +570,7 @@ permissions:
 steps:
   - uses: actions/setup-node@v6
     with:
-      node-version: '20'
+      node-version: '24'
       registry-url: 'https://registry.npmjs.org'
 
   - run: pnpm exec releasekit release
@@ -565,7 +613,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
 
       - run: pnpm install --frozen-lockfile

--- a/packages/release/src/failure-report/failure-report.ts
+++ b/packages/release/src/failure-report/failure-report.ts
@@ -141,7 +141,11 @@ export interface RecoveryContext {
   mode: FailureReportMode;
   /** Standing PR number (standing-pr mode) used to phrase the dispatch/retry instruction. */
   standingPrNumber?: number;
-  /** Whether the `release:retry` label flow is available yet (issue #245). Off until it lands. */
+  /**
+   * Whether the `release:retry` label flow is wired (issue #245). When set, the label is the
+   * primary standing-pr recovery path; dispatch is offered as the manual fallback. Defaults off
+   * for callers that have not opted in (e.g. tests asserting the pre-#245 copy).
+   */
   retryLabelAvailable?: boolean;
 }
 
@@ -152,10 +156,18 @@ function renderRecovery(ctx: RecoveryContext): string[] {
     lines.push(
       `Re-run the publish for ${prRef}. Versions are already on \`main\`; retrying re-publishes only the packages that did not land.`,
       '',
-      `- **Dispatch the release workflow** targeting the merged standing PR (\`--pr ${ctx.standingPrNumber ?? '<number>'}\`).`,
     );
     if (ctx.retryLabelAvailable) {
-      lines.push(`- Or add the \`release:retry\` label to ${prRef} to trigger a retry automatically.`);
+      // The label is the primary recovery path — it dispatches the manifest-driven publish for
+      // this PR and removes itself, so it can be re-applied for another retry.
+      lines.push(
+        `- **Add the \`release:retry\` label** to ${prRef} to retry the publish automatically. The label is removed after each retry, so re-apply it to retry again.`,
+        `- Or **dispatch the release workflow** targeting the merged standing PR (\`--pr ${ctx.standingPrNumber ?? '<number>'}\`).`,
+      );
+    } else {
+      lines.push(
+        `- **Dispatch the release workflow** targeting the merged standing PR (\`--pr ${ctx.standingPrNumber ?? '<number>'}\`).`,
+      );
     }
   } else if (ctx.mode === 'direct') {
     lines.push(
@@ -292,7 +304,7 @@ export interface SupersedeWarningInput {
   total: number;
   /** Standing PR number carrying the failure report (the retry surface). */
   standingPrNumber?: number;
-  /** Whether `release:retry` is available yet (issue #245). */
+  /** Whether the `release:retry` label flow is wired (issue #245) — makes it the primary hint. */
   retryLabelAvailable?: boolean;
 }
 

--- a/packages/release/src/failure-report/post.ts
+++ b/packages/release/src/failure-report/post.ts
@@ -23,6 +23,7 @@ export interface PostFailureReportContext {
   /** PR to comment on. Omit for manual dispatch with no PR — the report goes to the step summary. */
   prNumber?: number;
   standingPrNumber?: number;
+  /** Whether the `release:retry` label flow is wired (issue #245) — makes it the primary hint. */
   retryLabelAvailable?: boolean;
 }
 

--- a/packages/release/src/label-utils.ts
+++ b/packages/release/src/label-utils.ts
@@ -3,6 +3,7 @@ export interface LabelConfig {
   prerelease: string;
   skip: string;
   immediate: string;
+  retry: string;
   major: string;
   minor: string;
   patch: string;
@@ -13,6 +14,7 @@ export const DEFAULT_LABELS: LabelConfig = {
   prerelease: 'channel:prerelease',
   skip: 'release:skip',
   immediate: 'release:immediate',
+  retry: 'release:retry',
   major: 'bump:major',
   minor: 'bump:minor',
   patch: 'bump:patch',

--- a/packages/release/src/preview/preview.ts
+++ b/packages/release/src/preview/preview.ts
@@ -89,6 +89,7 @@ export async function runPreview(options: PreviewOptions): Promise<void> {
             published: unresolved.published,
             total: unresolved.total,
             standingPrNumber: unresolved.prNumber,
+            retryLabelAvailable: true,
           });
         }
       }

--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -800,6 +800,7 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
           published: unresolved.published,
           total: unresolved.total,
           standingPrNumber: unresolved.prNumber,
+          retryLabelAvailable: true,
         });
       }
     }
@@ -871,6 +872,23 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
     } catch {
       warn('Failed to apply labels to standing PR');
     }
+  }
+
+  // Ensure the retry label exists in the repo (with a description) so a maintainer can apply it
+  // to this PR after merge to retry a failed publish (issue #245). It is NOT applied here — the
+  // maintainer applies it on demand, and the release-retry workflow removes it after each retry.
+  // createLabel throws 422 if it already exists; that's expected and ignored.
+  const retryLabel = ciConfig?.labels?.retry ?? DEFAULT_LABELS.retry;
+  try {
+    await octokit.rest.issues.createLabel({
+      owner,
+      repo,
+      name: retryLabel,
+      color: 'ededed',
+      description: 'ReleaseKit: retry a failed publish on this merged standing PR',
+    });
+  } catch {
+    // Label already exists — no action needed.
   }
 
   // Find existing manifest to preserve firstUpdatedAt across updates
@@ -1087,6 +1105,7 @@ export async function publishFromManifest(prNumber: number, options: StandingPRO
             mode: 'standing-pr',
             prNumber,
             standingPrNumber: prNumber,
+            retryLabelAvailable: true,
           },
           manifest.versionOutput,
           err,

--- a/packages/release/test/unit/failure-report.spec.ts
+++ b/packages/release/test/unit/failure-report.spec.ts
@@ -207,6 +207,25 @@ describe('renderFailureReport', () => {
     expect(withoutRetry).not.toContain('release:retry');
   });
 
+  it('makes the release:retry label the primary recovery path when available', () => {
+    const body = renderFailureReport({
+      versionOutput,
+      publishOutput,
+      failedStage: 'npm-publish',
+      errorMessage: 'npm 403',
+      recovery: { mode: 'standing-pr', standingPrNumber: 42, retryLabelAvailable: true },
+    });
+    // The label instruction is listed before the dispatch fallback.
+    const labelIdx = body.indexOf('release:retry');
+    const dispatchIdx = body.indexOf('--pr 42');
+    expect(labelIdx).toBeGreaterThanOrEqual(0);
+    expect(dispatchIdx).toBeGreaterThanOrEqual(0);
+    expect(labelIdx).toBeLessThan(dispatchIdx);
+    // Still mentions that the label is removed / re-appliable, and keeps the dispatch fallback.
+    expect(body).toContain('re-apply');
+    expect(body).toContain('#42');
+  });
+
   it('gives direct-mode recovery instructions (re-run failed jobs)', () => {
     const body = renderFailureReport({
       versionOutput,
@@ -253,5 +272,28 @@ describe('renderSupersedeWarning', () => {
     expect(text).toContain('2/4 packages');
     expect(text).toContain('#42');
     expect(text).toContain('supersedes it');
+  });
+
+  it('references the release:retry label as the primary reconcile path when available', () => {
+    const text = renderSupersedeWarning({
+      previousLabel: 'v0.24.0',
+      published: 2,
+      total: 4,
+      standingPrNumber: 42,
+      retryLabelAvailable: true,
+    }).join('\n');
+    expect(text).toContain('release:retry');
+    expect(text).toContain('supersedes it');
+  });
+
+  it('falls back to the dispatch instruction when the label is not available', () => {
+    const text = renderSupersedeWarning({
+      previousLabel: 'v0.24.0',
+      published: 2,
+      total: 4,
+      standingPrNumber: 42,
+    }).join('\n');
+    expect(text).not.toContain('release:retry');
+    expect(text).toContain('dispatching the release workflow');
   });
 });

--- a/releasekit.schema.json
+++ b/releasekit.schema.json
@@ -867,6 +867,11 @@
               "default": "release:immediate",
               "description": "Label to bypass the standing PR for one merge — triggers a direct release. Standing-pr mode only."
             },
+            "retry": {
+              "type": "string",
+              "default": "release:retry",
+              "description": "Label to retry a failed publish by re-applying it to a merged standing PR. Standing-pr mode only."
+            },
             "major": {
               "type": "string",
               "default": "bump:major",


### PR DESCRIPTION
Implements #245. Gives maintainers a one-action retry for a failed standing-pr publish: apply a `release:retry` label to the merged standing PR. The failure report (#243) is the information surface; this label is the action surface.

## What changed

**New workflow** — `.github/workflows/release-retry.yml`
- Triggers on `pull_request: types: [labeled]`, guarded to `release:retry`.
- Validates the PR is MERGED and its head ref is the configured standing branch (`release/next`), then dispatches `release.yml` with `standing_pr_number` (the idempotent manifest-driven publish path), and removes the label so it can be re-applied for another retry.
- On a validation failure (non-standing or unmerged PR) it leaves an explanatory comment and removes the label without dispatching.
- `permissions: actions: write, pull-requests: write`; uses `gh` via `GH_TOKEN`, matching `standing-pr.yml`'s dispatch style.

**Label config** — added `retry` (default `release:retry`) to the labels config schema, `DEFAULT_LABELS`, and `releasekit.schema.json`, and ensure-create it on the standing PR with a description (consistent with `release:immediate`). The label is not auto-applied — the workflow removes it on each use.

**Recovery surfaces** — flipped `retryLabelAvailable` on at every failure-report caller (`standing-pr.ts`, `preview.ts`) so the label is the primary standing-pr recovery path in the failure report's recovery instructions and the next standing PR's supersede warning, with workflow dispatch as the manual fallback.

**Resolution** — a successful retry resolves the #243 failure report (`publishFromManifest` already calls `resolveFailureReportIfPresent`), clearing the supersede warning from the next standing PR.

**Docs** — recovery section (troubleshooting.md), standing-pr labels reference and decision guide (ci-setup.md), migration mapping; regenerated configuration.md.

## Acceptance criteria

- [x] Applying `release:retry` to a merged standing PR dispatches the manifest-driven publish for that PR
- [x] The label is removed after dispatch (re-appliable)
- [x] Applying to a non-standing / unmerged PR is a no-op with a clear comment explaining why
- [x] A retry after partial failure publishes only the missing packages, then pushes tags / creates releases (idempotent publish path, unchanged)
- [x] A successful retry resolves the #243 failure report, clearing the supersede warning
- [x] The failure report and the next standing PR's warning reference the label as the primary reconcile path in standing-pr mode
- [x] Docs: label documented in the recovery section and labels reference

## Verification
- `pnpm turbo run lint typecheck test` — 24/24 tasks pass
- `pnpm docs:config` regenerated, no residual diff

Closes #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a one-action publish retry for failed standing-PR releases: applying a `release:retry` label to a merged standing PR dispatches the idempotent manifest-driven publish path and removes the label, making it re-appliable.

- **New `release-retry.yml` workflow** validates the labeled PR is a merged standing PR, dispatches `release.yml` with `standing_pr_number`, and removes the label. The `ci-setup.md` template embeds the equivalent `retry-publish` job inline in the existing standing-pr workflow.
- **Schema / label infrastructure**: `retry` added to `CILabelsConfigSchema`, `DEFAULT_LABELS`, `LabelConfig`, and `releasekit.schema.json`; the label is ensure-created in `runStandingPRUpdate`.
- **Failure report copy** restructured to promote `release:retry` as the primary recovery path (with workflow dispatch as fallback) when `retryLabelAvailable` is true; new unit tests cover both paths.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge with the label-removal fix in the ci-setup.md template; the retry dispatch and idempotent publish path are correct.

The ci-setup.md template hardcodes release%3Aretry in the label removal URL. When a user renames their label and follows the documented migration (update the if guard), the removal step is left pointing at the old name, silently no-oping and leaving the renamed label stuck on every merged standing PR. The core workflow logic, schema additions, and failure-report copy changes are all correct.

packages/release/docs/ci-setup.md — label removal step hardcodes the default label name instead of using the event label.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/release-retry.yml | New standalone workflow: validates label event, dispatches release.yml for merged standing PR, removes label. Logic is sound but dispatch failure leaves label unremoved due to set -euo pipefail. |
| packages/release/docs/ci-setup.md | Template workflow gains retry-publish job; label removal step hardcodes release%3Aretry rather than the event label name — breaks one-shot invariant when users rename the label. |
| packages/release/src/standing-pr/standing-pr.ts | Adds retry label ensure-create and retryLabelAvailable:true flag; bare catch swallows all errors from createLabel (not just 422), masking auth or network failures. |
| packages/release/src/failure-report/failure-report.ts | Recovery rendering restructured to promote release:retry as primary path when retryLabelAvailable; dispatch preserved as fallback. Logic is correct. |
| packages/config/src/schema.ts | Adds retry field with default 'release:retry' to CILabelsConfigSchema and DEFAULT_LABELS; consistent with existing label fields. |
| packages/release/src/preview/preview.ts | Passes retryLabelAvailable:true to supersede warning in preview; straightforward one-liner addition. |
| packages/release/test/unit/failure-report.spec.ts | Adds tests for label-as-primary-path and falls-back-to-dispatch cases; coverage is appropriate and assertions are correct. |

</details>

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Apackages%2Frelease%2Fdocs%2Fci-setup.md%3A431-436%0AThe%20label%20removal%20URL%20hardcodes%20%60release%253Aretry%60%20rather%20than%20using%20the%20event%20label%20name.%20The%20documentation%20at%20line%20511%20says%20renaming%20the%20label%20only%20requires%20updating%20the%20%60if%60%20guard%2C%20but%20this%20removal%20step%20also%20needs%20to%20change.%20If%20a%20user%20renames%20to%20e.g.%20%60my-retry%60%2C%20the%20%60gh%20api%20DELETE%60%20call%20targets%20the%20non-existent%20%60release%3Aretry%60%20path%20and%20silently%20succeeds%20%28because%20%60%7C%7C%20true%60%20suppresses%20the%20404%29%2C%20leaving%20%60my-retry%60%20on%20the%20PR%20permanently%20%E2%80%94%20breaking%20the%20one-shot%20invariant%20on%20every%20rename.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%23%20Remove%20the%20label%20so%20each%20application%20is%20exactly%20one%20retry%3B%20re-apply%20to%20retry%20again.%0A%20%20%20%20%20%20-%20name%3A%20Remove%20retry%20label%0A%20%20%20%20%20%20%20%20if%3A%20always%28%29%0A%20%20%20%20%20%20%20%20run%3A%20gh%20pr%20edit%20%24%7B%7B%20github.event.pull_request.number%20%7D%7D%20--remove-label%20%22%24%7B%7B%20github.event.label.name%20%7D%7D%22%20--repo%20%22%24%7B%7B%20github.repository%20%7D%7D%22%20%7C%7C%20true%0A%20%20%20%20%20%20%20%20env%3A%0A%20%20%20%20%20%20%20%20%20%20GH_TOKEN%3A%20%24%7B%7B%20github.token%20%7D%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Apackages%2Frelease%2Fsrc%2Fstanding-pr%2Fstanding-pr.ts%3A890-892%0AThe%20bare%20%60catch%60%20silently%20swallows%20all%20errors%20from%20%60createLabel%60%2C%20not%20just%20the%20expected%20422%20%28label%20already%20exists%29.%20Auth%20errors%20%28403%29%2C%20rate-limit%20errors%20%28429%29%2C%20or%20unexpected%20server%20errors%20are%20all%20silently%20discarded.%20This%20masks%20real%20problems%20and%20is%20inconsistent%20with%20the%20comment's%20stated%20intent.%0A%0A%60%60%60suggestion%0A%20%20%7D%20catch%20%28err%3A%20unknown%29%20%7B%0A%20%20%20%20%2F%2F%20422%20%3D%20label%20already%20exists%20%E2%80%94%20expected%20and%20benign.%0A%20%20%20%20const%20status%20%3D%20%28err%20as%20%7B%20status%3F%3A%20number%20%7D%29%3F.status%3B%0A%20%20%20%20if%20%28status%20!%3D%3D%20422%29%20%7B%0A%20%20%20%20%20%20warn%28%60Failed%20to%20ensure%20retry%20label%20'%24%7BretryLabel%7D'%20exists%3A%20%24%7BString%28err%29%7D%60%29%3B%0A%20%20%20%20%7D%0A%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0A.github%2Fworkflows%2Frelease-retry.yml%3A103-109%0A**Label%20not%20removed%20on%20dispatch%20failure**%0A%0A%60set%20-euo%20pipefail%60%20causes%20the%20script%20to%20exit%20immediately%20if%20%60gh%20workflow%20run%60%20returns%20a%20non-zero%20exit%20code%2C%20jumping%20past%20the%20trailing%20%60remove_label%60%20call.%20The%20label%20then%20stays%20on%20the%20merged%20PR%20indefinitely%3B%20the%20user%20sees%20it%20still%20applied%20and%20has%20no%20indication%20of%20whether%20a%20dispatch%20was%20attempted.%20Wrapping%20the%20dispatch%20with%20%60%7C%7C%20%7B%20remove_label%3B%20exit%201%3B%20%7D%60%20ensures%20cleanup%20runs%20in%20both%20the%20success%20and%20error%20paths%20while%20still%20propagating%20the%20failure%20signal.%0A%0A&repo=goosewobbler%2Freleasekit&pr=255&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Apackages%2Frelease%2Fdocs%2Fci-setup.md%3A431-436%0AThe%20label%20removal%20URL%20hardcodes%20%60release%253Aretry%60%20rather%20than%20using%20the%20event%20label%20name.%20The%20documentation%20at%20line%20511%20says%20renaming%20the%20label%20only%20requires%20updating%20the%20%60if%60%20guard%2C%20but%20this%20removal%20step%20also%20needs%20to%20change.%20If%20a%20user%20renames%20to%20e.g.%20%60my-retry%60%2C%20the%20%60gh%20api%20DELETE%60%20call%20targets%20the%20non-existent%20%60release%3Aretry%60%20path%20and%20silently%20succeeds%20%28because%20%60%7C%7C%20true%60%20suppresses%20the%20404%29%2C%20leaving%20%60my-retry%60%20on%20the%20PR%20permanently%20%E2%80%94%20breaking%20the%20one-shot%20invariant%20on%20every%20rename.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%23%20Remove%20the%20label%20so%20each%20application%20is%20exactly%20one%20retry%3B%20re-apply%20to%20retry%20again.%0A%20%20%20%20%20%20-%20name%3A%20Remove%20retry%20label%0A%20%20%20%20%20%20%20%20if%3A%20always%28%29%0A%20%20%20%20%20%20%20%20run%3A%20gh%20pr%20edit%20%24%7B%7B%20github.event.pull_request.number%20%7D%7D%20--remove-label%20%22%24%7B%7B%20github.event.label.name%20%7D%7D%22%20--repo%20%22%24%7B%7B%20github.repository%20%7D%7D%22%20%7C%7C%20true%0A%20%20%20%20%20%20%20%20env%3A%0A%20%20%20%20%20%20%20%20%20%20GH_TOKEN%3A%20%24%7B%7B%20github.token%20%7D%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Apackages%2Frelease%2Fsrc%2Fstanding-pr%2Fstanding-pr.ts%3A890-892%0AThe%20bare%20%60catch%60%20silently%20swallows%20all%20errors%20from%20%60createLabel%60%2C%20not%20just%20the%20expected%20422%20%28label%20already%20exists%29.%20Auth%20errors%20%28403%29%2C%20rate-limit%20errors%20%28429%29%2C%20or%20unexpected%20server%20errors%20are%20all%20silently%20discarded.%20This%20masks%20real%20problems%20and%20is%20inconsistent%20with%20the%20comment's%20stated%20intent.%0A%0A%60%60%60suggestion%0A%20%20%7D%20catch%20%28err%3A%20unknown%29%20%7B%0A%20%20%20%20%2F%2F%20422%20%3D%20label%20already%20exists%20%E2%80%94%20expected%20and%20benign.%0A%20%20%20%20const%20status%20%3D%20%28err%20as%20%7B%20status%3F%3A%20number%20%7D%29%3F.status%3B%0A%20%20%20%20if%20%28status%20!%3D%3D%20422%29%20%7B%0A%20%20%20%20%20%20warn%28%60Failed%20to%20ensure%20retry%20label%20'%24%7BretryLabel%7D'%20exists%3A%20%24%7BString%28err%29%7D%60%29%3B%0A%20%20%20%20%7D%0A%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0A.github%2Fworkflows%2Frelease-retry.yml%3A103-109%0A**Label%20not%20removed%20on%20dispatch%20failure**%0A%0A%60set%20-euo%20pipefail%60%20causes%20the%20script%20to%20exit%20immediately%20if%20%60gh%20workflow%20run%60%20returns%20a%20non-zero%20exit%20code%2C%20jumping%20past%20the%20trailing%20%60remove_label%60%20call.%20The%20label%20then%20stays%20on%20the%20merged%20PR%20indefinitely%3B%20the%20user%20sees%20it%20still%20applied%20and%20has%20no%20indication%20of%20whether%20a%20dispatch%20was%20attempted.%20Wrapping%20the%20dispatch%20with%20%60%7C%7C%20%7B%20remove_label%3B%20exit%201%3B%20%7D%60%20ensures%20cleanup%20runs%20in%20both%20the%20success%20and%20error%20paths%20while%20still%20propagating%20the%20failure%20signal.%0A%0A&pr=255&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (3): Last reviewed commit: ["docs(release): consumer retry job in ci-..."](https://github.com/goosewobbler/releasekit/commit/aeabb73032c03f392acfc78399ddcd34b7390db0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35623049)</sub>

<!-- /greptile_comment -->