### PR TITLE
chore(deps)!: drop EOL Node 20, require Node 22+

### DIFF
--- a/.github/workflows/_ci-integration.reusable.yml
+++ b/.github/workflows/_ci-integration.reusable.yml
@@ -6,13 +6,17 @@ on:
       cache_key:
         required: true
         type: string
+      node-version:
+        required: false
+        type: string
+        default: '24'
 
 env:
   TURBO_TELEMETRY_DISABLED: 1
 
 jobs:
   integration-tests:
-    name: Integration Tests
+    name: Integration Tests [node ${{ inputs.node-version }}]
     runs-on: ubuntu-latest
 
     steps:
@@ -21,6 +25,8 @@ jobs:
 
       - name: Setup Development Environment
         uses: ./.github/workflows/actions/setup-workspace
+        with:
+          node-version: ${{ inputs.node-version }}
 
       - name: Download build artifacts
         uses: ./.github/workflows/actions/download-archive

--- a/.github/workflows/_ci-unit.reusable.yml
+++ b/.github/workflows/_ci-unit.reusable.yml
@@ -9,13 +9,17 @@ on:
       cache_key:
         required: true
         type: string
+      node-version:
+        required: false
+        type: string
+        default: '24'
 
 env:
   TURBO_TELEMETRY_DISABLED: 1
 
 jobs:
   unit-tests:
-    name: Unit Tests [${{ inputs.os }}]
+    name: Unit Tests [${{ inputs.os }}, node ${{ inputs.node-version }}]
     runs-on: ${{ inputs.os }}
 
     steps:
@@ -24,6 +28,8 @@ jobs:
 
       - name: Setup Development Environment
         uses: ./.github/workflows/actions/setup-workspace
+        with:
+          node-version: ${{ inputs.node-version }}
 
       - name: Download build artifacts
         uses: ./.github/workflows/actions/download-archive

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,18 +126,28 @@ jobs:
     name: Unit Tests
     needs: [detect-changes, build]
     if: needs.detect-changes.outputs.has_changes == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ['22', '24']
     uses: ./.github/workflows/_ci-unit.reusable.yml
     with:
       os: ubuntu-latest
       cache_key: ${{ needs.build.outputs.cache_key }}
+      node-version: ${{ matrix.node-version }}
 
   integration-tests:
     name: Integration Tests
     needs: [detect-changes, build]
     if: needs.detect-changes.outputs.run_integration == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ['22', '24']
     uses: ./.github/workflows/_ci-integration.reusable.yml
     with:
       cache_key: ${{ needs.build.outputs.cache_key }}
+      node-version: ${{ matrix.node-version }}
 
   package-tests:
     name: Package Tests

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,7 +4,7 @@ This guide walks through installing ReleaseKit, verifying your setup with a dry 
 
 ## Prerequisites
 
-- Node.js 20+
+- Node.js 22+
 - A git repository using [Conventional Commits](https://www.conventionalcommits.org/)
 - At least one git tag marking a previous release (e.g. `v0.0.0`), or no tags at all for a first release
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "author": "Sam Maister <goosewobbler@protonmail.com>",
   "engines": {
-    "node": ">=20.17",
+    "node": ">=22",
     "pnpm": ">=10.12.0"
   },
   "packageManager": "pnpm@10.27.0+sha512.72d699da16b1179c14ba9e64dc71c9a40988cbdc65c264cb0e489db7de917f20dcf4d64d8723625f2969ba52d4b7e2a1170682d9ac2a5dcaeaab732b7e16f04a",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -39,5 +39,8 @@
     "tsup": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"
+  },
+  "engines": {
+    "node": ">=22"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -36,5 +36,8 @@
     "tsup": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"
+  },
+  "engines": {
+    "node": ">=22"
   }
 }

--- a/packages/notes/package.json
+++ b/packages/notes/package.json
@@ -83,6 +83,6 @@
     "vitest": "catalog:"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   }
 }

--- a/packages/publish/package.json
+++ b/packages/publish/package.json
@@ -80,6 +80,6 @@
     "vitest": "catalog:"
   },
   "engines": {
-    "node": ">=20.17"
+    "node": ">=22"
   }
 }

--- a/packages/release/package.json
+++ b/packages/release/package.json
@@ -80,6 +80,6 @@
     "vitest": "catalog:"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   }
 }

--- a/packages/version/package.json
+++ b/packages/version/package.json
@@ -89,6 +89,6 @@
     "vitest": "catalog:"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   }
 }


### PR DESCRIPTION
## ⚠️ Breaking change — maintainer decision needed on the floor

