### PR TITLE
fix(config): add ci.scopeLabels to the JSON schema

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -74,7 +74,6 @@ Versioning configuration.
 | `mismatchStrategy` | `"error"` \| `"warn"` \| `"ignore"` \| `"prefer-package"` \| `"prefer-git"` | `"warn"` | How to handle version mismatches |
 | `versionPrefix` | string | `""` | Prefix for version tags |
 | `prereleaseIdentifier` | string | — | Identifier for prerelease versions (e.g., 'alpha', 'beta') |
-| `baseBranch` | string | — | Base branch for versioning |
 | `strictReachable` | boolean | `false` | Only use reachable tags |
 | `zeroMajor` | `"spec"` \| `"strict"` | `"spec"` | Pre-1.0 handling of commit-inferred breaking changes. 'spec' (default): bump the 0.x minor (0.24.0 → 0.25.0), per semver §4. 'strict': bump the next major (→ 1.0.0). Inferred path only — explicit overrides (--bump major, bump:major) always graduate to 1.0.0. |
 
@@ -255,6 +254,7 @@ Set to `false` to disable.
 |-----|------|---------|-------------|
 | `mode` | `"root"` \| `"packages"` \| `"both"` | — | Where to write release notes file. Omit to skip file output (LLM still runs if configured). |
 | `file` | string | — | Release notes file name override (default: RELEASE_NOTES.md) |
+| `links` | object | — | Extra links to append to the release notes. |
 
 **`notes.releaseNotes.templates`** — Template configuration for release notes.
 
@@ -276,6 +276,9 @@ LLM configuration for release notes.
 | `apiKey` | string | — | API key |
 | `concurrency` | integer | — | Concurrent LLM requests |
 | `style` | string | — | Writing style for LLM |
+| `examples` | integer | `3` | Number of few-shot examples to include in LLM prompts (0–5). |
+| `context` | object | — | Additional context sources for the LLM. |
+| `categoryOrder` | `string[]` | — | Explicit ordering of categories in the output. Categories not listed retain their configured order after the listed ones. |
 
 #### `notes.releaseNotes.llm.options`
 
@@ -340,8 +343,7 @@ Override built-in prompt instructions per task.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `instructions` | object | — | Per-task instruction overrides |
-| `templates` | object | — | Per-task prompt template overrides |
+| `instructions` | object | — | Per-task instruction overrides appended to the built-in prompts. |
 
 ---
 
@@ -358,6 +360,7 @@ CI automation configuration for release triggers, PR previews, and label managem
 | `autoRelease` | boolean | `false` | Automatically trigger a release when CI conditions are met, without manual intervention. |
 | `skipPatterns` | `string[]` | `["chore: release "]` | Commit message prefixes that suppress a release. The default matches the release commit template to prevent release loops. |
 | `minChanges` | integer | `1` | Minimum number of packages with releasable changes required to trigger a release. |
+| `scopeLabels` | object | — | Map of scope labels to package patterns. When a PR has a label matching a key, only packages matching the corresponding pattern are released. |
 
 ### `ci.labels`
 

--- a/packages/config/test/unit/schema.spec.ts
+++ b/packages/config/test/unit/schema.spec.ts
@@ -580,6 +580,27 @@ describe('CIConfigSchema', () => {
     expect(result.labels.patch).toBe('bump:patch');
   });
 
+  it('should parse scopeLabels as a string-to-string map', () => {
+    const result = CIConfigSchema.parse({
+      scopeLabels: {
+        'scope:all': '@releasekit/*',
+        'scope:cli': 'packages/release',
+      },
+    });
+    expect(result.scopeLabels).toEqual({
+      'scope:all': '@releasekit/*',
+      'scope:cli': 'packages/release',
+    });
+  });
+
+  it('should leave scopeLabels undefined when omitted', () => {
+    expect(CIConfigSchema.parse({}).scopeLabels).toBeUndefined();
+  });
+
+  it('should reject non-string scopeLabels values', () => {
+    expect(() => CIConfigSchema.parse({ scopeLabels: { 'scope:all': 123 } })).toThrow();
+  });
+
   it('should return undefined for standingPr when omitted', () => {
     const result = CIConfigSchema.parse({});
     expect(result.standingPr).toBeUndefined();

--- a/releasekit.schema.json
+++ b/releasekit.schema.json
@@ -869,6 +869,7 @@
                           },
                           "url": {
                             "type": "string",
+                            "format": "uri",
                             "description": "Link URL"
                           }
                         },

