### PR TITLE
fix(version): keep pre-1.0 breaking changes on the 0.x minor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ build
 # Claude Code local state
 .claude/scheduled_tasks.lock
 .claude/settings.local.json
+packages/*/releasekit-*.tgz

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -82,6 +82,18 @@ Git tags mark what was last released. Conventional commits between the last tag 
 - Deleting or moving a tag manually changes what ReleaseKit sees as the baseline.
 - `version.packageSpecificTags: true` creates per-package tags (e.g. `@scope/core@1.2.3`) instead of a single repo-wide tag.
 
+### Pre-1.0 breaking changes
+
+While a project is still pre-1.0 (current major version is `0`), a **commit-inferred** breaking change (`feat!:` / `BREAKING CHANGE:`) bumps the **0.x minor** — `0.24.0 → 0.25.0`, not `1.0.0`. This is semver §4 ("major version zero is for initial development; anything MAY change at any time"), and it matches npm caret semantics (`^0.24.0` already excludes `0.25.0`), Cargo, and changesets. The accidental, irreversible jump to `1.0.0` over-signals "first stable API," a semantic the maintainer never declared.
+
+To deliberately cut `1.0.0` while pre-1.0, use an **explicit** override — these always graduate, regardless of conventional commits:
+
+- `--bump major` on the CLI;
+- the `bump:major` label on the standing PR (or `release:immediate` + `bump:major` on a feeder PR to ship one PR directly);
+- `version.zeroMajor: "strict"` to restore the old "breaking always → next major" behavior for the inferred path.
+
+`feat` (non-breaking) still bumps the minor pre-1.0 (`0.24.0 → 0.25.0`); only the breaking → major jump is corrected. See [`version.zeroMajor`](../docs/configuration.md#versionzeromajor).
+
 ---
 
 ## Release strategies

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -84,15 +84,7 @@ Git tags mark what was last released. Conventional commits between the last tag 
 
 ### Pre-1.0 breaking changes
 
-While a project is still pre-1.0 (current major version is `0`), a **commit-inferred** breaking change (`feat!:` / `BREAKING CHANGE:`) bumps the **0.x minor** — `0.24.0 → 0.25.0`, not `1.0.0`. This is semver §4 ("major version zero is for initial development; anything MAY change at any time"), and it matches npm caret semantics (`^0.24.0` already excludes `0.25.0`), Cargo, and changesets. The accidental, irreversible jump to `1.0.0` over-signals "first stable API," a semantic the maintainer never declared.
-
-To deliberately cut `1.0.0` while pre-1.0, use an **explicit** override — these always graduate, regardless of conventional commits:
-
-- `--bump major` on the CLI;
-- the `bump:major` label on the standing PR (or `release:immediate` + `bump:major` on a feeder PR to ship one PR directly);
-- `version.zeroMajor: "strict"` to restore the old "breaking always → next major" behavior for the inferred path.
-
-`feat` (non-breaking) still bumps the minor pre-1.0 (`0.24.0 → 0.25.0`); only the breaking → major jump is corrected. See [`version.zeroMajor`](../docs/configuration.md#versionzeromajor).
+Pre-1.0 (current major `0`), a commit-inferred breaking change bumps the 0.x minor (`0.24.0 → 0.25.0`), not `1.0.0` — it never auto-graduates the project to a stable API. To cut `1.0.0` deliberately, use an explicit `bump:major` (or `--bump major`); see [`version.zeroMajor`](configuration.md#versionzeromajor) for the rule and the `strict` opt-out.
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -76,16 +76,16 @@ Versioning configuration.
 | `prereleaseIdentifier` | string | — | Identifier for prerelease versions (e.g., 'alpha', 'beta') |
 | `baseBranch` | string | — | Base branch for versioning |
 | `strictReachable` | boolean | `false` | Only use reachable tags |
-| `zeroMajor` | `"spec"` \| `"strict"` | `"spec"` | How commit-inferred breaking changes are handled while the project is still pre-1.0 (current major is 0). 'spec' (default): a breaking change bumps the 0.x minor (0.24.0 → 0.25.0), per semver §4 and npm caret/Cargo/changesets conventions. 'strict': a breaking change always bumps to the next major even pre-1.0 (0.24.0 → 1.0.0), the semantic-release convention. Only affects the commit-inferred path; explicit overrides (--bump major, bump:major, release:immediate + bump:major) always graduate to 1.0.0 regardless. |
+| `zeroMajor` | `"spec"` \| `"strict"` | `"spec"` | Pre-1.0 handling of commit-inferred breaking changes. 'spec' (default): bump the 0.x minor (0.24.0 → 0.25.0), per semver §4. 'strict': bump the next major (→ 1.0.0). Inferred path only — explicit overrides (--bump major, bump:major) always graduate to 1.0.0. |
 
 ### `version.zeroMajor`
 
-Controls how a **commit-inferred** breaking change (`feat!:` / `BREAKING CHANGE:`) is bumped while the project is still pre-1.0 (current major version is `0`).
+How a **commit-inferred** breaking change (`feat!:` / `BREAKING CHANGE:`) bumps a pre-1.0 version (current major `0`):
 
-- `"spec"` (default): the breaking change bumps the **0.x minor** (e.g. `0.24.0` → `0.25.0`). This follows semver §4 — "major version zero is for initial development; anything MAY change at any time" — and matches npm caret semantics (`^0.24.0` already excludes `0.25.0`) as well as Cargo and changesets.
-- `"strict"`: the breaking change always bumps to the **next major**, even pre-1.0 (e.g. `0.24.0` → `1.0.0`), matching the semantic-release convention.
+- `"spec"` (default): bumps the 0.x minor — `0.24.0` → `0.25.0`. Per [semver §4](https://semver.org/#spec-item-4); also matches npm caret (`^0.24.0` excludes `0.25.0`), Cargo, and changesets.
+- `"strict"`: bumps the next major — `0.24.0` → `1.0.0` (the semantic-release convention).
 
-Only the commit-inferred path consults this setting. Explicit overrides always graduate to `1.0.0` regardless of `zeroMajor`: `--bump major`, the `bump:major` label on the standing PR, or `release:immediate` + `bump:major` on a feeder PR. Graduating to 1.0 therefore stays a deliberate, opt-in act.
+Inferred path only. Explicit overrides (`--bump major`, `bump:major` on the standing PR, `release:immediate` + `bump:major` on a feeder PR) always graduate to `1.0.0` — cutting 1.0 stays a deliberate act.
 
 **`version.branchPatterns`** — Branch name patterns for version determination.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -76,6 +76,16 @@ Versioning configuration.
 | `prereleaseIdentifier` | string | — | Identifier for prerelease versions (e.g., 'alpha', 'beta') |
 | `baseBranch` | string | — | Base branch for versioning |
 | `strictReachable` | boolean | `false` | Only use reachable tags |
+| `zeroMajor` | `"spec"` \| `"strict"` | `"spec"` | How commit-inferred breaking changes are handled while the project is still pre-1.0 (current major is 0). 'spec' (default): a breaking change bumps the 0.x minor (0.24.0 → 0.25.0), per semver §4 and npm caret/Cargo/changesets conventions. 'strict': a breaking change always bumps to the next major even pre-1.0 (0.24.0 → 1.0.0), the semantic-release convention. Only affects the commit-inferred path; explicit overrides (--bump major, bump:major, release:immediate + bump:major) always graduate to 1.0.0 regardless. |
+
+### `version.zeroMajor`
+
+Controls how a **commit-inferred** breaking change (`feat!:` / `BREAKING CHANGE:`) is bumped while the project is still pre-1.0 (current major version is `0`).
+
+- `"spec"` (default): the breaking change bumps the **0.x minor** (e.g. `0.24.0` → `0.25.0`). This follows semver §4 — "major version zero is for initial development; anything MAY change at any time" — and matches npm caret semantics (`^0.24.0` already excludes `0.25.0`) as well as Cargo and changesets.
+- `"strict"`: the breaking change always bumps to the **next major**, even pre-1.0 (e.g. `0.24.0` → `1.0.0`), matching the semantic-release convention.
+
+Only the commit-inferred path consults this setting. Explicit overrides always graduate to `1.0.0` regardless of `zeroMajor`: `--bump major`, the `bump:major` label on the standing PR, or `release:immediate` + `bump:major` on a feeder PR. Graduating to 1.0 therefore stays a deliberate, opt-in act.
 
 **`version.branchPatterns`** — Branch name patterns for version determination.
 

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -67,19 +67,9 @@ export const VersionConfigSchema = z.object({
   prereleaseIdentifier: z.string().optional(),
   strictReachable: z.boolean().default(false),
   /**
-   * How commit-inferred breaking changes are handled while the project is still pre-1.0
-   * (current major version is 0).
-   *
-   * - 'spec' (default): a breaking change (`feat!:` / `BREAKING CHANGE:`) bumps the 0.x minor
-   *   (e.g. 0.24.0 -> 0.25.0), per semver §4 — "major version zero is for initial development;
-   *   anything MAY change at any time." This also matches npm caret semantics (`^0.24.0` already
-   *   excludes 0.25.0) and how Cargo/changesets treat 0.x.
-   * - 'strict': a breaking change always bumps to the next major even pre-1.0
-   *   (e.g. 0.24.0 -> 1.0.0), the semantic-release convention.
-   *
-   * Only affects the commit-inferred bump path. Explicit overrides (`--bump major`,
-   * `bump:major`, `release:immediate` + `bump:major`) always graduate to 1.0.0 regardless
-   * of this setting — graduating to 1.0 stays a deliberate, opt-in act.
+   * Pre-1.0 handling of commit-inferred breaking changes. 'spec' (default) keeps them on the 0.x
+   * minor; 'strict' graduates to the next major. Inferred path only — explicit overrides always
+   * graduate. Full reference: docs/configuration.md#versionzeromajor.
    */
   zeroMajor: z.enum(['spec', 'strict']).default('spec'),
   cargo: VersionCargoConfigSchema.optional(),

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -66,11 +66,7 @@ export const VersionConfigSchema = z.object({
   versionPrefix: z.string().default(''),
   prereleaseIdentifier: z.string().optional(),
   strictReachable: z.boolean().default(false),
-  /**
-   * Pre-1.0 handling of commit-inferred breaking changes. 'spec' (default) keeps them on the 0.x
-   * minor; 'strict' graduates to the next major. Inferred path only — explicit overrides always
-   * graduate. Full reference: docs/configuration.md#versionzeromajor.
-   */
+  /** Pre-1.0 inferred-breaking bump policy ('spec' | 'strict'). See docs/configuration.md#versionzeromajor. */
   zeroMajor: z.enum(['spec', 'strict']).default('spec'),
   cargo: VersionCargoConfigSchema.optional(),
 });

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -66,6 +66,22 @@ export const VersionConfigSchema = z.object({
   versionPrefix: z.string().default(''),
   prereleaseIdentifier: z.string().optional(),
   strictReachable: z.boolean().default(false),
+  /**
+   * How commit-inferred breaking changes are handled while the project is still pre-1.0
+   * (current major version is 0).
+   *
+   * - 'spec' (default): a breaking change (`feat!:` / `BREAKING CHANGE:`) bumps the 0.x minor
+   *   (e.g. 0.24.0 -> 0.25.0), per semver §4 — "major version zero is for initial development;
+   *   anything MAY change at any time." This also matches npm caret semantics (`^0.24.0` already
+   *   excludes 0.25.0) and how Cargo/changesets treat 0.x.
+   * - 'strict': a breaking change always bumps to the next major even pre-1.0
+   *   (e.g. 0.24.0 -> 1.0.0), the semantic-release convention.
+   *
+   * Only affects the commit-inferred bump path. Explicit overrides (`--bump major`,
+   * `bump:major`, `release:immediate` + `bump:major`) always graduate to 1.0.0 regardless
+   * of this setting — graduating to 1.0 stays a deliberate, opt-in act.
+   */
+  zeroMajor: z.enum(['spec', 'strict']).default('spec'),
   cargo: VersionCargoConfigSchema.optional(),
 });
 

