### PR TITLE
docs: mention .jsonc config support in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Versioning, changelogs, and publishing for JavaScript and Rust monorepos — dri
 
 ## Why ReleaseKit
 
-- **One config, two ecosystems** — JavaScript and Rust packages release from the same `releasekit.config.json` (or `.jsonc` with comments), including mixed monorepos.
+- **One config, two ecosystems** — JavaScript and Rust packages release from the same `releasekit.config.json`, including mixed monorepos.
 - **Composable, not opinionated** — three independent CLIs (`version`, `notes`, `publish`) you can pipe together, or a unified `release` command if you want the full pipeline.
 - **CI-native** — JSON output, OIDC publishing, PR preview comments, and label- or commit-driven triggers without bolting on extra tools.
 
@@ -99,7 +99,7 @@ See [docs/action.md](./docs/action.md) for the `preview` mode, full input/output
 
 ## Configuration
 
-ReleaseKit reads `releasekit.config.json` (or `releasekit.config.jsonc` — comments and trailing commas are supported in both) at the project root. All configuration is optional — sensible defaults apply. A typical config:
+ReleaseKit reads `releasekit.config.json` or `releasekit.config.jsonc` (comments and trailing commas supported) at the project root. All configuration is optional — sensible defaults apply. A typical config:
 
 ```json
 {
@@ -125,7 +125,7 @@ See the [package docs](#documentation) for the full option reference.
 - [Migration](./docs/migration.md) — from semantic-release or changesets
 
 **Reference**
-- [Configuration](./docs/configuration.md) — full config reference (all `releasekit.config.json` / `.jsonc` options)
+- [Configuration](./docs/configuration.md) — full config reference (all `releasekit.config.json` options)
 - [GitHub Action](./docs/action.md) — `goosewobbler/releasekit` action inputs, outputs, and rollout
 - [@releasekit/release](./packages/release/README.md) — unified pipeline, CI automation, programmatic API
 - [@releasekit/version](./packages/version/README.md) — versioning strategies, JSON output

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Versioning, changelogs, and publishing for JavaScript and Rust monorepos — dri
 
 ## Why ReleaseKit
 
-- **One config, two ecosystems** — JavaScript and Rust packages release from the same `releasekit.config.json`, including mixed monorepos.
+- **One config, two ecosystems** — JavaScript and Rust packages release from the same `releasekit.config.json` (or `.jsonc` with comments), including mixed monorepos.
 - **Composable, not opinionated** — three independent CLIs (`version`, `notes`, `publish`) you can pipe together, or a unified `release` command if you want the full pipeline.
 - **CI-native** — JSON output, OIDC publishing, PR preview comments, and label- or commit-driven triggers without bolting on extra tools.
 
@@ -99,7 +99,7 @@ See [docs/action.md](./docs/action.md) for the `preview` mode, full input/output
 
 ## Configuration
 
-ReleaseKit reads `releasekit.config.json` at the project root. All configuration is optional — sensible defaults apply. A typical config:
+ReleaseKit reads `releasekit.config.json` (or `releasekit.config.jsonc` — comments and trailing commas are supported in both) at the project root. All configuration is optional — sensible defaults apply. A typical config:
 
 ```json
 {
@@ -125,7 +125,7 @@ See the [package docs](#documentation) for the full option reference.
 - [Migration](./docs/migration.md) — from semantic-release or changesets
 
 **Reference**
-- [Configuration](./docs/configuration.md) — full config reference (all `releasekit.config.json` options)
+- [Configuration](./docs/configuration.md) — full config reference (all `releasekit.config.json` / `.jsonc` options)
 - [GitHub Action](./docs/action.md) — `goosewobbler/releasekit` action inputs, outputs, and rollout
 - [@releasekit/release](./packages/release/README.md) — unified pipeline, CI automation, programmatic API
 - [@releasekit/version](./packages/version/README.md) — versioning strategies, JSON output


### PR DESCRIPTION
Follow-up to #250: the README still presented `releasekit.config.json` as the only config filename. Now mentions `.jsonc` discovery and comment/trailing-comma support in the features list, the configuration section, and the docs index.

Doc-only change — also exercises the #254 lint-staged fix (md-only commit passes the pre-commit hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This is a documentation-only PR that updates `README.md` to surface `.jsonc` config file support (introduced in #250) in the Configuration section. The single changed line now tells users they can use either `releasekit.config.json` or `releasekit.config.jsonc` with comments and trailing commas.

- **Configuration section** (line 102): updated to mention both filenames and JSONC syntax benefits.
- **Features list & docs index**: the PR description says these were also updated, but the diff only contains the one Configuration-section change — two other occurrences of the bare `releasekit.config.json` name remain (the "Why ReleaseKit" bullet and the docs-index Configuration entry).
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — doc-only change with no code or logic impact.

The change is a single-line documentation update with no code, config, or test modifications. Nothing can break at runtime.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| README.md | Adds `.jsonc` filename and comment/trailing-comma support to the Configuration section; two other mentions of `releasekit.config.json` (the "Why ReleaseKit" bullet and the docs-index Configuration entry) were not updated. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Project root] --> B{Config file discovery}
    B --> C[releasekit.config.json\nstrict JSON]
    B --> D[releasekit.config.jsonc\ncomments + trailing commas]
    C --> E[ReleaseKit reads config]
    D --> E
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0AREADME.md%3A128%0AThe%20docs%20reference%20still%20describes%20the%20config%20file%20as%20%60releasekit.config.json%60%20only.%20Since%20this%20PR%20is%20specifically%20adding%20%60.jsonc%60%20support%20to%20the%20docs%2C%20this%20line%20is%20one%20more%20place%20worth%20updating%20for%20consistency.%0A%0A%60%60%60suggestion%0A-%20%5BConfiguration%5D%28.%2Fdocs%2Fconfiguration.md%29%20%E2%80%94%20full%20config%20reference%20%28all%20%60releasekit.config.json%60%20%2F%20%60releasekit.config.jsonc%60%20options%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0AREADME.md%3A12%0AThe%20%22Why%20ReleaseKit%22%20bullet%20still%20names%20only%20%60releasekit.config.json%60.%20A%20small%20tweak%20here%20would%20keep%20the%20new%20%60.jsonc%60%20mention%20consistent%20across%20the%20README%20intro%20as%20well.%0A%0A%60%60%60suggestion%0A-%20**One%20config%2C%20two%20ecosystems**%20%E2%80%94%20JavaScript%20and%20Rust%20packages%20release%20from%20the%20same%20%60releasekit.config.json%60%20%28or%20%60.jsonc%60%29%2C%20including%20mixed%20monorepos.%0A%60%60%60%0A%0A&repo=goosewobbler%2Freleasekit&pr=257&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0AREADME.md%3A128%0AThe%20docs%20reference%20still%20describes%20the%20config%20file%20as%20%60releasekit.config.json%60%20only.%20Since%20this%20PR%20is%20specifically%20adding%20%60.jsonc%60%20support%20to%20the%20docs%2C%20this%20line%20is%20one%20more%20place%20worth%20updating%20for%20consistency.%0A%0A%60%60%60suggestion%0A-%20%5BConfiguration%5D%28.%2Fdocs%2Fconfiguration.md%29%20%E2%80%94%20full%20config%20reference%20%28all%20%60releasekit.config.json%60%20%2F%20%60releasekit.config.jsonc%60%20options%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0AREADME.md%3A12%0AThe%20%22Why%20ReleaseKit%22%20bullet%20still%20names%20only%20%60releasekit.config.json%60.%20A%20small%20tweak%20here%20would%20keep%20the%20new%20%60.jsonc%60%20mention%20consistent%20across%20the%20README%20intro%20as%20well.%0A%0A%60%60%60suggestion%0A-%20**One%20config%2C%20two%20ecosystems**%20%E2%80%94%20JavaScript%20and%20Rust%20packages%20release%20from%20the%20same%20%60releasekit.config.json%60%20%28or%20%60.jsonc%60%29%2C%20including%20mixed%20monorepos.%0A%60%60%60%0A%0A&pr=257&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["docs: slim the jsonc mention to the conf..."](https://github.com/goosewobbler/releasekit/commit/d39c874ef18f0bb92dfd475acacb6ef516451ba1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35623571)</sub>

<!-- /greptile_comment -->