--- a/releasekit.schema.json
+++ b/releasekit.schema.json
@@ -236,10 +236,6 @@
           "type": "string",
           "description": "Identifier for prerelease versions (e.g., 'alpha', 'beta')"
         },
-        "baseBranch": {
-          "type": "string",
-          "description": "Base branch for versioning"
-        },
         "strictReachable": {
           "type": "boolean",
           "default": false,
@@ -797,25 +793,101 @@
                       "properties": {
                         "instructions": {
                           "type": "object",
-                          "additionalProperties": {
-                            "type": "string"
-                          },
-                          "description": "Per-task instruction overrides"
-                        },
-                        "templates": {
-                          "type": "object",
-                          "additionalProperties": {
-                            "type": "string"
-                          },
-                          "description": "Per-task prompt template overrides"
+                          "additionalProperties": false,
+                          "description": "Per-task instruction overrides appended to the built-in prompts.",
+                          "properties": {
+                            "enhance": {
+                              "type": "string",
+                              "description": "Instruction override for the enhance task"
+                            },
+                            "categorize": {
+                              "type": "string",
+                              "description": "Instruction override for the categorize task"
+                            },
+                            "enhanceAndCategorize": {
+                              "type": "string",
+                              "description": "Instruction override for the combined enhance + categorize task"
+                            },
+                            "summarize": {
+                              "type": "string",
+                              "description": "Instruction override for the summarize task"
+                            },
+                            "releaseNotes": {
+                              "type": "string",
+                              "description": "Instruction override for the release-notes task"
+                            }
+                          }
                         }
                       }
+                    },
+                    "examples": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "maximum": 5,
+                      "default": 3,
+                      "description": "Number of few-shot examples to include in LLM prompts (0–5)."
+                    },
+                    "context": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "description": "Additional context sources for the LLM.",
+                      "properties": {
+                        "pullRequests": {
+                          "type": "boolean",
+                          "default": true,
+                          "description": "Include linked pull request titles/bodies as context."
+                        }
+                      }
+                    },
+                    "categoryOrder": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "description": "Explicit ordering of categories in the output. Categories not listed retain their configured order after the listed ones."
                     }
                   },
                   "required": [
                     "provider",
                     "model"
                   ]
+                },
+                "links": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "description": "Extra links to append to the release notes.",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                          "label": {
+                            "type": "string",
+                            "description": "Link text"
+                          },
+                          "url": {
+                            "type": "string",
+                            "description": "Link URL"
+                          }
+                        },
+                        "required": [
+                          "label",
+                          "url"
+                        ]
+                      },
+                      "description": "Static list of links to append."
+                    },
+                    "fromPRBodyMarker": {
+                      "type": "string",
+                      "description": "Marker string in PR bodies; content after it is extracted and appended as links."
+                    },
+                    "title": {
+                      "type": "string",
+                      "description": "Heading for the links section."
+                    }
+                  }
                 }
               }
             }
@@ -927,6 +999,13 @@
               "description": "Label to force a patch bump"
             }
           }
