### PR TITLE
feat(release): add labels sync command

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -124,16 +124,46 @@ releasekit standing-pr merge --publish
 
 ---
 
+## `releasekit labels`
+
+Create and reconcile the GitHub labels ReleaseKit relies on (`bump:*`, `channel:*`, `release:*`, configured `scope:*`, and the standing-PR labels). The label names honour `ci.labels` renames and `ci.scopeLabels`; descriptions and colours are canonical.
+
+The repository is resolved from `--repo`, then `GITHUB_REPOSITORY`, then the `origin` git remote. The token is read from `GITHUB_TOKEN`, then `GH_TOKEN`.
+
+### `releasekit labels sync`
+
+Idempotently create every config-implied label that is missing from the repo. Existing labels are left untouched (a 422 "already exists" is ignored).
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `-c, --config <path>` | string | auto-discovered | Path to config file |
+| `--project-dir <path>` | string | `cwd` | Project directory |
+| `--repo <owner/repo>` | string | auto | Repository (auto-detected from `GITHUB_REPOSITORY` or the `origin` remote) |
+| `--check` | boolean | `false` | Report missing/misnamed labels and exit non-zero **without** making any changes |
+
+`--check` makes no mutations and exits non-zero when any label is missing — wire it into CI to catch the silent typo'd-label failure mode (a mistyped `bump:minor` means nothing releases, with no error).
+
+```bash
+releasekit labels sync
+releasekit labels sync --check   # CI guard: non-zero exit if labels are missing
+```
+
+---
+
 ## `releasekit init`
 
-Create a default `releasekit.config.json`. Detects whether the project is a monorepo to choose the changelog mode.
+Create a default `releasekit.config.json`. Detects whether the project is a monorepo to choose the changelog mode. After writing the config it prints a next-steps checklist (run `labels sync`, do a `--dry-run`, link the CI guide).
 
 | Flag | Type | Default | Description |
 |---|---|---|---|
 | `-f, --force` | boolean | `false` | Overwrite existing config |
+| `--labels` | boolean | `false` | Also run `labels sync` to create the required GitHub labels (requires a GitHub token) |
+
+`init` stays a local generator: it never touches the remote unless `--labels` is passed (and even then it falls back to the printed instructions if no token is available).
 
 ```bash
 releasekit init
+releasekit init --labels   # also create the GitHub labels (needs GITHUB_TOKEN)
 ```
 
 ---

