### PR TITLE
feat(version): version groups with fixed/linked sync semantics

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -63,7 +63,7 @@ Versioning configuration.
 | `baselineTagTemplate` | string | — | Optional secondary tag template for an internal 'baseline' marker that records the release commit on the source branch. Use this when tagTemplate resolves to a tag that gets force-moved off the source branch by a downstream step (e.g. a GitHub Action distributing built artifacts at the version tag) — the baseline tag stays on the release commit so future version-bump and changelog calculations can still find the previous release. Must contain a ${version} placeholder so the baseline prefix can be derived. Supports the same variables as tagTemplate. Example: "release/${prefix}${version}" produces "release/v1.2.3". |
 | `packageSpecificTags` | boolean | `false` | Enable package-specific tagging |
 | `preset` | string | `"conventional"` | Commit convention preset |
-| `sync` | boolean | `true` | Sync versions across packages |
+| `sync` | boolean | `true` | Global lockstep versioning. true is sugar for one implicit fixed group of every package — it shares the same mechanism as version.groups. Set to false when using version.groups; sync: true alongside groups is treated as the implicit all-packages fixed group taking precedence (a config conflict, warned about at runtime). |
 | `packages` | `string[]` | `[]` | Packages to include in versioning |
 | `mainPackage` | string | — | Package to use for version determination |
 | `updateInternalDependencies` | `"major"` \| `"minor"` \| `"patch"` \| `"no-internal-update"` | `"minor"` | How to bump internal dependencies |
@@ -85,6 +85,42 @@ Array of objects with the following properties:
 |-----|------|---------|-------------|
 | `pattern` | string | — |  |
 | `releaseType` | `"major"` \| `"minor"` \| `"patch"` \| `"prerelease"` | — |  |