+        },
+        "scopeLabels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Map of scope labels to package patterns. When a PR has a label matching a key, only packages matching the corresponding pattern are released."
         },
         "standingPr": {
           "type": "object",


### PR DESCRIPTION
## Problem

`ci.scopeLabels` is defined in the Zod schema (`packages/config/src/schema.ts`) and used in this repo's own `releasekit.config.json`, but was missing from the hand-maintained `releasekit.schema.json`. Since that schema is `additionalProperties: false`, configs using `ci.scopeLabels` fail strict validation, editors flag it as unknown, and the generated `docs/configuration.md` omits it.

## Fix

- Add `ci.scopeLabels` to `releasekit.schema.json` as an optional string→string map, mirroring the Zod definition.
- Regenerate `docs/configuration.md`. No prose change to the generator was needed — `scopeLabels` is a plain property and flows into the `ci` table automatically.
- Add config tests asserting `scopeLabels` parses (and rejects non-string values).

## Drift audit

Diffed every field in `packages/config/src/schema.ts` against `releasekit.schema.json` (Zod = source of truth). Found and fixed **6 more** discrepancies beyond `scopeLabels`:

| Field | Drift | Action |
|-------|-------|--------|
| `ci.scopeLabels` | Zod-only | **Added** (string→string map) |
| `version.baseBranch` | JSON-Schema-only phantom | **Removed** — runtime `baseBranch` is derived from `git.branch`, never read from user config |
| `notes.releaseNotes.llm.examples` | Zod-only | **Added** (integer 0–5, default 3) |
| `notes.releaseNotes.llm.context.pullRequests` | Zod-only | **Added** (boolean, default true) |
| `notes.releaseNotes.llm.categoryOrder` | Zod-only | **Added** (string[]) |
| `notes.releaseNotes.llm.prompts` | mismatched | `instructions` corrected to the fixed-key shape; phantom `prompts.templates` removed |
| `notes.releaseNotes.links` | Zod-only | **Added** (`{ items, fromPRBodyMarker, title }`) |

Each removal/reshape was checked against the Zod source (e.g. `LLMPromptsConfigSchema` is `{ instructions }` only; `baseBranch` is derived from `git.branch`).

## Durable-fix decision (for maintainer)

The root cause is the manual Zod↔JSON-Schema sync. Generating `releasekit.schema.json` from Zod (`zod-to-json-schema`) would eliminate this entire drift class. That's a larger change with tradeoffs (must keep the editor `$schema` consumers and the draft-7 ajv validation used by `examples-validate` working), so it's **deliberately not done here** — flagged as an open option. This PR is the immediate fix + audit.

## Verification

- This repo's own `releasekit.config.json` validates under the exact strict ajv settings `examples-validate` uses (`ajv-cli@5 --spec=draft7 --strict=false`) → valid.
- `pnpm turbo run lint typecheck test` passes (24/24; config spec 77/77 incl. new scopeLabels tests).
- Regenerating docs produces no diff.

Closes #277

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a long-standing Zod↔JSON-Schema drift in `releasekit.schema.json` by auditing every field in `packages/config/src/schema.ts` and reconciling seven discrepancies. The hand-maintained JSON schema had both phantom fields not in Zod and Zod-only fields absent from JSON schema, causing `additionalProperties: false` to reject valid configs, suppress IDE completion, and omit fields from generated docs.

- **Added** `ci.scopeLabels`, `notes.releaseNotes.links`, and three LLM fields (`examples`, `context`, `categoryOrder`) that existed in Zod but were missing from the JSON schema.
- **Removed** the phantom `version.baseBranch` and `llm.prompts.templates` properties, and reshaped `llm.prompts.instructions` from a free-form string map to a fixed-key object matching `LLMPromptOverridesSchema`.
- **Added** three Vitest tests specifically covering `scopeLabels` parse, omit, and rejection cases.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — all JSON schema changes are direct, verifiable transcriptions of the existing Zod definitions with no runtime logic modified.

Every addition and removal in the JSON schema was confirmed against the Zod source of truth in packages/config/src/schema.ts. The prompts.instructions reshape matches LLMPromptOverridesSchema exactly; version.baseBranch is correctly absent from VersionConfigSchema; links.url now carries format: uri in line with z.string().url(); and scopeLabels is covered by three targeted tests. No runtime code changed.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| releasekit.schema.json | Seven schema drift issues corrected; all changes faithfully mirror the Zod source of truth — added fields, removed phantoms, and reshaped prompts.instructions to a closed fixed-key object. |
| packages/config/test/unit/schema.spec.ts | Three new tests cover the primary fix (scopeLabels parse/omit/reject); placement adjacent to the labels tests is appropriate. |
| docs/configuration.md | Regenerated output correctly reflects the schema corrections — removed baseBranch, added scopeLabels/links/examples/context/categoryOrder rows, updated prompts description. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    ZOD["packages/config/src/schema.ts\n(Zod — source of truth)"]
    JSON["releasekit.schema.json\n(hand-maintained JSON Schema)"]
    DOCS["docs/configuration.md\n(generated)"]

    ZOD -->|"drift audit"| DIFF{"7 discrepancies found"}

    DIFF -->|"Zod-only → Added"| A["ci.scopeLabels\nstring→string map"]
    DIFF -->|"Zod-only → Added"| B["notes.releaseNotes.links\n{items, fromPRBodyMarker, title}"]
    DIFF -->|"Zod-only → Added"| C["llm.examples  integer 0–5\nllm.context.pullRequests  bool\nllm.categoryOrder  string[]"]
    DIFF -->|"JSON-only phantom → Removed"| D["version.baseBranch\nllm.prompts.templates"]
    DIFF -->|"Mismatched → Reshaped"| E["llm.prompts.instructions\nfree-form → fixed-key object"]

    A --> JSON
    B --> JSON
    C --> JSON
    D --> JSON
    E --> JSON

    JSON -->|"regenerate"| DOCS
```
</details>

<sub>Reviews (3): Last reviewed commit: ["merge main into fix/277-scopelabels-sche..."](https://github.com/goosewobbler/releasekit/commit/802992aa4bb30250ed5cb43052e238968d886d84) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36319485)</sub>

<!-- /greptile_comment -->