--- a/packages/release/src/commands/init-command.ts
+++ b/packages/release/src/commands/init-command.ts
@@ -73,7 +73,6 @@ export function createInitCommand(): Command {
         if (options.labels) {
           try {
             await runLabelsSync({ config: undefined, projectDir: process.cwd() });
-            return;
           } catch (err) {
             error(`Could not sync labels: ${err instanceof Error ? err.message : String(err)}`);
             info('Run `releasekit labels sync` once a GitHub token is available.');

--- a/packages/release/src/commands/init-command.ts
+++ b/packages/release/src/commands/init-command.ts
@@ -2,12 +2,24 @@ import * as fs from 'node:fs';
 import { EXIT_CODES, error, info, success } from '@releasekit/core';
 import { detectMonorepo } from '@releasekit/notes';
 import { Command } from 'commander';
+import { runLabelsSync } from './labels-command.js';
+
+const CI_GUIDE_URL = 'https://goosewobbler.github.io/releasekit/ci-setup';
+
+function printNextSteps(): void {
+  info('');
+  info('Next steps:');
+  info('  1. Create the labels ReleaseKit relies on:  releasekit labels sync');
+  info('  2. Preview a release without publishing:     releasekit --dry-run');
+  info(`  3. Wire up CI — see the setup guide:          ${CI_GUIDE_URL}`);
+}
 
 export function createInitCommand(): Command {
   return new Command('init')
     .description('Create a default releasekit.config.json')
     .option('-f, --force', 'Overwrite existing config')
-    .action((options) => {
+    .option('--labels', 'Also run `labels sync` to create the required GitHub labels (requires a GitHub token)', false)
+    .action(async (options) => {
       const configPath = 'releasekit.config.json';
 
       if (fs.existsSync(configPath) && !options.force) {
@@ -54,6 +66,21 @@ export function createInitCommand(): Command {
 
         fs.writeFileSync(configPath, JSON.stringify(defaultConfig, null, 2), 'utf-8');
         success(`Created ${configPath}`);
+
+        // --labels is opt-in sugar: init stays a local generator unless the user explicitly
+        // asks for the remote label setup. Run it now if a token is present; otherwise fall
+        // through to the next-steps epilogue so the manual command is always surfaced.
+        if (options.labels) {
+          try {
+            await runLabelsSync({ config: undefined, projectDir: process.cwd() });
+            return;
+          } catch (err) {
+            error(`Could not sync labels: ${err instanceof Error ? err.message : String(err)}`);
+            info('Run `releasekit labels sync` once a GitHub token is available.');
+          }
+        }
+
+        printNextSteps();
       }
     });
 }

--- a/packages/release/src/commands/labels-command.ts
+++ b/packages/release/src/commands/labels-command.ts
@@ -1,0 +1,127 @@
+import { execFileSync } from 'node:child_process';
+import { loadCIConfig } from '@releasekit/config';
+import { EXIT_CODES, error, info, success } from '@releasekit/core';
+import { Command } from 'commander';
+import { createOctokit } from '../github.js';
+import { checkLabels, deriveLabelDefinitions, syncLabels } from '../label-definitions.js';
+
+interface LabelsCommandContext {
+  owner: string;
+  repo: string;
+  token: string;
+}
+
+/**
+ * Resolve the repo + token context for label operations. Unlike the preview context this does
+ * not need a PR number, so it can run from a plain checkout or CI. Repo comes from `--repo`,
+ * then `GITHUB_REPOSITORY`, then the `origin` git remote. Token comes from `GITHUB_TOKEN` then
+ * `GH_TOKEN`.
+ */
+export function resolveLabelsContext(opts: { repo?: string; projectDir?: string }): LabelsCommandContext {
+  const token = process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN;
+  if (!token) {
+    throw new Error('A GitHub token is required. Set GITHUB_TOKEN (or GH_TOKEN).');
+  }
+
+  const repoStr = opts.repo ?? process.env.GITHUB_REPOSITORY ?? detectRepoFromGit(opts.projectDir);
+  if (!repoStr) {
+    throw new Error(
+      'Could not determine repository. Use --repo <owner/repo>, set GITHUB_REPOSITORY, or run inside a clone with an origin remote.',
+    );
+  }
+
+  const parts = repoStr.split('/');
+  if (parts.length !== 2 || !parts[0] || !parts[1]) {
+    throw new Error(`Invalid repository format: ${repoStr}. Expected "owner/repo".`);
+  }
+
+  return { owner: parts[0], repo: parts[1], token };
+}
+
+function detectRepoFromGit(projectDir?: string): string | undefined {
+  try {
+    const url = execFileSync('git', ['remote', 'get-url', 'origin'], {
+      cwd: projectDir ?? process.cwd(),
+      encoding: 'utf8',
+    }).trim();
+    // Handle both SSH (git@github.com:owner/repo.git) and HTTPS (https://github.com/owner/repo.git).
+    const match = url.match(/github\.com[:/]([^/]+)\/(.+?)(?:\.git)?$/);
+    if (match?.[1] && match[2]) {
+      return `${match[1]}/${match[2]}`;
+    }
+  } catch {
+    // No git remote available — fall through to undefined.
+  }
+  return undefined;
+}
+
+export function createLabelsCommand(): Command {
+  const cmd = new Command('labels').description('Create and reconcile the GitHub labels ReleaseKit relies on');
+
+  cmd
+    .command('sync')
+    .description('Ensure every config-implied label exists in the repo (idempotent)')
+    .option('-c, --config <path>', 'Path to config file')
+    .option('--project-dir <path>', 'Project directory', process.cwd())
+    .option('--repo <owner/repo>', 'Repository (auto-detected from GITHUB_REPOSITORY or the origin remote)')
+    .option('--check', 'Report missing/misnamed labels and exit non-zero without making changes', false)
+    .action(async (opts) => {
+      try {
+        await runLabelsSync({
+          config: opts.config,
+          projectDir: opts.projectDir,
+          repo: opts.repo,
+          check: opts.check,
+        });
+      } catch (err) {
+        error(err instanceof Error ? err.message : String(err));
+        process.exit(EXIT_CODES.GENERAL_ERROR);
+      }
+    });
+
+  return cmd;
+}
+
+export interface LabelsSyncOptions {
+  config?: string;
+  projectDir?: string;
+  repo?: string;
+  check?: boolean;
+}
+
+/**
+ * Core of `releasekit labels sync`. In `--check` mode it performs no mutations and exits
+ * non-zero (via the thrown error path / explicit exit) when labels are missing. Otherwise it
+ * idempotently creates the missing labels.
+ */
+export async function runLabelsSync(options: LabelsSyncOptions): Promise<void> {
+  const ciConfig = loadCIConfig({ cwd: options.projectDir, configPath: options.config });
+  const definitions = deriveLabelDefinitions(ciConfig);
+
+  const { owner, repo, token } = resolveLabelsContext({ repo: options.repo, projectDir: options.projectDir });
+  const octokit = createOctokit(token);
+
+  if (options.check) {
+    const { missing } = await checkLabels(octokit, owner, repo, definitions);
+    if (missing.length > 0) {
+      error(`Missing ${missing.length} label(s) in ${owner}/${repo}:`);
+      for (const name of missing) {
+        error(`  - ${name}`);
+      }
+      info('Run `releasekit labels sync` to create them.');
+      process.exit(EXIT_CODES.GENERAL_ERROR);
+    }
+    success(`All ${definitions.length} ReleaseKit label(s) present in ${owner}/${repo}`);
+    return;
+  }
+
+  const { created, existing } = await syncLabels(octokit, owner, repo, definitions);
+  if (created.length > 0) {
+    for (const name of created) {
+      info(`Created label: ${name}`);
+    }
+  }
+  success(
+    `Synced ${definitions.length} label(s) in ${owner}/${repo} (${created.length} created, ${existing.length} already present)`,
+  );
+}

--- a/packages/release/src/dispatcher.ts
+++ b/packages/release/src/dispatcher.ts
@@ -7,6 +7,7 @@ import { createPublishCommand } from '@releasekit/publish';
 import { createVersionCommand } from '@releasekit/version';
 import { Command } from 'commander';
 import { createInitCommand } from './commands/init-command.js';
+import { createLabelsCommand } from './commands/labels-command.js';
 import { createPreviewCommand } from './commands/preview-command.js';
 import { createReleaseCommand } from './commands/release-command.js';
 import { createStandingPRCommand } from './commands/standing-pr-command.js';
@@ -20,6 +21,7 @@ export function createDispatcherProgram(): Command {
   program.addCommand(createReleaseCommand());
   program.addCommand(createStandingPRCommand());
   program.addCommand(createInitCommand());
+  program.addCommand(createLabelsCommand());
   program.addCommand(createVersionCommand());
   program.addCommand(createNotesCommand());
   program.addCommand(createPublishCommand());

--- a/packages/release/src/label-definitions.ts
+++ b/packages/release/src/label-definitions.ts
@@ -4,8 +4,7 @@ import { DEFAULT_LABELS } from './label-utils.js';
 
 /**
  * Canonical definition of a label ReleaseKit relies on. `name` honours `ci.labels` renames
- * and `ci.scopeLabels` keys; `color`/`description` are fixed canonical values applied on
- * create. The colours are grouped by family so the label picker reads coherently.
+ * and `ci.scopeLabels` keys; `color`/`description` are fixed canonical values applied on create.
  */
 export interface LabelDefinition {
   name: string;

--- a/packages/release/src/label-definitions.ts
+++ b/packages/release/src/label-definitions.ts
@@ -170,5 +170,10 @@ export async function checkLabels(
 function isAlreadyExistsError(err: unknown): boolean {
   if (typeof err !== 'object' || err === null) return false;
   const status = (err as { status?: number }).status;
-  return status === 422;
+  if (status !== 422) return false;
+  // A 422 for "already exists" carries errors[0].code === 'already_exists'.
+  // Other 422s (label name too long, disallowed characters, etc.) are real
+  // validation failures and must surface to the caller.
+  const errors = (err as { response?: { data?: { errors?: { code?: string }[] } } }).response?.data?.errors;
+  return Array.isArray(errors) && errors.some((e) => e?.code === 'already_exists');
 }

--- a/packages/release/src/label-definitions.ts
+++ b/packages/release/src/label-definitions.ts
@@ -1,0 +1,172 @@
+import type { Octokit } from '@octokit/rest';
+import type { CIConfig } from '@releasekit/config';
+import { DEFAULT_LABELS } from './label-utils.js';
+
+/**
+ * Canonical definition of a label ReleaseKit relies on. `name` honours `ci.labels` renames
+ * and `ci.scopeLabels` keys; `color`/`description` are fixed canonical values applied on
+ * create. The colours are grouped by family so the label picker reads coherently.
+ */
+export interface LabelDefinition {
+  name: string;
+  color: string;
+  description: string;
+}
+
+// Colours are grouped by family so labels are visually scannable in the GitHub picker.
+const COLOR_BUMP = '0e8a16'; // green — magnitude controls
+const COLOR_CHANNEL = '1d76db'; // blue — release channel
+const COLOR_RELEASE = 'd93f0b'; // orange — release-flow toggles
+const COLOR_SCOPE = '5319e7'; // purple — scope targeting
+const COLOR_STANDING = 'ededed'; // grey — standing PR markers (matches legacy createLabel colour)
+
+/**
+ * Derive the full set of labels implied by the resolved config: bump magnitudes, channel
+ * modifiers, the release-flow toggles, every configured `scope:*` label, and the standing-PR
+ * labels. Honours `ci.labels` renames and `ci.scopeLabels`. The result is deduped by name —
+ * if a rename collides with another label (or a scope label reuses a reserved name) the first
+ * definition wins, so we never emit two definitions for the same label name.
+ */
+export function deriveLabelDefinitions(ciConfig: CIConfig | undefined): LabelDefinition[] {
+  const labels = ciConfig?.labels ?? DEFAULT_LABELS;
+  const scopeLabels = ciConfig?.scopeLabels ?? {};
+  const standingPrLabels = ciConfig?.standingPr?.labels ?? ['release'];
+
+  const definitions: LabelDefinition[] = [
+    { name: labels.patch, color: COLOR_BUMP, description: 'ReleaseKit: request a patch version bump' },
+    { name: labels.minor, color: COLOR_BUMP, description: 'ReleaseKit: request a minor version bump' },
+    { name: labels.major, color: COLOR_BUMP, description: 'ReleaseKit: request a major version bump' },
+    { name: labels.stable, color: COLOR_CHANNEL, description: 'ReleaseKit: release to the stable channel' },
+    {
+      name: labels.prerelease,
+      color: COLOR_CHANNEL,
+      description: 'ReleaseKit: release to the prerelease channel',
+    },
+    { name: labels.skip, color: COLOR_RELEASE, description: 'ReleaseKit: skip the release for this change' },
+    {
+      name: labels.immediate,
+      color: COLOR_RELEASE,
+      description: 'ReleaseKit: bypass the standing PR and release immediately',
+    },
+    {
+      name: labels.retry,
+      color: COLOR_RELEASE,
+      description: 'ReleaseKit: retry a failed publish on this merged standing PR',
+    },
+  ];
+
+  for (const scopeLabel of Object.keys(scopeLabels)) {
+    definitions.push({
+      name: scopeLabel,
+      color: COLOR_SCOPE,
+      description: 'ReleaseKit: scope the release to a subset of packages',
+    });
+  }
+
+  for (const standingLabel of standingPrLabels) {
+    definitions.push({
+      name: standingLabel,
+      color: COLOR_STANDING,
+      description: 'ReleaseKit: marks this PR for automated release',
+    });
+  }
+
+  // Dedupe by name — renames or scope labels could collide with a reserved name; keep the
+  // first (more specific) definition so each label is created exactly once.
+  const seen = new Set<string>();
+  return definitions.filter((def) => {
+    if (!def.name || seen.has(def.name)) return false;
+    seen.add(def.name);
+    return true;
+  });
+}
+
+/**
+ * Fetch all label names currently defined in the repo (paginated, case-preserving).
+ */
+async function listRepoLabelNames(octokit: Octokit, owner: string, repo: string): Promise<Set<string>> {
+  const names = new Set<string>();
+  const iterator = octokit.paginate.iterator(octokit.rest.issues.listLabelsForRepo, {
+    owner,
+    repo,
+    per_page: 100,
+  });
+  for await (const response of iterator) {
+    for (const label of response.data) {
+      names.add(label.name);
+    }
+  }
+  return names;
+}
+
+export interface LabelSyncResult {
+  created: string[];
+  existing: string[];
+}
+
+/**
+ * Idempotently create every config-implied label that is missing from the repo. Already-existing
+ * labels are left untouched (createLabel throws 422; ignored). Returns which labels were created
+ * vs already present.
+ */
+export async function syncLabels(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  definitions: LabelDefinition[],
+): Promise<LabelSyncResult> {
+  const created: string[] = [];
+  const existing: string[] = [];
+
+  for (const def of definitions) {
+    try {
+      await octokit.rest.issues.createLabel({
+        owner,
+        repo,
+        name: def.name,
+        color: def.color,
+        description: def.description,
+      });
+      created.push(def.name);
+    } catch (err) {
+      // 422 means the label already exists — that's the idempotent happy path. Any other
+      // status is a real failure (auth, rate limit) and should surface to the caller.
+      if (isAlreadyExistsError(err)) {
+        existing.push(def.name);
+      } else {
+        throw err;
+      }
+    }
+  }
+
+  return { created, existing };
+}
+
+/**
+ * Check (no mutations) which config-implied labels are missing from the repo. Returns the list
+ * of missing label names; an empty list means the repo is fully provisioned.
+ */
+export async function checkLabels(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  definitions: LabelDefinition[],
+): Promise<{ missing: string[]; present: string[] }> {
+  const existing = await listRepoLabelNames(octokit, owner, repo);
+  const missing: string[] = [];
+  const present: string[] = [];
+  for (const def of definitions) {
+    if (existing.has(def.name)) {
+      present.push(def.name);
+    } else {
+      missing.push(def.name);
+    }
+  }
+  return { missing, present };
+}
+
+function isAlreadyExistsError(err: unknown): boolean {
+  if (typeof err !== 'object' || err === null) return false;
+  const status = (err as { status?: number }).status;
+  return status === 422;
+}

--- a/packages/release/src/label-definitions.ts
+++ b/packages/release/src/label-definitions.ts
@@ -82,7 +82,9 @@ export function deriveLabelDefinitions(ciConfig: CIConfig | undefined): LabelDef
 }
 
 /**
- * Fetch all label names currently defined in the repo (paginated, case-preserving).
+ * Fetch all label names currently defined in the repo (paginated). Returns a Set of lowercased
+ * names so callers can do case-insensitive comparisons; GitHub's `createLabel` API uses
+ * case-insensitive uniqueness, so `bump:minor` and `Bump:Minor` are the same label.
  */
 async function listRepoLabelNames(octokit: Octokit, owner: string, repo: string): Promise<Set<string>> {
   const names = new Set<string>();
@@ -93,7 +95,7 @@ async function listRepoLabelNames(octokit: Octokit, owner: string, repo: string)
   });
   for await (const response of iterator) {
     for (const label of response.data) {
-      names.add(label.name);
+      names.add(label.name.toLowerCase());
     }
   }
   return names;
@@ -156,7 +158,7 @@ export async function checkLabels(
   const missing: string[] = [];
   const present: string[] = [];
   for (const def of definitions) {
-    if (existing.has(def.name)) {
+    if (existing.has(def.name.toLowerCase())) {
       present.push(def.name);
     } else {
       missing.push(def.name);

--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -11,6 +11,7 @@ import { renderSupersedeWarning } from '../failure-report/failure-report.js';
 import { detectUnresolvedFailure, postFailureReport, resolveFailureReportIfPresent } from '../failure-report/post.js';
 import { getGitHubContext, getHeadCommitMessage, matchesSkipPattern } from '../git.js';
 import { createOctokit } from '../github.js';
+import { deriveLabelDefinitions, syncLabels } from '../label-definitions.js';
 import { DEFAULT_LABELS } from '../label-utils.js';
 import { runNotesStep, runPublishStep, runVersionStep } from '../steps.js';
 import type { ReleaseOptions, ReleaseOutput } from '../types.js';
@@ -841,25 +842,22 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
     info(`Created standing PR #${prNumber}`);
   }
 
-  // Apply labels — preserve any maintainer-added labels (e.g. bump:major, scope:foo) by
-  // taking the union of currently-applied labels and the configured set. Without this,
-  // every update would wipe maintainer overrides.
+  // Ensure the full ReleaseKit label set (bump/channel/release/scope + standing-PR labels)
+  // exists in the repo, from the single shared label-definitions source. This subsumes the
+  // previous ad-hoc createLabel blocks for the standing-PR labels and the retry label, and
+  // gives standing-pr consumers full label setup for free. The retry label is created here but
+  // NOT applied to the PR — a maintainer applies it on demand after merge to retry a failed
+  // publish (issue #245). Best-effort: a sync failure must not block the standing-PR update.
+  try {
+    await syncLabels(octokit, owner, repo, deriveLabelDefinitions(ciConfig));
+  } catch (err) {
+    warn(`Could not ensure ReleaseKit labels exist: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  // Apply the standing-PR labels — preserve any maintainer-added labels (e.g. bump:major,
+  // scope:foo) by taking the union of currently-applied labels and the configured set. Without
+  // this, every update would wipe maintainer overrides.
   if (labels.length > 0) {
-    // Ensure each configured label exists in the repo with a description. createLabel
-    // throws 422 if the label already exists — that's expected and ignored.
-    for (const label of labels) {
-      try {
-        await octokit.rest.issues.createLabel({
-          owner,
-          repo,
-          name: label,
-          color: 'ededed',
-          description: 'ReleaseKit: marks this PR for automated release',
-        });
-      } catch {
-        // Label already exists — no action needed.
-      }
-    }
     try {
       const currentLabels = existingStandingPr?.labels ?? [];
       const mergedLabels = [...new Set([...currentLabels, ...labels])];
@@ -872,23 +870,6 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
     } catch {
       warn('Failed to apply labels to standing PR');
     }
-  }
-
-  // Ensure the retry label exists in the repo (with a description) so a maintainer can apply it
-  // to this PR after merge to retry a failed publish (issue #245). It is NOT applied here — the
-  // maintainer applies it on demand, and the release-retry workflow removes it after each retry.
-  // createLabel throws 422 if it already exists; that's expected and ignored.
-  const retryLabel = ciConfig?.labels?.retry ?? DEFAULT_LABELS.retry;
-  try {
-    await octokit.rest.issues.createLabel({
-      owner,
-      repo,
-      name: retryLabel,
-      color: 'ededed',
-      description: 'ReleaseKit: retry a failed publish on this merged standing PR',
-    });
-  } catch {
-    // Label already exists — no action needed.
   }
 
   // Find existing manifest to preserve firstUpdatedAt across updates

--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -842,12 +842,9 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
     info(`Created standing PR #${prNumber}`);
   }
 
-  // Ensure the full ReleaseKit label set (bump/channel/release/scope + standing-PR labels)
-  // exists in the repo, from the single shared label-definitions source. This subsumes the
-  // previous ad-hoc createLabel blocks for the standing-PR labels and the retry label, and
-  // gives standing-pr consumers full label setup for free. The retry label is created here but
-  // NOT applied to the PR — a maintainer applies it on demand after merge to retry a failed
-  // publish (issue #245). Best-effort: a sync failure must not block the standing-PR update.
+  // Ensure the full ReleaseKit label set exists in the repo from the shared definitions. The
+  // retry label is created but NOT applied — a maintainer applies it on demand after merge to
+  // retry a failed publish (issue #245). Best-effort: a sync failure must not block the update.
   try {
     await syncLabels(octokit, owner, repo, deriveLabelDefinitions(ciConfig));
   } catch (err) {

--- a/packages/release/test/unit/dispatcher.spec.ts
+++ b/packages/release/test/unit/dispatcher.spec.ts
@@ -53,6 +53,18 @@ describe('createDispatcherProgram', () => {
     expect(cmd).toBeDefined();
   });
 
+  it('should register the labels command', () => {
+    const program = createDispatcherProgram();
+    const cmd = program.commands.find((c) => c.name() === 'labels');
+    expect(cmd).toBeDefined();
+  });
+
+  it('should register the init command', () => {
+    const program = createDispatcherProgram();
+    const cmd = program.commands.find((c) => c.name() === 'init');
+    expect(cmd).toBeDefined();
+  });
+
   it('should have preview as the default command', () => {
     const program = createDispatcherProgram();
     expect((program as unknown as { _defaultCommandName: string })._defaultCommandName).toBe('preview');

--- a/packages/release/test/unit/init-command.spec.ts
+++ b/packages/release/test/unit/init-command.spec.ts
@@ -6,10 +6,14 @@ vi.mock('@releasekit/core');
 vi.mock('@releasekit/notes', () => ({
   detectMonorepo: vi.fn(),
 }));
+vi.mock('../../src/commands/labels-command.js', () => ({
+  runLabelsSync: vi.fn(),
+}));
 
-import { EXIT_CODES } from '@releasekit/core';
+import { EXIT_CODES, info } from '@releasekit/core';
 import { detectMonorepo } from '@releasekit/notes';
 import { createInitCommand } from '../../src/commands/init-command.js';
+import { runLabelsSync } from '../../src/commands/labels-command.js';
 
 function parseInit(args: string[] = []) {
   return createInitCommand().parseAsync(['node', 'init', ...args]);
@@ -121,6 +125,53 @@ describe('createInitCommand', () => {
       await parseInit(['--force']);
 
       expect(vi.mocked(fs.writeFileSync)).toHaveBeenCalled();
+    });
+  });
+
+  describe('next steps', () => {
+    it('should print a next-steps epilogue mentioning labels sync', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+      vi.mocked(fs.readFileSync).mockReturnValue('{"name":"my-pkg"}' as never);
+      vi.mocked(fs.writeFileSync).mockImplementation(() => undefined);
+      vi.mocked(detectMonorepo).mockReturnValue({ isMonorepo: false, packagesPath: '' });
+
+      await parseInit();
+
+      const printed = vi
+        .mocked(info)
+        .mock.calls.map((c) => String(c[0]))
+        .join('\n');
+      expect(printed).toMatch(/labels sync/);
+      expect(printed).toMatch(/--dry-run/);
+      expect(vi.mocked(runLabelsSync)).not.toHaveBeenCalled();
+    });
+
+    it('should run labels sync when --labels is passed', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+      vi.mocked(fs.readFileSync).mockReturnValue('{"name":"my-pkg"}' as never);
+      vi.mocked(fs.writeFileSync).mockImplementation(() => undefined);
+      vi.mocked(detectMonorepo).mockReturnValue({ isMonorepo: false, packagesPath: '' });
+      vi.mocked(runLabelsSync).mockResolvedValue(undefined);
+
+      await parseInit(['--labels']);
+
+      expect(vi.mocked(runLabelsSync)).toHaveBeenCalled();
+    });
+
+    it('should fall back to the epilogue when --labels sync fails', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+      vi.mocked(fs.readFileSync).mockReturnValue('{"name":"my-pkg"}' as never);
+      vi.mocked(fs.writeFileSync).mockImplementation(() => undefined);
+      vi.mocked(detectMonorepo).mockReturnValue({ isMonorepo: false, packagesPath: '' });
+      vi.mocked(runLabelsSync).mockRejectedValue(new Error('no token'));
+
+      await parseInit(['--labels']);
+
+      const printed = vi
+        .mocked(info)
+        .mock.calls.map((c) => String(c[0]))
+        .join('\n');
+      expect(printed).toMatch(/labels sync/);
     });
   });
 });

--- a/packages/release/test/unit/label-definitions.spec.ts
+++ b/packages/release/test/unit/label-definitions.spec.ts
@@ -1,0 +1,194 @@
+import type { CIConfig } from '@releasekit/config';
+import { describe, expect, it, vi } from 'vitest';
+import { checkLabels, deriveLabelDefinitions, type LabelDefinition, syncLabels } from '../../src/label-definitions.js';
+
+// A fully-defaulted CIConfig.labels block (mirrors CILabelsConfigSchema defaults). Tests build
+// on this so a rename only has to override the field under test.
+const DEFAULT_LABELS_CONFIG = {
+  stable: 'channel:stable',
+  prerelease: 'channel:prerelease',
+  skip: 'release:skip',
+  immediate: 'release:immediate',
+  retry: 'release:retry',
+  major: 'bump:major',
+  minor: 'bump:minor',
+  patch: 'bump:patch',
+};
+
+function ciConfig(overrides: Partial<CIConfig> = {}): CIConfig {
+  return {
+    releaseStrategy: 'direct',
+    releaseTrigger: 'label',
+    prPreview: true,
+    autoRelease: false,
+    skipPatterns: ['chore: release '],
+    minChanges: 1,
+    labels: DEFAULT_LABELS_CONFIG,
+    ...overrides,
+  } as CIConfig;
+}
+
+function names(defs: LabelDefinition[]): string[] {
+  return defs.map((d) => d.name);
+}
+
+describe('deriveLabelDefinitions', () => {
+  it('should include every default label when config is undefined', () => {
+    const defs = deriveLabelDefinitions(undefined);
+    expect(names(defs)).toEqual(
+      expect.arrayContaining([
+        'bump:patch',
+        'bump:minor',
+        'bump:major',
+        'channel:stable',
+        'channel:prerelease',
+        'release:skip',
+        'release:immediate',
+        'release:retry',
+        'release', // default standing-PR label
+      ]),
+    );
+  });
+
+  it('should give every definition a name, color, and description', () => {
+    const defs = deriveLabelDefinitions(undefined);
+    for (const def of defs) {
+      expect(def.name).toBeTruthy();
+      expect(def.color).toMatch(/^[0-9a-f]{6}$/);
+      expect(def.description.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('should honor ci.labels renames', () => {
+    const defs = deriveLabelDefinitions(ciConfig({ labels: { ...DEFAULT_LABELS_CONFIG, minor: 'semver:minor' } }));
+    expect(names(defs)).toContain('semver:minor');
+    expect(names(defs)).not.toContain('bump:minor');
+  });
+
+  it('should include configured scope labels from ci.scopeLabels', () => {
+    const defs = deriveLabelDefinitions(
+      ciConfig({ scopeLabels: { 'scope:frontend': 'packages/web', 'scope:backend': 'packages/api' } }),
+    );
+    expect(names(defs)).toContain('scope:frontend');
+    expect(names(defs)).toContain('scope:backend');
+  });
+
+  it('should include the configured standing-PR labels', () => {
+    const config = ciConfig({ standingPr: { labels: ['release', 'queued'] } } as Partial<CIConfig>);
+    const defs = deriveLabelDefinitions(config);
+    expect(names(defs)).toContain('release');
+    expect(names(defs)).toContain('queued');
+  });
+
+  it('should dedupe when a scope label collides with a reserved label name', () => {
+    const defs = deriveLabelDefinitions(ciConfig({ scopeLabels: { 'bump:minor': 'packages/web' } }));
+    const minorCount = names(defs).filter((n) => n === 'bump:minor').length;
+    expect(minorCount).toBe(1);
+  });
+
+  it('should dedupe duplicate standing-PR labels', () => {
+    const config = ciConfig({ standingPr: { labels: ['release', 'release'] } } as Partial<CIConfig>);
+    const defs = deriveLabelDefinitions(config);
+    const releaseCount = names(defs).filter((n) => n === 'release').length;
+    expect(releaseCount).toBe(1);
+  });
+});
+
+function mockOctokitForCreate(failures: Record<string, number> = {}) {
+  const createLabel = vi.fn(async ({ name }: { name: string }) => {
+    const status = failures[name];
+    if (status) {
+      const err = new Error(`HTTP ${status}`) as Error & { status: number };
+      err.status = status;
+      throw err;
+    }
+    return { data: {} };
+  });
+  return { rest: { issues: { createLabel } }, _createLabel: createLabel };
+}
+
+describe('syncLabels', () => {
+  it('should create every definition that does not already exist', async () => {
+    const octokit = mockOctokitForCreate();
+    const defs: LabelDefinition[] = [
+      { name: 'bump:minor', color: '0e8a16', description: 'x' },
+      { name: 'release:skip', color: 'd93f0b', description: 'y' },
+    ];
+
+    const result = await syncLabels(octokit as never, 'owner', 'repo', defs);
+
+    expect(result.created).toEqual(['bump:minor', 'release:skip']);
+    expect(result.existing).toEqual([]);
+    expect(octokit._createLabel).toHaveBeenCalledTimes(2);
+  });
+
+  it('should treat a 422 as already-existing and not as a failure (idempotent)', async () => {
+    const octokit = mockOctokitForCreate({ 'bump:minor': 422 });
+    const defs: LabelDefinition[] = [
+      { name: 'bump:minor', color: '0e8a16', description: 'x' },
+      { name: 'release:skip', color: 'd93f0b', description: 'y' },
+    ];
+
+    const result = await syncLabels(octokit as never, 'owner', 'repo', defs);
+
+    expect(result.existing).toEqual(['bump:minor']);
+    expect(result.created).toEqual(['release:skip']);
+  });
+
+  it('should rethrow non-422 errors (e.g. auth/rate-limit)', async () => {
+    const octokit = mockOctokitForCreate({ 'bump:minor': 403 });
+    const defs: LabelDefinition[] = [{ name: 'bump:minor', color: '0e8a16', description: 'x' }];
+
+    await expect(syncLabels(octokit as never, 'owner', 'repo', defs)).rejects.toThrow('HTTP 403');
+  });
+});
+
+function mockOctokitForList(existing: string[]) {
+  const listLabelsForRepo = vi.fn();
+  const iterator = vi.fn().mockReturnValue({
+    async *[Symbol.asyncIterator]() {
+      yield { data: existing.map((name) => ({ name })) };
+    },
+  });
+  return { paginate: { iterator }, rest: { issues: { listLabelsForRepo } } };
+}
+
+describe('checkLabels', () => {
+  it('should report all labels missing when the repo has none', async () => {
+    const octokit = mockOctokitForList([]);
+    const defs: LabelDefinition[] = [
+      { name: 'bump:minor', color: '0e8a16', description: 'x' },
+      { name: 'release:skip', color: 'd93f0b', description: 'y' },
+    ];
+
+    const { missing, present } = await checkLabels(octokit as never, 'owner', 'repo', defs);
+
+    expect(missing).toEqual(['bump:minor', 'release:skip']);
+    expect(present).toEqual([]);
+  });
+
+  it('should report only the missing subset', async () => {
+    const octokit = mockOctokitForList(['bump:minor']);
+    const defs: LabelDefinition[] = [
+      { name: 'bump:minor', color: '0e8a16', description: 'x' },
+      { name: 'release:skip', color: 'd93f0b', description: 'y' },
+    ];
+
+    const { missing, present } = await checkLabels(octokit as never, 'owner', 'repo', defs);
+
+    expect(missing).toEqual(['release:skip']);
+    expect(present).toEqual(['bump:minor']);
+  });
+
+  it('should report nothing missing when the repo is fully provisioned', async () => {
+    const octokit = mockOctokitForList(['bump:minor', 'release:skip']);
+    const defs: LabelDefinition[] = [
+      { name: 'bump:minor', color: '0e8a16', description: 'x' },
+      { name: 'release:skip', color: 'd93f0b', description: 'y' },
+    ];
+
+    const { missing } = await checkLabels(octokit as never, 'owner', 'repo', defs);
+
+    expect(missing).toEqual([]);
+  });
+});

--- a/packages/release/test/unit/label-definitions.spec.ts
+++ b/packages/release/test/unit/label-definitions.spec.ts
@@ -107,6 +107,25 @@ function mockOctokitForCreate(failures: Record<string, number> = {}) {
   return { rest: { issues: { createLabel } }, _createLabel: createLabel };
 }
 
+function mockOctokitForCreateWithErrorBody(failures: Record<string, { status: number; errors?: { code: string }[] }>) {
+  const createLabel = vi.fn(async ({ name }: { name: string }) => {
+    const failure = failures[name];
+    if (failure) {
+      const err = new Error(`HTTP ${failure.status}`) as Error & {
+        status: number;
+        response?: { data: { errors?: { code: string }[] } };
+      };
+      err.status = failure.status;
+      if (failure.errors) {
+        err.response = { data: { errors: failure.errors } };
+      }
+      throw err;
+    }
+    return { data: {} };
+  });
+  return { rest: { issues: { createLabel } }, _createLabel: createLabel };
+}
+
 describe('syncLabels', () => {
   it('should create every definition that does not already exist', async () => {
     const octokit = mockOctokitForCreate();
@@ -122,8 +141,10 @@ describe('syncLabels', () => {
     expect(octokit._createLabel).toHaveBeenCalledTimes(2);
   });
 
-  it('should treat a 422 as already-existing and not as a failure (idempotent)', async () => {
-    const octokit = mockOctokitForCreate({ 'bump:minor': 422 });
+  it('should treat a 422 with already_exists error code as idempotent', async () => {
+    const octokit = mockOctokitForCreateWithErrorBody({
+      'bump:minor': { status: 422, errors: [{ code: 'already_exists' }] },
+    });
     const defs: LabelDefinition[] = [
       { name: 'bump:minor', color: '0e8a16', description: 'x' },
       { name: 'release:skip', color: 'd93f0b', description: 'y' },
@@ -133,6 +154,31 @@ describe('syncLabels', () => {
 
     expect(result.existing).toEqual(['bump:minor']);
     expect(result.created).toEqual(['release:skip']);
+  });
+
+  it('should rethrow 422 validation errors (e.g. label name too long) so the caller sees the real failure', async () => {
+    const octokit = mockOctokitForCreateWithErrorBody({
+      'scope:very-long-feature-area-name-that-exceeds-the-limit': {
+        status: 422,
+        errors: [{ code: 'invalid' }],
+      },
+    });
+    const defs: LabelDefinition[] = [
+      {
+        name: 'scope:very-long-feature-area-name-that-exceeds-the-limit',
+        color: '5319e7',
+        description: 'x',
+      },
+    ];
+
+    await expect(syncLabels(octokit as never, 'owner', 'repo', defs)).rejects.toThrow('HTTP 422');
+  });
+
+  it('should rethrow 422 errors without a structured body as a real failure', async () => {
+    const octokit = mockOctokitForCreate({ 'bump:minor': 422 });
+    const defs: LabelDefinition[] = [{ name: 'bump:minor', color: '0e8a16', description: 'x' }];
+
+    await expect(syncLabels(octokit as never, 'owner', 'repo', defs)).rejects.toThrow('HTTP 422');
   });
 
   it('should rethrow non-422 errors (e.g. auth/rate-limit)', async () => {

--- a/packages/release/test/unit/labels-command.spec.ts
+++ b/packages/release/test/unit/labels-command.spec.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@releasekit/config', () => ({
+  loadCIConfig: vi.fn().mockReturnValue(undefined),
+}));
+vi.mock('@releasekit/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@releasekit/core')>();
+  return {
+    ...actual,
+    info: vi.fn(),
+    success: vi.fn(),
+    error: vi.fn(),
+  };
+});
+vi.mock('../../src/github.js', () => ({
+  createOctokit: vi.fn(),
+}));
+
+import { EXIT_CODES } from '@releasekit/core';
+import { runLabelsSync } from '../../src/commands/labels-command.js';
+import { createOctokit } from '../../src/github.js';
+
+function mockOctokit(existingLabels: string[] = [], failures: Record<string, number> = {}) {
+  const createLabel = vi.fn(async ({ name }: { name: string }) => {
+    const status = failures[name];
+    if (status) {
+      const err = new Error(`HTTP ${status}`) as Error & { status: number };
+      err.status = status;
+      throw err;
+    }
+    return { data: {} };
+  });
+  const iterator = vi.fn().mockReturnValue({
+    async *[Symbol.asyncIterator]() {
+      yield { data: existingLabels.map((name) => ({ name })) };
+    },
+  });
+  return {
+    octokit: {
+      paginate: { iterator },
+      rest: { issues: { createLabel, listLabelsForRepo: vi.fn() } },
+    },
+    createLabel,
+  };
+}
+
+describe('runLabelsSync', () => {
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    process.env.GITHUB_TOKEN = 'token';
+    process.env.GITHUB_REPOSITORY = 'owner/repo';
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    exitSpy.mockRestore();
+    delete process.env.GITHUB_TOKEN;
+    delete process.env.GITHUB_REPOSITORY;
+    delete process.env.GH_TOKEN;
+  });
+
+  it('should create missing labels in sync mode', async () => {
+    const { octokit, createLabel } = mockOctokit([]);
+    vi.mocked(createOctokit).mockReturnValue(octokit as never);
+
+    await runLabelsSync({ repo: 'owner/repo' });
+
+    // Default config implies the 8 reserved labels + the default 'release' standing-PR label.
+    expect(createLabel).toHaveBeenCalled();
+    const created = createLabel.mock.calls.map((c) => (c[0] as { name: string }).name);
+    expect(created).toEqual(expect.arrayContaining(['bump:minor', 'channel:stable', 'release:skip', 'release']));
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it('should be idempotent — 422 already-exists does not fail the run', async () => {
+    const { octokit } = mockOctokit([], { 'bump:minor': 422 });
+    vi.mocked(createOctokit).mockReturnValue(octokit as never);
+
+    await expect(runLabelsSync({ repo: 'owner/repo' })).resolves.toBeUndefined();
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it('should exit non-zero in --check mode when labels are missing', async () => {
+    const { octokit, createLabel } = mockOctokit([]); // repo has no labels → all missing
+    vi.mocked(createOctokit).mockReturnValue(octokit as never);
+
+    await runLabelsSync({ repo: 'owner/repo', check: true });
+
+    expect(exitSpy).toHaveBeenCalledWith(EXIT_CODES.GENERAL_ERROR);
+    // --check performs NO mutations.
+    expect(createLabel).not.toHaveBeenCalled();
+  });
+
+  it('should not exit in --check mode when all labels are present', async () => {
+    const { octokit, createLabel } = mockOctokit([
+      'bump:patch',
+      'bump:minor',
+      'bump:major',
+      'channel:stable',
+      'channel:prerelease',
+      'release:skip',
+      'release:immediate',
+      'release:retry',
+      'release',
+    ]);
+    vi.mocked(createOctokit).mockReturnValue(octokit as never);
+
+    await runLabelsSync({ repo: 'owner/repo', check: true });
+
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(createLabel).not.toHaveBeenCalled();
+  });
+
+  it('should throw when no GitHub token is available', async () => {
+    delete process.env.GITHUB_TOKEN;
+    delete process.env.GH_TOKEN;
+
+    await expect(runLabelsSync({ repo: 'owner/repo' })).rejects.toThrow(/token/i);
+  });
+});

--- a/packages/release/test/unit/labels-command.spec.ts
+++ b/packages/release/test/unit/labels-command.spec.ts
@@ -24,8 +24,17 @@ function mockOctokit(existingLabels: string[] = [], failures: Record<string, num
   const createLabel = vi.fn(async ({ name }: { name: string }) => {
     const status = failures[name];
     if (status) {
-      const err = new Error(`HTTP ${status}`) as Error & { status: number };
+      const err = new Error(`HTTP ${status}`) as Error & {
+        status: number;
+        response?: { data: { errors?: { code: string }[] } };
+      };
       err.status = status;
+      // GitHub's 422 for "already exists" carries errors[0].code === 'already_exists';
+      // other 422s are real validation failures and must surface. Mock both as 422-with-body
+      // so the test exercises the existing/regression path the same way the real API would.
+      if (status === 422) {
+        err.response = { data: { errors: [{ code: 'already_exists' }] } };
+      }
       throw err;
     }
     return { data: {} };


### PR DESCRIPTION
## What

Adds `releasekit labels sync` — a non-interactive, idempotent command that reconciles the GitHub labels ReleaseKit's control surface depends on (`bump:*`, `channel:*`, `release:skip/immediate/retry`, configured `scope:*`, and the standing-PR labels), honoring `ci.labels` renames and `ci.scopeLabels`.

- `labels sync` ensure-creates every config-implied label (422 already-exists ignored).
- `labels sync --check` makes no mutations and exits non-zero listing missing labels — wire it into CI to kill the silent typo'd-label failure mode.
- Label definitions now live in one place (`label-definitions.ts`); standing-pr update reuses them, replacing its two ad-hoc `createLabel` blocks and giving standing-pr users full label setup for free.
- `init` prints a next-steps epilogue (run `labels sync`, `--dry-run`, CI guide) and gains opt-in `--labels` sugar that runs the sync when a token is present; it stays a local generator otherwise.

## Notes

- Does not touch `ci-setup.md` / `getting-started.md` (owned by #263). **Follow-up:** swap #263's interim `gh label create` block for a reference to `releasekit labels sync` once both land.
- Slice 3 (preview comment warning on missing labels) is deferred; `checkLabels` is reusable for it.

## Verification

`pnpm turbo run lint typecheck test` — 24/24 tasks pass. (Orchestrator applied biome formatting the agent's sandboxed session couldn't run.)

Closes #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces `releasekit labels sync` — an idempotent command that creates all config-implied GitHub labels (`bump:*`, `channel:*`, `release:*`, `scope:*`, and standing-PR labels) with a `--check` mode for CI guard use. Label definitions are centralized in `label-definitions.ts`, replacing two ad-hoc `createLabel` blocks in `standing-pr.ts` and giving all users automatic full label setup.

- **`labels sync`**: creates missing labels idempotently; `isAlreadyExistsError` now correctly inspects `errors[0].code` to distinguish \"already exists\" from validation failures; `checkLabels` and `listRepoLabelNames` both lowercase for case-insensitive matching aligned with GitHub's API semantics.
- **`init --labels`**: opt-in sugar that runs `syncLabels` immediately after config generation; `printNextSteps()` is called unconditionally so the dry-run and CI-guide hints are always surfaced.
- **`standing-pr update`**: now runs a best-effort `syncLabels` covering all 9+ labels on every update rather than creating only the 2–3 standing/retry labels; the outer try/catch means the PR update is never blocked by a label-sync failure.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the new command is additive, previously flagged issues are resolved, and the standing-pr change is correctly guarded as best-effort.

The label-sync logic is well-isolated: isAlreadyExistsError now correctly discriminates 422 subtypes, checkLabels and listRepoLabelNames both use lowercase comparisons aligned with GitHub's API, and printNextSteps() is unconditional. The standing-pr update change broadens the set of labels created on each run but wraps the call in a best-effort try/catch so no existing PR-update behavior is broken.

No files require special attention; the standing-pr.ts change is the only one with a subtle behavioral difference (early-exit on transient error), but it is explicitly documented as best-effort.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/release/src/label-definitions.ts | New module centralizing all label definitions; isAlreadyExistsError correctly inspects errors[0].code to distinguish already-exists 422s from validation failures; listRepoLabelNames and checkLabels both lowercase for case-insensitive comparisons. |
| packages/release/src/commands/labels-command.ts | New labels sync command and exported runLabelsSync; token/repo resolution chain (env → git remote) is solid; --check flag correctly delegates to checkLabels and exits non-zero without mutations. |
| packages/release/src/commands/init-command.ts | Adds --labels sugar and printNextSteps epilogue; printNextSteps() is now called unconditionally after the if (options.labels) block (previously reported issue resolved). |
| packages/release/src/standing-pr/standing-pr.ts | Replaces two ad-hoc createLabel blocks with a single syncLabels call; now creates ALL 9+ labels on every standing-PR update; outer best-effort try/catch means the PR update is never blocked, but a transient error mid-loop stops remaining labels in that run. |
| packages/release/src/dispatcher.ts | Trivial one-line registration of the new labels command — no issues. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant CLI as labels sync / init --labels
    participant runLabelsSync
    participant resolveLabelsContext
    participant GitHub as GitHub API

    User->>CLI: releasekit labels sync [--check]
    CLI->>runLabelsSync: runLabelsSync(options)
    runLabelsSync->>resolveLabelsContext: "resolveLabelsContext({repo, projectDir})"
    Note over resolveLabelsContext: token: GITHUB_TOKEN then GH_TOKEN, repo: --repo then GITHUB_REPOSITORY then git remote
    resolveLabelsContext-->>runLabelsSync: "{owner, repo, token}"

    alt --check mode
        runLabelsSync->>GitHub: paginate listLabelsForRepo (lowercase Set)
        GitHub-->>runLabelsSync: existing label names
        alt labels missing
            runLabelsSync-->>CLI: process.exit(GENERAL_ERROR)
        else all present
            runLabelsSync-->>CLI: success message
        end
    else sync mode
        loop for each LabelDefinition
            runLabelsSync->>GitHub: createLabel(name, color, description)
            alt 422 already_exists
                GitHub-->>runLabelsSync: existing[]
            else success
                GitHub-->>runLabelsSync: created[]
            else other error
                GitHub-->>runLabelsSync: throw (stops loop)
            end
        end
        runLabelsSync-->>CLI: "{created, existing} summary"
    end
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Frelease%2Fsrc%2Fstanding-pr%2Fstanding-pr.ts%3A848-852%0A**Early-exit%20on%20transient%20error%20silently%20skips%20remaining%20label%20creations**%0A%0A%60syncLabels%60%20throws%20on%20the%20first%20non-%60already_exists%60%20error%20%28auth%20error%2C%20rate-limit%2C%20etc.%29%2C%20which%20exits%20the%20inner%20%60for%60%20loop%20and%20propagates%20to%20this%20outer%20%60try%2Fcatch%60.%20The%20warning%20is%20logged%20and%20the%20PR%20update%20continues%2C%20but%20the%20labels%20that%20follow%20the%20failing%20one%20in%20the%20iteration%20are%20never%20attempted%20in%20that%20run.%20Previously%20each%20label%20had%20its%20own%20individual%20%60try%2Fcatch%60%2C%20so%20a%20failure%20on%20%60bump%3Apatch%60%20still%20attempted%20%60bump%3Aminor%60%20through%20%60release%60.%20The%20practical%20impact%20is%20low%20since%20subsequent%20runs%20recover%2C%20but%20on%20a%20first-time%20setup%20with%20a%20transient%20403%20%28e.g.%20token%20scoping%29%2C%20the%20repo%20might%20remain%20partially%20provisioned%20until%20the%20next%20push%20triggers%20another%20update.%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Frelease%2Fsrc%2Fcommands%2Finit-command.ts%3A82%0A**Next-steps%20step%201%20always%20says%20%22Create%20labels%22%20even%20after%20%60--labels%60%20succeeded**%0A%0A%60printNextSteps%28%29%60%20is%20unconditional%2C%20so%20a%20user%20who%20ran%20%60init%20--labels%60%20successfully%20still%20sees%20step%201%3A%20%60%221.%20Create%20the%20labels%20ReleaseKit%20relies%20on%3A%20releasekit%20labels%20sync%22%60.%20Since%20the%20labels%20were%20just%20created%2C%20the%20instruction%20is%20stale.%20Consider%20printing%20a%20condensed%20epilogue%20%28steps%202%20and%203%20only%29%20when%20%60--labels%60%20completes%20without%20error%2C%20or%20rephrasing%20step%201%20to%20%22Verify%20%2F%20re-sync%20labels%22%20so%20it%20remains%20accurate%20in%20both%20cases.%0A%0A&repo=goosewobbler%2Freleasekit&pr=272&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Frelease%2Fsrc%2Fstanding-pr%2Fstanding-pr.ts%3A848-852%0A**Early-exit%20on%20transient%20error%20silently%20skips%20remaining%20label%20creations**%0A%0A%60syncLabels%60%20throws%20on%20the%20first%20non-%60already_exists%60%20error%20%28auth%20error%2C%20rate-limit%2C%20etc.%29%2C%20which%20exits%20the%20inner%20%60for%60%20loop%20and%20propagates%20to%20this%20outer%20%60try%2Fcatch%60.%20The%20warning%20is%20logged%20and%20the%20PR%20update%20continues%2C%20but%20the%20labels%20that%20follow%20the%20failing%20one%20in%20the%20iteration%20are%20never%20attempted%20in%20that%20run.%20Previously%20each%20label%20had%20its%20own%20individual%20%60try%2Fcatch%60%2C%20so%20a%20failure%20on%20%60bump%3Apatch%60%20still%20attempted%20%60bump%3Aminor%60%20through%20%60release%60.%20The%20practical%20impact%20is%20low%20since%20subsequent%20runs%20recover%2C%20but%20on%20a%20first-time%20setup%20with%20a%20transient%20403%20%28e.g.%20token%20scoping%29%2C%20the%20repo%20might%20remain%20partially%20provisioned%20until%20the%20next%20push%20triggers%20another%20update.%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Frelease%2Fsrc%2Fcommands%2Finit-command.ts%3A82%0A**Next-steps%20step%201%20always%20says%20%22Create%20labels%22%20even%20after%20%60--labels%60%20succeeded**%0A%0A%60printNextSteps%28%29%60%20is%20unconditional%2C%20so%20a%20user%20who%20ran%20%60init%20--labels%60%20successfully%20still%20sees%20step%201%3A%20%60%221.%20Create%20the%20labels%20ReleaseKit%20relies%20on%3A%20releasekit%20labels%20sync%22%60.%20Since%20the%20labels%20were%20just%20created%2C%20the%20instruction%20is%20stale.%20Consider%20printing%20a%20condensed%20epilogue%20%28steps%202%20and%203%20only%29%20when%20%60--labels%60%20completes%20without%20error%2C%20or%20rephrasing%20step%201%20to%20%22Verify%20%2F%20re-sync%20labels%22%20so%20it%20remains%20accurate%20in%20both%20cases.%0A%0A&pr=272&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (4): Last reviewed commit: ["docs: trim duplicated/historical comment..."](https://github.com/goosewobbler/releasekit/commit/f8077d9aa29d3612705934abf2712d407fa51a5c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36234942)</sub>

<!-- /greptile_comment -->