Raising the engines floor is **breaking for consumers on Node 20**. The commit carries a `!` marker and a `BREAKING CHANGE:` footer so the release pipeline versions it as a breaking bump.

**Floor decision (please confirm):** this PR sets the floor to **`>=22`** (Node 22 is maintenance LTS until April 2027 — keeps all non-EOL LTS lines supported). The alternative is `>=24` (active LTS, simpler, but cuts off maintenance-LTS users). You may want to confirm `>=22` or fold this into a larger planned bump rather than shipping it alone.

## What changed

- **Engines floor → `>=22`** in all seven `package.json` files. Previously inconsistent (`>=20`, `>=20.17`) and entirely absent from `core` and `config`; now identical everywhere.
- **CI Node matrix (22, 24)** added to the unit and integration jobs so the claimed floor is actually exercised — previously CI ran a single version, so `>=20` was never tested. lint / typecheck / e2e stay on a single version (24) to limit cost. Implemented via a new optional `node-version` input on the `_ci-unit` / `_ci-integration` reusable workflows (default `'24'`), threaded into the existing `setup-workspace` action.
- **Docs:** `getting-started.md` prerequisite → `Node.js 22+`. The README Node badge reads `engines.node` from the published package automatically.

## Verification

`pnpm turbo run lint typecheck test` — 24/24 tasks pass.

Closes #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR drops EOL Node 20 support and standardises the `engines.node` field to `>=22` across all seven package manifests (two of which were missing the field entirely), then backs up the claim by running unit and integration tests against a Node 22 / 24 matrix in CI.

- **`engines` consistency**: all packages now declare `node: >=22`; `packages/config` and `packages/core` gain the field for the first time.
- **CI matrix**: unit and integration reusable workflows gain an optional `node-version` input (default `'24'`), wired into the existing `setup-workspace` action; `ci.yml` fans them out over `['22', '24']` with `fail-fast: false`.
- **Docs**: `getting-started.md` prerequisite updated from Node.js 20+ to 22+.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — purely a maintenance bump with no logic changes.

All changes are declarative: engines fields in package manifests, a CI matrix expansion, and a one-line docs update. The node-version input threads cleanly through both reusable workflows into the already-capable setup-workspace action. No application logic is touched.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Adds node-version matrix (['22', '24']) with fail-fast: false to unit-tests and integration-tests jobs; other jobs intentionally stay on a single Node 24 via the setup-workspace default. |
| .github/workflows/_ci-unit.reusable.yml | Adds optional node-version string input (default '24') and threads it through to the setup-workspace action; job name now shows the active Node version. |
| .github/workflows/_ci-integration.reusable.yml | Same node-version input addition as the unit reusable workflow; wired through to setup-workspace and reflected in the job name. |
| package.json | Root engines.node bumped from >=20.17 to >=22; pnpm constraint unchanged. |
| packages/config/package.json | Added previously-absent engines block with node: >=22. |
| packages/core/package.json | Added previously-absent engines block with node: >=22. |
| packages/notes/package.json | Bumped engines.node from >=20 to >=22. |
| packages/publish/package.json | Bumped engines.node from >=20.17 to >=22. |
| packages/release/package.json | Bumped engines.node from >=20 to >=22. |
| packages/version/package.json | Bumped engines.node from >=20 to >=22. |
| docs/getting-started.md | Updated prerequisite from Node.js 20+ to Node.js 22+ to match the engines field change. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    CI[ci.yml trigger] --> DET[detect-changes]
    DET --> BUILD[build]
    BUILD --> UNIT["unit-tests\nmatrix: node 22, 24"]
    BUILD --> INT["integration-tests\nmatrix: node 22, 24"]
    BUILD --> PKG["package-tests\nmatrix: ubuntu, macos, windows\n(Node 24 default)"]
    BUILD --> E2E["e2e-tests\nmatrix: ubuntu, macos, windows\n(Node 24 default)"]
    BUILD --> LINT["lint / typecheck\n(Node 24 default)"]
    UNIT --> RU["_ci-unit.reusable.yml\nnode-version input → setup-workspace"]
    INT --> RI["_ci-integration.reusable.yml\nnode-version input → setup-workspace"]
    RU --> SW["setup-workspace action\nactions/setup-node @ node-version"]
    RI --> SW
```
</details>

<sub>Reviews (2): Last reviewed commit: ["chore(deps)!: drop EOL Node 20, require ..."](https://github.com/goosewobbler/releasekit/commit/dc798eeb666a7bf6ac531fa7c45545e4ae031764) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36229113)</sub>

<!-- /greptile_comment -->