### PR TITLE
fix(version): only warn about fixed-group divergence when the group releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ build
 .claude/scheduled_tasks.lock
 .claude/settings.local.json
 packages/*/releasekit-*.tgz
+
+# Agent worktrees
+.claude/worktrees/

--- a/packages/version/src/core/groupStrategy.ts
+++ b/packages/version/src/core/groupStrategy.ts
@@ -355,9 +355,18 @@ export function createGroupStrategy(config: Config): (packages: PackagesWithRoot
         const members = group.members.filter(targetFilter).filter((p) => shouldProcess(p, config));
         if (members.length === 0) continue;
 
+        const plans = await Promise.all(members.map((pkg) => planMember(config, pkg, formattedPrefix, globalTag)));
+        const computation = computeGroup(group, plans, config);
+
+        if (!computation.hasChange) {
+          log(`Group "${group.name}": no releasable changes, skipping.`, 'info');
+          continue;
+        }
+
         // `config.skip` and the target filter both remove members from `members`, so a fixed group
         // can release with a subset of its declared members — leaving the group at divergent
-        // versions. Warn so the divergence is intentional, not a surprise.
+        // versions. Warn so the divergence is intentional, not a surprise. Only relevant once the
+        // group is actually releasing (past the no-change guard above).
         if (group.sync === 'fixed') {
           const released = new Set(members.map((m) => m.packageJson.name));
           const notInRelease = group.members.map((m) => m.packageJson.name).filter((name) => !released.has(name));
@@ -369,14 +378,6 @@ export function createGroupStrategy(config: Config): (packages: PackagesWithRoot
               'warning',
             );
           }
-        }
-
-        const plans = await Promise.all(members.map((pkg) => planMember(config, pkg, formattedPrefix, globalTag)));
-        const computation = computeGroup(group, plans, config);
-
-        if (!computation.hasChange) {
-          log(`Group "${group.name}": no releasable changes, skipping.`, 'info');
-          continue;
         }
 
         log(

--- a/packages/version/test/unit/core/groupStrategy.spec.ts
+++ b/packages/version/test/unit/core/groupStrategy.spec.ts
@@ -119,6 +119,44 @@ describe('createGroupStrategy', () => {
       expect(jsonOutput.setPackageUpdateGroup).toHaveBeenCalledWith('@wdio/native-spy', 'native');
     });
 
+    it('should warn about divergence when a releasing fixed group excludes a member', async () => {
+      const core = mkPackage('@wdio/native-core', '2.3.0');
+      const utils = mkPackage('@wdio/native-utils', '2.3.0');
+      const spy = mkPackage('@wdio/native-spy', '2.3.0');
+
+      // core changes; spy is excluded via config.skip, so the group releases without it.
+      vi.mocked(calculator.calculateVersion).mockImplementation(async (_cfg, opts) =>
+        opts.name === '@wdio/native-core' ? '2.3.1' : '',
+      );
+
+      const strategy = createGroupStrategy(
+        baseConfig({ skip: ['@wdio/native-spy'], groups: { native: { packages: ['@wdio/native-*'], sync: 'fixed' } } }),
+      );
+      await strategy(workspace([core, utils, spy]));
+
+      expect(logging.log).toHaveBeenCalledWith(
+        expect.stringContaining('will release without: @wdio/native-spy'),
+        'warning',
+      );
+    });
+
+    it('should NOT warn about divergence when the fixed group has no releasable changes', async () => {
+      const core = mkPackage('@wdio/native-core', '2.3.0');
+      const utils = mkPackage('@wdio/native-utils', '2.3.0');
+      const spy = mkPackage('@wdio/native-spy', '2.3.0');
+
+      // Nothing changes. spy is excluded via config.skip, but since the group does not release,
+      // the divergence warning must not fire (it would only confuse — nothing is being released).
+      vi.mocked(calculator.calculateVersion).mockResolvedValue('');
+
+      const strategy = createGroupStrategy(
+        baseConfig({ skip: ['@wdio/native-spy'], groups: { native: { packages: ['@wdio/native-*'], sync: 'fixed' } } }),
+      );
+      await strategy(workspace([core, utils, spy]));
+
+      expect(logging.log).not.toHaveBeenCalledWith(expect.stringContaining('will release without'), 'warning');
+    });
+
     it('should take the largest bump across members for the shared group version', async () => {
       const core = mkPackage('@wdio/native-core', '2.3.0');
       const utils = mkPackage('@wdio/native-utils', '2.3.0');


### PR DESCRIPTION
## What

Follow-up to #273. In `groupStrategy.ts`, the "fixed group will release without X" divergence warning fired **before** the `hasChange` guard — so a fixed group that had a member excluded (via `config.skip` / `--target`) but **no releasable changes** still emitted the divergence warning, even though nothing was being released. Noise.

Move the warning block to **after** the no-change guard, so it only fires when the group is actually releasing and the divergence is real.

## Tests

- New: a releasing fixed group that excludes a member still warns (`will release without: …`).
- New: a fixed group with an excluded member but no releasable changes does **not** warn.

`pnpm turbo run lint typecheck test` (version) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Fixes a noisy divergence warning in `groupStrategy.ts` that fired even when a fixed group had no releasable changes. The fix moves the `planMember`/`computeGroup` calls and the `hasChange` guard to before the warning block, so the warning only emits when the group is genuinely releasing.

- **`groupStrategy.ts`**: Reorders operations in the group loop — `planMember`, `computeGroup`, and the `hasChange` early-exit now precede the divergence-warning block, ensuring the warning is only surfaced during an actual release.
- **`groupStrategy.spec.ts`**: Two new tests cover the corrected behaviour: one confirms the warning fires when a releasing fixed group skips a member, and another confirms it is suppressed when there are no releasable changes.
- **`.gitignore`**: Adds `.claude/worktrees/` so Claude Code agent worktree directories are not accidentally committed, addressing the concern raised in the previous review.
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a straightforward reordering of existing logic with no behavioral risk to the happy path.

The reordering only affects a warning log statement; the actual release mechanics (planMember, computeGroup, releaseGroup) are unchanged. Both new tests exercise the corrected control-flow directly, and the .gitignore addition is hygiene-only.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/version/src/core/groupStrategy.ts | Moves planMember/computeGroup calls and the hasChange guard to before the divergence warning, so the warning only fires when the group is actually releasing. |
| packages/version/test/unit/core/groupStrategy.spec.ts | Adds two targeted tests: one asserting the warning fires when a releasing fixed group excludes a member, and one asserting it does not fire when the group has no releasable changes. |
| .gitignore | Adds .claude/worktrees/ to prevent Claude Code agent worktree directories from being tracked in version control. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[For each group] --> B[Filter members by target & shouldProcess]
    B --> C{members.length === 0?}
    C -- yes --> SKIP1[continue]
    C -- no --> D[planMember for each member]
    D --> E[computeGroup]
    E --> F{hasChange?}
    F -- no --> SKIP2[log 'no releasable changes' & continue]
    F -- yes --> G{group.sync === 'fixed'?}
    G -- no --> LOG[log 'releasing N members']
    G -- yes --> H{notInRelease.length > 0?}
    H -- yes --> WARN[warn: 'will release without: ...']
    H -- no --> LOG
    WARN --> LOG
    LOG --> RELEASE[releaseGroup]
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.claude/worktrees/agent-133-fix`, line 1 ([link](https://github.com/goosewobbler/releasekit/blob/2f4ac61241cfbfb875320bd13b34d74db70b4e75/.claude/worktrees/agent-133-fix#L1)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Unintended Claude Code worktrees committed as submodules**

   Ten `.claude/worktrees/agent-*` entries are being committed to the repository as git submodules. These are temporary working directories created by Claude Code agents and should not be tracked in version control. The `.gitignore` currently excludes `.claude/scheduled_tasks.lock` and `.claude/settings.local.json` but does not cover `.claude/worktrees/`. These entries will persist in git history and can confuse contributors or CI systems that try to initialize submodules. Adding `.claude/worktrees/` to `.gitignore` and removing the submodule entries before merging would keep the repo clean.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.claude%2Fworktrees%2Fagent-133-fix%0ALine%3A%201%0A%0AComment%3A%0A**Unintended%20Claude%20Code%20worktrees%20committed%20as%20submodules**%0A%0ATen%20%60.claude%2Fworktrees%2Fagent-*%60%20entries%20are%20being%20committed%20to%20the%20repository%20as%20git%20submodules.%20These%20are%20temporary%20working%20directories%20created%20by%20Claude%20Code%20agents%20and%20should%20not%20be%20tracked%20in%20version%20control.%20The%20%60.gitignore%60%20currently%20excludes%20%60.claude%2Fscheduled_tasks.lock%60%20and%20%60.claude%2Fsettings.local.json%60%20but%20does%20not%20cover%20%60.claude%2Fworktrees%2F%60.%20These%20entries%20will%20persist%20in%20git%20history%20and%20can%20confuse%20contributors%20or%20CI%20systems%20that%20try%20to%20initialize%20submodules.%20Adding%20%60.claude%2Fworktrees%2F%60%20to%20%60.gitignore%60%20and%20removing%20the%20submodule%20entries%20before%20merging%20would%20keep%20the%20repo%20clean.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=goosewobbler%2Freleasekit&pr=279&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.claude%2Fworktrees%2Fagent-133-fix%0ALine%3A%201%0A%0AComment%3A%0A**Unintended%20Claude%20Code%20worktrees%20committed%20as%20submodules**%0A%0ATen%20%60.claude%2Fworktrees%2Fagent-*%60%20entries%20are%20being%20committed%20to%20the%20repository%20as%20git%20submodules.%20These%20are%20temporary%20working%20directories%20created%20by%20Claude%20Code%20agents%20and%20should%20not%20be%20tracked%20in%20version%20control.%20The%20%60.gitignore%60%20currently%20excludes%20%60.claude%2Fscheduled_tasks.lock%60%20and%20%60.claude%2Fsettings.local.json%60%20but%20does%20not%20cover%20%60.claude%2Fworktrees%2F%60.%20These%20entries%20will%20persist%20in%20git%20history%20and%20can%20confuse%20contributors%20or%20CI%20systems%20that%20try%20to%20initialize%20submodules.%20Adding%20%60.claude%2Fworktrees%2F%60%20to%20%60.gitignore%60%20and%20removing%20the%20submodule%20entries%20before%20merging%20would%20keep%20the%20repo%20clean.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=279&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix(version): only warn about fixed-grou..."](https://github.com/goosewobbler/releasekit/commit/2f4ac61241cfbfb875320bd13b34d74db70b4e75) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36317966)</sub>

<!-- /greptile_comment -->