### PR TITLE
docs: fix pnpm setup in CI templates and document label creation

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -183,7 +183,7 @@ jobs:
 
 > **Using npm?** Drop the `pnpm/action-setup` step, set `cache: npm` on `setup-node`, and replace `pnpm install --frozen-lockfile` with `npm ci` and `pnpm exec` with `npx`.
 
-If you use the [label-based trigger](../packages/release/docs/ci-setup.md#label-based-trigger), also create the required `bump:*`, `channel:*`, and `release:skip` labels — see [Create the labels](../packages/release/docs/ci-setup.md#create-the-labels) for a copy-pasteable `gh label create` block.
+If you use the [label-based trigger](../packages/release/docs/ci-setup.md#label-based-trigger), create the required `bump:*`, `channel:*`, and `release:skip` labels with `releasekit labels sync` — see [Create the labels](../packages/release/docs/ci-setup.md#create-the-labels).
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -169,9 +169,11 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+      - uses: pnpm/action-setup@v5
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
+          cache: pnpm
           registry-url: 'https://registry.npmjs.org'
       - run: pnpm install --frozen-lockfile
       - run: pnpm exec releasekit release
@@ -179,7 +181,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-> **Using npm?** Replace `pnpm install --frozen-lockfile` with `npm ci` and `pnpm exec` with `npx`.
+> **Using npm?** Drop the `pnpm/action-setup` step, set `cache: npm` on `setup-node`, and replace `pnpm install --frozen-lockfile` with `npm ci` and `pnpm exec` with `npx`.
+
+If you use the [label-based trigger](../packages/release/docs/ci-setup.md#label-based-trigger), also create the required `bump:*`, `channel:*`, and `release:skip` labels — see [Create the labels](../packages/release/docs/ci-setup.md#create-the-labels) for a copy-pasteable `gh label create` block.
 
 ---
 

--- a/docs/rust.md
+++ b/docs/rust.md
@@ -191,9 +191,12 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
+      - uses: pnpm/action-setup@v5
+
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
+          cache: pnpm
 
       - name: Run releasekit
         uses: goosewobbler/releasekit@v1

--- a/docs/rust.md
+++ b/docs/rust.md
@@ -191,13 +191,9 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
-      - uses: pnpm/action-setup@v5
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: '24'
-          cache: pnpm
-
+      # No pnpm/Node setup needed: the bundled goosewobbler/releasekit action brings
+      # its own runtime, and a Rust-only repo has no pnpm-lock.yaml (setting cache: pnpm
+      # would fail with "Dependencies lock file is not found").
       - name: Run releasekit
         uses: goosewobbler/releasekit@v1
         env:

--- a/packages/release/docs/ci-setup.md
+++ b/packages/release/docs/ci-setup.md
@@ -36,9 +36,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: pnpm/action-setup@v5
+
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
+          cache: pnpm
           registry-url: 'https://registry.npmjs.org'
 
       - run: pnpm install --frozen-lockfile
@@ -50,7 +53,7 @@ jobs:
           # For token-based publishing: NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 ```
 
-> **Using npm?** Replace `pnpm install --frozen-lockfile` with `npm ci` and `pnpm exec` with `npx`.
+> **Using npm?** Drop the `pnpm/action-setup` step, set `cache: npm` on `setup-node`, and replace `pnpm install --frozen-lockfile` with `npm ci` and `pnpm exec` with `npx`.
 
 ---
 
@@ -68,6 +71,28 @@ Only release when a PR is merged with a release label. Conventional commits dete
 | `channel:stable` | Graduate a prerelease to stable |
 | `channel:prerelease` | Create a prerelease (requires bump:* label) |
 | `release:skip` | Suppress release on this PR |
+
+#### Create the labels
+
+> **Interim manual step.** These labels must exist in the repository before they can be applied to a PR — they are not created automatically (outside standing-pr mode, which ensures only its own two labels). Until [`releasekit labels sync`](https://github.com/goosewobbler/releasekit/issues/262) lands, create them once with the [`gh` CLI](https://cli.github.com/):
+
+```bash
+gh label create bump:patch        --color FBCA04 --description "Release: bump patch version"
+gh label create bump:minor        --color FBCA04 --description "Release: bump minor version"
+gh label create bump:major        --color FBCA04 --description "Release: bump major version"
+gh label create channel:stable    --color 0E8A16 --description "Release: graduate a prerelease to stable"
+gh label create channel:prerelease --color D4C5F9 --description "Release: create/increment a prerelease (with a bump:* label)"
+gh label create release:skip       --color E4E669 --description "Release: suppress release on this PR"
+```
+
+Add `--force` to any line to overwrite an existing label of the same name. If you customise the names in `ci.labels`, create labels matching your config instead of the defaults above.
+
+If you use [standing-pr mode](#standing-release-pr), also create the two labels that drive its bypass and recovery flows:
+
+```bash
+gh label create release:immediate --color 5319E7 --description "Release: ship this PR directly, bypassing the standing PR"
+gh label create release:retry     --color B60205 --description "Release: retry a failed publish on the merged standing PR"
+```
 
 #### Label combinations
 
@@ -112,9 +137,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: pnpm/action-setup@v5
+
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
+          cache: pnpm
           registry-url: 'https://registry.npmjs.org'
 
       - run: pnpm install --frozen-lockfile
@@ -124,7 +152,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-> **Using npm?** Replace `pnpm install --frozen-lockfile` with `npm ci` and `pnpm exec` with `npx`.
+> **Using npm?** Drop the `pnpm/action-setup` step, set `cache: npm` on `setup-node`, and replace `pnpm install --frozen-lockfile` with `npm ci` and `pnpm exec` with `npx`.
 
 Configure the trigger in `releasekit.config.json`:
 
@@ -205,9 +233,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: pnpm/action-setup@v5
+
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
+          cache: pnpm
 
       - run: pnpm install --frozen-lockfile
 
@@ -216,7 +247,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-> **Using npm?** Replace `pnpm install --frozen-lockfile` with `npm ci` and `pnpm exec` with `npx`.
+> **Using npm?** Drop the `pnpm/action-setup` step, set `cache: npm` on `setup-node`, and replace `pnpm install --frozen-lockfile` with `npm ci` and `pnpm exec` with `npx`.
 
 A ready-to-use template is available at [`templates/workflows/release-preview.yml`](../../../templates/workflows/release-preview.yml).
 
@@ -334,9 +365,12 @@ jobs:
           fetch-depth: 0
           token: ${{ github.token }}
 
+      - uses: pnpm/action-setup@v5
+
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
+          cache: pnpm
           registry-url: 'https://registry.npmjs.org'
 
       - run: pnpm install --frozen-lockfile
@@ -371,9 +405,12 @@ jobs:
           fetch-depth: 0
           token: ${{ github.token }}
 
+      - uses: pnpm/action-setup@v5
+
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
+          cache: pnpm
           registry-url: 'https://registry.npmjs.org'
 
       - run: pnpm install --frozen-lockfile
@@ -410,9 +447,12 @@ jobs:
           token: ${{ github.token }}
           ref: main  # the standing PR's branch is deleted on merge; publish from main
 
+      - uses: pnpm/action-setup@v5
+
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
+          cache: pnpm
           registry-url: 'https://registry.npmjs.org'
 
       - run: pnpm install --frozen-lockfile
@@ -436,7 +476,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 ```
 
-> **Using npm?** Replace `pnpm install --frozen-lockfile` with `npm ci` and `pnpm exec` with `npx`.
+> **Using npm?** Drop the `pnpm/action-setup` step, set `cache: npm` on `setup-node`, and replace `pnpm install --frozen-lockfile` with `npm ci` and `pnpm exec` with `npx`.
 
 ### How it works
 
@@ -570,10 +610,15 @@ permissions:
   id-token: write    # grants the OIDC token
 
 steps:
+  - uses: pnpm/action-setup@v5
+
   - uses: actions/setup-node@v6
     with:
       node-version: '24'
+      cache: pnpm
       registry-url: 'https://registry.npmjs.org'
+
+  - run: pnpm install --frozen-lockfile
 
   - run: pnpm exec releasekit release
     env:
@@ -613,9 +658,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: pnpm/action-setup@v5
+
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
+          cache: pnpm
           registry-url: 'https://registry.npmjs.org'
 
       - run: pnpm install --frozen-lockfile
@@ -625,7 +673,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-> **Using npm?** Replace `pnpm install --frozen-lockfile` with `npm ci` and `pnpm exec` with `npx`.
+> **Using npm?** Drop the `pnpm/action-setup` step, set `cache: npm` on `setup-node`, and replace `pnpm install --frozen-lockfile` with `npm ci` and `pnpm exec` with `npx`.
 
 ---
 

--- a/packages/release/docs/ci-setup.md
+++ b/packages/release/docs/ci-setup.md
@@ -74,25 +74,13 @@ Only release when a PR is merged with a release label. Conventional commits dete
 
 #### Create the labels
 
-> **Interim manual step.** These labels must exist in the repository before they can be applied to a PR — they are not created automatically (outside standing-pr mode, which ensures only its own two labels). Until [`releasekit labels sync`](https://github.com/goosewobbler/releasekit/issues/262) lands, create them once with the [`gh` CLI](https://cli.github.com/):
+These labels must exist in the repository before they can be applied to a PR (they are not created automatically outside standing-pr mode). Run `releasekit labels sync` — it creates every label your config implies (bump / channel / release, any configured `scope:*`, and the standing-PR labels), honouring `ci.labels` renames:
 
 ```bash
-gh label create bump:patch        --color FBCA04 --description "Release: bump patch version"
-gh label create bump:minor        --color FBCA04 --description "Release: bump minor version"
-gh label create bump:major        --color FBCA04 --description "Release: bump major version"
-gh label create channel:stable    --color 0E8A16 --description "Release: graduate a prerelease to stable"
-gh label create channel:prerelease --color D4C5F9 --description "Release: create/increment a prerelease (with a bump:* label)"
-gh label create release:skip       --color E4E669 --description "Release: suppress release on this PR"
+releasekit labels sync
 ```
 
-Add `--force` to any line to overwrite an existing label of the same name. If you customise the names in `ci.labels`, create labels matching your config instead of the defaults above.
-
-If you use [standing-pr mode](#standing-release-pr), also create the two labels that drive its bypass and recovery flows:
-
-```bash
-gh label create release:immediate --color 5319E7 --description "Release: ship this PR directly, bypassing the standing PR"
-gh label create release:retry     --color B60205 --description "Release: retry a failed publish on the merged standing PR"
-```
+Wire `releasekit labels sync --check` into CI to fail fast when a required label is missing — otherwise a mistyped `bump:minor` silently fails to release. See the [CLI reference](../../../docs/cli.md#releasekit-labels) for details.
 
 #### Label combinations
 

--- a/packages/release/docs/ci-setup.md
+++ b/packages/release/docs/ci-setup.md
@@ -74,13 +74,13 @@ Only release when a PR is merged with a release label. Conventional commits dete
 
 #### Create the labels
 
-These labels must exist in the repository before they can be applied to a PR (they are not created automatically outside standing-pr mode). Create every label your config implies — bump / channel / release, any configured `scope:*`, and the standing-PR labels, honouring `ci.labels` renames — with:
+The labels above aren't created automatically. Create them — plus any `scope:*` and standing-PR labels your config adds — with:
 
 ```bash
 releasekit labels sync
 ```
 
-Wire `--check` into CI to fail fast when a required label is missing — otherwise a mistyped `bump:minor` silently fails to release. See the [CLI reference](../../../docs/cli.md#releasekit-labels) for details.
+In CI, add `--check`: it exits non-zero on a missing label, catching the silent failure where a mistyped `bump:minor` just skips the release. See the [CLI reference](../../../docs/cli.md#releasekit-labels).
 
 #### Label combinations
 

--- a/packages/release/docs/ci-setup.md
+++ b/packages/release/docs/ci-setup.md
@@ -74,13 +74,13 @@ Only release when a PR is merged with a release label. Conventional commits dete
 
 #### Create the labels
 
-These labels must exist in the repository before they can be applied to a PR (they are not created automatically outside standing-pr mode). Run `releasekit labels sync` — it creates every label your config implies (bump / channel / release, any configured `scope:*`, and the standing-PR labels), honouring `ci.labels` renames:
+These labels must exist in the repository before they can be applied to a PR (they are not created automatically outside standing-pr mode). Create every label your config implies — bump / channel / release, any configured `scope:*`, and the standing-PR labels, honouring `ci.labels` renames — with:
 
 ```bash
 releasekit labels sync
 ```
 
-Wire `releasekit labels sync --check` into CI to fail fast when a required label is missing — otherwise a mistyped `bump:minor` silently fails to release. See the [CLI reference](../../../docs/cli.md#releasekit-labels) for details.
+Wire `--check` into CI to fail fast when a required label is missing — otherwise a mistyped `bump:minor` silently fails to release. See the [CLI reference](../../../docs/cli.md#releasekit-labels) for details.
 
 #### Label combinations
 


### PR DESCRIPTION
## What

Two fixes to the consumer-facing CI documentation.

**1. pnpm setup in every workflow template.** Templates installed dependencies with `pnpm install --frozen-lockfile` but never set up pnpm, and hosted GitHub runners don't ship it — so a consumer copying any template hit `pnpm: command not found` on the first run. Insert `pnpm/action-setup@v5` before `actions/setup-node@v6` (with `cache: pnpm`) in every template, mirroring the repo's own `setup-workspace` action. Each "Using npm?" callout updated to drop the pnpm step and switch to `cache: npm`.

Templates fixed across `packages/release/docs/ci-setup.md`, `docs/getting-started.md`, and `docs/rust.md` (the Rust-only example uses the bundled action, so it correctly has no pnpm setup).

**2. Document label creation.** The required `bump:*` / `channel:*` / `release:skip` labels were listed but no doc told consumers to create them, so label-mode's first run silently failed (label not in the picker). Add a "Create the labels" step to ci-setup's Label-Based Trigger section that uses **`releasekit labels sync`** (#262, now merged) to create every config-implied label, with `--check` noted as the CI guard. Cross-referenced from getting-started's CI step.

## Notes

- Cross-references #259 (the missing-runtime-tool failure is exactly the class actionlint can't catch — validated examples need an execution smoke-test, tracked in #276).
- Boundary: does not touch the getting-started Prerequisites/Node line (#264) or package.json.

## Verification

`pnpm turbo run lint typecheck test` passes.

Closes #263

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes two consumer-facing documentation issues: missing pnpm setup in CI workflow templates (causing `pnpm: command not found` on first run), and undocumented label creation for the label-based trigger mode.

- All JS/TS workflow snippets across `getting-started.md` and `ci-setup.md` now include `pnpm/action-setup@v5` before `setup-node` and `cache: pnpm`, mirroring the repo's own `setup-workspace` action. The Rust-only template correctly removes Node setup entirely (the bundled `@v1` action brings its own runtime and a pure-Rust repo has no lockfile).
- The OIDC partial snippet in `ci-setup.md` gains the previously absent `pnpm install --frozen-lockfile` step, making it self-consistent.
- A new "Create the labels" section documents `releasekit labels sync` and its `--check` flag for CI guards, with a cross-reference added to `getting-started.md`.
</details>

<h3>Confidence Score: 5/5</h3>

Documentation-only change that fixes broken CI templates and adds missing label-creation guidance; no logic or runtime code is touched.

Every workflow snippet now includes the full pnpm setup sequence that was previously missing, the Rust-only template correctly drops Node setup, the OIDC snippet gets its missing install step, and the cross-references resolve to real anchors. No behavioural code is changed.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/getting-started.md | Adds pnpm/action-setup@v5 and cache: pnpm to the release job template, updates the "Using npm?" note, and adds a cross-reference to the new label-creation section. |
| docs/rust.md | Removes the Node/pnpm setup steps from the Rust-only template (which uses the bundled action) and adds a comment explaining why; addresses the previous review comment about cache: pnpm failing with no lockfile. |
| packages/release/docs/ci-setup.md | Inserts pnpm/action-setup@v5 + cache: pnpm into all six workflow snippets, adds the missing pnpm install step to the OIDC partial snippet, updates all "Using npm?" callouts, and adds the new "Create the labels" section documenting releasekit labels sync. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Consumer copies template] --> B{Repo type?}
    B -->|JS with pnpm| C[pnpm action-setup v5]
    B -->|Rust-only| D[dtolnay rust-toolchain]
    B -->|JS with npm| E[setup-node cache npm]
    C --> F[setup-node cache pnpm]
    F --> G[pnpm install frozen-lockfile]
    G --> H[pnpm exec releasekit release]
    E --> I[npm ci]
    I --> H
    D --> J[goosewobbler releasekit v1 bundled runtime]
    H --> K{Label-based trigger?}
    K -->|Yes| L[releasekit labels sync]
    K -->|No| M[Done]
    L --> M
```
</details>

<sub>Reviews (4): Last reviewed commit: ["docs: tighten the create-the-labels sect..."](https://github.com/goosewobbler/releasekit/commit/aa0b0abe3eb373212225c26e208785e90c610c3f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36229708)</sub>

<!-- /greptile_comment -->