### PR TITLE
docs: add CLI reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ See the [package docs](#documentation) for the full option reference.
 - [Migration](./docs/migration.md) — from semantic-release or changesets
 
 **Reference**
+- [CLI](./docs/cli.md) — every command and flag for the `releasekit` CLI
 - [Configuration](./docs/configuration.md) — full config reference (all `releasekit.config.json` options)
 - [GitHub Action](./docs/action.md) — `goosewobbler/releasekit` action inputs, outputs, and rollout
 - [@releasekit/release](./packages/release/README.md) — unified pipeline, CI automation, programmatic API

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,263 @@
+# CLI Reference
+
+ReleaseKit ships a unified `releasekit` command plus three standalone binaries. This page is a reference: one section per command with a flags table and a short example. For workflows and concepts, start with [Getting Started](./getting-started.md) and the [Architecture](./architecture.md) guide.
+
+## Binaries
+
+| Binary | Provided by | Commands |
+|---|---|---|
+| `releasekit` | `@releasekit/release` | `preview` (default), `release`, `standing-pr`, `init`, `version`, `notes`, `publish` |
+| `releasekit-version` | `@releasekit/version` | `version` |
+| `releasekit-notes` | `@releasekit/notes` | `notes` |
+| `releasekit-publish` | `@releasekit/publish` | `publish` |
+
+The `releasekit` dispatcher re-exports `version`, `notes`, and `publish`, so `releasekit version` and `releasekit-version` are equivalent. Examples below use `releasekit`.
+
+> **Conventions:** `<value>` is required; `[value]` is optional. Boolean flags default to `false` unless noted. Every command accepts `--help`. `--version` prints the binary version.
+
+---
+
+## `releasekit preview`
+
+Post a release preview comment on the current pull request. This is the default command, so `releasekit` with no arguments runs `preview`.
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `-c, --config <path>` | string | auto-discovered | Path to config file |
+| `--project-dir <path>` | string | `cwd` | Project directory |
+| `--pr <number>` | string | auto | PR number (auto-detected from GitHub Actions) |
+| `--repo <owner/repo>` | string | auto | Repository (auto-detected from `GITHUB_REPOSITORY`) |
+| `-p, --prerelease [identifier]` | boolean \| string | auto | Force prerelease preview (auto-detected by default) |
+| `--stable` | boolean | `false` | Force stable release preview (graduation from prerelease) |
+| `-t, --target <packages>` | string | all | Target specific packages (comma-separated) |
+| `-d, --dry-run` | boolean | `false` | Print the comment to stdout without posting (GitHub context not available in dry-run mode) |
+
+```bash
+releasekit preview --dry-run
+```
+
+---
+
+## `releasekit release`
+
+Run the full release pipeline: version, changelog, publish, git, and GitHub Release.
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `-c, --config <path>` | string | auto-discovered | Path to config file |
+| `-d, --dry-run` | boolean | `false` | Preview all steps without side effects |
+| `-b, --bump <type>` | `patch` \| `minor` \| `major` \| `prerelease` | auto | Force bump type |
+| `-p, --prerelease [identifier]` | boolean \| string | - | Create prerelease version |
+| `--stable` | boolean | `false` | Graduate prerelease packages to stable without bumping |
+| `-s, --sync` | boolean | `false` | Use synchronized versioning across all packages |
+| `-t, --target <packages>` | string | all | Target specific packages (comma-separated) |
+| `--scope <name>` | string | - | Resolve scope name to target packages from `ci.scopeLabels` config |
+| `--branch <name>` | string | current | Override the git branch used for push |
+| `--npm-auth <method>` | `auto` \| `oidc` \| `token` | `auto` | NPM auth method |
+| `--skip-notes` | boolean | `false` | Skip changelog generation |
+| `--skip-publish` | boolean | `false` | Skip registry publishing and git operations |
+| `--skip-git` | boolean | `false` | Skip git commit/tag/push |
+| `--skip-github-release` | boolean | `false` | Skip GitHub release creation |
+| `--skip-verification` | boolean | `false` | Skip post-publish verification |
+| `-j, --json` | boolean | `false` | Output results as JSON |
+| `-v, --verbose` | boolean | `false` | Verbose logging |
+| `-q, --quiet` | boolean | `false` | Suppress non-error output |
+| `--project-dir <path>` | string | `cwd` | Project directory |
+
+`--stable` and `--prerelease` are mutually exclusive.
+
+```bash
+releasekit release --dry-run
+```
+
+---
+
+## `releasekit standing-pr`
+
+Manage the standing release PR (create/update or publish on merge). Pick a subcommand: `update`, `publish`, or `merge`. All three share these options:
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `-c, --config <path>` | string | auto-discovered | Path to config file |
+| `--project-dir <path>` | string | `cwd` | Project directory |
+| `--npm-auth <method>` | `auto` \| `oidc` \| `token` | `auto` | NPM auth method |
+| `-j, --json` | boolean | `false` | Output results as JSON |
+| `-v, --verbose` | boolean | `false` | Verbose logging |
+| `-q, --quiet` | boolean | `false` | Suppress non-error output |
+
+### `releasekit standing-pr update`
+
+Calculate versions, commit to the release branch, and create/update the standing PR.
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--reconcile` | boolean | `false` | Bypass the skip-pattern guard so a post-release reconcile run still updates the standing PR (HEAD is a release commit at that point) |
+
+```bash
+releasekit standing-pr update --reconcile
+```
+
+### `releasekit standing-pr publish`
+
+Publish packages from a merged standing release PR (reads the manifest from the PR comment).
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--pr <number>` | integer | auto | PR number of the merged standing release PR. When omitted, falls back to the `pull_request` event payload, then to the most recently merged standing PR via the GitHub API |
+
+```bash
+releasekit standing-pr publish --pr 123
+```
+
+### `releasekit standing-pr merge`
+
+Merge the open standing release PR, optionally publishing immediately.
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--publish` | boolean | `false` | Publish packages immediately after merging |
+
+```bash
+releasekit standing-pr merge --publish
+```
+
+---
+
+## `releasekit init`
+
+Create a default `releasekit.config.json`. Detects whether the project is a monorepo to choose the changelog mode.
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `-f, --force` | boolean | `false` | Overwrite existing config |
+
+```bash
+releasekit init
+```
+
+---
+
+## `releasekit version`
+
+Version a package or packages based on configuration and conventional commits. Also available as the standalone `releasekit-version` binary.
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `-c, --config <path>` | string | `releasekit.config.json` | Path to config file |
+| `-d, --dry-run` | boolean | `false` | Dry run (no changes made) |
+| `-b, --bump <type>` | `patch` \| `minor` \| `major` \| `prerelease` | auto | Specify bump type |
+| `-p, --prerelease [identifier]` | boolean \| string | - | Create prerelease version |
+| `--stable` | boolean | `false` | Graduate prerelease packages to stable without bumping |
+| `-s, --sync` | boolean | config | Use synchronized versioning across all packages |
+| `-j, --json` | boolean | `false` | Output results as JSON |
+| `-t, --target <packages>` | string | all | Comma-delimited list of package names to target |
+| `--project-dir <path>` | string | `cwd` | Project directory to run commands in |
+
+`--stable` and `--prerelease` are mutually exclusive. `--target` is ignored for single-package repos.
+
+```bash
+releasekit version --json --dry-run
+```
+
+---
+
+## `releasekit notes`
+
+Generate changelogs with optional LLM-powered enhancement and flexible templating. Also available as the standalone `releasekit-notes` binary. Subcommands: `generate` (default), `auth`, `providers`. See the [LLM providers guide](../packages/notes/docs/llm-providers.md) for provider setup.
+
+### `releasekit notes generate`
+
+Generate changelog from input data (a version-output JSON, read from a file or stdin). This is the default subcommand.
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `-i, --input <file>` | string | stdin | Input file |
+| `--no-changelog` | boolean | - | Disable changelog generation |
+| `--changelog-mode <mode>` | `root` \| `packages` \| `both` | config | Changelog location mode |
+| `--changelog-file <name>` | string | config | Changelog file name override |
+| `--release-notes-mode <mode>` | `root` \| `packages` \| `both` | config | Enable release notes and set location |
+| `--release-notes-file <name>` | string | config | Release notes file name override |
+| `--no-release-notes` | boolean | - | Disable release notes generation |
+| `-t, --template <path>` | string | config | Template file or directory |
+| `-e, --engine <engine>` | `handlebars` \| `liquid` \| `ejs` | config | Template engine |
+| `--monorepo <mode>` | `root` \| `packages` \| `both` | config | Monorepo mode |
+| `--llm-provider <provider>` | string | config | LLM provider |
+| `--llm-model <model>` | string | config | LLM model |
+| `--llm-base-url <url>` | string | config | LLM base URL (for `openai-compatible` provider) |
+| `--llm-tasks <tasks>` | string | config | Comma-separated LLM tasks (`enhance`, `summarize`, `categorize`, `release-notes`) |
+| `--no-llm` | boolean | - | Disable LLM processing |
+| `--target <package>` | string | all | Filter to a specific package name |
+| `--config <path>` | string | auto-discovered | Config file path |
+| `--regenerate` | boolean | `false` | Regenerate entire changelog instead of prepending new entries |
+| `--dry-run` | boolean | `false` | Preview without writing |
+| `-v, --verbose` | count | `0` | Increase verbosity (repeatable: `-vv`, `-vvv`) |
+| `-q, --quiet` | boolean | `false` | Suppress non-error output |
+
+```bash
+releasekit version --json | releasekit notes generate --dry-run
+```
+
+### `releasekit notes auth <provider>`
+
+Configure the API key for an LLM provider.
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--key <key>` | string | prompt | API key (omit to be prompted) |
+
+```bash
+releasekit notes auth anthropic --key sk-...
+```
+
+### `releasekit notes providers`
+
+List available LLM providers. Takes no flags.
+
+```bash
+releasekit notes providers
+```
+
+---
+
+## `releasekit publish`
+
+Publish packages to registries with git tagging and GitHub releases. Reads a version-output JSON from a file or stdin. Also available as the standalone `releasekit-publish` binary.
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--input <path>` | string | stdin | Path to version output JSON |
+| `--config <path>` | string | auto-discovered | Path to releasekit config |
+| `--registry <type>` | `npm` \| `cargo` \| `all` | `all` | Registry to publish to |
+| `--npm-auth <method>` | `oidc` \| `token` \| `auto` | `auto` | NPM auth method |
+| `--dry-run` | boolean | `false` | Simulate all operations |
+| `--skip-git` | boolean | `false` | Skip git commit/tag/push |
+| `--skip-publish` | boolean | `false` | Skip registry publishing |
+| `--skip-github-release` | boolean | `false` | Skip GitHub Release creation |
+| `--skip-verification` | boolean | `false` | Skip post-publish verification |
+| `--json` | boolean | `false` | Output results as JSON |
+| `--verbose` | boolean | `false` | Verbose logging |
+
+```bash
+releasekit version --json | releasekit publish --dry-run
+```
+
+---
+
+## `releasekit-release gate`
+
+The standalone `releasekit-release` binary (also from `@releasekit/release`) exposes an extra `gate` command used by the GitHub Action's `gate` mode. It checks whether a release should proceed based on PR labels and config.
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `-c, --config <path>` | string | auto-discovered | Path to config file |
+| `--scope <name>` | string | - | Resolve scope name to target packages from `ci.scopeLabels` config |
+| `-j, --json` | boolean | `false` | Output results as JSON |
+| `-v, --verbose` | boolean | `false` | Verbose logging |
+| `-q, --quiet` | boolean | `false` | Suppress non-error output |
+| `--project-dir <path>` | string | `cwd` | Project directory |
+
+```bash
+releasekit-release gate --json
+```
+
+> Most users run `gate` through the [GitHub Action](./action.md) (`mode: gate`) rather than the CLI directly.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -7,6 +7,7 @@ ReleaseKit ships a unified `releasekit` command plus three standalone binaries. 
 | Binary | Provided by | Commands |
 |---|---|---|
 | `releasekit` | `@releasekit/release` | `preview` (default), `release`, `standing-pr`, `init`, `version`, `notes`, `publish` |
+| `releasekit-release` | `@releasekit/release` | `preview` (default), `release`, `standing-pr`, [`gate`](#releasekit-release-gate) |
 | `releasekit-version` | `@releasekit/version` | `version` |
 | `releasekit-notes` | `@releasekit/notes` | `notes` |
 | `releasekit-publish` | `@releasekit/publish` | `publish` |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -26,7 +26,7 @@ npm install -g @releasekit/release
 pnpm add -g @releasekit/release
 ```
 
-This provides the `releasekit` command. Individual tools (`releasekit-version`, `releasekit-notes`, `releasekit-publish`) are also available if you need them independently.
+This provides the `releasekit` command. Individual tools (`releasekit-version`, `releasekit-notes`, `releasekit-publish`) are also available if you need them independently. See the [CLI reference](./cli.md) for every command and flag.
 
 ---
 
@@ -187,6 +187,7 @@ jobs:
 
 - **[Architecture](./architecture.md)** — pipeline design, mental model, and how everything fits together
 - **[CI setup guide](../packages/release/docs/ci-setup.md)** — complete workflow recipes
+- **[CLI reference](./cli.md)** — every command and flag
 - **[Configuration reference](./configuration.md)** — all `releasekit.config.json` options
 - **[Troubleshooting](./troubleshooting.md)** — symptom-indexed error guide
 - **[@releasekit/notes — LLM providers](../packages/notes/docs/llm-providers.md)** — add AI-enhanced release notes


### PR DESCRIPTION
## What

Adds `docs/cli.md` — a CLI reference (not a tutorial) with one section per command, each with a flags table (flag, type, default, description) and a short usage example.

Documents the full `releasekit` surface:

- `releasekit preview` (default command)
- `releasekit release`
- `releasekit standing-pr update` / `publish` / `merge`
- `releasekit init`
- `releasekit version`
- `releasekit notes generate` / `auth` / `providers`
- `releasekit publish`
- `releasekit-release gate` (standalone binary only; reached via the Action's `mode: gate`)

Previously-undocumented flags now have a home, including `standing-pr update --reconcile` (#246) and `standing-pr publish --pr <n>`.

## How

Content is derived from the commander definitions in `packages/*/src` so descriptions match `--help`. No flags were invented; each table row maps to an `.option()`/`.addOption()` call in source. Cross-checked the dispatcher's command set against `dispatcher.spec.ts`. Flags with no literal default are marked `auto`/`config`/`-` rather than inventing one; mutual exclusions (`--stable`/`--prerelease`) are called out in prose.

## Links

- Linked from the README documentation list (Reference section).
- Linked from `docs/getting-started.md` where the CLI is first introduced, and in its Next steps list.

## Verification

`pnpm turbo run lint typecheck test` passes (24/24 tasks). Markdown only — no code changed.

Closes #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds `docs/cli.md`, a comprehensive CLI reference for the `releasekit` toolchain, cross-linked from both the README and `docs/getting-started.md`. The content was derived directly from Commander.js option definitions in the package sources, and the documented flags match the source code accurately.

- **`docs/cli.md`** — new reference page covering all eight commands across five binaries, with flags tables and short usage examples for every subcommand.
- **`README.md` / `docs/getting-started.md`** — two targeted link additions to connect readers from existing docs to the new reference.
</details>

<h3>Confidence Score: 5/5</h3>

Documentation-only change with no code modifications; safe to merge.

Every flag table in the new CLI reference was verified against the corresponding Commander.js option definitions across all four package sources. Binaries table, command hierarchy, flag types, defaults, and mutual-exclusion notes all match the source exactly. The cross-links added to README and getting-started.md point to the correct relative paths.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/cli.md | New CLI reference; all flag tables cross-checked against Commander option definitions in packages/release, packages/version, packages/notes, and packages/publish — no inaccuracies found. |
| README.md | Single link addition to the Reference section pointing at docs/cli.md — correct and consistent with surrounding entries. |
| docs/getting-started.md | Two link additions to the install blurb and the Next steps list — both link to the new CLI reference correctly. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[releasekit] --> B[preview default]
    A --> C[release]
    A --> D[standing-pr]
    A --> E[init]
    A --> F[version]
    A --> G[notes]
    A --> H[publish]
    D --> D1[update]
    D --> D2[publish]
    D --> D3[merge]
    G --> G1[generate default]
    G --> G2[auth]
    G --> G3[providers]
    RR[releasekit-release] --> B2[preview default]
    RR --> C2[release]
    RR --> D4[standing-pr]
    RR --> I[gate]
    RV[releasekit-version] --> F2[version default]
    RN[releasekit-notes] --> G4[notes default]
    RP[releasekit-publish] --> H2[publish default]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["docs: add releasekit-release binary to t..."](https://github.com/goosewobbler/releasekit/commit/4ccf6b15ee416640b39251066acd43f87f3841d0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35627543)</sub>

<!-- /greptile_comment -->