### PR TITLE
docs: trim duplicated comments in smoke-test scenario manifest

### DIFF
--- a/scripts/examples-smoke/scenarios.ts
+++ b/scripts/examples-smoke/scenarios.ts
@@ -1,19 +1,11 @@
 /**
  * Scenario manifest for the examples execution smoke-test (issue #276).
  *
- * This is deliberately METADATA, not a mirror of the example workflows' steps.
- * It names, per scenario:
- *   - which example workflow file + job's setup steps to EXTRACT (so the smoke
- *     test runs the real shipped steps and cannot drift — a future change to the
- *     example flows straight through the generator);
- *   - which shipped releasekit.config.json the throwaway fixture uses;
- *   - the fixture shape (npm-only or npm+cargo) the example assumes;
- *   - the releasekit invocation to probe the environment with (always --dry-run,
- *     so publish / the OIDC exchange never fire — see the README residual-gap note).
- *
- * The setup steps themselves are never written here; they are read out of the
- * example YAML at generation time. Drift is impossible to merge because CI runs
- * the generator with --check and fails on any diff.
+ * Deliberately METADATA, not a mirror of the example steps: it names which
+ * example workflow/job to EXTRACT setup steps from, which shipped config the
+ * fixture uses, the fixture shape, and the (always `--dry-run`) releasekit
+ * invocation. The steps themselves are read out of the example YAML at
+ * generation time, so they can't drift — CI runs the generator with `--check`.
  */
 
 export interface Scenario {
@@ -22,21 +14,16 @@ export interface Scenario {
   /** Example workflow file, relative to examples/ci/<id>/. */
   workflow: string;
   /**
-   * Job whose setup steps to extract. The terminal `releasekit ...` step and the
-   * example's own `actions/checkout` are dropped by the extractor; everything in
-   * between (pnpm/action-setup, setup-node, rust-toolchain, pnpm install, rm -f
-   * .npmrc, git config, ...) is kept verbatim.
+   * Job whose setup steps to extract. The extractor drops the terminal
+   * `releasekit ...` step and the example's `actions/checkout`; everything
+   * between is kept verbatim.
    */
   job: string;
   /** Shipped config copied into the throwaway fixture. */
   config: string;
   /** Fixture layout the example assumes. */
   fixture: 'npm-single' | 'npm-monorepo' | 'npm-cargo-monorepo';
-  /**
-   * releasekit subcommand + flags appended after `--dry-run`. The example's own
-   * terminal step is replaced with this so publish/event/secret paths stay out of
-   * scope while the real setup is still exercised.
-   */
+  /** releasekit subcommand + flags (always including `--dry-run`) that replaces the example's terminal step. */
   releaseArgs: string[];
   /** One-line note shown in the job log explaining what this scenario proves. */
   proves: string;
@@ -94,9 +81,8 @@ export const SCENARIOS: Scenario[] = [
     job: 'update',
     config: 'releasekit.config.json',
     fixture: 'npm-single',
-    // standing-pr update mutates a real PR via the GitHub API (out of scope). We
-    // extract its setup and probe the environment with a plain dry-run release so
-    // the missing-tool class is still covered without the API-mutating path.
+    // standing-pr update mutates a real PR via the GitHub API (out of scope), so probe the
+    // environment with a plain dry-run release instead of the real `standing-pr update`.
     releaseArgs: ['release', '--dry-run'],
     proves: 'standing-pr update setup resolves; the PR-mutating API path stays out of scope.',
   },


### PR DESCRIPTION
Follow-up review of #279 and #281, focused on comments and docs.

## Findings

**Bundle-name bug (#281) — already fixed on main.** The generator's restore step hardcoded `fixture.bundle` instead of `${scenario.id}.bundle` (Greptile P1; the "Prepare fixtures" CI failure). The fix landed in #281 before merge — verified line 142 uses `${scenario.id}.bundle` and `examples-smoke.yml` clones `minimal.bundle` etc. No drift (`examples:smoke:check` clean). Nothing to do here.

**Comment over-detail in `scenarios.ts` — trimmed (this PR).** The "always `--dry-run` / out of scope" rationale was stated four times for the standing-pr scenario (header, `releaseArgs` JSDoc, an inline comment, and the `proves` line), and the `job` JSDoc re-listed the exact steps (`pnpm/action-setup`, `setup-node`, …) that the extractor already owns and could drift from. Consolidated to the canonical spots (−14 lines).

## Deliberately left intact

The smoke-test design is genuinely subtle, so most of its comments are load-bearing "why" and were kept:
- `build-fixture.ts`: the `--ignore-workspace` walk-up trap, the `packageManager` hash-suffix stripping, the seed-lockfile-needs-pnpm-only-in-prepare rule, the exhaustiveness check.
- `generate-smoke-workflow.ts`: the act-vs-extraction decision (why a real runner, not `act`), the secret-env stripping, the config-derived cargo probe.
- The `examples/README.md` validation note (rewritten well in #281).
- #279's warning-placement comment and its two regression tests — correct as-is.

## Verification

`pnpm turbo run lint typecheck test` → 24/24. `examples:smoke:check` reports up to date. Comments don't affect generated output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR consolidates over-repeated comment text in `scenarios.ts`, the smoke-test scenario manifest. The "always `--dry-run` / out of scope" rationale that was stated four times across the `standing-pr` scenario entry is trimmed to one clear inline comment, and the file-level and `job`/`releaseArgs` JSDoc blocks are condensed without losing any semantically distinct information.

- **File header**: Refactored from a 10-line block enumerating each manifest field into a concise 7-line description that still conveys METADATA intent, EXTRACT pattern, and drift-prevention mechanism.
- **`job` JSDoc**: Removed the enumerated list of concrete steps (`pnpm/action-setup`, `setup-node`, …) that belonged to extractor implementation detail and could silently drift from the generator logic; the drop-rule for `releasekit ...` and `actions/checkout` is preserved.
- **`releaseArgs` + inline comment**: Merged the multi-line JSDoc and redundant inline rationale into a single `/** … */` and one inline comment for the `standing-pr` scenario.
</details>

<h3>Confidence Score: 5/5</h3>

Documentation-only change with no runtime or generated-output impact; safe to merge.

Every deletion removes duplicated prose that restated the same "always --dry-run / out of scope" rationale in three to four spots. The remaining comments still accurately describe the manifest's purpose, the extractor's drop rules, and the standing-pr substitution. No code paths, types, or generated YAML are touched, and the PR description confirms `examples:smoke:check` reports up to date.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/examples-smoke/scenarios.ts | Comment-only trimming: file header, job JSDoc, releaseArgs JSDoc, and standing-pr inline comment condensed. No logic or runtime behaviour changed. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[scenarios.ts SCENARIOS array] -->|id, workflow, job, config, fixture, releaseArgs| B[generate-smoke-workflow.ts]
    B -->|reads setup steps| C[Example YAML\ne.g. examples/ci/minimal/release.yml]
    B -->|writes| D[examples-smoke.yml]
    D -->|CI --check| E{Diff?}
    E -- No diff --> F[CI passes]
    E -- Diff found --> G[CI fails — drift detected]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: trim duplicated comments in the sm..."](https://github.com/goosewobbler/releasekit/commit/254fb9c6f97903657b9d0f61c9175d810d0bb735) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36352274)</sub>

<!-- /greptile_comment -->