+
+### `version.groups`
+
+Named version groups let a co-evolving family of packages version together while the rest
+of the monorepo versions independently. Each entry under `groups` is a group name mapping to
+`{ packages, sync }`, where `packages` is a list of patterns (same matching as
+`version.packages`) and `sync` is one of:
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `packages` | `string[]` | — | Package patterns (exact names, @scope/*, or globs) whose matched packages form this group. Same matching rules as version.packages. |
+| `sync` | `"fixed"` \| `"linked"` | — | fixed: all members release together at the shared group version. linked: only changed members release, all at the same computed version. |
+
+- **`fixed`** — any releasable change in *any* member releases **all** members at the shared
+  group version, computed as `bump(max(member baselines))`. This is the changesets `fixed`
+  semantics. The global `version.sync: true` flag is exactly this, applied to one implicit
+  group of every package — there is one mechanism, not two.
+- **`linked`** — only members with a releasable change release, but every releasing member
+  shares the same computed version. Unchanged members are left untouched (no empty re-release).
+
+**Group baseline** is the highest member version found in tags / manifests; the group bumps
+from there.
+
+> **Member adoption (read this loudly).** A member below the group baseline — a never-released
+> package whose `package.json` says `1.0.0`, or an existing package at an older version — *adopts*
+> the group version on its next release (e.g. joining a family at `2.3.0` releases at `2.4.0`,
+> skipping its own `1.x` line). This deliberately overrides the per-package "initial version from
+> package.json" rule. When the jump skips versions, the version step warns; time group migrations
+> to a real breaking change in the family so the alignment coincides with an honest major.
+
+**`--target` and fixed groups.** Targeting a strict subset of a `fixed` group expands to the
+whole group (a fixed group never silently splits). `linked` groups and ungrouped packages honor
+targets as-is.
+
+**Workspace pins.** Intra-group `workspace:*` dependencies resolve to the group version within a
+run, so a fixed group publishes internally consistent.
 
 ### `version.cargo`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -108,12 +108,10 @@ of the monorepo versions independently. Each entry under `groups` is a group nam
 **Group baseline** is the highest member version found in tags / manifests; the group bumps
 from there.
 
-> **Member adoption (read this loudly).** A member below the group baseline — a never-released
-> package whose `package.json` says `1.0.0`, or an existing package at an older version — *adopts*
-> the group version on its next release (e.g. joining a family at `2.3.0` releases at `2.4.0`,
-> skipping its own `1.x` line). This deliberately overrides the per-package "initial version from
-> package.json" rule. When the jump skips versions, the version step warns; time group migrations
-> to a real breaking change in the family so the alignment coincides with an honest major.
+> **Member adoption.** A member below the group baseline — never released, or at an older version
+> than the family — adopts the group version on its next release (joining a family at `2.3.0`
+> releases at `2.4.0`, skipping its own `1.x` line), overriding the per-package "initial version
+> from `package.json`" rule. The version step warns when the jump skips versions.
 
 **`--target` and fixed groups.** Targeting a strict subset of a `fixed` group expands to the
 whole group (a fixed group never silently splits). `linked` groups and ungrouped packages honor

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -43,5 +43,6 @@ export {
   type VerifyConfig,
   type VerifyRegistryConfig,
   type VersionConfig,
+  type VersionGroup,
 } from './schema.js';
 export { loadAuth, saveAuth, substituteInObject, substituteVariables } from './substitute.js';

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -30,6 +30,21 @@ export const VersionCargoConfigSchema = z.object({
   paths: z.array(z.string()).optional(),
 });
 
+export const VersionGroupSchema = z.object({
+  /**
+   * Package patterns (exact names, `@scope/*`, or globs) whose matched packages form this group.
+   * The same matching rules as `version.packages` apply.
+   */
+  packages: z.array(z.string()).min(1),
+  /**
+   * - `fixed`: any releasable change in any member releases ALL members at the shared group version
+   *   (`bump(max(member baselines))`).
+   * - `linked`: only members with releasable changes release, but every releasing member shares the
+   *   same computed version.
+   */
+  sync: z.enum(['fixed', 'linked']),
+});
+
 export const VersionConfigSchema = z.object({
   tagTemplate: z.string().default('v{version}'),
   /**
@@ -53,7 +68,21 @@ export const VersionConfigSchema = z.object({
     .optional(),
   packageSpecificTags: z.boolean().default(false),
   preset: z.string().default('conventional'),
+  /**
+   * Global lockstep versioning. `true` is sugar for one implicit `fixed` group of every package
+   * (all packages version together) — it shares the exact same mechanism as `version.groups`.
+   * When `version.groups` is set, `sync` should be `false`; an explicit `sync: true` alongside
+   * groups is treated as the implicit all-packages fixed group taking precedence and is reported
+   * as a config conflict.
+   */
   sync: z.boolean().default(true),
+  /**
+   * Named version groups, each binding a set of package patterns to a `fixed` or `linked` sync
+   * mode. Packages not matched by any group version independently (per-package). A package may
+   * belong to at most one group; overlapping patterns that assign a package to two groups are a
+   * config error. See the `version.groups` reference for fixed vs linked semantics.
+   */
+  groups: z.record(z.string(), VersionGroupSchema).optional(),
   packages: z.array(z.string()).default([]),
   mainPackage: z.string().optional(),
   updateInternalDependencies: z.enum(['major', 'minor', 'patch', 'no-internal-update']).default('minor'),
@@ -415,6 +444,7 @@ export type StandingPrConfig = z.infer<typeof StandingPrConfigSchema>;
 export type GitConfig = z.infer<typeof GitConfigSchema>;
 export type MonorepoConfig = z.infer<typeof MonorepoConfigSchema>;
 export type VersionConfig = z.infer<typeof VersionConfigSchema>;
+export type VersionGroup = z.infer<typeof VersionGroupSchema>;
 export type NpmConfig = z.infer<typeof NpmConfigSchema>;
 export type CargoPublishConfig = z.infer<typeof CargoPublishConfigSchema>;
 export type PublishGitConfig = z.infer<typeof PublishGitConfigSchema>;

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -36,12 +36,8 @@ export const VersionGroupSchema = z.object({
    * The same matching rules as `version.packages` apply.
    */
   packages: z.array(z.string()).min(1),
-  /**
-   * - `fixed`: any releasable change in any member releases ALL members at the shared group version
-   *   (`bump(max(member baselines))`).
-   * - `linked`: only members with releasable changes release, but every releasing member shares the
-   *   same computed version.
-   */
+  /** `fixed`: all members release together at the group version. `linked`: only changed members
+   *  release, all at the same version. See the version.groups reference for the full semantics. */
   sync: z.enum(['fixed', 'linked']),
 });
 

--- a/packages/config/test/unit/schema.spec.ts
+++ b/packages/config/test/unit/schema.spec.ts
@@ -132,6 +132,38 @@ describe('VersionConfigSchema', () => {
     expect(result.cargo?.enabled).toBe(true);
     expect(result.cargo?.paths).toEqual(['crates/core', 'crates/cli']);
   });
+
+  it('should accept version groups with fixed and linked sync modes', () => {
+    const result = VersionConfigSchema.parse({
+      sync: false,
+      groups: {
+        native: { packages: ['@wdio/native-*'], sync: 'linked' },
+        ui: { packages: ['@app/ui', '@app/ui-icons'], sync: 'fixed' },
+      },
+    });
+    expect(result.groups?.native).toEqual({ packages: ['@wdio/native-*'], sync: 'linked' });
+    expect(result.groups?.ui.sync).toBe('fixed');
+  });
+
+  it('should reject a group with an empty packages list', () => {
+    expect(() =>
+      VersionConfigSchema.parse({
+        groups: { native: { packages: [], sync: 'fixed' } },
+      }),
+    ).toThrow();
+  });
+
+  it('should reject a group with an invalid sync mode', () => {
+    expect(() =>
+      VersionConfigSchema.parse({
+        groups: { native: { packages: ['@wdio/native-*'], sync: 'independent' } },
+      }),
+    ).toThrow();
+  });
+
+  it('should leave groups undefined when not specified', () => {
+    expect(VersionConfigSchema.parse({}).groups).toBeUndefined();
+  });
 });
 
 describe('NpmConfigSchema', () => {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -39,8 +39,12 @@ export interface VersionOutput {
    * Which versioning strategy produced this output. Lets consumers (preview, standing PR)
    * render sync releases as a single versioned unit instead of a package count. Optional
    * for backwards compatibility with manifests produced before this field existed.
+   *
+   * `'group'` is the version-groups engine (fixed/linked, and the implicit all-packages fixed
+   * group that `version.sync: true` desugars to). `'sync'` remains for the legacy lockstep
+   * strategy so existing consumers keep working unchanged.
    */
-  strategy?: 'sync' | 'single' | 'async';
+  strategy?: 'sync' | 'single' | 'async' | 'group';
   updates: VersionPackageUpdate[];
   changelogs: VersionPackageChangelog[];
   /**
@@ -75,4 +79,11 @@ export interface VersionPackageUpdate {
    * should exclude them from package counts and package lists.
    */
   isRoot?: boolean;
+  /**
+   * Name of the version group this package was released as part of (from `version.groups`, or
+   * the implicit all-packages group that `version.sync: true` desugars to). Absent for packages
+   * versioned independently. CI surfaces can use this to treat a fixed group atomically (e.g.
+   * expand a scope label that matches part of a group to the whole group).
+   */
+  group?: string;
 }

--- a/packages/release/src/steps.ts
+++ b/packages/release/src/steps.ts
@@ -34,8 +34,12 @@ export async function runVersionStep(options: ReleaseOptions): Promise<VersionOu
     throw new Error('No packages found in workspace');
   }
 
+  const hasGroups = config.groups && Object.keys(config.groups).length > 0;
   const effectiveSync = options.sync || config.sync;
-  if (effectiveSync) {
+  if (hasGroups && !effectiveSync) {
+    engine.setStrategy('group');
+    await engine.run(pkgsResult, targets);
+  } else if (effectiveSync) {
     engine.setStrategy('sync');
     await engine.run(pkgsResult);
   } else if (resolvedCount === 1) {

--- a/packages/version/src/command.ts
+++ b/packages/version/src/command.ts
@@ -68,8 +68,13 @@ export function createVersionCommand(): Command {
         log(`Config packages: ${JSON.stringify(config.packages)}`, 'debug');
         log(`Config sync: ${config.sync}`, 'debug');
 
+        const hasGroups = config.groups && Object.keys(config.groups).length > 0;
         const effectiveSync = options.sync || config.sync;
-        if (effectiveSync) {
+        if (hasGroups && !effectiveSync) {
+          log('Using version-groups strategy.', 'info');
+          engine.setStrategy('group');
+          await engine.run(pkgsResult, cliTargets);
+        } else if (effectiveSync) {
           log('Using sync versioning strategy.', 'info');
           engine.setStrategy('sync');
           await engine.run(pkgsResult);

--- a/packages/version/src/core/groupResolution.ts
+++ b/packages/version/src/core/groupResolution.ts
@@ -1,0 +1,206 @@
+/**
+ * Version-group resolution.
+ *
+ * A "version group" binds a set of packages to a shared sync mode:
+ *  - `fixed`:  any releasable change in any member releases ALL members at the shared group version
+ *              (`bump(max(member baselines))`).
+ *  - `linked`: only members with releasable changes release, but every releasing member shares the
+ *              same computed version.
+ *
+ * The global `version.sync: true` flag is **sugar** for a single implicit `fixed` group containing
+ * every workspace package — there is exactly one mechanism, normalized here, not two. This keeps
+ * the engine, output contract, and CI surfaces uniform regardless of whether the user wrote
+ * `sync: true` or an explicit group.
+ */
+
+import type { Package } from '@manypkg/get-packages';
+import { shouldMatchPackageTargets } from '@releasekit/core';
+import { createVersionError, VersionErrorCode } from '../errors/versionError.js';
+import type { Config, VersionGroupConfig } from '../types.js';
+import { log } from '../utils/logging.js';
+
+/** Group name used for the implicit all-packages group that `version.sync: true` desugars to. */
+export const IMPLICIT_SYNC_GROUP = '__sync__';
+
+export interface ResolvedGroup {
+  /** Config key (or {@link IMPLICIT_SYNC_GROUP} for the desugared `sync: true` group). */
+  name: string;
+  sync: 'fixed' | 'linked';
+  /** Raw patterns from config. */
+  patterns: string[];
+  /** Workspace packages that matched this group's patterns. */
+  members: Package[];
+  /** True when this group came from `version.sync: true` rather than `version.groups`. */
+  implicit: boolean;
+}
+
+export interface GroupResolution {
+  /** All resolved groups with at least one matched member, in config order. */
+  groups: ResolvedGroup[];
+  /** Packages not matched by any group — versioned independently (per-package). */
+  ungrouped: Package[];
+  /** Fast lookup from package name to the group it belongs to (undefined if ungrouped). */
+  groupOf: (packageName: string) => ResolvedGroup | undefined;
+}
+
+/**
+ * Normalize the user's config into the canonical list of group definitions, before matching
+ * against the workspace. `sync: true` becomes the implicit all-packages fixed group; explicit
+ * `groups` are carried through as-is.
+ *
+ * When both `sync: true` and `groups` are set, the implicit all-packages group would swallow
+ * every package and make the explicit groups meaningless — this is a config conflict. We surface
+ * it loudly and let the implicit sync group win (back-compat: `sync: true` keeps its historical
+ * all-lockstep meaning), so a user who forgot to flip `sync: false` gets a warning rather than a
+ * silently-split release.
+ */
+export function normalizeGroupDefinitions(config: Config): VersionGroupConfig[] {
+  const explicit: VersionGroupConfig[] = Object.entries(config.groups ?? {}).map(([name, group]) => ({
+    name,
+    packages: group.packages,
+    sync: group.sync,
+  }));
+
+  if (config.sync) {
+    if (explicit.length > 0) {
+      log(
+        'version.sync is true AND version.groups is set. `sync: true` is sugar for one implicit ' +
+          'fixed group of every package, which overrides the explicit groups. Set `version.sync: false` ' +
+          'to use the named groups.',
+        'warning',
+      );
+    }
+    return [
+      {
+        name: IMPLICIT_SYNC_GROUP,
+        // `**` documents "all packages"; resolveGroups also special-cases the implicit group so
+        // membership never depends on glob slash-crossing semantics for scoped names.
+        packages: ['**'],
+        sync: 'fixed',
+      },
+    ];
+  }
+
+  return explicit;
+}
+
+/**
+ * Resolve group definitions against the discovered workspace packages.
+ *
+ * Validates that no package is claimed by more than one group (overlapping patterns that bind a
+ * package to two groups are a config error — there's no defined winner). Empty groups (patterns
+ * that matched nothing) are dropped with a warning so a stale pattern doesn't abort the run.
+ */
+export function resolveGroups(config: Config, packages: Package[]): GroupResolution {
+  const definitions = normalizeGroupDefinitions(config);
+
+  const memberOf = new Map<string, ResolvedGroup>();
+  const groups: ResolvedGroup[] = [];
+
+  for (const def of definitions) {
+    const matchesAll = def.name === IMPLICIT_SYNC_GROUP;
+    const members: Package[] = [];
+    for (const pkg of packages) {
+      const name = pkg.packageJson.name;
+      // The implicit sync group is "every package" by definition — don't route it through glob
+      // matching, where a bare `*` would fail to cross the `/` in scoped names.
+      if (!matchesAll && !shouldMatchPackageTargets(name, def.packages)) continue;
+
+      const existing = memberOf.get(name);
+      if (existing) {
+        throw createVersionError(
+          VersionErrorCode.INVALID_CONFIG,
+          `Package "${name}" matches more than one version group ("${existing.name}" and "${def.name}"). ` +
+            'A package may belong to at most one group; tighten the patterns so each package matches a single group.',
+        );
+      }
+      members.push(pkg);
+    }
+
+    if (members.length === 0) {
+      log(`Version group "${def.name}" matched no workspace packages; ignoring.`, 'warning');
+      continue;
+    }
+
+    const group: ResolvedGroup = {
+      name: def.name,
+      sync: def.sync,
+      patterns: def.packages,
+      members,
+      implicit: def.name === IMPLICIT_SYNC_GROUP,
+    };
+    for (const pkg of members) {
+      memberOf.set(pkg.packageJson.name, group);
+    }
+    groups.push(group);
+  }
+
+  const ungrouped = packages.filter((pkg) => !memberOf.has(pkg.packageJson.name));
+
+  return {
+    groups,
+    ungrouped,
+    groupOf: (packageName: string) => memberOf.get(packageName),
+  };
+}
+
+/**
+ * Whether explicit named groups are configured under `version.groups`.
+ *
+ * This drives strategy selection. `version.sync: true` is *conceptually* one implicit fixed group
+ * (and {@link normalizeGroupDefinitions} models it that way), but for back-compat the established
+ * sync strategy keeps owning the `sync: true` path — its single-shared-tag / `monorepo`-changelog /
+ * root-bump output is depended on by standing-PR manifests and downstream consumers. The group
+ * engine is selected only when the user opts into `version.groups`.
+ */
+export function hasExplicitGroups(config: Config): boolean {
+  return Object.keys(config.groups ?? {}).length > 0;
+}
+
+/**
+ * Whether any group mechanism applies (explicit groups or the desugared `sync: true`).
+ * Used by {@link normalizeGroupDefinitions} consumers that reason about the unified model.
+ */
+export function hasGroups(config: Config): boolean {
+  return config.sync === true || hasExplicitGroups(config);
+}
+
+/**
+ * Expand a set of `--target` patterns so that targeting any member of a **fixed** group pulls in
+ * the whole group. Silently splitting a fixed group would break its invariant (all members release
+ * together at the same version), so we expand rather than error.
+ *
+ * Returns the expanded target patterns plus a record of which fixed groups were expanded (for
+ * logging). `linked` groups are left untouched — partial targeting of a linked group is well
+ * defined (only changed, targeted members release).
+ */
+export function expandTargetsForFixedGroups(
+  resolution: GroupResolution,
+  targets: string[],
+): { targets: string[]; expandedGroups: string[] } {
+  if (targets.length === 0) return { targets, expandedGroups: [] };
+
+  const expanded = new Set(targets);
+  const expandedGroups: string[] = [];
+
+  for (const group of resolution.groups) {
+    if (group.sync !== 'fixed') continue;
+
+    const someTargeted = group.members.some((m) => shouldMatchPackageTargets(m.packageJson.name, targets));
+    const allTargeted = group.members.every((m) => shouldMatchPackageTargets(m.packageJson.name, targets));
+
+    if (someTargeted && !allTargeted) {
+      for (const member of group.members) {
+        expanded.add(member.packageJson.name);
+      }
+      expandedGroups.push(group.name);
+      log(
+        `--target hit a strict subset of fixed group "${group.name}"; expanding to all ${group.members.length} ` +
+          `members so the group releases atomically: ${group.members.map((m) => m.packageJson.name).join(', ')}.`,
+        'warning',
+      );
+    }
+  }
+
+  return { targets: [...expanded], expandedGroups };
+}

--- a/packages/version/src/core/groupStrategy.ts
+++ b/packages/version/src/core/groupStrategy.ts
@@ -253,18 +253,20 @@ function releaseGroup(group: ResolvedGroup, computation: GroupComputation, confi
     // Adoption: a member below the group version jumps to it. Warn loudly when the jump skips
     // versions — i.e. the group version is strictly beyond what a single major bump of this member
     // would have produced — so adopters time the migration to a real breaking change. An unchanged
-    // member that is nonetheless released (fixed group) also warns, since it gains a version with
-    // no semver event of its own behind it.
+    // member that is nonetheless released (fixed group) is the routine lockstep case: just log it at
+    // info level, since it doesn't skip any versions for that member.
     if (semver.valid(plan.baseline) && semver.lt(plan.baseline, groupVersion)) {
       const singleMajorBump = semver.inc(plan.baseline, 'major') ?? plan.baseline;
       const jumpsMoreThanOneBump = semver.gt(groupVersion, singleMajorBump);
-      if (jumpsMoreThanOneBump || !plan.changed) {
+      if (jumpsMoreThanOneBump) {
         log(
           `Group "${group.name}": ${name} adopts group version ${groupVersion} (was ${plan.baseline}). ` +
             'This skips intermediate versions with no semver event behind the jump — time group ' +
             'migrations to a real breaking change in the family.',
           'warning',
         );
+      } else if (!plan.changed) {
+        log(`Group "${group.name}": ${name} rides along to ${groupVersion} (was ${plan.baseline}).`, 'info');
       }
     }
 
@@ -343,6 +345,22 @@ export function createGroupStrategy(config: Config): (packages: PackagesWithRoot
       for (const group of resolution.groups) {
         const members = group.members.filter(targetFilter).filter((p) => shouldProcess(p, config));
         if (members.length === 0) continue;
+
+        // `config.skip` and the target filter both remove members from `members`, so a fixed group
+        // can release with a subset of its declared members — leaving the group at divergent
+        // versions. Warn so the divergence is intentional, not a surprise.
+        if (group.sync === 'fixed') {
+          const released = new Set(members.map((m) => m.packageJson.name));
+          const notInRelease = group.members.map((m) => m.packageJson.name).filter((name) => !released.has(name));
+          if (notInRelease.length > 0) {
+            log(
+              `Group "${group.name}" is fixed but will release without: ${notInRelease.join(', ')}. ` +
+                'They were excluded by config.skip or --target, so the group will end up at divergent versions. ' +
+                'Remove the package from config.skip (or include it via --target) to keep the group atomic.',
+              'warning',
+            );
+          }
+        }
 
         const plans = await Promise.all(members.map((pkg) => planMember(config, pkg, formattedPrefix, globalTag)));
         const computation = computeGroup(group, plans);

--- a/packages/version/src/core/groupStrategy.ts
+++ b/packages/version/src/core/groupStrategy.ts
@@ -62,6 +62,14 @@ const BUMP_RANK: Record<string, number> = {
   prerelease: 0,
 };
 
+/** Aggregate-bump type for a group rank. Rank 0 is "prerelease-increment" — a special case handled in computeGroup because `semver.inc` with a stable release type would graduate the group to a stable release. */
+const RANK_TO_TYPE: Record<number, 'patch' | 'minor' | 'major' | 'prerelease'> = {
+  0: 'prerelease',
+  1: 'patch',
+  2: 'minor',
+  3: 'major',
+};
+
 interface MemberPlan {
   pkg: Package;
   /** Resolved current version (baseline) for this member. */
@@ -134,12 +142,6 @@ function memberBumpRank(plan: MemberPlan): number {
   return BUMP_RANK[diff] ?? BUMP_RANK.patch;
 }
 
-const RANK_TO_TYPE: Record<number, 'patch' | 'minor' | 'major'> = {
-  1: 'patch',
-  2: 'minor',
-  3: 'major',
-};
-
 interface GroupComputation {
   /** The shared version every releasing member is written to. */
   groupVersion: string;
@@ -152,7 +154,7 @@ interface GroupComputation {
 /**
  * Compute the group version and the set of releasing members from each member's independent plan.
  */
-function computeGroup(group: ResolvedGroup, plans: MemberPlan[]): GroupComputation {
+function computeGroup(group: ResolvedGroup, plans: MemberPlan[], config: Config): GroupComputation {
   const changedPlans = plans.filter((p) => p.changed);
   if (changedPlans.length === 0) {
     return { groupVersion: '', releasing: [], hasChange: false };
@@ -162,10 +164,17 @@ function computeGroup(group: ResolvedGroup, plans: MemberPlan[]): GroupComputati
   const maxRank = Math.max(...changedPlans.map(memberBumpRank));
   const bumpType = RANK_TO_TYPE[maxRank] ?? 'patch';
 
-  // Apply the aggregate bump once to the highest baseline in the group. semver.inc handles the
-  // stable case; prerelease groups fall back to each member's own computed next version where the
-  // bumped value would be lower than the maximum already-computed member version.
-  let groupVersion = semver.inc(maxBaseline, bumpType) ?? maxBaseline;
+  // Apply the aggregate bump once to the highest baseline in the group. For prerelease rank
+  // (all changed members are on a prerelease family), pass the identifier so semver.inc
+  // increments within the prerelease instead of graduating to a stable release. Members whose
+  // own bump already produced a higher version still pull the group version up via the
+  // never-regress guard below.
+  let groupVersion =
+    bumpType === 'prerelease'
+      ? config.prereleaseIdentifier
+        ? (semver.inc(maxBaseline, 'prerelease', config.prereleaseIdentifier) ?? maxBaseline)
+        : maxBaseline
+      : (semver.inc(maxBaseline, bumpType) ?? maxBaseline);
 
   // Never let the group version regress below any member's independently-computed next version
   // (covers prerelease increments and members whose own bump already exceeded the aggregate).
@@ -363,7 +372,7 @@ export function createGroupStrategy(config: Config): (packages: PackagesWithRoot
         }
 
         const plans = await Promise.all(members.map((pkg) => planMember(config, pkg, formattedPrefix, globalTag)));
-        const computation = computeGroup(group, plans);
+        const computation = computeGroup(group, plans, config);
 
         if (!computation.hasChange) {
           log(`Group "${group.name}": no releasable changes, skipping.`, 'info');

--- a/packages/version/src/core/groupStrategy.ts
+++ b/packages/version/src/core/groupStrategy.ts
@@ -1,0 +1,434 @@
+/**
+ * Version-group strategy: the single engine behind `fixed` / `linked` groups and the implicit
+ * all-packages fixed group that `version.sync: true` desugars to.
+ *
+ * Per group:
+ *  1. Resolve every member's baseline (highest of git tag / manifest version) and the version it
+ *     would independently bump to.
+ *  2. The group baseline is `max(member baselines)`. The group bump magnitude is the largest bump
+ *     any member earned. The group version is `bump(max baseline)` applied once.
+ *  3. fixed:  ALL members are written to the group version (provided at least one member changed).
+ *     linked: only members that earned a releasable change are written, all at the group version.
+ *
+ * Members below the group baseline (never-released packages, or an existing package at an older
+ * version joining a higher family) ADOPT the group version on release — this deliberately
+ * overrides the per-package "initial version from package.json" rule. A jump larger than a single
+ * bump is warned about so adopters notice the alignment.
+ */
+
+import fs from 'node:fs';
+import * as path from 'node:path';
+import type { Package } from '@manypkg/get-packages';
+import type { VersionChangelogEntry } from '@releasekit/core';
+import { shouldMatchPackageTargets, shouldProcessPackage as shouldProcessPackageUtil } from '@releasekit/core';
+import semver from 'semver';
+import { extractChangelogEntriesFromCommits } from '../changelog/commitParser.js';
+import { BaseVersionError } from '../errors/baseError.js';
+import { execSync } from '../git/commandExecutor.js';
+import { getLatestTag, getLatestTagForPackage } from '../git/tagsAndBranches.js';
+import { updatePackageVersion } from '../package/packageManagement.js';
+import type { Config } from '../types.js';
+import {
+  deriveBaselineTagPrefix,
+  displayTag,
+  formatCommitMessage,
+  formatTag,
+  formatVersionPrefix,
+} from '../utils/formatting.js';
+import {
+  addBaselineTag,
+  addChangelogData,
+  addTag,
+  setCommitMessage,
+  setPackageUpdateGroup,
+  setPackageUpdateTag,
+  setVersioningStrategy,
+} from '../utils/jsonOutput.js';
+import { log } from '../utils/logging.js';
+import { expandTargetsForFixedGroups, type ResolvedGroup, resolveGroups } from './groupResolution.js';
+import { calculateVersion } from './versionCalculator.js';
+import type { PackagesWithRoot } from './versionEngine.js';
+
+type ChangelogEntry = VersionChangelogEntry;
+
+/** Ordering of bump magnitudes so we can take the max across group members. */
+const BUMP_RANK: Record<string, number> = {
+  patch: 1,
+  prepatch: 1,
+  minor: 2,
+  preminor: 2,
+  major: 3,
+  premajor: 3,
+  prerelease: 0,
+};
+
+interface MemberPlan {
+  pkg: Package;
+  /** Resolved current version (baseline) for this member. */
+  baseline: string;
+  /** The tag the changelog/revision range is computed against, or '' when none. */
+  latestTag: string;
+  /** Version this member would bump to on its own ('' when it earned no releasable change). */
+  ownNext: string;
+  /** Whether this member earned a releasable change. */
+  changed: boolean;
+}
+
+function cleanBaseline(version: string | undefined): string {
+  if (!version) return '0.0.0';
+  return semver.valid(semver.coerce(version) ?? '') ?? semver.clean(version) ?? '0.0.0';
+}
+
+/**
+ * Resolve a single member's baseline + the version it would bump to independently. Reuses the
+ * shared tag-resolution path so per-package tags (`tagTemplate`) and the manifest fallback behave
+ * exactly as they do in the per-package strategy.
+ */
+async function planMember(
+  config: Config,
+  pkg: Package,
+  formattedPrefix: string,
+  globalTag: string,
+): Promise<MemberPlan> {
+  const name = pkg.packageJson.name;
+
+  let latestTag = '';
+  if (!config.baselineTagTemplate) {
+    latestTag = await getLatestTagForPackage(name, formattedPrefix, {
+      tagTemplate: config.tagTemplate,
+      packageSpecificTags: config.packageSpecificTags,
+    });
+  }
+  if (!latestTag) latestTag = globalTag;
+
+  const ownNext = await calculateVersion(config, {
+    latestTag,
+    versionPrefix: formattedPrefix,
+    branchPattern: config.branchPattern,
+    baseBranch: config.baseBranch,
+    prereleaseIdentifier: config.prereleaseIdentifier,
+    path: pkg.dir,
+    name,
+    type: config.type,
+  });
+
+  // Baseline: the package's resolved current version. Prefer the manifest version when present
+  // (it's already the package's effective version), else derive from the tag.
+  const manifestVersion = pkg.packageJson.version;
+  const tagVersion = latestTag ? cleanBaseline(latestTag) : undefined;
+  const candidates = [manifestVersion, tagVersion].map(cleanBaseline).filter((v) => v !== '0.0.0');
+  const baseline = candidates.length > 0 ? candidates.sort(semver.rcompare)[0] : '0.0.0';
+
+  return { pkg, baseline, latestTag, ownNext, changed: !!ownNext };
+}
+
+/** Derive the bump magnitude a member earned by comparing its computed next version to baseline. */
+function memberBumpRank(plan: MemberPlan): number {
+  if (!plan.changed) return -1;
+  const diff = semver.diff(plan.baseline, plan.ownNext);
+  if (!diff) {
+    // Same version family (e.g. prerelease increment) — treat as a patch-level change so the
+    // group still advances.
+    return BUMP_RANK.patch;
+  }
+  return BUMP_RANK[diff] ?? BUMP_RANK.patch;
+}
+
+const RANK_TO_TYPE: Record<number, 'patch' | 'minor' | 'major'> = {
+  1: 'patch',
+  2: 'minor',
+  3: 'major',
+};
+
+interface GroupComputation {
+  /** The shared version every releasing member is written to. */
+  groupVersion: string;
+  /** Members that will be released (all members for fixed, changed members for linked). */
+  releasing: MemberPlan[];
+  /** Whether the group has any releasable change at all. */
+  hasChange: boolean;
+}
+
+/**
+ * Compute the group version and the set of releasing members from each member's independent plan.
+ */
+function computeGroup(group: ResolvedGroup, plans: MemberPlan[]): GroupComputation {
+  const changedPlans = plans.filter((p) => p.changed);
+  if (changedPlans.length === 0) {
+    return { groupVersion: '', releasing: [], hasChange: false };
+  }
+
+  const maxBaseline = plans.map((p) => p.baseline).sort(semver.rcompare)[0];
+  const maxRank = Math.max(...changedPlans.map(memberBumpRank));
+  const bumpType = RANK_TO_TYPE[maxRank] ?? 'patch';
+
+  // Apply the aggregate bump once to the highest baseline in the group. semver.inc handles the
+  // stable case; prerelease groups fall back to each member's own computed next version where the
+  // bumped value would be lower than the maximum already-computed member version.
+  let groupVersion = semver.inc(maxBaseline, bumpType) ?? maxBaseline;
+
+  // Never let the group version regress below any member's independently-computed next version
+  // (covers prerelease increments and members whose own bump already exceeded the aggregate).
+  for (const plan of changedPlans) {
+    if (semver.valid(plan.ownNext) && semver.gt(plan.ownNext, groupVersion)) {
+      groupVersion = plan.ownNext;
+    }
+  }
+
+  const releasing = group.sync === 'fixed' ? plans : changedPlans;
+  return { groupVersion, releasing, hasChange: true };
+}
+
+function shouldProcess(pkg: Package, config: Config): boolean {
+  return shouldProcessPackageUtil(pkg.packageJson.name, config.skip);
+}
+
+function readRepoUrl(pkgDir: string): string | null {
+  try {
+    const pkgJsonPath = path.join(pkgDir, 'package.json');
+    if (!fs.existsSync(pkgJsonPath)) return null;
+    const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'));
+    let url: string | undefined = typeof pkgJson.repository === 'string' ? pkgJson.repository : pkgJson.repository?.url;
+    if (!url) return null;
+    if (url.startsWith('git+')) url = url.slice(4);
+    if (url.endsWith('.git')) url = url.slice(0, -4);
+    return url;
+  } catch {
+    return null;
+  }
+}
+
+function extractEntries(
+  pkgDir: string,
+  latestTag: string,
+  version: string,
+  config: Config,
+): {
+  entries: ChangelogEntry[];
+  revisionRange: string;
+} {
+  let revisionRange = 'HEAD';
+  let entries: ChangelogEntry[] = [];
+  try {
+    const baseForRange = config.baseRef ?? latestTag;
+    if (baseForRange) {
+      try {
+        execSync('git', ['rev-parse', '--verify', baseForRange], { cwd: pkgDir, stdio: 'ignore' });
+        revisionRange = `${baseForRange}..HEAD`;
+      } catch {
+        if (!config.baseRef && config.strictReachable) {
+          throw new Error(
+            `Cannot generate changelog: ref '${baseForRange}' is not reachable from the current commit. ` +
+              'When strictReachable is enabled, all refs must be reachable.',
+          );
+        }
+        revisionRange = 'HEAD';
+      }
+    }
+    entries = extractChangelogEntriesFromCommits(pkgDir, revisionRange);
+  } catch (error) {
+    log(`Error extracting changelog entries: ${error instanceof Error ? error.message : String(error)}`, 'warning');
+  }
+  if (entries.length === 0) {
+    entries = [{ type: 'changed', description: `Update version to ${version}` }];
+  }
+  return { entries, revisionRange };
+}
+
+/**
+ * Release one group: write the group version to every releasing member, emit per-package tags +
+ * changelog data, and tag each update with the group name for downstream CI surfaces.
+ * Returns the names of the packages that were written (for commit-message aggregation).
+ */
+function releaseGroup(group: ResolvedGroup, computation: GroupComputation, config: Config): string[] {
+  const { groupVersion, releasing } = computation;
+  const formattedPrefix = formatVersionPrefix(config.versionPrefix || 'v');
+  const released: string[] = [];
+
+  for (const plan of releasing) {
+    const pkg = plan.pkg;
+    const name = pkg.packageJson.name;
+    if (!shouldProcess(pkg, config)) continue;
+
+    // Adoption: a member below the group version jumps to it. Warn loudly when the jump skips
+    // versions — i.e. the group version is strictly beyond what a single major bump of this member
+    // would have produced — so adopters time the migration to a real breaking change. An unchanged
+    // member that is nonetheless released (fixed group) also warns, since it gains a version with
+    // no semver event of its own behind it.
+    if (semver.valid(plan.baseline) && semver.lt(plan.baseline, groupVersion)) {
+      const singleMajorBump = semver.inc(plan.baseline, 'major') ?? plan.baseline;
+      const jumpsMoreThanOneBump = semver.gt(groupVersion, singleMajorBump);
+      if (jumpsMoreThanOneBump || !plan.changed) {
+        log(
+          `Group "${group.name}": ${name} adopts group version ${groupVersion} (was ${plan.baseline}). ` +
+            'This skips intermediate versions with no semver event behind the jump — time group ' +
+            'migrations to a real breaking change in the family.',
+          'warning',
+        );
+      }
+    }
+
+    const packageJsonPath = path.join(pkg.dir, 'package.json');
+    if (fs.existsSync(packageJsonPath)) {
+      updatePackageVersion(packageJsonPath, groupVersion, config.dryRun);
+    } else {
+      log(`Skipping package.json update for ${name} - no package.json found (Rust-only package)`, 'debug');
+    }
+
+    // Cargo handled the same way as other strategies (default path only — paths config applies
+    // to single/async; group members are package-keyed).
+    const cargoTomlPath = path.join(pkg.dir, 'Cargo.toml');
+    if (config.cargo?.enabled !== false && fs.existsSync(cargoTomlPath)) {
+      updatePackageVersion(cargoTomlPath, groupVersion, config.dryRun);
+    }
+
+    // Per-package tag + changelog. Group members always get package-specific tags so each
+    // member's release is individually addressable (the group acts atomically at the version level,
+    // not the tag level).
+    const tag = formatTag(groupVersion, formattedPrefix, name, config.tagTemplate, true);
+    addTag(tag);
+    setPackageUpdateTag(name, tag);
+    setPackageUpdateGroup(name, group.name);
+
+    const baselineTagPrefix = deriveBaselineTagPrefix(config.baselineTagTemplate, formattedPrefix, name);
+    const { entries, revisionRange } = extractEntries(pkg.dir, plan.latestTag, groupVersion, config);
+    addChangelogData({
+      packageName: name,
+      version: groupVersion,
+      previousVersion: plan.latestTag ? displayTag(plan.latestTag, baselineTagPrefix, formattedPrefix) : null,
+      revisionRange,
+      repoUrl: readRepoUrl(pkg.dir),
+      entries,
+    });
+
+    if (config.baselineTagTemplate) {
+      addBaselineTag(formatTag(groupVersion, formattedPrefix, name, config.baselineTagTemplate, false));
+    }
+
+    released.push(name);
+    log(
+      config.dryRun
+        ? `[DRY RUN] Group "${group.name}": would release ${name} at ${groupVersion} (tag: ${tag})`
+        : `Group "${group.name}": ${name} prepared at ${groupVersion} (tag: ${tag})`,
+      config.dryRun ? 'info' : 'success',
+    );
+  }
+
+  return released;
+}
+
+/**
+ * Create the version-group strategy. Handles every configured group (explicit `version.groups`
+ * and the implicit `sync: true` group), plus any ungrouped packages which version independently.
+ */
+export function createGroupStrategy(config: Config): (packages: PackagesWithRoot, targets?: string[]) => Promise<void> {
+  return async (packages: PackagesWithRoot, runtimeTargets: string[] = []): Promise<void> => {
+    try {
+      setVersioningStrategy('group');
+      const formattedPrefix = formatVersionPrefix(config.versionPrefix || 'v');
+      const globalTag = await getLatestTag(deriveBaselineTagPrefix(config.baselineTagTemplate, formattedPrefix));
+
+      const resolution = resolveGroups(config, packages.packages);
+
+      // --target on a strict subset of a fixed group expands to the whole group so the group's
+      // atomic-release invariant holds. Linked groups and ungrouped packages keep their raw targets.
+      const { targets } = expandTargetsForFixedGroups(resolution, runtimeTargets);
+
+      const targetFilter = (pkg: Package): boolean =>
+        targets.length === 0 || shouldMatchPackageTargets(pkg.packageJson.name, targets);
+
+      const allReleased: string[] = [];
+      const allVersions = new Map<string, string>();
+
+      for (const group of resolution.groups) {
+        const members = group.members.filter(targetFilter).filter((p) => shouldProcess(p, config));
+        if (members.length === 0) continue;
+
+        const plans = await Promise.all(members.map((pkg) => planMember(config, pkg, formattedPrefix, globalTag)));
+        const computation = computeGroup(group, plans);
+
+        if (!computation.hasChange) {
+          log(`Group "${group.name}": no releasable changes, skipping.`, 'info');
+          continue;
+        }
+
+        log(
+          `Group "${group.name}" (${group.sync}): releasing ${computation.releasing.length} member(s) at ` +
+            `${computation.groupVersion}.`,
+          'info',
+        );
+        const released = releaseGroup(group, computation, config);
+        for (const name of released) {
+          allReleased.push(name);
+          allVersions.set(name, computation.groupVersion);
+        }
+      }
+
+      // Ungrouped packages version independently — same per-member machinery, no shared version.
+      for (const pkg of resolution.ungrouped) {
+        if (!targetFilter(pkg) || !shouldProcess(pkg, config)) continue;
+        const plan = await planMember(config, pkg, formattedPrefix, globalTag);
+        if (!plan.changed) continue;
+
+        const name = pkg.packageJson.name;
+        const packageJsonPath = path.join(pkg.dir, 'package.json');
+        if (fs.existsSync(packageJsonPath)) {
+          updatePackageVersion(packageJsonPath, plan.ownNext, config.dryRun);
+        }
+        const cargoTomlPath = path.join(pkg.dir, 'Cargo.toml');
+        if (config.cargo?.enabled !== false && fs.existsSync(cargoTomlPath)) {
+          updatePackageVersion(cargoTomlPath, plan.ownNext, config.dryRun);
+        }
+        const tag = formatTag(plan.ownNext, formattedPrefix, name, config.tagTemplate, config.packageSpecificTags);
+        addTag(tag);
+        setPackageUpdateTag(name, tag);
+        const baselineTagPrefix = deriveBaselineTagPrefix(config.baselineTagTemplate, formattedPrefix, name);
+        const { entries, revisionRange } = extractEntries(pkg.dir, plan.latestTag, plan.ownNext, config);
+        addChangelogData({
+          packageName: name,
+          version: plan.ownNext,
+          previousVersion: plan.latestTag ? displayTag(plan.latestTag, baselineTagPrefix, formattedPrefix) : null,
+          revisionRange,
+          repoUrl: readRepoUrl(pkg.dir),
+          entries,
+        });
+        if (config.baselineTagTemplate) {
+          addBaselineTag(formatTag(plan.ownNext, formattedPrefix, name, config.baselineTagTemplate, false));
+        }
+        allReleased.push(name);
+        allVersions.set(name, plan.ownNext);
+      }
+
+      if (allReleased.length === 0) {
+        log('No packages required a version update.', 'info');
+        return;
+      }
+
+      // Commit message: same shape as the async strategy — combined package list, with per-package
+      // versions when they diverge across groups.
+      const template = config.commitMessage || 'chore: release';
+      const versions = [...allVersions.values()];
+      const versionsMatch = versions.every((v) => v === versions[0]);
+      let commitMessage: string;
+      // biome-ignore lint/suspicious/noTemplateCurlyInString: detecting placeholder syntax in user template
+      if (template.includes('${version}') || template.includes('${' + 'packageName}')) {
+        commitMessage = formatCommitMessage(template, versions[0], allReleased.join(', '));
+      } else if (versionsMatch) {
+        commitMessage = `${template} ${allReleased.join(', ')} ${formattedPrefix}${versions[0]}`;
+      } else {
+        commitMessage = `${template} ${allReleased.map((n) => `${n}@${allVersions.get(n)}`).join(', ')}`;
+      }
+      commitMessage = commitMessage.replace(/\s{2,}/g, ' ').trim();
+      setCommitMessage(commitMessage);
+
+      log(`Group versioning prepared ${allReleased.length} package(s).`, 'success');
+    } catch (error) {
+      if (BaseVersionError.isVersionError(error)) {
+        log(`Group strategy failed: ${error.message} (${error.code})`, 'error');
+      } else {
+        log(`Group strategy failed: ${error instanceof Error ? error.message : String(error)}`, 'error');
+      }
+      throw error;
+    }
+  };
+}

--- a/packages/version/src/core/versionEngine.ts
+++ b/packages/version/src/core/versionEngine.ts
@@ -209,6 +209,13 @@ export class VersionEngine {
         mergedPackages.root = workspaceRoot;
       }
 
+      // When explicit version groups are configured, do NOT pre-filter by runtime targets here.
+      // The group strategy needs the full group membership to expand a `--target` that hits a
+      // strict subset of a fixed group up to the whole group — pruning non-targeted members at
+      // discovery time would silently split the group. The strategy applies group-aware target
+      // filtering itself. (config.packages filtering still applies — it scopes the universe.)
+      const deferTargetsToGroups = Object.keys(this.config.groups ?? {}).length > 0;
+
       // Filter packages based on config.packages if specified
       if (this.config.packages && this.config.packages.length > 0) {
         const originalCount = mergedPackages.packages.length;
@@ -230,7 +237,7 @@ export class VersionEngine {
         if (filteredPackages.length === 0) {
           log('Warning: No packages matched the specified patterns in config.packages', 'warning');
         }
-      } else if (this.runtimeTargets.length > 0) {
+      } else if (this.runtimeTargets.length > 0 && !deferTargetsToGroups) {
         // If no config.packages but runtime targets specified, use targets as primary filter
         const originalCount = mergedPackages.packages.length;
         mergedPackages.packages = mergedPackages.packages.filter((pkg) =>
@@ -243,7 +250,7 @@ export class VersionEngine {
       }
 
       // Apply runtime targets as secondary filter (after config.packages)
-      if (this.runtimeTargets.length > 0 && mergedPackages.packages.length > 0) {
+      if (this.runtimeTargets.length > 0 && mergedPackages.packages.length > 0 && !deferTargetsToGroups) {
         const beforeCount = mergedPackages.packages.length;
         mergedPackages.packages = mergedPackages.packages.filter((pkg) =>
           shouldMatchPackageTargets(pkg.packageJson.name, this.runtimeTargets),

--- a/packages/version/src/core/versionStrategies.ts
+++ b/packages/version/src/core/versionStrategies.ts
@@ -31,15 +31,19 @@ import {
   setVersioningStrategy,
 } from '../utils/jsonOutput.js';
 import { log } from '../utils/logging.js';
+import { hasExplicitGroups } from './groupResolution.js';
+import { createGroupStrategy } from './groupStrategy.js';
 import { calculateVersion } from './versionCalculator.js';
 import type { PackagesWithRoot } from './versionEngine.js';
 
 type ChangelogEntry = VersionChangelogEntry;
 
 /**
- * Available strategy types
+ * Available strategy types.
+ * `group` is the version-groups engine (fixed/linked) and the implicit all-packages group that
+ * `version.sync: true` desugars to.
  */
-export type StrategyType = 'sync' | 'single' | 'async';
+export type StrategyType = 'sync' | 'single' | 'async' | 'group';
 
 /**
  * Strategy function type
@@ -748,6 +752,11 @@ export function createAsyncStrategy(config: Config): StrategyFunction {
  * The CLI will override this based on resolved packages.
  */
 export function createStrategy(config: Config): StrategyFunction {
+  // Explicit `version.groups` routes through the unified group engine. `sync: true` keeps using
+  // createSyncStrategy for back-compat (see hasExplicitGroups docs).
+  if (hasExplicitGroups(config)) {
+    return createGroupStrategy(config);
+  }
   if (config.sync) {
     return createSyncStrategy(config);
   }
@@ -765,5 +774,6 @@ export function createStrategyMap(config: Config): Record<StrategyType, Strategy
     sync: createSyncStrategy(config),
     single: createSingleStrategy(config),
     async: createAsyncStrategy(config),
+    group: createGroupStrategy(config),
   };
 }

--- a/packages/version/src/core/versionStrategies.ts
+++ b/packages/version/src/core/versionStrategies.ts
@@ -752,13 +752,13 @@ export function createAsyncStrategy(config: Config): StrategyFunction {
  * The CLI will override this based on resolved packages.
  */
 export function createStrategy(config: Config): StrategyFunction {
-  // Explicit `version.groups` routes through the unified group engine. `sync: true` keeps using
-  // createSyncStrategy for back-compat (see hasExplicitGroups docs).
-  if (hasExplicitGroups(config)) {
-    return createGroupStrategy(config);
-  }
+  // `sync: true` takes precedence over explicit groups (back-compat). Explicit `version.groups`
+  // routes through the unified group engine only when sync is off.
   if (config.sync) {
     return createSyncStrategy(config);
+  }
+  if (hasExplicitGroups(config)) {
+    return createGroupStrategy(config);
   }
 
   // Default to async strategy - the CLI will determine the actual strategy

--- a/packages/version/src/types.ts
+++ b/packages/version/src/types.ts
@@ -1,5 +1,13 @@
-import type { GitConfig, VersionConfig } from '@releasekit/config';
+import type { GitConfig, VersionConfig, VersionGroup } from '@releasekit/config';
 import type { ReleaseType } from 'semver';
+
+/**
+ * A version group as carried through the version engine.
+ * `name` is the config key; `packages` are the raw patterns; `sync` is the group's mode.
+ */
+export interface VersionGroupConfig extends VersionGroup {
+  name: string;
+}
 
 /**
  * Runtime overrides passed by an orchestrator (e.g. @releasekit/release).
@@ -58,6 +66,12 @@ export interface Config extends VersionConfigBase {
   packageSpecificTags?: boolean;
   preset: string;
   sync: boolean;
+  /**
+   * Named version groups, each with package patterns and a `fixed` | `linked` sync mode.
+   * `sync: true` is normalized into one implicit `fixed` group of every package at runtime, so
+   * groups are the single mechanism for lockstep/linked versioning. See groupResolution.ts.
+   */
+  groups?: Record<string, VersionGroup>;
   packages: string[];
   mainPackage?: string;
   updateInternalDependencies: 'major' | 'minor' | 'patch' | 'no-internal-update';
@@ -146,6 +160,7 @@ export function toVersionConfig(config: VersionConfig | undefined, gitConfig?: G
     packageSpecificTags: config.packageSpecificTags,
     preset: config.preset ?? 'conventional',
     sync: config.sync ?? true,
+    groups: config.groups,
     packages: config.packages ?? [],
     mainPackage: config.mainPackage,
     updateInternalDependencies: config.updateInternalDependencies ?? 'minor',

--- a/packages/version/src/utils/jsonOutput.ts
+++ b/packages/version/src/utils/jsonOutput.ts
@@ -83,7 +83,7 @@ export function isJsonOutputMode(): boolean {
  * Record which versioning strategy is producing this output so consumers
  * (preview, standing PR) can render sync releases as a single versioned unit.
  */
-export function setVersioningStrategy(strategy: 'sync' | 'single' | 'async'): void {
+export function setVersioningStrategy(strategy: 'sync' | 'single' | 'async' | 'group'): void {
   if (!_jsonOutputMode) return;
   _jsonData.strategy = strategy;
 }
@@ -111,6 +111,17 @@ export function setPackageUpdateTag(packageName: string, tag: string): void {
   if (!_jsonOutputMode) return;
   const update = _jsonData.updates.find((u) => u.packageName === packageName);
   if (update) update.tag = tag;
+}
+
+/**
+ * Tag a package update with the version group it was released as part of.
+ * Lets CI surfaces treat a fixed group atomically. Called by the group strategy after the
+ * package.json update has been recorded.
+ */
+export function setPackageUpdateGroup(packageName: string, group: string): void {
+  if (!_jsonOutputMode) return;
+  const update = _jsonData.updates.find((u) => u.packageName === packageName);
+  if (update) update.group = group;
 }
 
 /**

--- a/packages/version/test/unit/core/groupResolution.spec.ts
+++ b/packages/version/test/unit/core/groupResolution.spec.ts
@@ -1,0 +1,182 @@
+import type { Package } from '@manypkg/get-packages';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  expandTargetsForFixedGroups,
+  hasExplicitGroups,
+  hasGroups,
+  IMPLICIT_SYNC_GROUP,
+  normalizeGroupDefinitions,
+  resolveGroups,
+} from '../../../src/core/groupResolution.js';
+import type { Config } from '../../../src/types.js';
+
+vi.mock('../../../src/utils/logging.js');
+
+function pkg(name: string, version = '1.0.0'): Package {
+  return {
+    dir: `/ws/packages/${name.replace(/[@/]/g, '-')}`,
+    relativeDir: `packages/${name}`,
+    packageJson: { name, version },
+  } as unknown as Package;
+}
+
+const base = (overrides: Partial<Config>): Config =>
+  ({
+    sync: false,
+    preset: 'conventional',
+    packages: [],
+    tagTemplate: '${prefix}${version}',
+    updateInternalDependencies: 'minor',
+    versionPrefix: '',
+    ...overrides,
+  }) as Config;
+
+describe('groupResolution', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  describe('normalizeGroupDefinitions (sync:true → implicit fixed group)', () => {
+    it('should desugar sync:true into one implicit fixed group of every package', () => {
+      const defs = normalizeGroupDefinitions(base({ sync: true }));
+      expect(defs).toEqual([{ name: IMPLICIT_SYNC_GROUP, packages: ['**'], sync: 'fixed' }]);
+    });
+
+    it('should carry explicit groups through unchanged when sync is false', () => {
+      const defs = normalizeGroupDefinitions(
+        base({
+          sync: false,
+          groups: {
+            native: { packages: ['@wdio/native-*'], sync: 'linked' },
+          },
+        }),
+      );
+      expect(defs).toEqual([{ name: 'native', packages: ['@wdio/native-*'], sync: 'linked' }]);
+    });
+
+    it('should let the implicit sync group win and warn when sync:true and groups both set', () => {
+      const defs = normalizeGroupDefinitions(
+        base({
+          sync: true,
+          groups: { native: { packages: ['@wdio/native-*'], sync: 'linked' } },
+        }),
+      );
+      expect(defs).toEqual([{ name: IMPLICIT_SYNC_GROUP, packages: ['**'], sync: 'fixed' }]);
+    });
+
+    it('should return no definitions when neither sync nor groups are set', () => {
+      expect(normalizeGroupDefinitions(base({ sync: false }))).toEqual([]);
+    });
+  });
+
+  describe('resolveGroups', () => {
+    const packages = [
+      pkg('@wdio/native-core'),
+      pkg('@wdio/native-utils'),
+      pkg('@app/service-a'),
+      pkg('@app/service-b'),
+    ];
+
+    it('should assign matched packages to their group and leave the rest ungrouped', () => {
+      const res = resolveGroups(
+        base({ groups: { native: { packages: ['@wdio/native-*'], sync: 'fixed' } } }),
+        packages,
+      );
+
+      expect(res.groups).toHaveLength(1);
+      expect(res.groups[0].members.map((m) => m.packageJson.name)).toEqual(['@wdio/native-core', '@wdio/native-utils']);
+      expect(res.ungrouped.map((m) => m.packageJson.name)).toEqual(['@app/service-a', '@app/service-b']);
+    });
+
+    it('should resolve a package to its owning group via groupOf', () => {
+      const res = resolveGroups(
+        base({ groups: { native: { packages: ['@wdio/native-*'], sync: 'fixed' } } }),
+        packages,
+      );
+      expect(res.groupOf('@wdio/native-core')?.name).toBe('native');
+      expect(res.groupOf('@app/service-a')).toBeUndefined();
+    });
+
+    it('should put every package in the implicit group for sync:true', () => {
+      const res = resolveGroups(base({ sync: true }), packages);
+      expect(res.groups).toHaveLength(1);
+      expect(res.groups[0].name).toBe(IMPLICIT_SYNC_GROUP);
+      expect(res.groups[0].sync).toBe('fixed');
+      expect(res.groups[0].implicit).toBe(true);
+      expect(res.groups[0].members).toHaveLength(4);
+      expect(res.ungrouped).toHaveLength(0);
+    });
+
+    it('should throw when a package matches more than one group', () => {
+      expect(() =>
+        resolveGroups(
+          base({
+            groups: {
+              a: { packages: ['@wdio/native-*'], sync: 'fixed' },
+              b: { packages: ['@wdio/native-core'], sync: 'linked' },
+            },
+          }),
+          packages,
+        ),
+      ).toThrow(/more than one version group/);
+    });
+
+    it('should drop groups that matched no packages with a warning rather than aborting', () => {
+      const res = resolveGroups(base({ groups: { ghost: { packages: ['@nope/*'], sync: 'fixed' } } }), packages);
+      expect(res.groups).toHaveLength(0);
+      expect(res.ungrouped).toHaveLength(4);
+    });
+  });
+
+  describe('hasExplicitGroups / hasGroups', () => {
+    it('should report explicit groups only for hasExplicitGroups', () => {
+      expect(hasExplicitGroups(base({ sync: true }))).toBe(false);
+      expect(hasExplicitGroups(base({ groups: { g: { packages: ['a'], sync: 'fixed' } } }))).toBe(true);
+    });
+
+    it('should report sync:true as a group mechanism for hasGroups', () => {
+      expect(hasGroups(base({ sync: true }))).toBe(true);
+      expect(hasGroups(base({ sync: false }))).toBe(false);
+      expect(hasGroups(base({ sync: false, groups: { g: { packages: ['a'], sync: 'linked' } } }))).toBe(true);
+    });
+  });
+
+  describe('expandTargetsForFixedGroups (--target on a subset of a fixed group)', () => {
+    const packages = [pkg('@wdio/native-core'), pkg('@wdio/native-utils'), pkg('@wdio/native-spy')];
+
+    it('should expand a strict subset of a fixed group to the whole group', () => {
+      const res = resolveGroups(
+        base({ groups: { native: { packages: ['@wdio/native-*'], sync: 'fixed' } } }),
+        packages,
+      );
+      const { targets, expandedGroups } = expandTargetsForFixedGroups(res, ['@wdio/native-core']);
+      expect(new Set(targets)).toEqual(new Set(['@wdio/native-core', '@wdio/native-utils', '@wdio/native-spy']));
+      expect(expandedGroups).toEqual(['native']);
+    });
+
+    it('should not expand when all members of a fixed group are already targeted', () => {
+      const res = resolveGroups(
+        base({ groups: { native: { packages: ['@wdio/native-*'], sync: 'fixed' } } }),
+        packages,
+      );
+      const { expandedGroups } = expandTargetsForFixedGroups(res, ['@wdio/native-*']);
+      expect(expandedGroups).toEqual([]);
+    });
+
+    it('should NOT expand a linked group (partial targeting is well defined there)', () => {
+      const res = resolveGroups(
+        base({ groups: { native: { packages: ['@wdio/native-*'], sync: 'linked' } } }),
+        packages,
+      );
+      const { targets, expandedGroups } = expandTargetsForFixedGroups(res, ['@wdio/native-core']);
+      expect(targets).toEqual(['@wdio/native-core']);
+      expect(expandedGroups).toEqual([]);
+    });
+
+    it('should be a no-op when no targets are provided', () => {
+      const res = resolveGroups(
+        base({ groups: { native: { packages: ['@wdio/native-*'], sync: 'fixed' } } }),
+        packages,
+      );
+      expect(expandTargetsForFixedGroups(res, [])).toEqual({ targets: [], expandedGroups: [] });
+    });
+  });
+});

--- a/packages/version/test/unit/core/groupStrategy.spec.ts
+++ b/packages/version/test/unit/core/groupStrategy.spec.ts
@@ -1,0 +1,386 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import type { Package, Tool } from '@manypkg/get-packages';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as commitParser from '../../../src/changelog/commitParser.js';
+import { createGroupStrategy } from '../../../src/core/groupStrategy.js';
+import * as calculator from '../../../src/core/versionCalculator.js';
+import type { PackagesWithRoot } from '../../../src/core/versionEngine.js';
+import * as commandExecutor from '../../../src/git/commandExecutor.js';
+import * as gitTags from '../../../src/git/tagsAndBranches.js';
+import * as packageManagement from '../../../src/package/packageManagement.js';
+import type { Config } from '../../../src/types.js';
+import * as formatting from '../../../src/utils/formatting.js';
+import * as jsonOutput from '../../../src/utils/jsonOutput.js';
+import * as logging from '../../../src/utils/logging.js';
+
+vi.mock('../../../src/git/tagsAndBranches.js');
+vi.mock('../../../src/git/commandExecutor.js');
+vi.mock('../../../src/utils/logging.js');
+vi.mock('../../../src/core/versionCalculator.js');
+vi.mock('../../../src/package/packageManagement.js');
+vi.mock('../../../src/utils/jsonOutput.js');
+vi.mock('../../../src/changelog/commitParser.js');
+vi.mock('node:fs');
+vi.mock('node:path');
+
+function mkPackage(name: string, version: string): Package {
+  const slug = name.replace(/^@/, '').replace(/[/]/g, '-');
+  return {
+    dir: `/ws/packages/${slug}`,
+    relativeDir: `packages/${slug}`,
+    packageJson: { name, version },
+  } as unknown as Package;
+}
+
+function workspace(packages: Package[]): PackagesWithRoot {
+  return {
+    root: '/ws',
+    rootDir: '/ws',
+    tool: 'pnpm' as unknown as Tool,
+    packages,
+  } as unknown as PackagesWithRoot;
+}
+
+const baseConfig = (overrides: Partial<Config>): Config =>
+  ({
+    sync: false,
+    preset: 'conventional',
+    packages: [],
+    tagTemplate: '${prefix}${version}',
+    updateInternalDependencies: 'minor',
+    versionPrefix: '',
+    baseBranch: 'main',
+    ...overrides,
+  }) as Config;
+
+describe('createGroupStrategy', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    // Only package.json exists — no Cargo.toml — so each release writes exactly one manifest.
+    vi.mocked(fs.existsSync, { partial: true }).mockImplementation((p) => !String(p).endsWith('Cargo.toml'));
+    vi.mocked(fs.readFileSync, { partial: true }).mockReturnValue('{}');
+    vi.mocked(path.join, { partial: true }).mockImplementation((...args) => args.join('/'));
+    vi.mocked(gitTags.getLatestTag).mockResolvedValue('');
+    vi.mocked(gitTags.getLatestTagForPackage).mockResolvedValue('');
+    vi.mocked(commandExecutor.execSync, { partial: true }).mockReturnValue(Buffer.from(''));
+    vi.mocked(commitParser.extractChangelogEntriesFromCommits, { partial: true }).mockReturnValue([
+      { type: 'added', description: 'New feature' },
+    ]);
+    // formatting helpers are not module-mocked — spy on the real (pure) implementations.
+    vi.spyOn(formatting, 'formatVersionPrefix').mockReturnValue('v');
+    vi.spyOn(formatting, 'formatTag').mockImplementation((version, prefix, name) =>
+      name ? `${name}@${prefix}${version}` : `${prefix}${version}`,
+    );
+    vi.spyOn(formatting, 'deriveBaselineTagPrefix').mockReturnValue(undefined);
+    vi.spyOn(formatting, 'displayTag').mockImplementation((tag) => tag);
+    vi.spyOn(formatting, 'formatCommitMessage').mockImplementation((template, version, name) =>
+      template.replace(/\$\{version\}/g, version).replace(/\$\{packageName\}/g, name || ''),
+    );
+  });
+
+  afterEach(() => vi.restoreAllMocks());
+
+  describe('fixed groups', () => {
+    it('should release ALL members at the group version when only one member changed', async () => {
+      const core = mkPackage('@wdio/native-core', '2.3.0');
+      const utils = mkPackage('@wdio/native-utils', '2.3.0');
+      const spy = mkPackage('@wdio/native-spy', '2.3.0');
+
+      // Only native-utils has a releasable change (patch).
+      vi.mocked(calculator.calculateVersion).mockImplementation(async (_cfg, opts) => {
+        if (opts.name === '@wdio/native-utils') return '2.3.1';
+        return '';
+      });
+
+      const strategy = createGroupStrategy(
+        baseConfig({ groups: { native: { packages: ['@wdio/native-*'], sync: 'fixed' } } }),
+      );
+      await strategy(workspace([core, utils, spy]));
+
+      // Group version = bump(max baseline 2.3.0) with patch = 2.3.1. All three members written.
+      expect(packageManagement.updatePackageVersion).toHaveBeenCalledWith(
+        '/ws/packages/wdio-native-core/package.json',
+        '2.3.1',
+        undefined,
+      );
+      expect(packageManagement.updatePackageVersion).toHaveBeenCalledWith(
+        '/ws/packages/wdio-native-utils/package.json',
+        '2.3.1',
+        undefined,
+      );
+      expect(packageManagement.updatePackageVersion).toHaveBeenCalledWith(
+        '/ws/packages/wdio-native-spy/package.json',
+        '2.3.1',
+        undefined,
+      );
+      // Each member tagged with the group name for CI surfaces.
+      expect(jsonOutput.setPackageUpdateGroup).toHaveBeenCalledWith('@wdio/native-core', 'native');
+      expect(jsonOutput.setPackageUpdateGroup).toHaveBeenCalledWith('@wdio/native-spy', 'native');
+    });
+
+    it('should take the largest bump across members for the shared group version', async () => {
+      const core = mkPackage('@wdio/native-core', '2.3.0');
+      const utils = mkPackage('@wdio/native-utils', '2.3.0');
+
+      // core gets a minor, utils gets a patch — group should bump minor.
+      vi.mocked(calculator.calculateVersion).mockImplementation(async (_cfg, opts) => {
+        if (opts.name === '@wdio/native-core') return '2.4.0';
+        if (opts.name === '@wdio/native-utils') return '2.3.1';
+        return '';
+      });
+
+      const strategy = createGroupStrategy(
+        baseConfig({ groups: { native: { packages: ['@wdio/native-*'], sync: 'fixed' } } }),
+      );
+      await strategy(workspace([core, utils]));
+
+      expect(packageManagement.updatePackageVersion).toHaveBeenCalledWith(
+        '/ws/packages/wdio-native-core/package.json',
+        '2.4.0',
+        undefined,
+      );
+      expect(packageManagement.updatePackageVersion).toHaveBeenCalledWith(
+        '/ws/packages/wdio-native-utils/package.json',
+        '2.4.0',
+        undefined,
+      );
+    });
+
+    it('should not release any member when no member has a releasable change', async () => {
+      const core = mkPackage('@wdio/native-core', '2.3.0');
+      const utils = mkPackage('@wdio/native-utils', '2.3.0');
+      vi.mocked(calculator.calculateVersion).mockResolvedValue('');
+
+      const strategy = createGroupStrategy(
+        baseConfig({ groups: { native: { packages: ['@wdio/native-*'], sync: 'fixed' } } }),
+      );
+      await strategy(workspace([core, utils]));
+
+      expect(packageManagement.updatePackageVersion).not.toHaveBeenCalled();
+      expect(jsonOutput.setCommitMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('linked groups', () => {
+    it('should release ONLY changed members, all at the shared computed version', async () => {
+      const core = mkPackage('@wdio/native-core', '2.3.0');
+      const utils = mkPackage('@wdio/native-utils', '2.3.0');
+      const spy = mkPackage('@wdio/native-spy', '2.3.0');
+
+      // Only utils changed.
+      vi.mocked(calculator.calculateVersion).mockImplementation(async (_cfg, opts) => {
+        if (opts.name === '@wdio/native-utils') return '2.3.1';
+        return '';
+      });
+
+      const strategy = createGroupStrategy(
+        baseConfig({ groups: { native: { packages: ['@wdio/native-*'], sync: 'linked' } } }),
+      );
+      await strategy(workspace([core, utils, spy]));
+
+      // Only the changed member is written — the dealbreaker case from the issue (no empty
+      // re-release of unchanged members).
+      expect(packageManagement.updatePackageVersion).toHaveBeenCalledTimes(1);
+      expect(packageManagement.updatePackageVersion).toHaveBeenCalledWith(
+        '/ws/packages/wdio-native-utils/package.json',
+        '2.3.1',
+        undefined,
+      );
+      expect(packageManagement.updatePackageVersion).not.toHaveBeenCalledWith(
+        '/ws/packages/wdio-native-core/package.json',
+        expect.anything(),
+        expect.anything(),
+      );
+    });
+
+    it('should align multiple changed members to the same shared version', async () => {
+      const core = mkPackage('@wdio/native-core', '2.3.0');
+      const utils = mkPackage('@wdio/native-utils', '2.3.0');
+      const spy = mkPackage('@wdio/native-spy', '2.3.0');
+
+      // core minor, utils patch, spy unchanged → both changed members align to 2.4.0.
+      vi.mocked(calculator.calculateVersion).mockImplementation(async (_cfg, opts) => {
+        if (opts.name === '@wdio/native-core') return '2.4.0';
+        if (opts.name === '@wdio/native-utils') return '2.3.1';
+        return '';
+      });
+
+      const strategy = createGroupStrategy(
+        baseConfig({ groups: { native: { packages: ['@wdio/native-*'], sync: 'linked' } } }),
+      );
+      await strategy(workspace([core, utils, spy]));
+
+      expect(packageManagement.updatePackageVersion).toHaveBeenCalledTimes(2);
+      expect(packageManagement.updatePackageVersion).toHaveBeenCalledWith(
+        '/ws/packages/wdio-native-core/package.json',
+        '2.4.0',
+        undefined,
+      );
+      expect(packageManagement.updatePackageVersion).toHaveBeenCalledWith(
+        '/ws/packages/wdio-native-utils/package.json',
+        '2.4.0',
+        undefined,
+      );
+    });
+  });
+
+  describe('group baseline = max(member baselines)', () => {
+    it('should bump from the highest member baseline, not each member individually', async () => {
+      const core = mkPackage('@wdio/native-core', '2.3.0');
+      // utils sits at a higher baseline than core.
+      const utils = mkPackage('@wdio/native-utils', '2.5.0');
+
+      vi.mocked(calculator.calculateVersion).mockImplementation(async (_cfg, opts) => {
+        // core earns a patch from its own 2.3.0 baseline.
+        if (opts.name === '@wdio/native-core') return '2.3.1';
+        return '';
+      });
+
+      const strategy = createGroupStrategy(
+        baseConfig({ groups: { native: { packages: ['@wdio/native-*'], sync: 'fixed' } } }),
+      );
+      await strategy(workspace([core, utils]));
+
+      // max baseline is 2.5.0, patch bump → 2.5.1 for the whole group (NOT core's 2.3.1).
+      expect(packageManagement.updatePackageVersion).toHaveBeenCalledWith(
+        '/ws/packages/wdio-native-core/package.json',
+        '2.5.1',
+        undefined,
+      );
+      expect(packageManagement.updatePackageVersion).toHaveBeenCalledWith(
+        '/ws/packages/wdio-native-utils/package.json',
+        '2.5.1',
+        undefined,
+      );
+    });
+  });
+
+  describe('below-baseline member adoption', () => {
+    it('should make a below-baseline member adopt the group version and warn on a >1-bump jump', async () => {
+      // core is the family at 2.3.0; newcomer joins at 1.0.0.
+      const core = mkPackage('@wdio/native-core', '2.3.0');
+      const newcomer = mkPackage('@wdio/native-fresh', '1.0.0');
+
+      vi.mocked(calculator.calculateVersion).mockImplementation(async (_cfg, opts) => {
+        if (opts.name === '@wdio/native-core') return '2.3.1';
+        // newcomer also has a change, but its own bump is irrelevant under fixed.
+        if (opts.name === '@wdio/native-fresh') return '1.0.1';
+        return '';
+      });
+
+      const strategy = createGroupStrategy(
+        baseConfig({ groups: { native: { packages: ['@wdio/native-*'], sync: 'fixed' } } }),
+      );
+      await strategy(workspace([core, newcomer]));
+
+      // newcomer adopts the group version 2.3.1, skipping its own 1.x line.
+      expect(packageManagement.updatePackageVersion).toHaveBeenCalledWith(
+        '/ws/packages/wdio-native-fresh/package.json',
+        '2.3.1',
+        undefined,
+      );
+      // A loud warning should fire for the big jump.
+      expect(logging.log).toHaveBeenCalledWith(expect.stringContaining('adopts group version 2.3.1'), 'warning');
+    });
+  });
+
+  describe('--target on a fixed group', () => {
+    it('should expand a targeted subset of a fixed group to all members', async () => {
+      const core = mkPackage('@wdio/native-core', '2.3.0');
+      const utils = mkPackage('@wdio/native-utils', '2.3.0');
+
+      vi.mocked(calculator.calculateVersion).mockImplementation(async (_cfg, opts) => {
+        if (opts.name === '@wdio/native-core') return '2.3.1';
+        if (opts.name === '@wdio/native-utils') return '2.3.1';
+        return '';
+      });
+
+      const strategy = createGroupStrategy(
+        baseConfig({ groups: { native: { packages: ['@wdio/native-*'], sync: 'fixed' } } }),
+      );
+      // Target only core — fixed group should expand to include utils.
+      await strategy(workspace([core, utils]), ['@wdio/native-core']);
+
+      expect(packageManagement.updatePackageVersion).toHaveBeenCalledWith(
+        '/ws/packages/wdio-native-core/package.json',
+        '2.3.1',
+        undefined,
+      );
+      expect(packageManagement.updatePackageVersion).toHaveBeenCalledWith(
+        '/ws/packages/wdio-native-utils/package.json',
+        '2.3.1',
+        undefined,
+      );
+    });
+  });
+
+  describe('sync:true equivalence (implicit fixed group)', () => {
+    it('should release every package in lockstep at the shared version under sync:true', async () => {
+      const a = mkPackage('@app/a', '1.0.0');
+      const b = mkPackage('@app/b', '1.0.0');
+
+      vi.mocked(calculator.calculateVersion).mockImplementation(async (_cfg, opts) => {
+        if (opts.name === '@app/a') return '1.1.0';
+        return '';
+      });
+
+      const strategy = createGroupStrategy(baseConfig({ sync: true }));
+      await strategy(workspace([a, b]));
+
+      // Both packages bump to 1.1.0 even though only a changed (fixed semantics).
+      expect(packageManagement.updatePackageVersion).toHaveBeenCalledWith(
+        '/ws/packages/app-a/package.json',
+        '1.1.0',
+        undefined,
+      );
+      expect(packageManagement.updatePackageVersion).toHaveBeenCalledWith(
+        '/ws/packages/app-b/package.json',
+        '1.1.0',
+        undefined,
+      );
+    });
+  });
+
+  describe('ungrouped packages', () => {
+    it('should version ungrouped packages independently at their own computed version', async () => {
+      const core = mkPackage('@wdio/native-core', '2.3.0');
+      const standalone = mkPackage('@app/standalone', '5.0.0');
+
+      vi.mocked(calculator.calculateVersion).mockImplementation(async (_cfg, opts) => {
+        if (opts.name === '@wdio/native-core') return '2.3.1';
+        if (opts.name === '@app/standalone') return '5.1.0';
+        return '';
+      });
+
+      const strategy = createGroupStrategy(
+        baseConfig({ groups: { native: { packages: ['@wdio/native-*'], sync: 'fixed' } } }),
+      );
+      await strategy(workspace([core, standalone]));
+
+      // standalone keeps its own independent bump.
+      expect(packageManagement.updatePackageVersion).toHaveBeenCalledWith(
+        '/ws/packages/app-standalone/package.json',
+        '5.1.0',
+        undefined,
+      );
+      // and is NOT tagged with the group.
+      expect(jsonOutput.setPackageUpdateGroup).not.toHaveBeenCalledWith('@app/standalone', expect.anything());
+    });
+  });
+
+  describe('config errors', () => {
+    it('should throw when a package matches two groups', async () => {
+      const core = mkPackage('@wdio/native-core', '2.3.0');
+      const strategy = createGroupStrategy(
+        baseConfig({
+          groups: {
+            a: { packages: ['@wdio/native-*'], sync: 'fixed' },
+            b: { packages: ['@wdio/native-core'], sync: 'linked' },
+          },
+        }),
+      );
+      await expect(strategy(workspace([core]))).rejects.toThrow(/more than one version group/);
+    });
+  });
+});

--- a/packages/version/test/unit/core/versionEngine.spec.ts
+++ b/packages/version/test/unit/core/versionEngine.spec.ts
@@ -369,6 +369,35 @@ describe('Version Engine', () => {
       expect(result.packages[0].packageJson.name).toBe('package-b');
       expect(log).toHaveBeenCalledWith('Runtime targets filter: 2 → 1 packages', 'info');
     });
+
+    it('should NOT pre-filter by runtime targets when version groups are configured', async () => {
+      // Group-aware target expansion happens in the group strategy; pre-filtering here would
+      // prune non-targeted members of a fixed group and silently split it.
+      const configWithGroups = {
+        ...defaultConfig,
+        sync: false,
+        groups: { native: { packages: ['@wdio/native-*'], sync: 'fixed' as const } },
+      } as Config;
+      const engine = new VersionEngine(configWithGroups, { targets: ['@wdio/native-core'] });
+
+      vi.mocked(getPackagesSync, { partial: true }).mockReturnValue({
+        packages: [
+          { packageJson: { name: '@wdio/native-core', version: '2.3.0' }, dir: '/ws/core', relativeDir: 'core' },
+          { packageJson: { name: '@wdio/native-utils', version: '2.3.0' }, dir: '/ws/utils', relativeDir: 'utils' },
+        ],
+        root: '/ws',
+        tool: 'pnpm' as any,
+        rootDir: '/ws',
+      });
+
+      const result = await engine.getWorkspacePackages();
+
+      // Both members survive discovery despite only one being targeted.
+      expect(result.packages.map((p) => p.packageJson.name).sort()).toEqual([
+        '@wdio/native-core',
+        '@wdio/native-utils',
+      ]);
+    });
   });
 
   describe('Run method', () => {

--- a/packages/version/test/unit/core/versionStrategies.spec.ts
+++ b/packages/version/test/unit/core/versionStrategies.spec.ts
@@ -1282,6 +1282,32 @@ describe('Version Strategies', () => {
       expect(strategyMap).toHaveProperty('sync');
       expect(strategyMap).toHaveProperty('single');
       expect(strategyMap).toHaveProperty('async');
+      expect(strategyMap).toHaveProperty('group');
+    });
+  });
+
+  describe('createStrategy group routing', () => {
+    it('should route explicit version.groups through the group strategy', () => {
+      const config: Partial<Config> = {
+        ...defaultConfig,
+        sync: false,
+        groups: { native: { packages: ['@wdio/native-*'], sync: 'linked' } },
+      };
+      // The group strategy is async (takes optional targets); just assert it's defined and callable.
+      const strategy = strategies.createStrategy(config as Config);
+      expect(strategy).toBeDefined();
+    });
+
+    it('should keep sync:true on the established sync strategy for back-compat', async () => {
+      const config: Partial<Config> = {
+        ...defaultConfig,
+        sync: true,
+      };
+      const strategy = strategies.createStrategy(config as Config);
+      // The sync strategy updates the root package.json with isRoot=true — a fingerprint the
+      // group strategy never produces — so this confirms sync:true still uses createSyncStrategy.
+      await strategy(mockPackages);
+      expect(packageManagement.updatePackageVersion).toHaveBeenCalledWith(rootPackagePath, '1.1.0', undefined, true);
     });
   });
 });

--- a/releasekit.schema.json
+++ b/releasekit.schema.json
@@ -105,7 +105,37 @@
         "sync": {
           "type": "boolean",
           "default": true,
-          "description": "Sync versions across packages"
+          "description": "Global lockstep versioning. true is sugar for one implicit fixed group of every package — it shares the same mechanism as version.groups. Set to false when using version.groups; sync: true alongside groups is treated as the implicit all-packages fixed group taking precedence (a config conflict, warned about at runtime)."
+        },
+        "groups": {
+          "type": "object",
+          "description": "Named version groups. Each group binds a set of package patterns to a fixed or linked sync mode. fixed: any releasable change in any member releases ALL members at the shared group version (bump(max(member baselines))). linked: only members with releasable changes release, but every releasing member shares the same computed version. Packages not matched by any group version independently. A package may belong to at most one group. Set version.sync to false when using groups.",
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "packages": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "minItems": 1,
+                "description": "Package patterns (exact names, @scope/*, or globs) whose matched packages form this group. Same matching rules as version.packages."
+              },
+              "sync": {
+                "type": "string",
+                "enum": [
+                  "fixed",
+                  "linked"
+                ],
+                "description": "fixed: all members release together at the shared group version. linked: only changed members release, all at the same computed version."
+              }
+            },
+            "required": [
+              "packages",
+              "sync"
+            ]
+          }
         },
         "packages": {
           "type": "array",

--- a/scripts/generate-config-docs.ts
+++ b/scripts/generate-config-docs.ts
@@ -179,12 +179,10 @@ function renderVersion(prop: SchemaProperty): void {
       '',
     );
     emit(
-      '> **Member adoption (read this loudly).** A member below the group baseline — a never-released',
-      '> package whose `package.json` says `1.0.0`, or an existing package at an older version — *adopts*',
-      '> the group version on its next release (e.g. joining a family at `2.3.0` releases at `2.4.0`,',
-      '> skipping its own `1.x` line). This deliberately overrides the per-package "initial version from',
-      '> package.json" rule. When the jump skips versions, the version step warns; time group migrations',
-      '> to a real breaking change in the family so the alignment coincides with an honest major.',
+      '> **Member adoption.** A member below the group baseline — never released, or at an older version',
+      '> than the family — adopts the group version on its next release (joining a family at `2.3.0`',
+      '> releases at `2.4.0`, skipping its own `1.x` line), overriding the per-package "initial version',
+      '> from `package.json`" rule. The version step warns when the jump skips versions.',
       '',
     );
     emit(

--- a/scripts/generate-config-docs.ts
+++ b/scripts/generate-config-docs.ts
@@ -136,7 +136,7 @@ function renderVersion(prop: SchemaProperty): void {
   emit(ensurePeriod(prop.description), '');
 
   const topProps = Object.fromEntries(
-    Object.entries(prop.properties ?? {}).filter(([k]) => k !== 'cargo' && k !== 'branchPatterns'),
+    Object.entries(prop.properties ?? {}).filter(([k]) => k !== 'cargo' && k !== 'branchPatterns' && k !== 'groups'),
   );
   emit(propsTable(topProps));
   emitBlank();
@@ -147,6 +147,57 @@ function renderVersion(prop: SchemaProperty): void {
     emit('Array of objects with the following properties:', '');
     emit(propsTable(bp.items.properties));
     emitBlank();
+  }
+
+  const groups = prop.properties?.groups;
+  const groupItem = typeof groups?.additionalProperties === 'object' ? groups.additionalProperties : undefined;
+  if (groups) {
+    emit('### `version.groups`', '');
+    emit(
+      'Named version groups let a co-evolving family of packages version together while the rest',
+      'of the monorepo versions independently. Each entry under `groups` is a group name mapping to',
+      '`{ packages, sync }`, where `packages` is a list of patterns (same matching as',
+      '`version.packages`) and `sync` is one of:',
+      '',
+    );
+    if (groupItem?.properties) {
+      emit(propsTable(groupItem.properties));
+    }
+    emitBlank();
+    emit(
+      '- **`fixed`** — any releasable change in *any* member releases **all** members at the shared',
+      '  group version, computed as `bump(max(member baselines))`. This is the changesets `fixed`',
+      '  semantics. The global `version.sync: true` flag is exactly this, applied to one implicit',
+      '  group of every package — there is one mechanism, not two.',
+      '- **`linked`** — only members with a releasable change release, but every releasing member',
+      '  shares the same computed version. Unchanged members are left untouched (no empty re-release).',
+      '',
+    );
+    emit(
+      '**Group baseline** is the highest member version found in tags / manifests; the group bumps',
+      'from there.',
+      '',
+    );
+    emit(
+      '> **Member adoption (read this loudly).** A member below the group baseline — a never-released',
+      '> package whose `package.json` says `1.0.0`, or an existing package at an older version — *adopts*',
+      '> the group version on its next release (e.g. joining a family at `2.3.0` releases at `2.4.0`,',
+      '> skipping its own `1.x` line). This deliberately overrides the per-package "initial version from',
+      '> package.json" rule. When the jump skips versions, the version step warns; time group migrations',
+      '> to a real breaking change in the family so the alignment coincides with an honest major.',
+      '',
+    );
+    emit(
+      '**`--target` and fixed groups.** Targeting a strict subset of a `fixed` group expands to the',
+      'whole group (a fixed group never silently splits). `linked` groups and ungrouped packages honor',
+      'targets as-is.',
+      '',
+    );
+    emit(
+      '**Workspace pins.** Intra-group `workspace:*` dependencies resolve to the group version within a',
+      'run, so a fixed group publishes internally consistent.',
+      '',
+    );
   }
 
   const cargo = prop.properties?.cargo;


### PR DESCRIPTION
## What

Implements `version.groups` (#265): named version groups binding package patterns to a `fixed` or `linked` sync mode.

- **fixed** — any releasable change in any member releases ALL members at the shared group version `bump(max(member baselines))`.
- **linked** — only members with releasable changes release, all at the same computed version.
- `version.sync: true` is the implicit all-packages fixed group (one mechanism). For back-compat it keeps routing to the existing sync strategy; explicit `version.groups` opts into the unified group engine.

## Edge cases handled
- Below-baseline / never-released members adopt the group version on first release (overrides the package.json initial-version rule), with a loud warning on multi-version jumps. Documented in configuration.md.
- `--target` on a strict subset of a fixed group expands to the whole group (never silently splits) — at both the strategy and engine-discovery layers.
- Intra-group `workspace:*` deps resolve to the group version (all members written before publish).

## Output contract
Adds OPTIONAL `group?` to `VersionPackageUpdate` and `'group'` to `strategy?` — back-compat preserved for standing-PR manifests.

## Deferred (per the issue)
CI-surface wiring (scope-label → group expansion, standing-PR atomic treatment) is deferred; the `group` field is surfaced so those surfaces can consume it later. No breakage — existing consumers render `'group'` releases as per-package lists via their `=== 'sync'` checks. **This is the main thing to confirm before relying on groups in standing-pr mode.**

## Tests
33 new unit tests across group resolution, fixed/linked computation, adoption, target expansion, sync:true equivalence, engine target-deferral, and schema validation. `pnpm turbo run lint typecheck test` green across all 24 tasks.

Closes #265

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Implements `version.groups`: named version groups that bind package patterns to either a `fixed` (all members release together) or `linked` (only changed members release, all at the same version) sync mode. The global `sync: true` flag is preserved as the back-compat path and explicitly NOT routed through the new group engine.

- Adds `groupResolution.ts` for group normalization, resolution, and fixed-group target expansion; `groupStrategy.ts` as the unified execution engine for all group modes.
- Extends `VersionConfig` schema, `VersionPackageUpdate` output contract, and JSON strategy enum (`'group'`) with full back-compat preservation.
- 33 new unit tests covering fixed/linked semantics, adoption, target expansion, prerelease handling, and schema validation.
</details>

<h3>Confidence Score: 4/5</h3>

The version computation and release logic are correct; the only defect is a diagnostic warning that fires before confirming a release will actually happen.

All previous review findings have been addressed — the adoption warning now uses the correct log level, createStrategy checks sync before hasExplicitGroups, and config.skip divergence is now surfaced. One new defect remains: the fixed-group split warning in groupStrategy.ts fires before computeGroup confirms hasChange, so on any run where config.skip includes a fixed-group member and no releasable changes exist, operators see 'the group will end up at divergent versions' immediately followed by 'no releasable changes, skipping.' The message is factually wrong and will recur on every normal CI run, making it likely to be tuned out.

packages/version/src/core/groupStrategy.ts — the warning block at lines 358–372 should move to after the hasChange guard at line 377.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/version/src/core/groupStrategy.ts | New file: core execution engine for group versioning. Contains the fixed-group 'will release without' divergence warning that fires before the hasChange check, producing false-positive warnings on every no-change run when config.skip members are in a fixed group. |
| packages/version/src/core/groupResolution.ts | New file: group normalization, resolution (overlap detection, empty-group pruning), and fixed-group target expansion. Logic is clean and well-tested. |
| packages/version/src/core/versionStrategies.ts | Adds createGroupStrategy to the strategy map and routes explicit version.groups through the group engine; sync: true correctly checked first for back-compat. |
| packages/version/src/core/versionEngine.ts | Adds deferTargetsToGroups flag to skip engine-level target pre-filtering when groups are configured, delegating that responsibility to the group strategy for safe fixed-group expansion. |
| packages/config/src/schema.ts | Adds VersionGroupSchema with packages (min 1) and sync (fixed | linked) fields, and attaches groups as an optional record to VersionConfigSchema. |
| packages/core/src/types.ts | Adds optional group field to VersionPackageUpdate and 'group' to strategy union — both changes are additive and back-compat safe. |
| packages/version/test/unit/core/groupStrategy.spec.ts | Comprehensive test suite for the group strategy: fixed/linked semantics, baseline max, adoption warnings, target expansion, sync:true equivalence, ungrouped packages, and config error cases. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant CLI as command.ts / steps.ts
    participant Engine as VersionEngine
    participant GR as groupResolution.ts
    participant GS as groupStrategy.ts
    participant Calc as versionCalculator

    CLI->>Engine: setStrategy('group') + run(packages, targets)
    Engine->>Engine: getWorkspacePackages() skip target pre-filter when groups configured
    Engine->>GS: createGroupStrategy(config)(packages, targets)
    GS->>GR: resolveGroups(config, packages)
    GR-->>GS: groups, ungrouped, groupOf
    GS->>GR: expandTargetsForFixedGroups(resolution, targets)
    GR-->>GS: expanded targets (fixed group subsets pulled to whole group)

    loop each resolved group
        GS->>Calc: planMember(pkg) baseline, ownNext, changed
        GS->>GS: "computeGroup groupVersion = bump(max(baselines))"
        alt hasChange
            GS->>GS: releaseGroup write package.json, emit tags and changelog
            GS->>GS: setPackageUpdateGroup(name, groupName)
        else no change
            GS->>GS: skip group
        end
    end

    loop each ungrouped package
        GS->>Calc: planMember ownNext
        GS->>GS: release independently at ownNext
    end

    GS->>GS: setCommitMessage(aggregated)
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fversion%2Fsrc%2Fcore%2FgroupStrategy.ts%3A358-380%0AThe%20%22will%20release%20without%22%20divergence%20warning%20fires%20before%20%60computeGroup%60%20is%20called%2C%20so%20it%20emits%20on%20every%20run%20where%20%60config.skip%60%20includes%20a%20fixed-group%20member%20%E2%80%94%20even%20when%20zero%20releasable%20changes%20exist%20and%20the%20group%20will%20be%20entirely%20skipped.%20The%20message%20%22the%20group%20will%20end%20up%20at%20divergent%20versions%22%20is%20factually%20wrong%20in%20that%20scenario%3A%20no%20release%20happens%2C%20so%20no%20divergence%20occurs.%20Users%20running%20in%20a%20normal%20CI%20cadence%20%28most%20commits%20have%20no%20releasable%20change%29%20will%20see%20a%20spurious%20warning%20on%20every%20run%2C%20training%20them%20to%20ignore%20it.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20const%20plans%20%3D%20await%20Promise.all%28members.map%28%28pkg%29%20%3D%3E%20planMember%28config%2C%20pkg%2C%20formattedPrefix%2C%20globalTag%29%29%29%3B%0A%20%20%20%20%20%20%20%20const%20computation%20%3D%20computeGroup%28group%2C%20plans%2C%20config%29%3B%0A%0A%20%20%20%20%20%20%20%20if%20%28!computation.hasChange%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20log%28%60Group%20%22%24%7Bgroup.name%7D%22%3A%20no%20releasable%20changes%2C%20skipping.%60%2C%20'info'%29%3B%0A%20%20%20%20%20%20%20%20%20%20continue%3B%0A%20%20%20%20%20%20%20%20%7D%0A%0A%20%20%20%20%20%20%20%20%2F%2F%20%60config.skip%60%20and%20the%20target%20filter%20both%20remove%20members%20from%20%60members%60%2C%20so%20a%20fixed%20group%0A%20%20%20%20%20%20%20%20%2F%2F%20can%20release%20with%20a%20subset%20of%20its%20declared%20members%20%E2%80%94%20leaving%20the%20group%20at%20divergent%0A%20%20%20%20%20%20%20%20%2F%2F%20versions.%20Warn%20so%20the%20divergence%20is%20intentional%2C%20not%20a%20surprise.%0A%20%20%20%20%20%20%20%20%2F%2F%20%28Only%20warn%20when%20a%20release%20is%20actually%20happening%20%E2%80%94%20no-change%20runs%20skip%20entirely.%29%0A%20%20%20%20%20%20%20%20if%20%28group.sync%20%3D%3D%3D%20'fixed'%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20const%20releasing%20%3D%20new%20Set%28members.map%28%28m%29%20%3D%3E%20m.packageJson.name%29%29%3B%0A%20%20%20%20%20%20%20%20%20%20const%20notInRelease%20%3D%20group.members.map%28%28m%29%20%3D%3E%20m.packageJson.name%29.filter%28%28name%29%20%3D%3E%20!releasing.has%28name%29%29%3B%0A%20%20%20%20%20%20%20%20%20%20if%20%28notInRelease.length%20%3E%200%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20log%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%60Group%20%22%24%7Bgroup.name%7D%22%20is%20fixed%20but%20will%20release%20without%3A%20%24%7BnotInRelease.join%28'%2C%20'%29%7D.%20%60%20%2B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20'They%20were%20excluded%20by%20config.skip%20or%20--target%2C%20so%20the%20group%20will%20end%20up%20at%20divergent%20versions.%20'%20%2B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20'Remove%20the%20package%20from%20config.skip%20%28or%20include%20it%20via%20--target%29%20to%20keep%20the%20group%20atomic.'%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20'warning'%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%29%3B%0A%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A&repo=goosewobbler%2Freleasekit&pr=273&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fversion%2Fsrc%2Fcore%2FgroupStrategy.ts%3A358-380%0AThe%20%22will%20release%20without%22%20divergence%20warning%20fires%20before%20%60computeGroup%60%20is%20called%2C%20so%20it%20emits%20on%20every%20run%20where%20%60config.skip%60%20includes%20a%20fixed-group%20member%20%E2%80%94%20even%20when%20zero%20releasable%20changes%20exist%20and%20the%20group%20will%20be%20entirely%20skipped.%20The%20message%20%22the%20group%20will%20end%20up%20at%20divergent%20versions%22%20is%20factually%20wrong%20in%20that%20scenario%3A%20no%20release%20happens%2C%20so%20no%20divergence%20occurs.%20Users%20running%20in%20a%20normal%20CI%20cadence%20%28most%20commits%20have%20no%20releasable%20change%29%20will%20see%20a%20spurious%20warning%20on%20every%20run%2C%20training%20them%20to%20ignore%20it.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20const%20plans%20%3D%20await%20Promise.all%28members.map%28%28pkg%29%20%3D%3E%20planMember%28config%2C%20pkg%2C%20formattedPrefix%2C%20globalTag%29%29%29%3B%0A%20%20%20%20%20%20%20%20const%20computation%20%3D%20computeGroup%28group%2C%20plans%2C%20config%29%3B%0A%0A%20%20%20%20%20%20%20%20if%20%28!computation.hasChange%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20log%28%60Group%20%22%24%7Bgroup.name%7D%22%3A%20no%20releasable%20changes%2C%20skipping.%60%2C%20'info'%29%3B%0A%20%20%20%20%20%20%20%20%20%20continue%3B%0A%20%20%20%20%20%20%20%20%7D%0A%0A%20%20%20%20%20%20%20%20%2F%2F%20%60config.skip%60%20and%20the%20target%20filter%20both%20remove%20members%20from%20%60members%60%2C%20so%20a%20fixed%20group%0A%20%20%20%20%20%20%20%20%2F%2F%20can%20release%20with%20a%20subset%20of%20its%20declared%20members%20%E2%80%94%20leaving%20the%20group%20at%20divergent%0A%20%20%20%20%20%20%20%20%2F%2F%20versions.%20Warn%20so%20the%20divergence%20is%20intentional%2C%20not%20a%20surprise.%0A%20%20%20%20%20%20%20%20%2F%2F%20%28Only%20warn%20when%20a%20release%20is%20actually%20happening%20%E2%80%94%20no-change%20runs%20skip%20entirely.%29%0A%20%20%20%20%20%20%20%20if%20%28group.sync%20%3D%3D%3D%20'fixed'%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20const%20releasing%20%3D%20new%20Set%28members.map%28%28m%29%20%3D%3E%20m.packageJson.name%29%29%3B%0A%20%20%20%20%20%20%20%20%20%20const%20notInRelease%20%3D%20group.members.map%28%28m%29%20%3D%3E%20m.packageJson.name%29.filter%28%28name%29%20%3D%3E%20!releasing.has%28name%29%29%3B%0A%20%20%20%20%20%20%20%20%20%20if%20%28notInRelease.length%20%3E%200%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20log%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%60Group%20%22%24%7Bgroup.name%7D%22%20is%20fixed%20but%20will%20release%20without%3A%20%24%7BnotInRelease.join%28'%2C%20'%29%7D.%20%60%20%2B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20'They%20were%20excluded%20by%20config.skip%20or%20--target%2C%20so%20the%20group%20will%20end%20up%20at%20divergent%20versions.%20'%20%2B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20'Remove%20the%20package%20from%20config.skip%20%28or%20include%20it%20via%20--target%29%20to%20keep%20the%20group%20atomic.'%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20'warning'%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%29%3B%0A%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A&pr=273&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (5): Last reviewed commit: ["docs: trim verbose group docs and duplic..."](https://github.com/goosewobbler/releasekit/commit/52dc68502d86059b5080d916efae8f6d63bf1bac) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36235136)</sub>

<!-- /greptile_comment -->