### PR TITLE
test: adopt it('should …') title convention across all packages

### DIFF
--- a/packages/config/test/unit/load.spec.ts
+++ b/packages/config/test/unit/load.spec.ts
@@ -300,7 +300,7 @@ describe('loadCIConfig', () => {
     vi.clearAllMocks();
   });
 
-  it('returns CI config from loaded config', () => {
+  it('should return CI config from loaded config', () => {
     mockedFs.existsSync.mockReturnValue(true);
     mockedFs.readFileSync.mockReturnValue(
       JSON.stringify({
@@ -313,7 +313,7 @@ describe('loadCIConfig', () => {
     expect(result?.autoRelease).toBe(true);
   });
 
-  it('returns undefined when no CI config', () => {
+  it('should return undefined when no CI config', () => {
     mockedFs.existsSync.mockReturnValue(true);
     mockedFs.readFileSync.mockReturnValue('{}');
 

--- a/packages/notes/test/integration/pipeline-config.spec.ts
+++ b/packages/notes/test/integration/pipeline-config.spec.ts
@@ -263,7 +263,7 @@ describe('Pipeline: skipReleaseNotes / skipChangelogs flags', () => {
     vi.mocked(fs.writeFileSync).mockReturnValue(undefined);
   });
 
-  it('skipReleaseNotes:true should not write RELEASE_NOTES.md and should not invoke the LLM', async () => {
+  it('should not write RELEASE_NOTES.md and should not invoke the LLM when skipReleaseNotes:true', async () => {
     const { createProvider } = await import('../../src/llm/index.js');
     vi.mocked(createProvider).mockClear();
 
@@ -284,7 +284,7 @@ describe('Pipeline: skipReleaseNotes / skipChangelogs flags', () => {
     expect(result.releaseNotes).toBeUndefined();
   });
 
-  it('skipChangelogs:true should skip CHANGELOG.md but still write RELEASE_NOTES.md', async () => {
+  it('should skip CHANGELOG.md but still write RELEASE_NOTES.md when skipChangelogs:true', async () => {
     const { createProvider } = await import('../../src/llm/index.js');
     vi.mocked(createProvider).mockClear();
 
@@ -299,7 +299,7 @@ describe('Pipeline: skipReleaseNotes / skipChangelogs flags', () => {
     expect(result.files).toContain('RELEASE_NOTES.md');
   });
 
-  it('both flags omitted preserves existing behaviour (changelog + release notes both written)', async () => {
+  it('should preserve existing behaviour with both flags omitted (changelog + release notes both written)', async () => {
     const { runPipeline } = await import('../../src/core/pipeline.js');
     const config: Config = {
       changelog: { mode: 'root', file: 'CHANGELOG.md' },

--- a/packages/notes/test/integration/snapshot.spec.ts
+++ b/packages/notes/test/integration/snapshot.spec.ts
@@ -83,7 +83,7 @@ describe('Pipeline: render snapshot', () => {
     vi.mocked(fs.writeFileSync).mockReturnValue(undefined);
   });
 
-  it('renders Breaking first, scope groups, and leadIn phrases', async () => {
+  it('should render Breaking first, scope groups, and leadIn phrases', async () => {
     const { createProvider } = await import('../../src/llm/index.js');
     const mockProvider: LLMProvider = {
       name: 'mock',

--- a/packages/notes/test/unit/llm.spec.ts
+++ b/packages/notes/test/unit/llm.spec.ts
@@ -690,7 +690,7 @@ describe('capabilities: schema options gating', () => {
     };
   }
 
-  it('passes schema and toolName to enhanceAndCategorize when structuredOutputs is true', async () => {
+  it('should pass schema and toolName to enhanceAndCategorize when structuredOutputs is true', async () => {
     let captured: CompleteOptions | undefined;
     const provider = makeCapabilityProvider(true, threeEntryResponse, (o) => (captured = o));
     await enhanceAndCategorize(provider, sampleEntries, llmContext);
@@ -698,14 +698,14 @@ describe('capabilities: schema options gating', () => {
     expect(captured?.toolName).toBe('emit_release_notes');
   });
 
-  it('omits schema options from enhanceAndCategorize when structuredOutputs is false', async () => {
+  it('should omit schema options from enhanceAndCategorize when structuredOutputs is false', async () => {
     let captured: CompleteOptions | undefined;
     const provider = makeCapabilityProvider(false, threeEntryResponse, (o) => (captured = o));
     await enhanceAndCategorize(provider, sampleEntries, llmContext);
     expect(captured).toBeUndefined();
   });
 
-  it('passes schema and toolName to categorizeEntries when structuredOutputs is true', async () => {
+  it('should pass schema and toolName to categorizeEntries when structuredOutputs is true', async () => {
     let captured: CompleteOptions | undefined;
     const provider = makeCapabilityProvider(true, threeEntryCategorizeResponse, (o) => (captured = o));
     await categorizeEntries(provider, sampleEntries, llmContext);
@@ -713,7 +713,7 @@ describe('capabilities: schema options gating', () => {
     expect(captured?.toolName).toBe('categorize_entries');
   });
 
-  it('omits schema options from categorizeEntries when structuredOutputs is false', async () => {
+  it('should omit schema options from categorizeEntries when structuredOutputs is false', async () => {
     let captured: CompleteOptions | undefined;
     const provider = makeCapabilityProvider(false, threeEntryCategorizeResponse, (o) => (captured = o));
     await categorizeEntries(provider, sampleEntries, llmContext);

--- a/packages/publish/test/unit/utils/publish-retry.spec.ts
+++ b/packages/publish/test/unit/utils/publish-retry.spec.ts
@@ -16,11 +16,11 @@ describe('classifyPublishError', () => {
       ['socket hang up', 'request to crates.io failed: socket hang up'],
     ];
 
-    it.each(transient)('classifies %s as transient', (_label, message) => {
+    it.each(transient)('should classify %s as transient', (_label, message) => {
       expect(classifyPublishError(new Error(message))).toBe('transient');
     });
 
-    it('reads stdout/stderr from exec-style errors', () => {
+    it('should read stdout/stderr from exec-style errors', () => {
       const error = Object.assign(new Error('Command failed: npm publish'), {
         stdout: '',
         stderr: 'npm ERR! 503 Service Unavailable',
@@ -40,27 +40,27 @@ describe('classifyPublishError', () => {
       ['validation', 'npm ERR! Invalid package name'],
     ];
 
-    it.each(permanent)('classifies %s as permanent', (_label, message) => {
+    it.each(permanent)('should classify %s as permanent', (_label, message) => {
       expect(classifyPublishError(new Error(message))).toBe('permanent');
     });
 
-    it('treats unknown errors as permanent (fail-fast default)', () => {
+    it('should treat unknown errors as permanent (fail-fast default)', () => {
       expect(classifyPublishError(new Error('failed to verify package tarball'))).toBe('permanent');
     });
 
-    it('prefers permanent when an auth error also mentions a status code', () => {
+    it('should prefer permanent when an auth error also mentions a status code', () => {
       // 403 is a status code, but auth failures must not be retried.
       expect(classifyPublishError(new Error('npm ERR! 403 Forbidden - authentication failed'))).toBe('permanent');
     });
 
-    it('does not treat "invalid" inside raw socket errors as permanent', () => {
+    it('should not treat "invalid" inside raw socket errors as permanent', () => {
       // Node can phrase transient socket failures with the word "invalid" —
       // these must remain transient or retries would be suppressed.
       expect(classifyPublishError(new Error('read ECONNRESET, invalid argument'))).toBe('transient');
       expect(classifyPublishError(new Error('write EPIPE, invalid argument'))).toBe('transient');
     });
 
-    it('still classifies validation-context "invalid" messages as permanent', () => {
+    it('should still classify validation-context "invalid" messages as permanent', () => {
       expect(classifyPublishError(new Error('npm ERR! Invalid tag name "latest@"'))).toBe('permanent');
       expect(classifyPublishError(new Error('Invalid version: "1.0.0.0" is not valid semver'))).toBe('permanent');
     });
@@ -75,7 +75,7 @@ describe('withPublishRetry', () => {
     noSleep.mockClear();
   });
 
-  it('returns the result and attempts=1 on first success', async () => {
+  it('should return the result and attempts=1 on first success', async () => {
     const fn = vi.fn().mockResolvedValue('ok');
 
     const result = await withPublishRetry(fn, opts);
@@ -85,7 +85,7 @@ describe('withPublishRetry', () => {
     expect(noSleep).not.toHaveBeenCalled();
   });
 
-  it('retries a transient failure and succeeds, reporting attempt count', async () => {
+  it('should retry a transient failure and succeed, reporting attempt count', async () => {
     const fn = vi.fn().mockRejectedValueOnce(new Error('503 Service Unavailable')).mockResolvedValue('recovered');
 
     const result = await withPublishRetry(fn, opts);
@@ -94,7 +94,7 @@ describe('withPublishRetry', () => {
     expect(fn).toHaveBeenCalledTimes(2);
   });
 
-  it('exhausts retries on persistent transient failure and rethrows the real error', async () => {
+  it('should exhaust retries on persistent transient failure and rethrow the real error', async () => {
     const realError = new Error('ETIMEDOUT');
     const fn = vi.fn().mockRejectedValue(realError);
 
@@ -104,7 +104,7 @@ describe('withPublishRetry', () => {
     expect(fn).toHaveBeenCalledTimes(6);
   });
 
-  it('does not retry a permanent failure (fail-fast, zero retries)', async () => {
+  it('should not retry a permanent failure (fail-fast, zero retries)', async () => {
     const fn = vi.fn().mockRejectedValue(new Error('npm ERR! code ENEEDAUTH'));
 
     await expect(withPublishRetry(fn, opts)).rejects.toThrow('ENEEDAUTH');
@@ -113,7 +113,7 @@ describe('withPublishRetry', () => {
     expect(noSleep).not.toHaveBeenCalled();
   });
 
-  it('reports every attempt via onAttempt, including when all attempts fail', async () => {
+  it('should report every attempt via onAttempt, including when all attempts fail', async () => {
     const fn = vi.fn().mockRejectedValue(new Error('ETIMEDOUT'));
     const onAttempt = vi.fn();
 
@@ -123,7 +123,7 @@ describe('withPublishRetry', () => {
     expect(onAttempt.mock.calls.map(([n]) => n)).toEqual([1, 2, 3]);
   });
 
-  it('uses exponential backoff between retries', async () => {
+  it('should use exponential backoff between retries', async () => {
     const sleep = vi.fn().mockResolvedValue(undefined);
     const fn = vi.fn().mockRejectedValue(new Error('ECONNRESET'));
 
@@ -133,7 +133,7 @@ describe('withPublishRetry', () => {
     expect(sleep.mock.calls).toEqual([[1000], [2000]]);
   });
 
-  it('honours a custom shouldRetry predicate', async () => {
+  it('should honour a custom shouldRetry predicate', async () => {
     const fn = vi.fn().mockRejectedValue(new Error('503 Service Unavailable'));
     const shouldRetry = vi.fn().mockReturnValue(false);
 

--- a/packages/release/test/unit/duration.spec.ts
+++ b/packages/release/test/unit/duration.spec.ts
@@ -64,7 +64,7 @@ describe('formatDuration', () => {
     expect(formatDuration(30_000)).toBe('30s');
   });
 
-  it('rounds up partial seconds', () => {
+  it('should round up partial seconds', () => {
     expect(formatDuration(500)).toBe('1s');
   });
 });

--- a/packages/release/test/unit/failure-report-post.spec.ts
+++ b/packages/release/test/unit/failure-report-post.spec.ts
@@ -78,7 +78,7 @@ const versionOutput = versionOutputFor([
 ]);
 
 describe('postFailureReport', () => {
-  it('creates a new marker comment when none exists', async () => {
+  it('should create a new marker comment when none exists', async () => {
     const { octokit, createComment } = mockOctokit([]);
     await postFailureReport(
       { octokit, owner: 'o', repo: 'r', mode: 'standing-pr', prNumber: 42, standingPrNumber: 42 },
@@ -91,7 +91,7 @@ describe('postFailureReport', () => {
     expect(body).toContain('1/2 package(s) published');
   });
 
-  it('updates the existing report on a repeated failure (idempotent — does not stack)', async () => {
+  it('should update the existing report on a repeated failure (idempotent — does not stack)', async () => {
     const existing = renderFailureReport({
       versionOutput,
       publishOutput: publishOutputFor([]),
@@ -110,7 +110,7 @@ describe('postFailureReport', () => {
     expect(updateComment.mock.calls[0]?.[0]?.comment_id).toBe(7);
   });
 
-  it('writes to the step summary when no PR is available (manual dispatch)', async () => {
+  it('should write to the step summary when no PR is available (manual dispatch)', async () => {
     const tmp = `${process.env.RUNNER_TEMP ?? '/tmp'}/rk-step-summary-${Date.now()}.md`;
     const fs = await import('node:fs');
     process.env.GITHUB_STEP_SUMMARY = tmp;
@@ -134,7 +134,7 @@ describe('postFailureReport', () => {
 });
 
 describe('resolveFailureReportIfPresent', () => {
-  it('flips an existing report to resolved', async () => {
+  it('should flip an existing report to resolved', async () => {
     const existing = renderFailureReport({
       versionOutput,
       publishOutput: publishOutputFor([]),
@@ -149,7 +149,7 @@ describe('resolveFailureReportIfPresent', () => {
     expect(body).toContain('recovered');
   });
 
-  it('is a no-op when there is no existing report', async () => {
+  it('should be a no-op when there is no existing report', async () => {
     const { octokit, updateComment, createComment } = mockOctokit([]);
     await resolveFailureReportIfPresent(octokit, 'o', 'r', 42, versionOutput);
     expect(updateComment).not.toHaveBeenCalled();
@@ -158,7 +158,7 @@ describe('resolveFailureReportIfPresent', () => {
 });
 
 describe('detectUnresolvedFailure', () => {
-  it('detects an unresolved failure and recovers the headline numbers', async () => {
+  it('should detect an unresolved failure and recover the headline numbers', async () => {
     const report = renderFailureReport({
       versionOutput,
       publishOutput: publishOutputFor([
@@ -181,13 +181,13 @@ describe('detectUnresolvedFailure', () => {
     expect(result).toEqual({ previousLabel: 'v0.24.0', published: 1, total: 2, prNumber: 42 });
   });
 
-  it('returns null once the report is resolved', async () => {
+  it('should return null once the report is resolved', async () => {
     const resolved = renderResolvedReport(versionOutput);
     const { octokit } = mockOctokit([{ id: 9, body: resolved }]);
     expect(await detectUnresolvedFailure(octokit, 'o', 'r', 42)).toBeNull();
   });
 
-  it('returns null when there is no failure report', async () => {
+  it('should return null when there is no failure report', async () => {
     const { octokit } = mockOctokit([{ id: 1, body: 'unrelated comment' }]);
     expect(await detectUnresolvedFailure(octokit, 'o', 'r', 42)).toBeNull();
   });
@@ -202,7 +202,7 @@ describe('detectUnresolvedFailure env hygiene', () => {
     if (savedSummary === undefined) delete process.env.GITHUB_STEP_SUMMARY;
     else process.env.GITHUB_STEP_SUMMARY = savedSummary;
   });
-  it('placeholder to anchor the env reset hooks', () => {
+  it('should act as a placeholder to anchor the env reset hooks', () => {
     expect(true).toBe(true);
   });
 });

--- a/packages/release/test/unit/failure-report.spec.ts
+++ b/packages/release/test/unit/failure-report.spec.ts
@@ -51,7 +51,7 @@ function publishOutputFor(npm: PublishResult[]): PublishOutput {
 }
 
 describe('buildLedger', () => {
-  it('distinguishes published / skipped / failed / not-attempted', () => {
+  it('should distinguish published / skipped / failed / not-attempted', () => {
     const versionOutput = versionOutputFor([
       { name: '@scope/a', version: '1.0.0' },
       { name: '@scope/b', version: '1.0.0' },
@@ -81,7 +81,7 @@ describe('buildLedger', () => {
     ]);
   });
 
-  it('excludes the root lockstep bump from the ledger', () => {
+  it('should exclude the root lockstep bump from the ledger', () => {
     const versionOutput = versionOutputFor([{ name: '@scope/a', version: '2.0.0' }], { strategy: 'sync' });
     versionOutput.updates.push({
       packageName: 'root',
@@ -93,7 +93,7 @@ describe('buildLedger', () => {
     expect(ledger.map((e) => e.packageName)).toEqual(['@scope/a']);
   });
 
-  it('keeps the most significant outcome when a package appears on multiple registries', () => {
+  it('should keep the most significant outcome when a package appears on multiple registries', () => {
     const versionOutput = versionOutputFor([{ name: '@scope/a', version: '1.0.0' }]);
     const publishOutput = publishOutputFor([
       npmResult({ packageName: '@scope/a', version: '1.0.0', success: true, alreadyPublished: true }),
@@ -116,7 +116,7 @@ describe('renderFailureReport', () => {
     npmResult({ packageName: '@scope/b', version: '0.24.0', success: false, reason: 'npm 403' }),
   ]);
 
-  it('starts with the distinct marker and an unresolved status line', () => {
+  it('should start with the distinct marker and an unresolved status line', () => {
     const body = renderFailureReport({
       versionOutput,
       publishOutput,
@@ -128,7 +128,7 @@ describe('renderFailureReport', () => {
     expect(parseFailureReportStatus(body)).toBe('unresolved');
   });
 
-  it('embeds machine-readable headline data that round-trips independent of the prose', () => {
+  it('should embed machine-readable headline data that round-trips independent of the prose', () => {
     const body = renderFailureReport({
       versionOutput,
       publishOutput,
@@ -142,14 +142,14 @@ describe('renderFailureReport', () => {
     expect(parseFailureReportData(copyEdited)).toEqual({ label: 'v0.24.0', published: 1, total: 2 });
   });
 
-  it('returns null headline data for non-report bodies and malformed data comments', () => {
+  it('should return null headline data for non-report bodies and malformed data comments', () => {
     expect(parseFailureReportData('not a report')).toBeNull();
     expect(
       parseFailureReportData(`${FAILURE_MARKER}\n<!-- releasekit-publish-failure-data: {bad json} -->`),
     ).toBeNull();
   });
 
-  it('renders the per-package ledger with status icons and the published fraction', () => {
+  it('should render the per-package ledger with status icons and the published fraction', () => {
     const body = renderFailureReport({
       versionOutput,
       publishOutput,
@@ -162,7 +162,7 @@ describe('renderFailureReport', () => {
     expect(body).toContain('| `@scope/b` | 0.24.0 | ❌ failed | npm 403 |');
   });
 
-  it('includes the failed stage, error message, and the safe-retry note', () => {
+  it('should include the failed stage, error message, and the safe-retry note', () => {
     const body = renderFailureReport({
       versionOutput,
       publishOutput,
@@ -175,7 +175,7 @@ describe('renderFailureReport', () => {
     expect(body).toContain('Retrying is safe');
   });
 
-  it('gives standing-pr recovery instructions with the PR number', () => {
+  it('should give standing-pr recovery instructions with the PR number', () => {
     const body = renderFailureReport({
       versionOutput,
       publishOutput,
@@ -187,7 +187,7 @@ describe('renderFailureReport', () => {
     expect(body).not.toContain('Re-run failed jobs');
   });
 
-  it('mentions the release:retry label only when it is available', () => {
+  it('should mention the release:retry label only when it is available', () => {
     const withRetry = renderFailureReport({
       versionOutput,
       publishOutput,
@@ -207,7 +207,7 @@ describe('renderFailureReport', () => {
     expect(withoutRetry).not.toContain('release:retry');
   });
 
-  it('makes the release:retry label the primary recovery path when available', () => {
+  it('should make the release:retry label the primary recovery path when available', () => {
     const body = renderFailureReport({
       versionOutput,
       publishOutput,
@@ -226,7 +226,7 @@ describe('renderFailureReport', () => {
     expect(body).toContain('#42');
   });
 
-  it('gives direct-mode recovery instructions (re-run failed jobs)', () => {
+  it('should give direct-mode recovery instructions (re-run failed jobs)', () => {
     const body = renderFailureReport({
       versionOutput,
       publishOutput,
@@ -240,7 +240,7 @@ describe('renderFailureReport', () => {
 });
 
 describe('renderResolvedReport', () => {
-  it('keeps the marker and encodes resolved status', () => {
+  it('should keep the marker and encode resolved status', () => {
     const versionOutput = versionOutputFor([{ name: '@scope/a', version: '0.24.0' }]);
     const body = renderResolvedReport(versionOutput);
     expect(body.startsWith(FAILURE_MARKER)).toBe(true);
@@ -250,17 +250,17 @@ describe('renderResolvedReport', () => {
 });
 
 describe('parseFailureReportStatus', () => {
-  it('returns null for a non-report body', () => {
+  it('should return null for a non-report body', () => {
     expect(parseFailureReportStatus('just a normal comment')).toBeNull();
   });
 
-  it('defaults to unresolved when the status line is missing', () => {
+  it('should default to unresolved when the status line is missing', () => {
     expect(parseFailureReportStatus(`${FAILURE_MARKER}\n\n## something`)).toBe('unresolved');
   });
 });
 
 describe('renderSupersedeWarning', () => {
-  it('states the partial-publish fraction and both recovery paths', () => {
+  it('should state the partial-publish fraction and both recovery paths', () => {
     const lines = renderSupersedeWarning({
       previousLabel: 'v0.24.0',
       published: 2,
@@ -274,7 +274,7 @@ describe('renderSupersedeWarning', () => {
     expect(text).toContain('supersedes it');
   });
 
-  it('references the release:retry label as the primary reconcile path when available', () => {
+  it('should reference the release:retry label as the primary reconcile path when available', () => {
     const text = renderSupersedeWarning({
       previousLabel: 'v0.24.0',
       published: 2,
@@ -286,7 +286,7 @@ describe('renderSupersedeWarning', () => {
     expect(text).toContain('supersedes it');
   });
 
-  it('falls back to the dispatch instruction when the label is not available', () => {
+  it('should fall back to the dispatch instruction when the label is not available', () => {
     const text = renderSupersedeWarning({
       previousLabel: 'v0.24.0',
       published: 2,

--- a/packages/release/test/unit/preview-format.spec.ts
+++ b/packages/release/test/unit/preview-format.spec.ts
@@ -1047,7 +1047,7 @@ describe('formatPreviewComment', () => {
       '',
     ];
 
-    it('renders the warning above the standing PR snapshot when present', () => {
+    it('should render the warning above the standing PR snapshot when present', () => {
       const snapshot = snapshotFor([{ name: '@a/notes', version: '0.5.0' }]);
       const result = formatPreviewComment(releaseOutput, {
         strategy: 'standing-pr',
@@ -1060,7 +1060,7 @@ describe('formatPreviewComment', () => {
       expect(result.indexOf('partially published')).toBeLessThan(result.indexOf('**Standing release PR:**'));
     });
 
-    it('omits the warning when none is supplied (failure cleared / never occurred)', () => {
+    it('should omit the warning when none is supplied (failure cleared / never occurred)', () => {
       const snapshot = snapshotFor([{ name: '@a/notes', version: '0.5.0' }]);
       const result = formatPreviewComment(releaseOutput, {
         strategy: 'standing-pr',
@@ -1069,7 +1069,7 @@ describe('formatPreviewComment', () => {
       expect(result).not.toContain('partially published');
     });
 
-    it('suppresses the warning outside standing-pr strategy (defensive)', () => {
+    it('should suppress the warning outside standing-pr strategy (defensive)', () => {
       const result = formatPreviewComment(releaseOutput, {
         strategy: 'direct',
         supersedeWarning: warning,

--- a/packages/release/test/unit/release-command.spec.ts
+++ b/packages/release/test/unit/release-command.spec.ts
@@ -105,7 +105,7 @@ describe('createReleaseCommand', () => {
       ['--skip-git', 'skipGit'],
       ['--skip-github-release', 'skipGithubRelease'],
       ['--skip-verification', 'skipVerification'],
-    ] as const)('%s sets %s: true', async (flag, key) => {
+    ] as const)('should make %s set %s: true', async (flag, key) => {
       await createReleaseCommand().parseAsync(['node', 'test', flag]);
       expect(capturedOptions()[key]).toBe(true);
     });

--- a/packages/release/test/unit/release-gate.spec.ts
+++ b/packages/release/test/unit/release-gate.spec.ts
@@ -141,7 +141,7 @@ describe('evaluatePR — commit mode', () => {
     expect(result.shouldRelease).toBe(true);
   });
 
-  it('blocks on channel:stable + channel:prerelease conflict in commit mode', () => {
+  it('should block on channel:stable + channel:prerelease conflict in commit mode', () => {
     const result = evaluatePR(1, ['channel:stable', 'channel:prerelease'], DEFAULT_LABELS, commitMode);
     expect(result.blocked).toBe(true);
   });

--- a/packages/release/test/unit/standing-pr.spec.ts
+++ b/packages/release/test/unit/standing-pr.spec.ts
@@ -130,14 +130,14 @@ describe('createReleaseTags', () => {
     vi.resetAllMocks();
   });
 
-  it('is a no-op for an empty tag list', async () => {
+  it('should be a no-op for an empty tag list', async () => {
     const { execSync, execFileSync } = await import('node:child_process');
     createReleaseTags([], '/tmp/test');
     expect(execSync).not.toHaveBeenCalled();
     expect(execFileSync).not.toHaveBeenCalled();
   });
 
-  it('creates a tag when none exists', async () => {
+  it('should create a tag when none exists', async () => {
     const { execFileSync } = await import('node:child_process');
     // git rev-parse HEAD
     vi.mocked(execFileSync).mockReturnValueOnce('headsha\n');
@@ -157,7 +157,7 @@ describe('createReleaseTags', () => {
     );
   });
 
-  it('skips creation when the tag already points at HEAD', async () => {
+  it('should skip creation when the tag already points at HEAD', async () => {
     const { execFileSync } = await import('node:child_process');
     vi.mocked(execFileSync).mockReturnValueOnce('headsha\n');
     // tag exists at HEAD
@@ -170,7 +170,7 @@ describe('createReleaseTags', () => {
     expect(execFileSync).not.toHaveBeenCalledWith('git', expect.arrayContaining(['tag', '-a']), expect.anything());
   });
 
-  it('does not recreate a tag that points at a different commit', async () => {
+  it('should not recreate a tag that points at a different commit', async () => {
     const { execFileSync } = await import('node:child_process');
     vi.mocked(execFileSync).mockReturnValueOnce('headsha\n');
     vi.mocked(execFileSync).mockReturnValueOnce('othersha\n');
@@ -180,7 +180,7 @@ describe('createReleaseTags', () => {
     expect(execFileSync).not.toHaveBeenCalledWith('git', expect.arrayContaining(['tag', '-a']), expect.anything());
   });
 
-  it('processes multiple tags independently', async () => {
+  it('should process multiple tags independently', async () => {
     const { execFileSync } = await import('node:child_process');
     // git rev-parse HEAD
     vi.mocked(execFileSync).mockReturnValueOnce('headsha\n');
@@ -205,7 +205,7 @@ describe('createReleaseTags', () => {
     expect(tagCalls).toHaveLength(1);
   });
 
-  it('does not throw when tag creation fails', async () => {
+  it('should not throw when tag creation fails', async () => {
     const { execFileSync } = await import('node:child_process');
     vi.mocked(execFileSync).mockReturnValueOnce('headsha\n');
     vi.mocked(execFileSync).mockImplementationOnce(() => {
@@ -218,7 +218,7 @@ describe('createReleaseTags', () => {
     expect(() => createReleaseTags(['v1.2.3'], '/tmp/test')).not.toThrow();
   });
 
-  it('does not throw when HEAD lookup fails', async () => {
+  it('should not throw when HEAD lookup fails', async () => {
     const { execFileSync } = await import('node:child_process');
     vi.mocked(execFileSync).mockImplementationOnce(() => {
       throw new Error('fatal: not a git repository');
@@ -610,7 +610,7 @@ describe('runStandingPRUpdate', () => {
       return (args: { state?: string }) => Promise.resolve({ data: args.state === 'closed' ? merged : [] });
     }
 
-    it('includes the warning when the latest merged standing PR has an unresolved failure', async () => {
+    it('should include the warning when the latest merged standing PR has an unresolved failure', async () => {
       const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
       const versionOutput = createMockVersionOutput([{ packageName: '@scope/core', newVersion: '0.25.0' }]);
       vi.mocked(runVersionStep)
@@ -636,7 +636,7 @@ describe('runStandingPRUpdate', () => {
       expect(createCall?.body).toContain('#7');
     });
 
-    it('omits the warning when the latest merged standing PR failure is resolved', async () => {
+    it('should omit the warning when the latest merged standing PR failure is resolved', async () => {
       const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
       const versionOutput = createMockVersionOutput([{ packageName: '@scope/core', newVersion: '0.25.0' }]);
       vi.mocked(runVersionStep)
@@ -665,7 +665,7 @@ describe('runStandingPRUpdate', () => {
       expect(createCall?.body).not.toContain('partially published');
     });
 
-    it('omits the warning when there is no merged standing PR', async () => {
+    it('should omit the warning when there is no merged standing PR', async () => {
       const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
       const versionOutput = createMockVersionOutput([{ packageName: '@scope/core', newVersion: '0.25.0' }]);
       vi.mocked(runVersionStep)

--- a/packages/version/test/integration/sync-tags.spec.ts
+++ b/packages/version/test/integration/sync-tags.spec.ts
@@ -50,7 +50,7 @@ describe('sync strategy — JSON tag output', () => {
     cleanupTempDir(tempDir);
   });
 
-  it('produces per-package tags when packageSpecificTags is true', () => {
+  it('should produce per-package tags when packageSpecificTags is true', () => {
     writeReleaseKitConfig(tempDir, {
       preset: 'angular',
       packages: ['packages/pkg-a', 'packages/pkg-b'],
@@ -74,7 +74,7 @@ describe('sync strategy — JSON tag output', () => {
     expect(output.tags).toHaveLength(2);
   });
 
-  it('produces a single root tag when packageSpecificTags is false', () => {
+  it('should produce a single root tag when packageSpecificTags is false', () => {
     writeReleaseKitConfig(tempDir, {
       preset: 'angular',
       packages: ['packages/pkg-a', 'packages/pkg-b'],

--- a/test/integration/scoped-release.spec.ts
+++ b/test/integration/scoped-release.spec.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 
 describe('Integration: scoped release (wdio-style)', () => {
   describe('scope:spy targeting @test/native-spy only', () => {
-    it('generates changelog only for targeted package', () => {
+    it('should generate changelog only for targeted package', () => {
       const versionOutput = {
         dryRun: true,
         updates: [
@@ -41,7 +41,7 @@ describe('Integration: scoped release (wdio-style)', () => {
   });
 
   describe('scope:electron targeting @test/electron-* (multiple packages)', () => {
-    it('generates per-package changelog entries for electron scope', () => {
+    it('should generate per-package changelog entries for electron scope', () => {
       const versionOutput = {
         dryRun: true,
         updates: [
@@ -92,7 +92,7 @@ describe('Integration: scoped release (wdio-style)', () => {
   });
 
   describe('prerelease update for tauri-service (3.x prerelease range)', () => {
-    it('generates changelog for prerelease version increment', () => {
+    it('should generate changelog for prerelease version increment', () => {
       const versionOutput = {
         dryRun: true,
         updates: [
@@ -127,7 +127,7 @@ describe('Integration: scoped release (wdio-style)', () => {
   });
 
   describe('stable graduation for tauri-service', () => {
-    it('generates changelog for prerelease-to-stable graduation', () => {
+    it('should generate changelog for prerelease-to-stable graduation', () => {
       const versionOutput = {
         dryRun: true,
         updates: [

--- a/test/integration/single.spec.ts
+++ b/test/integration/single.spec.ts
@@ -75,7 +75,7 @@ describe('Integration: single package', () => {
   });
 
   describe('Breaking change -> major version bump', () => {
-    it('generates correct changelog entry with breaking marker', () => {
+    it('should generate correct changelog entry with breaking marker', () => {
       const versionOutput = {
         dryRun: true,
         updates: [
@@ -110,7 +110,7 @@ describe('Integration: single package', () => {
   });
 
   describe('Scoped feature -> changelog with scope', () => {
-    it('includes scope in changelog entry', () => {
+    it('should include scope in changelog entry', () => {
       const versionOutput = {
         dryRun: true,
         updates: [


### PR DESCRIPTION
## What

Sweeps every vitest test title to the `it('should …')` convention across all packages (`packages/*/test/**`) and the root integration tests (`test/integration/`). Only `it`/`test`/`it.each` TITLES change — no `describe` blocks, logic, assertions, or structure were touched.

## Non-conforming title counts

- Before: **75** non-conforming titles across 15 files
- After: **0** (verified via a title parser and an independent grep cross-check)

Titles already starting with "should" (1,774) were left as-is. Third-person verbs were rewritten to `should <infinitive>` preserving all information; `it.each` placeholders (`%s`) were kept intact and in positional order.

## Test-count parity proof

`pnpm turbo run lint typecheck test` → 24 tasks, all successful. Per-package test counts are identical before and after:

| Package | Files | Tests |
|---|---|---|
| core | 5 | 64 |
| config | 8 | 184 |
| publish | 22 | 232 |
| notes | 22 | 333 |
| version | 23 | 517 |
| integration-tests | 4 | 35 |
| release | 19 | 500 |
| **TOTAL** | **103** | **1,865** |

Diff is exactly 75 insertions / 75 deletions — pure title-only changes.

(`test/e2e/` contains shell scripts, not vitest specs — out of scope.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR standardises vitest test titles across all packages by prepending `should` to every `it()`/`it.each()` title that did not already follow that convention. No test logic, assertions, `describe` blocks, or file structure were changed.

- **75 titles renamed** across 15 spec files in `packages/*/test/` and `test/integration/`, verified with a parser + grep cross-check; the PR is exactly 75 insertions / 75 deletions.
- One `it.each` entry in `release-command.spec.ts` was rephrased to `'should make %s set %s: true'`; the `%s` interpolation placeholders remain in the correct positional order.
</details>

<h3>Confidence Score: 5/5</h3>

Pure test-title rename with no logic, assertion, or structure changes — safe to merge.

Every change is a string-literal rename of a test title; no assertions, mocks, describe blocks, imports, or implementation code were touched. The PR description confirms test counts and pipeline results are identical before and after.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/config/test/unit/load.spec.ts | 2 titles renamed to `should return …`; no logic changes. |
| packages/notes/test/integration/pipeline-config.spec.ts | 3 titles reworded to `should … when flag:value` form, moving the flag context to the end; no logic changes. |
| packages/notes/test/integration/snapshot.spec.ts | 1 title renamed; no logic changes. |
| packages/notes/test/unit/llm.spec.ts | 4 titles renamed; no logic changes. |
| packages/publish/test/unit/utils/publish-retry.spec.ts | 12 titles renamed including two `it.each` entries; no logic changes. |
| packages/release/test/unit/duration.spec.ts | 1 title renamed; no logic changes. |
| packages/release/test/unit/failure-report-post.spec.ts | 8 titles renamed; no logic changes. |
| packages/release/test/unit/failure-report.spec.ts | 17 titles renamed; no logic changes. |
| packages/release/test/unit/preview-format.spec.ts | 3 titles renamed; no logic changes. |
| packages/release/test/unit/release-command.spec.ts | 1 `it.each` title renamed; `%s` placeholders preserved in correct positions; no logic changes. |
| packages/release/test/unit/release-gate.spec.ts | 1 title renamed; no logic changes. |
| packages/release/test/unit/standing-pr.spec.ts | 10 titles renamed; no logic changes. |
| packages/version/test/integration/sync-tags.spec.ts | 2 titles renamed; no logic changes. |
| test/integration/scoped-release.spec.ts | 4 titles renamed; no logic changes. |
| test/integration/single.spec.ts | 2 titles renamed; no logic changes. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["it('verb …')"]
    B["it.each(data)('verb %s …')"]
    C["it('should …')  ✓"]
    D["it.each(data)('should verb %s …')  ✓"]
    E["it('should …')  — unchanged"]

    A -->|"prepend 'should '  +  infinitive"| C
    B -->|"prepend 'should '  +  infinitive"| D
    E --> E
```
</details>

<sub>Reviews (1): Last reviewed commit: ["test: adopt it(&#39;should …&#39;) title convent..."](https://github.com/goosewobbler/releasekit/commit/8dcac063ba10dfe3df5ab63fb34980e05d2ebd3f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35630610)</sub>

<!-- /greptile_comment -->