--- a/packages/config/test/unit/schema.spec.ts
+++ b/packages/config/test/unit/schema.spec.ts
@@ -99,6 +99,16 @@ describe('VersionConfigSchema', () => {
     expect(result.versionStrategy).toBe('commitMessage');
     expect(result.mismatchStrategy).toBe('warn');
     expect(result.versionPrefix).toBe('');
+    expect(result.zeroMajor).toBe('spec');
+  });
+
+  it("should accept zeroMajor: 'strict'", () => {
+    const result = VersionConfigSchema.parse({ zeroMajor: 'strict' });
+    expect(result.zeroMajor).toBe('strict');
+  });
+
+  it('should reject an unknown zeroMajor value', () => {
+    expect(() => VersionConfigSchema.parse({ zeroMajor: 'always' })).toThrow();
   });
 
   it('should accept branchPatterns', () => {

--- a/packages/release/docs/ci-setup.md
+++ b/packages/release/docs/ci-setup.md
@@ -487,6 +487,8 @@ The `standing-pr update` workflow **preserves maintainer-added labels across run
 
 **Why this design**: labels live in one canonical place. There's no question about which feeder PR's bump label "wins" when multiple PRs disagree — there is only the standing PR. Provenance is GitHub's own audit log (`gh pr view <n> --json events`).
 
+> **Pre-1.0 → 1.0.0 is a deliberate, opt-in act.** While the project is pre-1.0 (current major is `0`), a conventional breaking change (`feat!:` / `BREAKING CHANGE:`) auto-bumps the **0.x minor** (`0.24.0 → 0.25.0`), per semver §4 — it does **not** jump to `1.0.0` on its own. To graduate to `1.0.0`, add the **`bump:major`** label to the standing PR (or use `release:immediate` + `bump:major` on a feeder PR to ship a single PR directly). Both override surfaces ignore the pre-1.0 rule and produce `1.0.0`. To restore the old "breaking always → next major" behavior for commit-inferred bumps, set [`version.zeroMajor: "strict"`](../../../docs/configuration.md#versionzeromajor).
+
 #### Bypassing the standing PR for one merge
 
 To ship a single PR directly without queueing it, label it **`release:immediate`** (configurable via `ci.labels.immediate`). Companion labels work normally:

--- a/packages/release/docs/ci-setup.md
+++ b/packages/release/docs/ci-setup.md
@@ -487,7 +487,7 @@ The `standing-pr update` workflow **preserves maintainer-added labels across run
 
 **Why this design**: labels live in one canonical place. There's no question about which feeder PR's bump label "wins" when multiple PRs disagree — there is only the standing PR. Provenance is GitHub's own audit log (`gh pr view <n> --json events`).
 
-> **Pre-1.0 → 1.0.0 is a deliberate, opt-in act.** While the project is pre-1.0 (current major is `0`), a conventional breaking change (`feat!:` / `BREAKING CHANGE:`) auto-bumps the **0.x minor** (`0.24.0 → 0.25.0`), per semver §4 — it does **not** jump to `1.0.0` on its own. To graduate to `1.0.0`, add the **`bump:major`** label to the standing PR (or use `release:immediate` + `bump:major` on a feeder PR to ship a single PR directly). Both override surfaces ignore the pre-1.0 rule and produce `1.0.0`. To restore the old "breaking always → next major" behavior for commit-inferred bumps, set [`version.zeroMajor: "strict"`](../../../docs/configuration.md#versionzeromajor).
+> **Graduating to 1.0.0 is opt-in.** Pre-1.0, a conventional breaking change auto-bumps the 0.x minor, not `1.0.0` (see [`version.zeroMajor`](../../../docs/configuration.md#versionzeromajor)). To cut `1.0.0`, add the **`bump:major`** label to the standing PR — an explicit override always graduates.
 
 #### Bypassing the standing PR for one merge
 

--- a/packages/version/src/core/versionCalculator.ts
+++ b/packages/version/src/core/versionCalculator.ts
@@ -362,26 +362,21 @@ export async function calculateVersion(config: Config, options: VersionOptions):
       // `conventional-recommended-bump` returns `major` for any breaking change without ever
       // looking at the current version, so a `feat!:` on 0.24.0 would otherwise jump to 1.0.0.
       // Per semver §4 (and npm caret / Cargo / changesets), a breaking change pre-1.0 belongs on
-      // the 0.x minor (0.24.0 -> 0.25.0), since `^0.24.0` already excludes 0.25.0. We only
-      // downgrade the major->minor magnitude (and premajor->preminor for the prerelease flow);
-      // we deliberately do NOT downgrade inferred minor (feat) -> patch — feat->minor pre-1.0 is a
-      // defensible convention and non-destructive either way, whereas the 1.0.0 jump is irreversible.
+      // the 0.x minor (0.24.0 -> 0.25.0), since `^0.24.0` already excludes 0.25.0. We downgrade
+      // the inferred major to minor; the prerelease flow then turns that minor + identifier into a
+      // preminor inside bumpVersion (0.24.0 -> 0.25.0-next.0). We deliberately do NOT downgrade
+      // inferred minor (feat) -> patch — feat->minor pre-1.0 is a defensible convention and
+      // non-destructive either way, whereas the 1.0.0 jump is irreversible. (The bumper only ever
+      // emits major/minor/patch, so major is the only magnitude that can need downgrading here.)
       // Explicit overrides (specifiedType / --bump major / bump:major) take the branch above and
       // are intentionally untouched, so graduating to 1.0.0 stays a deliberate, opt-in act.
       // zeroMajor: 'spec' (default) applies the downgrade; 'strict' preserves breaking->major.
       // See https://github.com/goosewobbler/releasekit/issues/274.
       let effectiveReleaseType = releaseTypeFromCommits;
       const currentMajor = semver.parse(currentVersion)?.major;
-      if (
-        (config.zeroMajor ?? 'spec') === 'spec' &&
-        currentMajor === 0 &&
-        (releaseTypeFromCommits === 'major' || releaseTypeFromCommits === 'premajor')
-      ) {
-        effectiveReleaseType = releaseTypeFromCommits === 'premajor' ? 'preminor' : 'minor';
-        log(
-          `Pre-1.0 breaking change: downgrading inferred '${releaseTypeFromCommits}' to '${effectiveReleaseType}' (zeroMajor: 'spec')`,
-          'info',
-        );
+      if ((config.zeroMajor ?? 'spec') === 'spec' && currentMajor === 0 && releaseTypeFromCommits === 'major') {
+        effectiveReleaseType = 'minor';
+        log("Pre-1.0 breaking change: downgrading inferred 'major' to 'minor' (zeroMajor: 'spec')", 'info');
       }
 
       const isPrereleaseBumpType = ['prerelease', 'premajor', 'preminor', 'prepatch'].includes(effectiveReleaseType);

--- a/packages/version/src/core/versionCalculator.ts
+++ b/packages/version/src/core/versionCalculator.ts
@@ -357,11 +357,38 @@ export async function calculateVersion(config: Config, options: VersionOptions):
       }
 
       log(`Release type from commits: ${releaseTypeFromCommits}`, 'debug');
-      const isPrereleaseBumpType = ['prerelease', 'premajor', 'preminor', 'prepatch'].includes(releaseTypeFromCommits);
+
+      // Pre-1.0 0.x-awareness for the COMMIT-INFERRED path only.
+      // `conventional-recommended-bump` returns `major` for any breaking change without ever
+      // looking at the current version, so a `feat!:` on 0.24.0 would otherwise jump to 1.0.0.
+      // Per semver §4 (and npm caret / Cargo / changesets), a breaking change pre-1.0 belongs on
+      // the 0.x minor (0.24.0 -> 0.25.0), since `^0.24.0` already excludes 0.25.0. We only
+      // downgrade the major->minor magnitude (and premajor->preminor for the prerelease flow);
+      // we deliberately do NOT downgrade inferred minor (feat) -> patch — feat->minor pre-1.0 is a
+      // defensible convention and non-destructive either way, whereas the 1.0.0 jump is irreversible.
+      // Explicit overrides (specifiedType / --bump major / bump:major) take the branch above and
+      // are intentionally untouched, so graduating to 1.0.0 stays a deliberate, opt-in act.
+      // zeroMajor: 'spec' (default) applies the downgrade; 'strict' preserves breaking->major.
+      // See https://github.com/goosewobbler/releasekit/issues/274.
+      let effectiveReleaseType = releaseTypeFromCommits;
+      const currentMajor = semver.parse(currentVersion)?.major;
+      if (
+        (config.zeroMajor ?? 'spec') === 'spec' &&
+        currentMajor === 0 &&
+        (releaseTypeFromCommits === 'major' || releaseTypeFromCommits === 'premajor')
+      ) {
+        effectiveReleaseType = releaseTypeFromCommits === 'premajor' ? 'preminor' : 'minor';
+        log(
+          `Pre-1.0 breaking change: downgrading inferred '${releaseTypeFromCommits}' to '${effectiveReleaseType}' (zeroMajor: 'spec')`,
+          'info',
+        );
+      }
+
+      const isPrereleaseBumpType = ['prerelease', 'premajor', 'preminor', 'prepatch'].includes(effectiveReleaseType);
       log(`Is prerelease bump type: ${isPrereleaseBumpType}`, 'debug');
       const prereleaseId = config.isPrerelease || isPrereleaseBumpType ? normalizedPrereleaseId : undefined;
       log(`Prerelease ID: ${prereleaseId}`, 'debug');
-      const result = bumpVersion(currentVersion, releaseTypeFromCommits, prereleaseId);
+      const result = bumpVersion(currentVersion, effectiveReleaseType, prereleaseId);
       log(`Conventional commits version: ${result}`, 'debug');
       return result;
     } catch (error) {

--- a/packages/version/src/core/versionCalculator.ts
+++ b/packages/version/src/core/versionCalculator.ts
@@ -358,23 +358,14 @@ export async function calculateVersion(config: Config, options: VersionOptions):
 
       log(`Release type from commits: ${releaseTypeFromCommits}`, 'debug');
 
-      // Pre-1.0 0.x-awareness for the COMMIT-INFERRED path only.
-      // `conventional-recommended-bump` returns `major` for any breaking change without ever
-      // looking at the current version, so a `feat!:` on 0.24.0 would otherwise jump to 1.0.0.
-      // Per semver §4 (and npm caret / Cargo / changesets), a breaking change pre-1.0 belongs on
-      // the 0.x minor (0.24.0 -> 0.25.0), since `^0.24.0` already excludes 0.25.0. We downgrade
-      // the inferred major to minor; the prerelease flow then turns that minor + identifier into a
-      // preminor inside bumpVersion (0.24.0 -> 0.25.0-next.0). We deliberately do NOT downgrade
-      // inferred minor (feat) -> patch — feat->minor pre-1.0 is a defensible convention and
-      // non-destructive either way, whereas the 1.0.0 jump is irreversible. (The bumper only ever
-      // emits major/minor/patch, so major is the only magnitude that can need downgrading here.)
-      // Explicit overrides (specifiedType / --bump major / bump:major) take the branch above and
-      // are intentionally untouched, so graduating to 1.0.0 stays a deliberate, opt-in act.
-      // zeroMajor: 'spec' (default) applies the downgrade; 'strict' preserves breaking->major.
-      // See https://github.com/goosewobbler/releasekit/issues/274.
+      // The bumper returns 'major' for a breaking change without consulting the current version,
+      // so pre-1.0 it would jump 0.x straight to 1.0.0. Keep inferred breaking changes on the 0.x
+      // minor instead (rationale + the zeroMajor escape hatch: docs/configuration.md, issue #274).
+      // Inferred-only: the explicit-override branch above is intentionally left to graduate to 1.0.
+      // Only 'major' needs downgrading — the bumper never emits a pre-type here.
       let effectiveReleaseType = releaseTypeFromCommits;
-      const currentMajor = semver.parse(currentVersion)?.major;
-      if ((config.zeroMajor ?? 'spec') === 'spec' && currentMajor === 0 && releaseTypeFromCommits === 'major') {
+      const isPre1 = semver.parse(currentVersion)?.major === 0;
+      if ((config.zeroMajor ?? 'spec') === 'spec' && isPre1 && releaseTypeFromCommits === 'major') {
         effectiveReleaseType = 'minor';
         log("Pre-1.0 breaking change: downgrading inferred 'major' to 'minor' (zeroMajor: 'spec')", 'info');
       }

--- a/packages/version/src/types.ts
+++ b/packages/version/src/types.ts
@@ -75,6 +75,10 @@ export interface Config extends VersionConfigBase {
   baseRef?: string;
   mismatchStrategy?: 'error' | 'warn' | 'ignore' | 'prefer-package' | 'prefer-git';
   strictReachable?: boolean;
+  /** Pre-1.0 handling of commit-inferred breaking changes. 'spec' (default) keeps breaking
+   *  changes on the 0.x minor; 'strict' graduates them to 1.0.0. Only the inferred path
+   *  consults this — explicit overrides always graduate. See VersionConfig.zeroMajor. */
+  zeroMajor?: 'spec' | 'strict';
   cargo?: {
     enabled?: boolean;
     paths?: string[];
@@ -158,6 +162,7 @@ export function toVersionConfig(config: VersionConfig | undefined, gitConfig?: G
     })),
     defaultReleaseType: config.defaultReleaseType as ReleaseType | undefined,
     mismatchStrategy: config.mismatchStrategy,
+    zeroMajor: config.zeroMajor,
     versionPrefix: config.versionPrefix ?? '',
     prereleaseIdentifier: config.prereleaseIdentifier,
     baseBranch: gitConfig?.branch,

--- a/packages/version/src/types.ts
+++ b/packages/version/src/types.ts
@@ -75,9 +75,7 @@ export interface Config extends VersionConfigBase {
   baseRef?: string;
   mismatchStrategy?: 'error' | 'warn' | 'ignore' | 'prefer-package' | 'prefer-git';
   strictReachable?: boolean;
-  /** Pre-1.0 handling of commit-inferred breaking changes. 'spec' (default) keeps breaking
-   *  changes on the 0.x minor; 'strict' graduates them to 1.0.0. Only the inferred path
-   *  consults this — explicit overrides always graduate. See VersionConfig.zeroMajor. */
+  /** Pre-1.0 inferred-breaking bump policy ('spec' | 'strict'). See docs/configuration.md#versionzeromajor. */
   zeroMajor?: 'spec' | 'strict';
   cargo?: {
     enabled?: boolean;

--- a/packages/version/test/unit/core/versionCalculator.spec.ts
+++ b/packages/version/test/unit/core/versionCalculator.spec.ts
@@ -1,6 +1,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { Bumper, type BumperRecommendationResult } from 'conventional-recommended-bump';
+import type { ReleaseType } from 'semver';
 import semver from 'semver';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { calculateVersion } from '../../../src/core/versionCalculator.js';
@@ -867,6 +868,116 @@ describe('Version Calculator', () => {
       const version = await calculateVersion(defaultConfig as Config, options);
 
       expect(version).toBe('0.0.1');
+    });
+  });
+
+  describe('Pre-1.0 breaking changes (zeroMajor)', () => {
+    // Helper: drive the commit-inferred path with a given inferred release type and current version.
+    function setupInferred(releaseType: ReleaseType, currentVersion: string): void {
+      vi.spyOn(Bumper.prototype, 'bump').mockResolvedValue({
+        releaseType,
+      } as unknown as BumperRecommendationResult);
+      vi.spyOn(versionUtils, 'getBestVersionSource').mockResolvedValue({
+        source: 'git',
+        version: `v${currentVersion}`,
+        reason: 'Git tag exists',
+      });
+    }
+
+    it('should bump the 0.x minor for an inferred breaking change under the default (0.24.0 -> 0.25.0)', async () => {
+      setupInferred('major', '0.24.0');
+      const bumpSpy = vi.spyOn(versionUtils, 'bumpVersion').mockReturnValue('0.25.0');
+
+      const version = await calculateVersion(defaultConfig as Config, {
+        latestTag: 'v0.24.0',
+        versionPrefix: 'v',
+      });
+
+      // The inferred 'major' is downgraded to 'minor' before bumpVersion is called.
+      expect(bumpSpy).toHaveBeenCalledWith('0.24.0', 'minor', undefined);
+      expect(version).toBe('0.25.0');
+    });
+
+    it('should bump to the next major for an inferred breaking change at/after 1.0.0 (1.2.0 -> 2.0.0)', async () => {
+      setupInferred('major', '1.2.0');
+      const bumpSpy = vi.spyOn(versionUtils, 'bumpVersion').mockReturnValue('2.0.0');
+
+      const version = await calculateVersion(defaultConfig as Config, {
+        latestTag: 'v1.2.0',
+        versionPrefix: 'v',
+      });
+
+      // major >= 1 is unaffected by the downgrade.
+      expect(bumpSpy).toHaveBeenCalledWith('1.2.0', 'major', undefined);
+      expect(version).toBe('2.0.0');
+    });
+
+    it("should bump to 1.0.0 for an inferred breaking change pre-1.0 when zeroMajor is 'strict'", async () => {
+      setupInferred('major', '0.24.0');
+      const bumpSpy = vi.spyOn(versionUtils, 'bumpVersion').mockReturnValue('1.0.0');
+
+      const config = { ...defaultConfig, zeroMajor: 'strict' } as Config;
+      const version = await calculateVersion(config, {
+        latestTag: 'v0.24.0',
+        versionPrefix: 'v',
+      });
+
+      // strict preserves the current/semantic-release behavior: breaking -> major even pre-1.0.
+      expect(bumpSpy).toHaveBeenCalledWith('0.24.0', 'major', undefined);
+      expect(version).toBe('1.0.0');
+    });
+
+    it('should NOT downgrade an explicit major bump pre-1.0 (specifiedType: major on 0.24.0 -> 1.0.0)', async () => {
+      // The explicit (specifiedType) branch must stay untouched by the fix and the config.
+      vi.spyOn(versionUtils, 'getBestVersionSource').mockResolvedValue({
+        source: 'git',
+        version: 'v0.24.0',
+        reason: 'Git tag exists',
+      });
+      const bumpSpy = vi.spyOn(versionUtils, 'bumpVersion').mockReturnValue('1.0.0');
+
+      const version = await calculateVersion(defaultConfig as Config, {
+        latestTag: 'v0.24.0',
+        type: 'major',
+        versionPrefix: 'v',
+      });
+
+      expect(bumpSpy).toHaveBeenCalledWith('0.24.0', 'major', undefined);
+      expect(version).toBe('1.0.0');
+    });
+
+    it('should leave an inferred feat (minor) untouched pre-1.0 (0.24.0 -> 0.25.0, not 0.24.1)', async () => {
+      setupInferred('minor', '0.24.0');
+      const bumpSpy = vi.spyOn(versionUtils, 'bumpVersion').mockReturnValue('0.25.0');
+
+      const version = await calculateVersion(defaultConfig as Config, {
+        latestTag: 'v0.24.0',
+        versionPrefix: 'v',
+      });
+
+      // Decision: feat->minor is NOT downgraded to patch pre-1.0; only the irreversible
+      // breaking->major (1.0.0) jump is corrected.
+      expect(bumpSpy).toHaveBeenCalledWith('0.24.0', 'minor', undefined);
+      expect(version).toBe('0.25.0');
+    });
+
+    it('should downgrade an inferred premajor to preminor pre-1.0 in the prerelease flow (0.24.0 -> 0.25.0-next.0)', async () => {
+      // conventional-recommended-bump returns 'major' for a breaking change; the prerelease
+      // flow is driven by config.isPrerelease, which makes bumpVersion produce a pre-version.
+      // Either way the magnitude is downgraded: breaking pre-1.0 stays on the 0.x minor.
+      setupInferred('major', '0.24.0');
+      const bumpSpy = vi.spyOn(versionUtils, 'bumpVersion').mockReturnValue('0.25.0-next.0');
+
+      const config = { ...defaultConfig, isPrerelease: true, prereleaseIdentifier: 'next' } as Config;
+      const version = await calculateVersion(config, {
+        latestTag: 'v0.24.0',
+        versionPrefix: 'v',
+      });
+
+      // 'major' downgraded to 'minor'; the prerelease identifier is threaded through so
+      // bumpVersion emits the preminor-shaped 0.25.0-next.0.
+      expect(bumpSpy).toHaveBeenCalledWith('0.24.0', 'minor', 'next');
+      expect(version).toBe('0.25.0-next.0');
     });
   });
 

--- a/packages/version/test/unit/core/versionCalculator.spec.ts
+++ b/packages/version/test/unit/core/versionCalculator.spec.ts
@@ -961,10 +961,10 @@ describe('Version Calculator', () => {
       expect(version).toBe('0.25.0');
     });
 
-    it('should downgrade an inferred premajor to preminor pre-1.0 in the prerelease flow (0.24.0 -> 0.25.0-next.0)', async () => {
+    it('should downgrade an inferred breaking change to minor pre-1.0 in the prerelease flow (0.24.0 -> 0.25.0-next.0)', async () => {
       // conventional-recommended-bump returns 'major' for a breaking change; the prerelease
-      // flow is driven by config.isPrerelease, which makes bumpVersion produce a pre-version.
-      // Either way the magnitude is downgraded: breaking pre-1.0 stays on the 0.x minor.
+      // flow is driven by config.isPrerelease, which makes bumpVersion turn the downgraded
+      // 'minor' + identifier into the preminor-shaped 0.25.0-next.0.
       setupInferred('major', '0.24.0');
       const bumpSpy = vi.spyOn(versionUtils, 'bumpVersion').mockReturnValue('0.25.0-next.0');
 

--- a/releasekit.schema.json
+++ b/releasekit.schema.json
@@ -215,6 +215,15 @@
           "default": false,
           "description": "Only use reachable tags"
         },
+        "zeroMajor": {
+          "type": "string",
+          "enum": [
+            "spec",
+            "strict"
+          ],
+          "default": "spec",
+          "description": "How commit-inferred breaking changes are handled while the project is still pre-1.0 (current major is 0). 'spec' (default): a breaking change bumps the 0.x minor (0.24.0 → 0.25.0), per semver §4 and npm caret/Cargo/changesets conventions. 'strict': a breaking change always bumps to the next major even pre-1.0 (0.24.0 → 1.0.0), the semantic-release convention. Only affects the commit-inferred path; explicit overrides (--bump major, bump:major, release:immediate + bump:major) always graduate to 1.0.0 regardless."
+        },
         "cargo": {
           "type": "object",
           "description": "Cargo/Rust configuration",

--- a/releasekit.schema.json
+++ b/releasekit.schema.json
@@ -222,7 +222,7 @@
             "strict"
           ],
           "default": "spec",
-          "description": "How commit-inferred breaking changes are handled while the project is still pre-1.0 (current major is 0). 'spec' (default): a breaking change bumps the 0.x minor (0.24.0 → 0.25.0), per semver §4 and npm caret/Cargo/changesets conventions. 'strict': a breaking change always bumps to the next major even pre-1.0 (0.24.0 → 1.0.0), the semantic-release convention. Only affects the commit-inferred path; explicit overrides (--bump major, bump:major, release:immediate + bump:major) always graduate to 1.0.0 regardless."
+          "description": "Pre-1.0 handling of commit-inferred breaking changes. 'spec' (default): bump the 0.x minor (0.24.0 → 0.25.0), per semver §4. 'strict': bump the next major (→ 1.0.0). Inferred path only — explicit overrides (--bump major, bump:major) always graduate to 1.0.0."
         },
         "cargo": {
           "type": "object",

--- a/scripts/generate-config-docs.ts
+++ b/scripts/generate-config-docs.ts
@@ -141,6 +141,21 @@ function renderVersion(prop: SchemaProperty): void {
   emit(propsTable(topProps));
   emitBlank();
 
+  emit('### `version.zeroMajor`', '');
+  emit(
+    'Controls how a **commit-inferred** breaking change (`feat!:` / `BREAKING CHANGE:`) is bumped while the project is still pre-1.0 (current major version is `0`).',
+    '',
+  );
+  emit(
+    '- `"spec"` (default): the breaking change bumps the **0.x minor** (e.g. `0.24.0` → `0.25.0`). This follows semver §4 — "major version zero is for initial development; anything MAY change at any time" — and matches npm caret semantics (`^0.24.0` already excludes `0.25.0`) as well as Cargo and changesets.',
+    '- `"strict"`: the breaking change always bumps to the **next major**, even pre-1.0 (e.g. `0.24.0` → `1.0.0`), matching the semantic-release convention.',
+    '',
+  );
+  emit(
+    'Only the commit-inferred path consults this setting. Explicit overrides always graduate to `1.0.0` regardless of `zeroMajor`: `--bump major`, the `bump:major` label on the standing PR, or `release:immediate` + `bump:major` on a feeder PR. Graduating to 1.0 therefore stays a deliberate, opt-in act.',
+    '',
+  );
+
   const bp = prop.properties?.branchPatterns;
   if (bp?.items?.properties) {
     emit(`**\`version.branchPatterns\`** — ${ensurePeriod(bp.description)}`, '');

--- a/scripts/generate-config-docs.ts
+++ b/scripts/generate-config-docs.ts
@@ -143,16 +143,16 @@ function renderVersion(prop: SchemaProperty): void {
 
   emit('### `version.zeroMajor`', '');
   emit(
-    'Controls how a **commit-inferred** breaking change (`feat!:` / `BREAKING CHANGE:`) is bumped while the project is still pre-1.0 (current major version is `0`).',
+    'How a **commit-inferred** breaking change (`feat!:` / `BREAKING CHANGE:`) bumps a pre-1.0 version (current major `0`):',
     '',
   );
   emit(
-    '- `"spec"` (default): the breaking change bumps the **0.x minor** (e.g. `0.24.0` → `0.25.0`). This follows semver §4 — "major version zero is for initial development; anything MAY change at any time" — and matches npm caret semantics (`^0.24.0` already excludes `0.25.0`) as well as Cargo and changesets.',
-    '- `"strict"`: the breaking change always bumps to the **next major**, even pre-1.0 (e.g. `0.24.0` → `1.0.0`), matching the semantic-release convention.',
+    '- `"spec"` (default): bumps the 0.x minor — `0.24.0` → `0.25.0`. Per [semver §4](https://semver.org/#spec-item-4); also matches npm caret (`^0.24.0` excludes `0.25.0`), Cargo, and changesets.',
+    '- `"strict"`: bumps the next major — `0.24.0` → `1.0.0` (the semantic-release convention).',
     '',
   );
   emit(
-    'Only the commit-inferred path consults this setting. Explicit overrides always graduate to `1.0.0` regardless of `zeroMajor`: `--bump major`, the `bump:major` label on the standing PR, or `release:immediate` + `bump:major` on a feeder PR. Graduating to 1.0 therefore stays a deliberate, opt-in act.',
+    'Inferred path only. Explicit overrides (`--bump major`, `bump:major` on the standing PR, `release:immediate` + `bump:major` on a feeder PR) always graduate to `1.0.0` — cutting 1.0 stays a deliberate act.',
     '',
   );
 

--- a/test/e2e/single.sh
+++ b/test/e2e/single.sh
@@ -52,9 +52,12 @@ if [[ -z "$version" ]]; then
 fi
 assert_version "0.2.0" "$version"
 
-# Test 3: breaking change → major bump
+# Test 3: inferred breaking change pre-1.0 → minor bump (NOT 1.0.0)
+# Per semver §4, a breaking change on a 0.x version stays on the 0.x minor
+# (0.1.0 → 0.2.0); auto-jumping to 1.0.0 would over-signal stability. Governed
+# by version.zeroMajor (default "spec").
 echo ""
-echo "--- Test: breaking change → major bump ---"
+echo "--- Test: inferred breaking change pre-1.0 → minor bump ---"
 create_git_repo
 create_package_json "test-single-package" "0.1.0"
 create_releasekit_config '{"version":{"preset":"conventionalcommits","packages":["./"]}}'
@@ -63,6 +66,30 @@ git_commit "feat!: breaking API change"
 
 set +e
 output=$(run_cli_json releasekit release --dry-run --json --project-dir "$REPO_DIR")
+set -e
+version=$(get_version_from_json "$output")
+if [[ -z "$version" ]]; then
+  echo "FAIL: Could not parse JSON output"
+  echo "Output: $output"
+  exit 1
+fi
+assert_version "0.2.0" "$version"
+
+# Test 3b: explicit --bump major still deliberately graduates a 0.x project to 1.0.0.
+# The override path is untouched by the zeroMajor downgrade — cutting 1.0 stays opt-in.
+# Uses a tagged (established) repo: explicit bumps on a tagless first release return the
+# package.json version as-is, so the tag is what makes this a real graduation scenario.
+echo ""
+echo "--- Test: explicit --bump major on an established 0.x repo → 1.0.0 (deliberate graduation) ---"
+create_git_repo
+create_package_json "test-single-package" "0.1.0"
+create_releasekit_config '{"version":{"preset":"conventionalcommits","versionPrefix":"v","packages":["./"]}}'
+git_commit "chore: initial commit"
+git tag "v0.1.0"
+git_commit "feat!: breaking API change"
+
+set +e
+output=$(run_cli_json releasekit release --dry-run --json --bump major --project-dir "$REPO_DIR")
 set -e
 version=$(get_version_from_json "$output")
 if [[ -z "$version" ]]; then

--- a/test/e2e/single.sh
+++ b/test/e2e/single.sh
@@ -52,10 +52,7 @@ if [[ -z "$version" ]]; then
 fi
 assert_version "0.2.0" "$version"
 
-# Test 3: inferred breaking change pre-1.0 → minor bump (NOT 1.0.0)
-# Per semver §4, a breaking change on a 0.x version stays on the 0.x minor
-# (0.1.0 → 0.2.0); auto-jumping to 1.0.0 would over-signal stability. Governed
-# by version.zeroMajor (default "spec").
+# Test 3: inferred breaking change pre-1.0 stays on the 0.x minor (0.1.0 → 0.2.0, not 1.0.0).
 echo ""
 echo "--- Test: inferred breaking change pre-1.0 → minor bump ---"
 create_git_repo
@@ -75,10 +72,9 @@ if [[ -z "$version" ]]; then
 fi
 assert_version "0.2.0" "$version"
 
-# Test 3b: explicit --bump major still deliberately graduates a 0.x project to 1.0.0.
-# The override path is untouched by the zeroMajor downgrade — cutting 1.0 stays opt-in.
-# Uses a tagged (established) repo: explicit bumps on a tagless first release return the
-# package.json version as-is, so the tag is what makes this a real graduation scenario.
+# Test 3b: explicit --bump major still graduates a 0.x project to 1.0.0 (override path untouched).
+# Tag the repo: an explicit bump on a tagless first release returns the package.json version
+# as-is, so the tag is what makes this a real graduation scenario rather than a first release.
 echo ""
 echo "--- Test: explicit --bump major on an established 0.x repo → 1.0.0 (deliberate graduation) ---"
 create_git_repo

--- a/test/e2e/single.sh
+++ b/test/e2e/single.sh
@@ -72,9 +72,9 @@ if [[ -z "$version" ]]; then
 fi
 assert_version "0.2.0" "$version"
 
-# Test 3b: explicit --bump major still graduates a 0.x project to 1.0.0 (override path untouched).
-# Tag the repo: an explicit bump on a tagless first release returns the package.json version
-# as-is, so the tag is what makes this a real graduation scenario rather than a first release.
+# Test 4: explicit --bump major still graduates a 0.x project to 1.0.0 (override path untouched).
+# The repo is tagged on purpose: an explicit bump on a *tagless* first release returns the
+# package.json version as-is, so the tag is what makes this a real graduation rather than a first release.
 echo ""
 echo "--- Test: explicit --bump major on an established 0.x repo → 1.0.0 (deliberate graduation) ---"
 create_git_repo


### PR DESCRIPTION
## What

A conventional-commit breaking change (`feat!:` / `BREAKING CHANGE:`) on a pre-1.0 project bumped to **1.0.0** instead of the next 0.x minor (e.g. `0.24.0 → 1.0.0` instead of `0.25.0`). `conventional-recommended-bump` returns `releaseType: 'major'` for any breaking change without ever consulting the current version, and `bumpVersion` has no 0.x awareness.

This makes the **commit-inferred** bump path 0.x-aware: when `major(currentVersion) === 0`, an inferred `major` is downgraded to `minor` (and `premajor → preminor` in the prerelease flow) before bumping. Per semver §4 ("major version zero is for initial development; anything MAY change at any time"), npm caret semantics (`^0.24.0` already excludes `0.25.0`), Cargo, and changesets.

## Scope

- **Inferred path only.** The explicit `specifiedType` branch is untouched — `--bump major`, `bump:major` on the standing PR, and `release:immediate` + `bump:major` on a feeder PR all still graduate to `1.0.0`. Graduating to 1.0 stays a deliberate, opt-in act; no escape hatch is lost.
- **New config `version.zeroMajor`:** `"spec"` (default) keeps breaking changes on the 0.x minor; `"strict"` restores the old breaking → next-major behavior for the inferred path.

## Decisions (flagged for review)

- **feat → minor left as-is.** Inferred `minor` (feat) is **not** downgraded to patch pre-1.0. Only the irreversible 1.0.0 jump is wrong; feat → minor is defensible and non-destructive either way.
- **Prerelease + 0.x + breaking.** Magnitude downgraded consistently: in the active prerelease flow, an inferred breaking change on `0.24.0` produces `0.25.0-next.0`, not `1.0.0-next.0`. Pinned by a dedicated test.

## Tests

`versionCalculator.spec.ts` (inferred 0.x → minor, inferred ≥1.0 → major, `strict` → 1.0.0, explicit major → 1.0.0, feat untouched, prerelease premajor → preminor) and `schema.spec.ts` (default `spec`, accepts `strict`, rejects unknown). Full `pnpm turbo run lint typecheck test` green.

## Docs

Generated config reference (`version.zeroMajor` section), a "Pre-1.0 breaking changes" note in `docs/architecture.md`, and a note in the standing-PR override section of ci-setup on deliberately cutting 1.0.0.

## Relationship to #269

With this merged, the Node-20-drop PR (#269) will correctly preview `0.25.0 → 0.26.0` instead of jumping to 1.0.0. Merge this first, then rebase #269.

Closes #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds 0.x-awareness to the commit-inferred version bump path, so `feat!:` / `BREAKING CHANGE:` commits on a pre-1.0 project bump the 0.x minor (`0.24.0 → 0.25.0`) rather than jumping straight to `1.0.0`. The new `version.zeroMajor` config option (`"spec"` default / `"strict"` opt-out) gates the behaviour.

- **`versionCalculator.ts`**: after `conventional-recommended-bump` returns `'major'`, a new guard downgrades it to `'minor'` when `semver.major(currentVersion) === 0` and `zeroMajor !== 'strict'`. The explicit `specifiedType` branch and all prerelease logic are untouched.
- **Schema + types**: `zeroMajor` added to `VersionConfigSchema` (Zod, with `.default('spec')`) and to the `Config` interface (optional, with `?? 'spec'` fallback in the calculator). JSON schema, generated config docs, and architecture docs are all updated to match.
- **Tests**: unit tests for all six described paths plus updated e2e (old "breaking → 1.0.0" case flipped to "breaking → 0.x minor"; new test verifying explicit `--bump major` still graduates to 1.0.0).
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is narrowly scoped to the commit-inferred bump path and guarded by a schema-validated config option with a sensible default.

The downgrade guard is a single, well-bounded conditional in the conventional-commits fallback path. The explicit specifiedType branch is untouched, preserving deliberate 1.0 graduation. All six new unit-test scenarios pass, the schema tests confirm enum validation, and the e2e suite was updated to match the new default behaviour.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/version/src/core/versionCalculator.ts | Core logic change: inferred 'major' downgraded to 'minor' when major === 0 and zeroMajor !== 'strict'. Logic is clean, well-commented, and correctly scoped to the conventional-commits fallback path only. |
| packages/version/src/types.ts | Adds optional `zeroMajor` to Config interface and threads it through toVersionConfig; follows identical pattern to existing optional fields like `strictReachable`. |
| packages/config/src/schema.ts | Adds `zeroMajor: z.enum(['spec', 'strict']).default('spec')` to VersionConfigSchema; consistent with existing enum fields in the schema. |
| packages/version/test/unit/core/versionCalculator.spec.ts | Six new unit tests covering default spec behaviour, ≥1.0 passthrough, strict mode, explicit-type passthrough, feat passthrough, and prerelease downgrade. All assertions align with the implementation. |
| test/e2e/single.sh | Old 'breaking → 1.0.0' test correctly updated to 'breaking → 0.2.0'. New test 4 verifies explicit --bump major still graduates to 1.0.0. The tag in test 4 is necessary and well-commented. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[conventional-recommended-bump\nreturns releaseType] --> B{releaseType defined?}
    B -- No --> Z[return '' - no bump]
    B -- Yes --> C{zeroMajor === 'spec'\nAND major === 0\nAND releaseType === 'major'?}
    C -- Yes --> D[effectiveReleaseType = 'minor'\nlog downgrade info]
    C -- No --> E[effectiveReleaseType = releaseType\nunchanged]
    D --> F[bumpVersion\ncurrentVersion, 'minor', prereleaseId?]
    E --> G[bumpVersion\ncurrentVersion, releaseType, prereleaseId?]
    F --> H[returns 0.x+1.0\ne.g. 0.25.0]
    G --> I{releaseType}
    I -- major / strict --> J[returns 1.0.0]
    I -- minor --> K[returns 0.x+1.0]
    I -- patch --> L[returns 0.x.y+1]

    style D fill:#d4edda
    style H fill:#d4edda
```
</details>

<sub>Reviews (5): Last reviewed commit: ["docs: reduce zeroMajor code JSDocs to on..."](https://github.com/goosewobbler/releasekit/commit/8d419d19195420c372d97cdd285fc5bc62321bcc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36248355)</sub>

<!-- /greptile_comment -->