### PR TITLE
docs: add validated CI usage examples

### DIFF
--- a/.github/workflows/examples-validate.yml
+++ b/.github/workflows/examples-validate.yml
@@ -38,8 +38,10 @@ jobs:
         run: |
           # actionlint's auto-detection only scans .github/workflows. The example
           # workflows live under examples/, so download the binary and point it at
-          # each file explicitly.
-          bash <(curl -sSf https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+          # each file explicitly. Pin the installer ref and the version so a new
+          # actionlint release can't fail this job out of band.
+          ACTIONLINT_VERSION=1.7.12
+          bash <(curl -sSf "https://raw.githubusercontent.com/rhysd/actionlint/v${ACTIONLINT_VERSION}/scripts/download-actionlint.bash") "$ACTIONLINT_VERSION"
           shopt -s globstar nullglob
           files=(examples/**/*.yml examples/**/*.yaml)
           if [ ${#files[@]} -eq 0 ]; then

--- a/.github/workflows/examples-validate.yml
+++ b/.github/workflows/examples-validate.yml
@@ -1,0 +1,80 @@
+# Validates the runnable examples in examples/ so they cannot rot silently.
+#   1. actionlint over every example workflow YAML.
+#   2. JSON Schema validation of every example releasekit.config.json against
+#      the repo's releasekit.schema.json.
+#
+# NOTE: actionlint is a STATIC linter and does NOT know what tools a hosted
+# runner ships. A workflow that calls pnpm without a pnpm/action-setup step (or
+# cargo without a rust-toolchain step) lints clean and only fails at runtime.
+# Catching that needs an execution smoke-test — tracked as a follow-up.
+# See issues #259 and #263.
+name: Examples Validate
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'examples/**'
+      - 'releasekit.schema.json'
+      - '.github/workflows/examples-validate.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'examples/**'
+      - 'releasekit.schema.json'
+      - '.github/workflows/examples-validate.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    name: actionlint (examples)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Run actionlint over example workflows
+        run: |
+          # actionlint's auto-detection only scans .github/workflows. The example
+          # workflows live under examples/, so download the binary and point it at
+          # each file explicitly.
+          bash <(curl -sSf https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+          shopt -s globstar nullglob
+          files=(examples/**/*.yml examples/**/*.yaml)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "No example workflows found under examples/ — nothing to lint."
+            exit 0
+          fi
+          ./actionlint -color "${files[@]}"
+
+  config-schema:
+    name: config schema (examples)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: Validate each example config against releasekit.schema.json
+        run: |
+          shopt -s globstar nullglob
+          configs=(examples/**/releasekit.config.json)
+          if [ ${#configs[@]} -eq 0 ]; then
+            echo "No example configs found — nothing to validate."
+            exit 0
+          fi
+          # ajv-cli@5 bundles ajv@8; --spec=draft7 matches the schema's declared draft.
+          # strict=false: the schema uses a string "default" on a boolean-enum field,
+          # which ajv's strict mode rejects as a meta-schema warning, not a data error.
+          for cfg in "${configs[@]}"; do
+            echo "::group::$cfg"
+            npx --yes ajv-cli@5 validate \
+              --spec=draft7 \
+              --strict=false \
+              -s releasekit.schema.json \
+              -d "$cfg"
+            echo "::endgroup::"
+          done

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ See the [package docs](#documentation) for the full option reference.
 - [Getting Started](./docs/getting-started.md) — install, first dry run, first release, CI setup
 - [Architecture](./docs/architecture.md) — pipeline design, mental model, release strategies
 - [CI setup](./packages/release/docs/ci-setup.md) — GitHub Actions workflows, OIDC, PR preview, prerelease
+- [CI examples](./examples) — runnable, CI-validated workflow + config scenarios (minimal, label-driven, standing-PR, OIDC, monorepo-rust, prerelease)
 - [Rust / Cargo](./docs/rust.md) — Rust crate versioning and crates.io publishing
 - [Migration](./docs/migration.md) — from semantic-release or changesets
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -33,9 +33,7 @@ wrong in hand-written workflows:
   to compute the bump.
 - **Explicit `permissions:` blocks are zero-by-default.** Naming any scope
   removes every scope you didn't name, so each workflow lists exactly what its
-  jobs need (`contents: write` for tags/releases, `id-token: write` for OIDC,
-  `pull-requests: *` where labels/PRs are read or written, `statuses: write` for
-  the standing-PR status check).
+  jobs need (e.g. `contents: write` for tags/releases, `id-token: write` for OIDC).
 - **OIDC needs `.npmrc` removed.** `setup-node` with `registry-url` writes an
   `.npmrc` with `_authToken=${NODE_AUTH_TOKEN}`; with OIDC that token is empty
   and npm fails `ENEEDAUTH`. The OIDC-publishing examples `rm -f .npmrc` first.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,62 @@
+# ReleaseKit examples
+
+Runnable, validated CI scenarios. Each scenario is a self-contained directory:
+a workflow file (header comment says where to copy it), a minimal
+`releasekit.config.json`, and a README stating the scenario's assumptions.
+
+These files are the **single validated source of truth** for CI usage. They are
+checked in CI on every change (see [`Validation`](#validation) below), so unlike
+markdown snippets they cannot rot silently.
+
+## CI scenarios
+
+| Scenario | What it shows |
+|----------|---------------|
+| [`ci/minimal`](./ci/minimal) | Push-to-main direct release driven by Conventional Commits. |
+| [`ci/label-driven`](./ci/label-driven) | Release only when a merged PR carries a `bump:*` label (trigger + gate). |
+| [`ci/standing-pr`](./ci/standing-pr) | Standing release PR: `update` + `publish` + `retry-publish` jobs. |
+| [`ci/oidc`](./ci/oidc) | npm OIDC trusted publishing — no `NPM_TOKEN`. |
+| [`ci/monorepo-rust`](./ci/monorepo-rust) | Mixed npm + Cargo monorepo (npm OIDC + crates.io token). |
+| [`ci/prerelease`](./ci/prerelease) | Manual `workflow_dispatch` prerelease with a chosen identifier. |
+
+## Cross-cutting correctness rules
+
+Every workflow here follows these rules — they are the ones most often gotten
+wrong in hand-written workflows:
+
+- **Set up pnpm before `actions/setup-node`.** Hosted GitHub runners do **not**
+  ship pnpm. Add `pnpm/action-setup@v5` *before* `actions/setup-node`, so that
+  `setup-node`'s `cache: pnpm` can find the binary. Omitting this is the single
+  most common failure — and `actionlint` will **not** catch it (see below).
+- **Node 24** in `actions/setup-node`.
+- **`fetch-depth: 0`** on `actions/checkout` — releasekit walks full git history
+  to compute the bump.
+- **Explicit `permissions:` blocks are zero-by-default.** Naming any scope
+  removes every scope you didn't name, so each workflow lists exactly what its
+  jobs need (`contents: write` for tags/releases, `id-token: write` for OIDC,
+  `pull-requests: *` where labels/PRs are read or written, `statuses: write` for
+  the standing-PR status check).
+- **OIDC needs `.npmrc` removed.** `setup-node` with `registry-url` writes an
+  `.npmrc` with `_authToken=${NODE_AUTH_TOKEN}`; with OIDC that token is empty
+  and npm fails `ENEEDAUTH`. The OIDC-publishing examples `rm -f .npmrc` first.
+
+## Validation
+
+`.github/workflows/examples-validate.yml` runs on every change under `examples/`:
+
+1. **`actionlint`** over `examples/**/*.yml` — catches workflow syntax errors,
+   bad `uses:` refs, invalid `if:` expressions, unknown contexts, shellcheck
+   findings in `run:` steps.
+2. **JSON Schema validation** of every `examples/**/releasekit.config.json`
+   against the repo's `releasekit.schema.json` (via `ajv-cli`). Because the
+   schema is `additionalProperties: false`, a typo'd or removed config key fails
+   the build.
+
+> **What validation does NOT catch.** `actionlint` is a static linter: it has no
+> model of what tools a hosted runner ships. A workflow that calls `pnpm` but
+> never runs `pnpm/action-setup` is **syntactically valid** and lints clean — it
+> only fails at runtime with `pnpm: command not found`. The same is true for a
+> missing `dtolnay/rust-toolchain` before `cargo`. Catching those requires an
+> **execution smoke-test** (actually running the workflow on a runner), which is
+> recommended as a follow-up. See issue #263 (the existing docs templates ship
+> exactly this missing-pnpm bug) and issue #259.

--- a/examples/ci/label-driven/README.md
+++ b/examples/ci/label-driven/README.md
@@ -41,13 +41,4 @@ There are **two** gates, and they must agree:
    authoritative decision. The workflow gate is just there to avoid spinning up
    a runner for PRs that obviously won't release.
 
-## Correctness notes
-
-- **pnpm before setup-node** (hosted runners lack pnpm).
-- **`fetch-depth: 0`** for full history.
-- The `permissions` block lists `pull-requests: read` because the gate inspects
-  the merged PR's labels; `contents: write` and `id-token: write` are for
-  tagging/releases and OIDC respectively.
-- Trigger is `pull_request: [closed]` (not `push`), because the label lives on
-  the PR. The `merged == true` check excludes PRs that were closed without
-  merging.
+The trigger is `pull_request: [closed]` with a `merged == true` guard — the label lives on the PR, not a push. Shared [correctness rules](../../README.md#cross-cutting-correctness-rules) apply.

--- a/examples/ci/label-driven/README.md
+++ b/examples/ci/label-driven/README.md
@@ -1,0 +1,53 @@
+# label-driven — `bump:*` label trigger + gate
+
+A release fires only when a PR is **merged with a `bump:*` label**. Conventional
+commits still produce the changelog entries; the label decides whether to
+release and at what magnitude.
+
+| Label on the merged PR | Result (from `1.2.3`) |
+|------------------------|-----------------------|
+| `bump:patch` | `1.2.4` |
+| `bump:minor` | `1.3.0` |
+| `bump:major` | `2.0.0` |
+| `release:skip` | no release |
+| _(none)_ | no release |
+
+## Files
+
+| File | Copy to |
+|------|---------|
+| [`release.yml`](./release.yml) | `.github/workflows/release.yml` |
+| [`releasekit.config.json`](./releasekit.config.json) | repo root |
+
+## Assumptions
+
+- The default branch is `main` and PRs are merged into it.
+- The repo has the labels `bump:patch`, `bump:minor`, `bump:major` (and
+  optionally `release:skip`). These match releasekit's defaults; the `labels`
+  block in the config is shown for clarity and can be omitted if you keep the
+  defaults.
+- npm publishing via OIDC. Swap to `NODE_AUTH_TOKEN`/`NPM_TOKEN` if you prefer
+  token auth (see [`oidc`](../oidc)).
+
+## How the gate works
+
+There are **two** gates, and they must agree:
+
+1. **Workflow `if:`** — a coarse guard that the merged PR carries one of the
+   `bump:*` labels. Workflow expressions cannot read `releasekit.config.json`,
+   so the label names here are **hardcoded** to the defaults. If you rename a
+   label via `ci.labels.*`, update this `if:` to match.
+2. **`releasekit release`** — re-reads `ci.labels` from config and is the
+   authoritative decision. The workflow gate is just there to avoid spinning up
+   a runner for PRs that obviously won't release.
+
+## Correctness notes
+
+- **pnpm before setup-node** (hosted runners lack pnpm).
+- **`fetch-depth: 0`** for full history.
+- The `permissions` block lists `pull-requests: read` because the gate inspects
+  the merged PR's labels; `contents: write` and `id-token: write` are for
+  tagging/releases and OIDC respectively.
+- Trigger is `pull_request: [closed]` (not `push`), because the label lives on
+  the PR. The `merged == true` check excludes PRs that were closed without
+  merging.

--- a/examples/ci/label-driven/release.yml
+++ b/examples/ci/label-driven/release.yml
@@ -43,6 +43,12 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      # setup-node's registry-url writes a .npmrc with `_authToken=${NODE_AUTH_TOKEN}`.
+      # With OIDC that var is empty, so npm fails ENEEDAUTH instead of the OIDC exchange.
+      # Remove it before publishing. (Drop this step if you publish with NODE_AUTH_TOKEN.)
+      - name: Remove token-based .npmrc so OIDC can take over
+        run: rm -f .npmrc
+
       - run: pnpm exec releasekit release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/examples/ci/label-driven/release.yml
+++ b/examples/ci/label-driven/release.yml
@@ -1,0 +1,49 @@
+# Copy to: .github/workflows/release.yml
+#
+# Label-driven release: a merged PR only releases when it carries a `bump:*`
+# label. Conventional commits still determine the changelog; the label is the
+# gate that decides whether (and at what magnitude) to release.
+#
+# The gate below is a workflow-level guard, so the label names are hardcoded to
+# releasekit's defaults. `releasekit release` re-reads ci.labels from config and
+# is the authoritative check — keep the two in sync if you customise the names.
+name: Release
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: write
+  id-token: write # npm OIDC trusted publishing
+  pull-requests: read # gate reads the merged PR's labels
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    # Gate: only run for a merged PR that carries a bump:* label.
+    if: >
+      github.event.pull_request.merged == true &&
+      (contains(github.event.pull_request.labels.*.name, 'bump:patch') ||
+       contains(github.event.pull_request.labels.*.name, 'bump:minor') ||
+       contains(github.event.pull_request.labels.*.name, 'bump:major'))
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v5
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: pnpm
+          registry-url: 'https://registry.npmjs.org'
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm exec releasekit release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }} # only if not using OIDC

--- a/examples/ci/label-driven/releasekit.config.json
+++ b/examples/ci/label-driven/releasekit.config.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://goosewobbler.github.io/releasekit/schema.json",
+  "git": {
+    "branch": "main"
+  },
+  "version": {
+    "preset": "angular"
+  },
+  "publish": {
+    "npm": {
+      "enabled": true,
+      "access": "public"
+    }
+  },
+  "ci": {
+    "releaseStrategy": "direct",
+    "releaseTrigger": "label",
+    "labels": {
+      "major": "bump:major",
+      "minor": "bump:minor",
+      "patch": "bump:patch",
+      "skip": "release:skip"
+    }
+  }
+}

--- a/examples/ci/minimal/README.md
+++ b/examples/ci/minimal/README.md
@@ -17,23 +17,6 @@ the command exits 0 and the workflow is a no-op.
 - Releases are driven by commits (`ci.releaseTrigger: "commit"`), not labels —
   every push that contains a `feat:`/`fix:`/etc. commit since the last tag
   releases. To require a `bump:*` label instead, see [`label-driven`](../label-driven).
-- npm publishing is enabled. The example uses **npm OIDC trusted publishing**
-  (`id-token: write` + no `NPM_TOKEN`). To publish with a token instead, drop
-  `id-token: write`, set `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}`, and see
-  [`oidc`](../oidc) for the OIDC details.
+- npm publishing via OIDC (no `NPM_TOKEN`); see [`oidc`](../oidc) to switch to token auth.
 
-## Correctness notes
-
-- **pnpm is installed before setup-node.** Hosted GitHub runners do not ship
-  pnpm; `pnpm/action-setup@v5` must run first, and before `actions/setup-node`
-  so that `cache: pnpm` can locate the binary. Omitting it is the single most
-  common mistake (see the validation note in [`../README.md`](../README.md)).
-- **`fetch-depth: 0`** gives releasekit the full git history it needs to compute
-  the bump.
-- **The `permissions` block is explicit.** Declaring any scope zeroes all the
-  others, so `contents: write` is listed even though the default token has it.
-- **`.npmrc` is removed before publishing under OIDC.** `actions/setup-node`
-  with `registry-url` writes a `.npmrc` containing
-  `_authToken=${NODE_AUTH_TOKEN}`; with OIDC that variable is empty, so npm
-  exits `ENEEDAUTH` instead of performing the OIDC exchange. Drop the
-  `rm -f .npmrc` step if you switch to `NODE_AUTH_TOKEN`/token auth.
+The workflow follows the [correctness rules](../../README.md#cross-cutting-correctness-rules) every example shares; its inline comments cover the per-step reasoning.

--- a/examples/ci/minimal/README.md
+++ b/examples/ci/minimal/README.md
@@ -1,0 +1,34 @@
+# minimal — push-to-main direct release
+
+The simplest setup: every push to `main` runs `releasekit release`. Bumps are
+derived from Conventional Commits since the last tag; if nothing is releasable
+the command exits 0 and the workflow is a no-op.
+
+## Files
+
+| File | Copy to |
+|------|---------|
+| [`release.yml`](./release.yml) | `.github/workflows/release.yml` |
+| [`releasekit.config.json`](./releasekit.config.json) | repo root |
+
+## Assumptions
+
+- The default branch is `main`.
+- Releases are driven by commits (`ci.releaseTrigger: "commit"`), not labels —
+  every push that contains a `feat:`/`fix:`/etc. commit since the last tag
+  releases. To require a `bump:*` label instead, see [`label-driven`](../label-driven).
+- npm publishing is enabled. The example uses **npm OIDC trusted publishing**
+  (`id-token: write` + no `NPM_TOKEN`). To publish with a token instead, drop
+  `id-token: write`, set `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}`, and see
+  [`oidc`](../oidc) for the OIDC details.
+
+## Correctness notes
+
+- **pnpm is installed before setup-node.** Hosted GitHub runners do not ship
+  pnpm; `pnpm/action-setup@v5` must run first, and before `actions/setup-node`
+  so that `cache: pnpm` can locate the binary. Omitting it is the single most
+  common mistake (see the validation note in [`../README.md`](../README.md)).
+- **`fetch-depth: 0`** gives releasekit the full git history it needs to compute
+  the bump.
+- **The `permissions` block is explicit.** Declaring any scope zeroes all the
+  others, so `contents: write` is listed even though the default token has it.

--- a/examples/ci/minimal/README.md
+++ b/examples/ci/minimal/README.md
@@ -32,3 +32,8 @@ the command exits 0 and the workflow is a no-op.
   the bump.
 - **The `permissions` block is explicit.** Declaring any scope zeroes all the
   others, so `contents: write` is listed even though the default token has it.
+- **`.npmrc` is removed before publishing under OIDC.** `actions/setup-node`
+  with `registry-url` writes a `.npmrc` containing
+  `_authToken=${NODE_AUTH_TOKEN}`; with OIDC that variable is empty, so npm
+  exits `ENEEDAUTH` instead of performing the OIDC exchange. Drop the
+  `rm -f .npmrc` step if you switch to `NODE_AUTH_TOKEN`/token auth.

--- a/examples/ci/minimal/release.yml
+++ b/examples/ci/minimal/release.yml
@@ -35,6 +35,12 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      # setup-node's registry-url writes a .npmrc with `_authToken=${NODE_AUTH_TOKEN}`.
+      # With OIDC that var is empty, so npm fails ENEEDAUTH instead of the OIDC exchange.
+      # Remove it before publishing. (Drop this step if you publish with NODE_AUTH_TOKEN.)
+      - name: Remove token-based .npmrc so OIDC can take over
+        run: rm -f .npmrc
+
       - run: pnpm exec releasekit release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/examples/ci/minimal/release.yml
+++ b/examples/ci/minimal/release.yml
@@ -1,0 +1,42 @@
+# Copy to: .github/workflows/release.yml
+#
+# Minimal release: every push to main runs `releasekit release`.
+# If there are no releasable commits the command exits 0 and does nothing.
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+# An explicit permissions block zeroes every scope that is not listed, so
+# `contents: write` (tags + GitHub Releases) must be named even though the
+# default token would otherwise have it.
+permissions:
+  contents: write
+  id-token: write # npm OIDC trusted publishing — drop if you publish with NPM_TOKEN
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # releasekit walks full history to determine the bump
+
+      # Hosted runners do NOT ship pnpm. This step must come BEFORE setup-node
+      # so that setup-node's `cache: pnpm` can find the pnpm binary.
+      - uses: pnpm/action-setup@v5
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: pnpm
+          registry-url: 'https://registry.npmjs.org'
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm exec releasekit release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Token-based npm auth instead of OIDC? Uncomment:
+          # NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/examples/ci/minimal/releasekit.config.json
+++ b/examples/ci/minimal/releasekit.config.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://goosewobbler.github.io/releasekit/schema.json",
+  "git": {
+    "branch": "main"
+  },
+  "version": {
+    "preset": "angular"
+  },
+  "publish": {
+    "npm": {
+      "enabled": true,
+      "access": "public"
+    }
+  },
+  "ci": {
+    "releaseStrategy": "direct",
+    "releaseTrigger": "commit"
+  }
+}

--- a/examples/ci/monorepo-rust/README.md
+++ b/examples/ci/monorepo-rust/README.md
@@ -28,13 +28,7 @@ automatically.
 
 ## Correctness notes
 
-- **Two runtimes to install.** Hosted runners ship neither pnpm nor the Rust
-  toolchain. `pnpm/action-setup@v5` (before setup-node) handles pnpm;
-  `dtolnay/rust-toolchain@stable` provides `cargo`. Omitting the latter yields
-  `cargo: command not found` at the publish stage.
-- **Delete `.npmrc`** before publishing so npm OIDC isn't shadowed by an empty
-  token (see [`oidc`](../oidc) for why).
-- **`fetch-depth: 0`** for full history.
-- crates.io index propagation is slower than npm; releasekit polls after each
-  publish (configurable under `publish.verify.cargo`) and skips already-published
-  versions, so re-running a partially failed release is safe.
+Rust-specific (shared [correctness rules](../../README.md#cross-cutting-correctness-rules) apply too, including the OIDC `.npmrc` step):
+
+- **A second runtime.** Beyond pnpm, hosted runners ship no Rust toolchain — `dtolnay/rust-toolchain@stable` provides `cargo`, else the publish stage hits `cargo: command not found`.
+- crates.io index propagation lags npm; releasekit polls after each publish (`publish.verify.cargo`) and skips already-published versions, so re-running a partially failed release is safe.

--- a/examples/ci/monorepo-rust/README.md
+++ b/examples/ci/monorepo-rust/README.md
@@ -1,0 +1,40 @@
+# monorepo-rust — mixed npm + Cargo release
+
+One config releases both npm packages and Rust crates. npm publishes via OIDC
+trusted publishing; crates.io has no OIDC, so it uses a `CARGO_REGISTRY_TOKEN`
+secret. Crates are published in topological (path-dependency) order
+automatically.
+
+## Files
+
+| File | Copy to |
+|------|---------|
+| [`release.yml`](./release.yml) | `.github/workflows/release.yml` |
+| [`releasekit.config.json`](./releasekit.config.json) | repo root |
+
+## Assumptions
+
+- Layout: npm packages under `packages/*` (listed in `version.packages`), Rust
+  crates under `crates/*` (listed in `version.cargo.paths`). Adjust both lists
+  to your repo. If your crates sit alongside the `version.packages` directories,
+  `version.cargo.paths` can be omitted and releasekit infers them from adjacent
+  `Cargo.toml` files.
+- `publish.cargo.enabled` is **`true`** explicitly — it defaults to `false`, so
+  nothing reaches crates.io unless you opt in.
+- Secrets: `CARGO_REGISTRY_TOKEN` (crates.io API token with publish scopes) is
+  set in repo Actions secrets. npm needs no secret thanks to OIDC.
+- npm packages have trusted publishers configured on npmjs.com (see
+  [`oidc`](../oidc)).
+
+## Correctness notes
+
+- **Two runtimes to install.** Hosted runners ship neither pnpm nor the Rust
+  toolchain. `pnpm/action-setup@v5` (before setup-node) handles pnpm;
+  `dtolnay/rust-toolchain@stable` provides `cargo`. Omitting the latter yields
+  `cargo: command not found` at the publish stage.
+- **Delete `.npmrc`** before publishing so npm OIDC isn't shadowed by an empty
+  token (see [`oidc`](../oidc) for why).
+- **`fetch-depth: 0`** for full history.
+- crates.io index propagation is slower than npm; releasekit polls after each
+  publish (configurable under `publish.verify.cargo`) and skips already-published
+  versions, so re-running a partially failed release is safe.

--- a/examples/ci/monorepo-rust/release.yml
+++ b/examples/ci/monorepo-rust/release.yml
@@ -1,0 +1,47 @@
+# Copy to: .github/workflows/release.yml
+#
+# Mixed npm + Cargo monorepo: releasekit versions and publishes both the npm
+# packages (to npmjs.org) and the Rust crates (to crates.io) from one config.
+# npm uses OIDC trusted publishing; crates.io has no OIDC, so it needs a
+# CARGO_REGISTRY_TOKEN secret.
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  id-token: write # npm OIDC (crates.io auth is the CARGO_REGISTRY_TOKEN secret)
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      # Hosted runners ship NEITHER pnpm NOR the Rust toolchain — set up both.
+      - uses: pnpm/action-setup@v5
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: pnpm
+          registry-url: 'https://registry.npmjs.org'
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - run: pnpm install --frozen-lockfile
+
+      # OIDC for npm: setup-node's .npmrc would inject an empty token, so remove
+      # it (see the oidc example for the full explanation).
+      - name: Remove token-based .npmrc so npm OIDC can take over
+        run: rm -f .npmrc
+
+      - run: pnpm exec releasekit release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # crates.io has no OIDC — token auth only.
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/examples/ci/monorepo-rust/releasekit.config.json
+++ b/examples/ci/monorepo-rust/releasekit.config.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://goosewobbler.github.io/releasekit/schema.json",
+  "git": {
+    "branch": "main"
+  },
+  "version": {
+    "preset": "angular",
+    "packages": [
+      "packages/js-lib",
+      "packages/cli"
+    ],
+    "cargo": {
+      "enabled": true,
+      "paths": [
+        "crates/core",
+        "crates/ffi"
+      ]
+    }
+  },
+  "publish": {
+    "npm": {
+      "enabled": true,
+      "access": "public",
+      "auth": "oidc"
+    },
+    "cargo": {
+      "enabled": true
+    }
+  },
+  "ci": {
+    "releaseStrategy": "direct",
+    "releaseTrigger": "commit"
+  }
+}

--- a/examples/ci/oidc/README.md
+++ b/examples/ci/oidc/README.md
@@ -1,0 +1,39 @@
+# oidc — npm trusted publishing (no NPM_TOKEN)
+
+Publish to npm with **OIDC trusted publishing**: the runner exchanges a
+GitHub-issued OIDC token for a short-lived npm token at publish time, so there is
+no long-lived `NPM_TOKEN` secret to manage. ReleaseKit detects OIDC
+automatically; `publish.npm.auth: "oidc"` here forces it.
+
+## Files
+
+| File | Copy to |
+|------|---------|
+| [`release.yml`](./release.yml) | `.github/workflows/release.yml` |
+| [`releasekit.config.json`](./releasekit.config.json) | repo root |
+
+## Assumptions
+
+- **npm >= 9.5.0.** Node 24 ships a recent enough npm, so `setup-node@v6` is
+  fine as-is.
+- Each package has a **trusted publisher** configured on npmjs.com (package
+  Settings -> Trusted publishing -> add a GitHub Actions publisher for this repo
+  **and this workflow filename**). The publisher is keyed to the top-level
+  workflow file, so all OIDC publishes for a package must run from the same
+  workflow file.
+- `id-token: write` is granted (it is what mints the OIDC token).
+- `provenance: true` attaches build provenance — supported on the public registry
+  with OIDC.
+
+## Correctness notes
+
+- **`id-token: write` is mandatory.** Without it there is no OIDC token and the
+  publish falls back to needing a token it doesn't have.
+- **Delete `.npmrc` before publishing.** `actions/setup-node` with `registry-url`
+  writes a project `.npmrc` containing `_authToken=${NODE_AUTH_TOKEN}`. With OIDC
+  there is no `NODE_AUTH_TOKEN`, so npm resolves it to an **empty** token and
+  fails with `ENEEDAUTH` instead of performing the OIDC exchange. The
+  `rm -f .npmrc` step removes it. (We still pass `registry-url` so pnpm's cache
+  and the registry default are set; only the auth line is the problem.)
+- **pnpm before setup-node** (hosted runners lack pnpm).
+- **`fetch-depth: 0`** for full history.

--- a/examples/ci/oidc/README.md
+++ b/examples/ci/oidc/README.md
@@ -27,13 +27,7 @@ automatically; `publish.npm.auth: "oidc"` here forces it.
 
 ## Correctness notes
 
-- **`id-token: write` is mandatory.** Without it there is no OIDC token and the
-  publish falls back to needing a token it doesn't have.
-- **Delete `.npmrc` before publishing.** `actions/setup-node` with `registry-url`
-  writes a project `.npmrc` containing `_authToken=${NODE_AUTH_TOKEN}`. With OIDC
-  there is no `NODE_AUTH_TOKEN`, so npm resolves it to an **empty** token and
-  fails with `ENEEDAUTH` instead of performing the OIDC exchange. The
-  `rm -f .npmrc` step removes it. (We still pass `registry-url` so pnpm's cache
-  and the registry default are set; only the auth line is the problem.)
-- **pnpm before setup-node** (hosted runners lack pnpm).
-- **`fetch-depth: 0`** for full history.
+OIDC-specific (the shared [correctness rules](../../README.md#cross-cutting-correctness-rules) apply too):
+
+- **`id-token: write` is mandatory** — it's what mints the OIDC token.
+- **Delete `.npmrc` before publishing.** `setup-node` with `registry-url` writes `_authToken=${NODE_AUTH_TOKEN}`; under OIDC that token is empty, so npm fails `ENEEDAUTH` instead of doing the OIDC exchange. `registry-url` still stays (it sets the cache + registry default — only the auth line is the problem).

--- a/examples/ci/oidc/release.yml
+++ b/examples/ci/oidc/release.yml
@@ -1,0 +1,49 @@
+# Copy to: .github/workflows/release.yml
+#
+# npm OIDC trusted publishing: no NPM_TOKEN secret. The runner exchanges a
+# GitHub-issued OIDC token for a short-lived npm token at publish time.
+#
+# Requirements:
+#   - npm >= 9.5.0 (Node 24 ships a newer npm, so setup-node@v6 is fine).
+#   - Each package has an npm "Automation" trusted publisher configured:
+#     npmjs.com -> package Settings -> Trusted publishing -> add a GitHub
+#     Actions publisher for THIS repo and THIS workflow filename.
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  id-token: write # REQUIRED for OIDC — this is what mints the OIDC token
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v5
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: pnpm
+          registry-url: 'https://registry.npmjs.org'
+
+      - run: pnpm install --frozen-lockfile
+
+      # setup-node with registry-url writes a project .npmrc containing
+      # `_authToken=${NODE_AUTH_TOKEN}`. With OIDC there is no NODE_AUTH_TOKEN,
+      # so npm resolves it to an EMPTY token and fails with ENEEDAUTH instead of
+      # falling through to the OIDC exchange. Remove the file before publishing.
+      - name: Remove token-based .npmrc so OIDC can take over
+        run: rm -f .npmrc
+
+      - run: pnpm exec releasekit release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # No NPM_TOKEN / NODE_AUTH_TOKEN — OIDC provides auth.

--- a/examples/ci/oidc/releasekit.config.json
+++ b/examples/ci/oidc/releasekit.config.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://goosewobbler.github.io/releasekit/schema.json",
+  "git": {
+    "branch": "main"
+  },
+  "version": {
+    "preset": "angular"
+  },
+  "publish": {
+    "npm": {
+      "enabled": true,
+      "access": "public",
+      "auth": "oidc",
+      "provenance": true
+    }
+  },
+  "ci": {
+    "releaseStrategy": "direct",
+    "releaseTrigger": "commit"
+  }
+}

--- a/examples/ci/prerelease/README.md
+++ b/examples/ci/prerelease/README.md
@@ -30,11 +30,4 @@ CLI: `gh workflow run prerelease.yml -f identifier=rc`.
 
 ## Correctness notes
 
-- **pnpm before setup-node** (hosted runners lack pnpm).
-- **`fetch-depth: 0`** for full history.
-- The workflow input `identifier` is passed via the `PRERELEASE_IDENTIFIER`
-  env var and referenced as `"$PRERELEASE_IDENTIFIER"` in the shell — never
-  via inline `${{ inputs.identifier }}` interpolation. A value like
-  `beta; rm -rf .` would otherwise be executed by the shell. The dispatch
-  input is also constrained by its `default` in the UI; treat dispatch
-  inputs as trusted-maintainer-only regardless.
+Shared [correctness rules](../../README.md#cross-cutting-correctness-rules) apply. Scenario-specific: the `identifier` input is passed via the `PRERELEASE_IDENTIFIER` env var and referenced as `"$PRERELEASE_IDENTIFIER"`, never inline `${{ inputs.identifier }}` — a value like `beta; rm -rf .` would otherwise reach the shell.

--- a/examples/ci/prerelease/README.md
+++ b/examples/ci/prerelease/README.md
@@ -1,0 +1,37 @@
+# prerelease — manual prerelease dispatch
+
+A maintainer manually dispatches this workflow and chooses a prerelease
+identifier (`beta`, `rc`, ...). releasekit produces versions like `1.4.0-beta.0`
+and publishes them under a non-`latest` npm dist-tag so they don't become the
+default install.
+
+## Files
+
+| File | Copy to |
+|------|---------|
+| [`prerelease.yml`](./prerelease.yml) | `.github/workflows/prerelease.yml` |
+| [`releasekit.config.json`](./releasekit.config.json) | repo root |
+
+## Running it
+
+GitHub UI: Actions -> **Prerelease** -> Run workflow -> set the identifier.
+CLI: `gh workflow run prerelease.yml -f identifier=rc`.
+
+## Assumptions
+
+- Prereleases are deliberate, maintainer-triggered events, hence
+  `workflow_dispatch` and `ci.releaseStrategy: "manual"` (no push/merge auto-fires
+  this).
+- `publish.npm.tag: "next"` keeps prereleases off the `latest` dist-tag —
+  consumers opt in with `npm install pkg@next`. Change to match your channel.
+- `version.prereleaseIdentifier` sets the default identifier; the workflow input
+  overrides it per run via `--prerelease`.
+- npm publishing via OIDC; swap to `NODE_AUTH_TOKEN`/`NPM_TOKEN` for token auth.
+
+## Correctness notes
+
+- **pnpm before setup-node** (hosted runners lack pnpm).
+- **`fetch-depth: 0`** for full history.
+- The workflow input `identifier` is interpolated into `--prerelease
+  ${{ inputs.identifier }}`. The dispatch input is constrained by its `default`
+  in the UI; treat dispatch inputs as trusted-maintainer-only.

--- a/examples/ci/prerelease/README.md
+++ b/examples/ci/prerelease/README.md
@@ -32,6 +32,9 @@ CLI: `gh workflow run prerelease.yml -f identifier=rc`.
 
 - **pnpm before setup-node** (hosted runners lack pnpm).
 - **`fetch-depth: 0`** for full history.
-- The workflow input `identifier` is interpolated into `--prerelease
-  ${{ inputs.identifier }}`. The dispatch input is constrained by its `default`
-  in the UI; treat dispatch inputs as trusted-maintainer-only.
+- The workflow input `identifier` is passed via the `PRERELEASE_IDENTIFIER`
+  env var and referenced as `"$PRERELEASE_IDENTIFIER"` in the shell — never
+  via inline `${{ inputs.identifier }}` interpolation. A value like
+  `beta; rm -rf .` would otherwise be executed by the shell. The dispatch
+  input is also constrained by its `default` in the UI; treat dispatch
+  inputs as trusted-maintainer-only regardless.

--- a/examples/ci/prerelease/prerelease.yml
+++ b/examples/ci/prerelease/prerelease.yml
@@ -1,0 +1,41 @@
+# Copy to: .github/workflows/prerelease.yml
+#
+# Manual prerelease: a maintainer dispatches this workflow and picks a
+# prerelease identifier (e.g. beta, rc). releasekit produces versions like
+# 1.4.0-beta.0 and publishes them under a matching npm dist-tag.
+name: Prerelease
+
+on:
+  workflow_dispatch:
+    inputs:
+      identifier:
+        description: 'Prerelease identifier (e.g. beta, rc, next)'
+        required: true
+        default: 'beta'
+
+permissions:
+  contents: write
+  id-token: write # npm OIDC trusted publishing
+
+jobs:
+  prerelease:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v5
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: pnpm
+          registry-url: 'https://registry.npmjs.org'
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm exec releasekit release --prerelease ${{ inputs.identifier }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }} # only if not using OIDC

--- a/examples/ci/prerelease/prerelease.yml
+++ b/examples/ci/prerelease/prerelease.yml
@@ -35,7 +35,16 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - run: pnpm exec releasekit release --prerelease ${{ inputs.identifier }}
+      # setup-node's registry-url writes a .npmrc with `_authToken=${NODE_AUTH_TOKEN}`.
+      # With OIDC that var is empty, so npm fails ENEEDAUTH instead of the OIDC exchange.
+      # Remove it before publishing. (Drop this step if you publish with NODE_AUTH_TOKEN.)
+      - name: Remove token-based .npmrc so OIDC can take over
+        run: rm -f .npmrc
+
+      # Pass the dispatch input via env, not inline interpolation — a value like
+      # `beta; rm -rf .` would otherwise be executed by the shell.
+      - run: pnpm exec releasekit release --prerelease "$PRERELEASE_IDENTIFIER"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PRERELEASE_IDENTIFIER: ${{ inputs.identifier }}
           # NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }} # only if not using OIDC

--- a/examples/ci/prerelease/releasekit.config.json
+++ b/examples/ci/prerelease/releasekit.config.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://goosewobbler.github.io/releasekit/schema.json",
+  "git": {
+    "branch": "main"
+  },
+  "version": {
+    "preset": "angular",
+    "prereleaseIdentifier": "beta"
+  },
+  "publish": {
+    "npm": {
+      "enabled": true,
+      "access": "public",
+      "tag": "next"
+    }
+  },
+  "ci": {
+    "releaseStrategy": "manual"
+  }
+}

--- a/examples/ci/standing-pr/README.md
+++ b/examples/ci/standing-pr/README.md
@@ -1,0 +1,49 @@
+# standing-pr — accumulate releases in a persistent PR
+
+A single "standing" release PR (on `release/next`) accumulates version bumps and
+release notes as commits land on `main`. Maintainers merge it when ready to ship;
+merging publishes. A `release:retry` label re-runs a publish that failed partway.
+
+One workflow file (`standing-pr.yml`) carries three jobs:
+
+| Job | Fires on | Does |
+|-----|----------|------|
+| `update` | push to `main`, hourly `schedule` | rebuilds `release/next` and the standing PR from the queued changes |
+| `publish` | the standing PR being **merged** | publishes the reviewed manifest, tags, GitHub Releases |
+| `retry-publish` | `release:retry` label on the **merged** standing PR | idempotently re-publishes whatever the failed run left unfinished |
+
+## Files
+
+| File | Copy to |
+|------|---------|
+| [`standing-pr.yml`](./standing-pr.yml) | `.github/workflows/standing-pr.yml` |
+| [`releasekit.config.json`](./releasekit.config.json) | repo root |
+
+## Assumptions
+
+- **Repo setting (required):** Settings -> Actions -> General -> Workflow
+  permissions -> enable **"Allow GitHub Actions to create and approve pull
+  requests"**. Without it the first `update` run fails with HTTP 403. The
+  `pull-requests: write` workflow permission is necessary but **not** sufficient
+  — this toggle is separate.
+- `release/next` is **not** branch-protected (the bot force-pushes it), or the
+  bot has bypass.
+- Squash merge produces a single `chore: release ...` commit on `main`, which
+  releasekit's skip pattern recognises so the merge doesn't trigger another
+  update on itself.
+- npm publishing via OIDC; swap to `NODE_AUTH_TOKEN`/`NPM_TOKEN` for token auth.
+
+## Correctness notes
+
+- **pnpm before setup-node** in every job (hosted runners lack pnpm).
+- **`fetch-depth: 0`** everywhere — releasekit walks full history.
+- The `permissions` block lists all four scopes the jobs need
+  (`contents`/`pull-requests`/`id-token`/`statuses`); an explicit block zeroes
+  anything unlisted.
+- The `pull_request` trigger subscribes to **both** `closed` and `labeled`. The
+  `publish` job guards on `action == 'closed'` so that a label added to an
+  already-merged PR can't re-trigger a publish; only `retry-publish` reacts to
+  `labeled`.
+- `retry-publish` checks out `ref: main` because `release/next` is deleted on
+  merge, then removes the `release:retry` label so each application is exactly
+  one retry.

--- a/examples/ci/standing-pr/README.md
+++ b/examples/ci/standing-pr/README.md
@@ -35,15 +35,7 @@ One workflow file (`standing-pr.yml`) carries three jobs:
 
 ## Correctness notes
 
-- **pnpm before setup-node** in every job (hosted runners lack pnpm).
-- **`fetch-depth: 0`** everywhere — releasekit walks full history.
-- The `permissions` block lists all four scopes the jobs need
-  (`contents`/`pull-requests`/`id-token`/`statuses`); an explicit block zeroes
-  anything unlisted.
-- The `pull_request` trigger subscribes to **both** `closed` and `labeled`. The
-  `publish` job guards on `action == 'closed'` so that a label added to an
-  already-merged PR can't re-trigger a publish; only `retry-publish` reacts to
-  `labeled`.
-- `retry-publish` checks out `ref: main` because `release/next` is deleted on
-  merge, then removes the `release:retry` label so each application is exactly
-  one retry.
+Shared [correctness rules](../../README.md#cross-cutting-correctness-rules) apply (the `permissions` block lists all four scopes the three jobs need). Scenario-specific:
+
+- The `pull_request` trigger subscribes to **both** `closed` and `labeled`. The `publish` job guards on `action == 'closed'` so a label on an already-merged PR can't re-trigger a publish; only `retry-publish` reacts to `labeled`.
+- `retry-publish` checks out `ref: main` (since `release/next` is deleted on merge), then removes the `release:retry` label so each application is exactly one retry.

--- a/examples/ci/standing-pr/releasekit.config.json
+++ b/examples/ci/standing-pr/releasekit.config.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://goosewobbler.github.io/releasekit/schema.json",
+  "git": {
+    "branch": "main"
+  },
+  "version": {
+    "preset": "angular",
+    "sync": true
+  },
+  "publish": {
+    "npm": {
+      "enabled": true,
+      "access": "public"
+    }
+  },
+  "ci": {
+    "releaseStrategy": "standing-pr",
+    "standingPr": {
+      "branch": "release/next",
+      "mergeMethod": "squash"
+    },
+    "labels": {
+      "retry": "release:retry"
+    }
+  }
+}

--- a/examples/ci/standing-pr/standing-pr.yml
+++ b/examples/ci/standing-pr/standing-pr.yml
@@ -97,6 +97,12 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+      # setup-node's registry-url writes a .npmrc with `_authToken=${NODE_AUTH_TOKEN}`.
+      # With OIDC that var is empty, so npm fails ENEEDAUTH instead of the OIDC exchange.
+      # Remove it before publishing. (Drop this step if you publish with NODE_AUTH_TOKEN.)
+      - name: Remove token-based .npmrc so OIDC can take over
+        run: rm -f .npmrc
+
       - run: pnpm exec releasekit standing-pr publish
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -139,6 +145,12 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      # setup-node's registry-url writes a .npmrc with `_authToken=${NODE_AUTH_TOKEN}`.
+      # With OIDC that var is empty, so npm fails ENEEDAUTH instead of the OIDC exchange.
+      # Remove it before publishing. (Drop this step if you publish with NODE_AUTH_TOKEN.)
+      - name: Remove token-based .npmrc so OIDC can take over
+        run: rm -f .npmrc
 
       - run: pnpm exec releasekit standing-pr publish --pr ${{ github.event.pull_request.number }}
         env:

--- a/examples/ci/standing-pr/standing-pr.yml
+++ b/examples/ci/standing-pr/standing-pr.yml
@@ -1,0 +1,153 @@
+# Copy to: .github/workflows/standing-pr.yml
+#
+# Standing release PR: a single PR (on `release/next`) accumulates version bumps
+# and release notes as commits land on main. Maintainers merge it to publish.
+#
+# One-time repo setting (REQUIRED): Settings -> Actions -> General ->
+# Workflow permissions -> enable "Allow GitHub Actions to create and approve
+# pull requests". Without it the first `standing-pr update` fails with HTTP 403;
+# the pull-requests: write permission below is necessary but not sufficient.
+name: Standing Release PR
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    # labeled: needed for the release:retry path, which fires on the merged
+    # (closed) standing PR.
+    types: [closed, labeled]
+    branches: [main]
+  schedule:
+    - cron: '0 * * * *' # hourly: advances the minAge status check as time passes
+
+concurrency:
+  group: standing-release-pr
+  cancel-in-progress: false
+
+permissions:
+  contents: write # push to release/next, create tags
+  pull-requests: write # create/update/close the standing PR and its comments
+  id-token: write # npm OIDC trusted publishing
+  statuses: write # post the releasekit/standing-pr status check
+
+jobs:
+  update:
+    name: Update Release PR
+    if: github.event_name == 'push' || github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ github.token }}
+
+      - uses: pnpm/action-setup@v5
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: pnpm
+          registry-url: 'https://registry.npmjs.org'
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - run: pnpm exec releasekit standing-pr update
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          # Uncomment the key matching notes.releaseNotes.llm.provider, if set.
+          # Without it, LLM enhancement falls back to ungrouped output (a warning,
+          # not a failure).
+          # OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          # ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          # OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
+
+  publish:
+    name: Publish Release
+    # action == 'closed' matters: with `labeled` also subscribed above, a label
+    # added to the already-merged PR must not re-match this job and publish again.
+    if: >
+      github.event_name == 'pull_request' &&
+      github.event.action == 'closed' &&
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'release/')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ github.token }}
+
+      - uses: pnpm/action-setup@v5
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: pnpm
+          registry-url: 'https://registry.npmjs.org'
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - run: pnpm exec releasekit standing-pr publish
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          # NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }} # only if not using OIDC
+
+  retry-publish:
+    name: Retry Publish
+    # Maintainer-invoked retry after a partial-publish failure: apply
+    # `release:retry` to the MERGED standing PR (label events fire on closed PRs).
+    # Publishing is idempotent — already-published versions are skipped and tags /
+    # GitHub releases are created only after a clean publish — so the retry
+    # finishes exactly what the failed run left undone. The label name is
+    # hardcoded here (workflow `if` can't read config); if you change
+    # ci.labels.retry, update this guard too.
+    if: >
+      github.event_name == 'pull_request' &&
+      github.event.action == 'labeled' &&
+      github.event.label.name == 'release:retry' &&
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'release/')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ github.token }}
+          ref: main # the standing PR branch is deleted on merge; publish from main
+
+      - uses: pnpm/action-setup@v5
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: pnpm
+          registry-url: 'https://registry.npmjs.org'
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - run: pnpm exec releasekit standing-pr publish --pr ${{ github.event.pull_request.number }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          # NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }} # only if not using OIDC
+
+      - name: Remove retry label
+        # Each application is exactly one retry; re-apply the label to retry again.
+        if: always()
+        run: gh api -X DELETE "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels/release%3Aretry" || true
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/examples/ci/standing-pr/standing-pr.yml
+++ b/examples/ci/standing-pr/standing-pr.yml
@@ -110,13 +110,11 @@ jobs:
 
   retry-publish:
     name: Retry Publish
-    # Maintainer-invoked retry after a partial-publish failure: apply
-    # `release:retry` to the MERGED standing PR (label events fire on closed PRs).
-    # Publishing is idempotent — already-published versions are skipped and tags /
-    # GitHub releases are created only after a clean publish — so the retry
-    # finishes exactly what the failed run left undone. The label name is
-    # hardcoded here (workflow `if` can't read config); if you change
-    # ci.labels.retry, update this guard too.
+    # Maintainer-invoked retry after a partial-publish failure: apply `release:retry`
+    # to the MERGED standing PR (label events fire on closed PRs). Publishing is
+    # idempotent, so the retry finishes whatever the failed run left undone. The label
+    # name is hardcoded (workflow `if` can't read config) — update it if you change
+    # ci.labels.retry.
     if: >
       github.event_name == 'pull_request' &&
       github.event.action == 'labeled' &&


### PR DESCRIPTION
Adds an `examples/ci/` directory of runnable, CI-validated workflow + config scenarios, addressing the "embedded snippets rot silently" problem in #259.

## Scenarios

| Scenario | Shows |
|----------|-------|
| `ci/minimal` | push-to-main direct release |
| `ci/label-driven` | `bump:*` label trigger + workflow gate |
| `ci/standing-pr` | standing PR: update + publish + retry-publish jobs |
| `ci/oidc` | npm OIDC trusted publishing (incl. the `.npmrc` removal) |
| `ci/monorepo-rust` | mixed npm (OIDC) + cargo (token) |
| `ci/prerelease` | manual `workflow_dispatch` prerelease |

Each is a directory with the workflow YAML, a minimal `releasekit.config.json`, and a README stating assumptions.

## Correctness

Every example sets up **pnpm before `actions/setup-node`** (hosted runners don't ship pnpm), Node 24, `fetch-depth: 0`, and explicit zero-by-default `permissions:` blocks. This is the class of bug the existing docs templates carry (#263) — those are intentionally left untouched here.

## Validation

`.github/workflows/examples-validate.yml` runs on `examples/` changes:
- `actionlint` over `examples/**/*.yml`
- `ajv-cli` validation of each `examples/**/releasekit.config.json` against `releasekit.schema.json` (`additionalProperties: false`, so typos fail)

⚠️ **actionlint does NOT catch a missing runtime tool.** A workflow that calls `pnpm` without `pnpm/action-setup` is syntactically valid and lints clean — it only fails at runtime. Catching that needs an **execution smoke-test**, recommended as a follow-up (cross-refs #263).

## Caveat surfaced

The example configs avoid `ci.scopeLabels` because it is in the repo's own `releasekit.config.json` but NOT in `releasekit.schema.json` — pre-existing schema/config drift that fails strict validation. Worth a separate issue.

Closes #259

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds an `examples/ci/` directory of six self-contained, CI-validated workflow+config scenarios (minimal, label-driven, standing-PR, OIDC, monorepo-rust, prerelease) and a new `.github/workflows/examples-validate.yml` that runs `actionlint` and `ajv-cli` schema validation over them on every change, directly addressing the "silent snippet rot" problem.

- All six example workflows correctly follow the cross-cutting rules: pnpm setup before `actions/setup-node`, `fetch-depth: 0`, explicit zero-default `permissions:` blocks, and `rm -f .npmrc` before any OIDC publish step.
- Previously flagged issues (missing `.npmrc` removal in `prerelease`, `standing-pr publish/retry-publish`, and `label-driven`; `inputs.identifier` shell injection) are all resolved in this revision.
- The validation workflow's acknowledged gap (no execution smoke-test for runtime-tool presence) is clearly documented and tracked as a follow-up.
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge — all previously flagged correctness issues are resolved and no new defects were found.

All six example workflows correctly implement the cross-cutting rules (pnpm ordering, fetch-depth, permissions, OIDC .npmrc removal). The previously reviewed injection and missing-.npmrc issues are fixed. The validation workflow is well-structured with explicit version-pinning and clear comments on its known limitation (no execution smoke-test). The changes are documentation/examples only; no runtime library code is modified.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/examples-validate.yml | New validation workflow: runs actionlint over example YAMLs and ajv-cli schema validation of example configs. Uses curl-pipe-bash for actionlint installation (version-pinned but no checksum), and npx ajv-cli@5 (major-pinned only). Correctness limitation is well-documented in comments. |
| examples/ci/standing-pr/standing-pr.yml | Most complex example: three jobs (update/publish/retry-publish) with correct concurrency group, proper if-guards, .npmrc removal in both publishing jobs, and env-var-clean PR number interpolation. |
| examples/ci/prerelease/prerelease.yml | workflow_dispatch prerelease example; identifier is correctly routed through PRERELEASE_IDENTIFIER env var (fixing the previously flagged injection), .npmrc removal present for OIDC. |
| examples/ci/label-driven/release.yml | Label-driven release on pull_request:closed with correct bump:* label gate, .npmrc removal present for OIDC, and explicit comment linking workflow-level gate to releasekit config labels. |
| examples/ci/minimal/release.yml | Push-to-main direct release; pnpm before setup-node, fetch-depth:0, .npmrc removal step all present and correct. |
| examples/ci/oidc/release.yml | Canonical OIDC example; id-token:write, registry-url kept for cache, .npmrc removed before publish — the reference implementation for OIDC correctness. |
| examples/ci/monorepo-rust/release.yml | Mixed npm+Cargo release; dtolnay/rust-toolchain set up before release, .npmrc removal present, CARGO_REGISTRY_TOKEN correctly scoped. |
| examples/ci/standing-pr/releasekit.config.json | Standing PR config with squash merge and retry label; publish.npm omits auth:oidc (relying on auto-detection, consistent with minimal/label-driven). |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[GitHub Event] --> B{Event type?}
    B -->|push to main / schedule| C[update job]
    B -->|pull_request closed + merged + release/* head| D[publish job]
    B -->|pull_request labeled + release:retry + merged + release/* head| E[retry-publish job]

    C --> C1[checkout fetch-depth:0]
    C1 --> C2[pnpm setup then setup-node]
    C2 --> C3[pnpm install]
    C3 --> C4[git config bot identity]
    C4 --> C5[releasekit standing-pr update]
    C5 --> C6[Rebuild release/next branch + standing PR]

    D --> D1[checkout fetch-depth:0]
    D1 --> D2[pnpm setup then setup-node]
    D2 --> D3[pnpm install]
    D3 --> D4[git config bot identity]
    D4 --> D5[rm -f .npmrc]
    D5 --> D6[releasekit standing-pr publish]
    D6 --> D7[Tags + GitHub Release + npm OIDC publish]

    E --> E1[checkout main ref, fetch-depth:0]
    E1 --> E2[pnpm setup then setup-node]
    E2 --> E3[pnpm install]
    E3 --> E4[git config bot identity]
    E4 --> E5[rm -f .npmrc]
    E5 --> E6[releasekit standing-pr publish --pr NUMBER]
    E6 --> E7[Remove release:retry label]
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `examples/ci/label-driven/release.yml`, line 267-277 ([link](https://github.com/goosewobbler/releasekit/blob/1b76f46b9a6794395c73bdaf3211a18b9bd1785c/examples/ci/label-driven/release.yml#L267-L277)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Missing `.npmrc` removal for OIDC publishing**

   This job has `id-token: write` and the README explicitly states "npm publishing via OIDC," but there is no `rm -f .npmrc` step before the `releasekit release` call. `actions/setup-node` with `registry-url` writes a project-level `.npmrc` containing `_authToken=${NODE_AUTH_TOKEN}`; with OIDC that variable is empty, so npm resolves it to an empty token and exits with `ENEEDAUTH` instead of performing the OIDC exchange. The `oidc` example (the canonical reference for this exact scenario) correctly removes the file before publishing. The same issue is present in `examples/ci/prerelease/prerelease.yml` and both the `publish` and `retry-publish` jobs of `examples/ci/standing-pr/standing-pr.yml`.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20examples%2Fci%2Flabel-driven%2Frelease.yml%0ALine%3A%20267-277%0A%0AComment%3A%0A**Missing%20%60.npmrc%60%20removal%20for%20OIDC%20publishing**%0A%0AThis%20job%20has%20%60id-token%3A%20write%60%20and%20the%20README%20explicitly%20states%20%22npm%20publishing%20via%20OIDC%2C%22%20but%20there%20is%20no%20%60rm%20-f%20.npmrc%60%20step%20before%20the%20%60releasekit%20release%60%20call.%20%60actions%2Fsetup-node%60%20with%20%60registry-url%60%20writes%20a%20project-level%20%60.npmrc%60%20containing%20%60_authToken%3D%24%7BNODE_AUTH_TOKEN%7D%60%3B%20with%20OIDC%20that%20variable%20is%20empty%2C%20so%20npm%20resolves%20it%20to%20an%20empty%20token%20and%20exits%20with%20%60ENEEDAUTH%60%20instead%20of%20performing%20the%20OIDC%20exchange.%20The%20%60oidc%60%20example%20%28the%20canonical%20reference%20for%20this%20exact%20scenario%29%20correctly%20removes%20the%20file%20before%20publishing.%20The%20same%20issue%20is%20present%20in%20%60examples%2Fci%2Fprerelease%2Fprerelease.yml%60%20and%20both%20the%20%60publish%60%20and%20%60retry-publish%60%20jobs%20of%20%60examples%2Fci%2Fstanding-pr%2Fstanding-pr.yml%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=goosewobbler%2Freleasekit&pr=271&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20examples%2Fci%2Flabel-driven%2Frelease.yml%0ALine%3A%20267-277%0A%0AComment%3A%0A**Missing%20%60.npmrc%60%20removal%20for%20OIDC%20publishing**%0A%0AThis%20job%20has%20%60id-token%3A%20write%60%20and%20the%20README%20explicitly%20states%20%22npm%20publishing%20via%20OIDC%2C%22%20but%20there%20is%20no%20%60rm%20-f%20.npmrc%60%20step%20before%20the%20%60releasekit%20release%60%20call.%20%60actions%2Fsetup-node%60%20with%20%60registry-url%60%20writes%20a%20project-level%20%60.npmrc%60%20containing%20%60_authToken%3D%24%7BNODE_AUTH_TOKEN%7D%60%3B%20with%20OIDC%20that%20variable%20is%20empty%2C%20so%20npm%20resolves%20it%20to%20an%20empty%20token%20and%20exits%20with%20%60ENEEDAUTH%60%20instead%20of%20performing%20the%20OIDC%20exchange.%20The%20%60oidc%60%20example%20%28the%20canonical%20reference%20for%20this%20exact%20scenario%29%20correctly%20removes%20the%20file%20before%20publishing.%20The%20same%20issue%20is%20present%20in%20%60examples%2Fci%2Fprerelease%2Fprerelease.yml%60%20and%20both%20the%20%60publish%60%20and%20%60retry-publish%60%20jobs%20of%20%60examples%2Fci%2Fstanding-pr%2Fstanding-pr.yml%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=271&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (6): Last reviewed commit: ["docs: trim duplicated correctness notes ..."](https://github.com/goosewobbler/releasekit/commit/093a547cfbaa4910be2e286124aa91283e5ff81c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36230334)</sub>

<!-- /greptile_comment -->