### PR TITLE
feat(config): generate the JSON schema from the Zod schema

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,9 @@ jobs:
       - name: Run lint
         run: pnpm lint
 
+      - name: Check generated JSON schema is up to date
+        run: pnpm schema:check
+
   typecheck:
     name: Typecheck
     needs: [detect-changes, build]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,8 +61,8 @@ Fresh worktrees need `pnpm install` first. If you change dependencies, run `pnpm
 
 ## Documentation Rules
 
-- **`docs/configuration.md` is generated** — never hand-edit. The source of truth is the hand-maintained `releasekit.schema.json`; regenerate with `pnpm docs:config`. Prose sections live in `scripts/generate-config-docs.ts`.
-- The Zod schemas in `packages/config/src/schema.ts` and `releasekit.schema.json` must be kept in sync manually.
+- **`releasekit.schema.json` is generated from the Zod schema** (`packages/config/src/schema.ts`) via `pnpm schema:gen` — never hand-edit it. Field descriptions live in the Zod schema as `.describe('...')` calls; that text is the single source of truth and flows Zod → `releasekit.schema.json` → `docs/configuration.md`. `pnpm schema:check` enforces that the committed JSON Schema matches the Zod schema, and runs in CI (the `lint` job), so the two can never drift. To add or change a config field, edit the Zod schema, then run `pnpm schema:gen && pnpm docs:config`.
+- **`docs/configuration.md` is generated** — never hand-edit. Regenerate with `pnpm docs:config` (reads the generated `releasekit.schema.json`). Prose sections live in `scripts/generate-config-docs.ts`.
 - CLI flags are documented in `docs/cli.md` — update it when adding/changing flags; derive descriptions from the commander definitions, never invent.
 - `packages/release/docs/ci-setup.md` embeds copy-pasteable workflow templates; keep them internally consistent (node version, auth notes) when editing any one of them.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -59,7 +59,7 @@ Versioning configuration.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `tagTemplate` | string | `"v{version}"` | Template for Git tags. Available variables: ${version} (version number), ${prefix} (versionPrefix value, e.g. 'v'), ${packageName} (sanitized package name, e.g. 'scope-pkg'). Example: "${packageName}-${prefix}${version}" produces "scope-pkg-v1.2.3". |
+| `tagTemplate` | string | `"${prefix}${version}"` | Template for Git tags. Available variables: ${version} (version number), ${prefix} (versionPrefix value, e.g. 'v'), ${packageName} (sanitized package name, e.g. 'scope-pkg'). Example: "${packageName}-${prefix}${version}" produces "scope-pkg-v1.2.3". |
 | `baselineTagTemplate` | string | — | Optional secondary tag template for an internal 'baseline' marker that records the release commit on the source branch. Use this when tagTemplate resolves to a tag that gets force-moved off the source branch by a downstream step (e.g. a GitHub Action distributing built artifacts at the version tag) — the baseline tag stays on the release commit so future version-bump and changelog calculations can still find the previous release. Must contain a ${version} placeholder so the baseline prefix can be derived. Supports the same variables as tagTemplate. Example: "release/${prefix}${version}" produces "release/v1.2.3". |
 | `packageSpecificTags` | boolean | `false` | Enable package-specific tagging |
 | `preset` | string | `"conventional"` | Commit convention preset |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -59,7 +59,7 @@ Versioning configuration.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `tagTemplate` | string | `"${prefix}${version}"` | Template for Git tags. Available variables: ${version} (version number), ${prefix} (versionPrefix value, e.g. 'v'), ${packageName} (sanitized package name, e.g. 'scope-pkg'). Example: "${packageName}-${prefix}${version}" produces "scope-pkg-v1.2.3". |
+| `tagTemplate` | string | `"v{version}"` | Template for Git tags. Available variables: ${version} (version number), ${prefix} (versionPrefix value, e.g. 'v'), ${packageName} (sanitized package name, e.g. 'scope-pkg'). Example: "${packageName}-${prefix}${version}" produces "scope-pkg-v1.2.3". |
 | `baselineTagTemplate` | string | — | Optional secondary tag template for an internal 'baseline' marker that records the release commit on the source branch. Use this when tagTemplate resolves to a tag that gets force-moved off the source branch by a downstream step (e.g. a GitHub Action distributing built artifacts at the version tag) — the baseline tag stays on the release commit so future version-bump and changelog calculations can still find the previous release. Must contain a ${version} placeholder so the baseline prefix can be derived. Supports the same variables as tagTemplate. Example: "release/${prefix}${version}" produces "release/v1.2.3". |
 | `packageSpecificTags` | boolean | `false` | Enable package-specific tagging |
 | `preset` | string | `"conventional"` | Commit convention preset |
@@ -195,6 +195,7 @@ GitHub Release configuration.
 | `prerelease` | boolean \| `"auto"` | `"auto"` | Mark as prerelease |
 | `body` | `"auto"` \| `"releaseNotes"` \| `"changelog"` \| `"generated"` \| `"none"` | `"auto"` | Source for GitHub release body. 'auto': use release notes if enabled, else changelog, else GitHub auto. 'releaseNotes': use LLM-generated release notes. 'changelog': use changelog entries. 'generated': GitHub auto-generated. 'none': no body. |
 | `titleTemplate` | string | `"${packageName}: ${version}"` | Template for the GitHub release title when a package name is resolved. Available variables: ${packageName} (original scoped name, e.g. '@scope/pkg'), ${version} (e.g. 'v1.0.0'). Version-only tags always use the tag string directly. |
+| `skipPackages` | `string[]` | `[]` | Package names to exclude from GitHub release creation |
 
 ### `publish.verify`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -92,8 +92,8 @@ Array of objects with the following properties:
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `pattern` | string | — |  |
-| `releaseType` | `"major"` \| `"minor"` \| `"patch"` \| `"prerelease"` | — |  |
+| `pattern` | string | — | Glob or regex matched against the branch name (e.g. 'release/*') |
+| `releaseType` | `"major"` \| `"minor"` \| `"patch"` \| `"prerelease"` | — | Version bump type applied when this pattern matches |
 
 ### `version.groups`
 
@@ -306,9 +306,9 @@ Array of category objects used for commit categorization. Each item has:
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `name` | string | — |  |
-| `description` | string | — |  |
-| `scopes` | `string[]` | — |  |
+| `name` | string | — | Category label shown in release notes (e.g. 'Features') |
+| `description` | string | — | LLM instruction describing what commits belong in this category |
+| `scopes` | `string[]` | — | Conventional commit scopes assigned to this category |
 
 #### `notes.releaseNotes.llm.scopes`
 
@@ -316,16 +316,16 @@ Scope validation configuration.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `mode` | `"restricted"` \| `"packages"` \| `"none"` \| `"unrestricted"` | `"unrestricted"` |  |
+| `mode` | `"restricted"` \| `"packages"` \| `"none"` \| `"unrestricted"` | `"unrestricted"` | Scope allowlist source: 'restricted' uses rules.allowed, 'packages' derives scopes from workspace package names, 'none' strips all scopes, 'unrestricted' allows any scope |
 
 **`notes.releaseNotes.llm.scopes.rules`**
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `allowed` | `string[]` | — |  |
-| `caseSensitive` | boolean | `false` |  |
-| `invalidScopeAction` | `"remove"` \| `"keep"` \| `"fallback"` | `"remove"` |  |
-| `fallbackScope` | string | — |  |
+| `allowed` | `string[]` | — | Explicit list of valid scope names; commits with unlisted scopes trigger invalidScopeAction |
+| `caseSensitive` | boolean | `false` | Whether scope comparison is case-sensitive |
+| `invalidScopeAction` | `"remove"` \| `"keep"` \| `"fallback"` | `"remove"` | Action for commits whose scope is not in the allowed list: 'remove' strips the scope, 'keep' leaves it, 'fallback' substitutes fallbackScope |
+| `fallbackScope` | string | — | Scope substituted when invalidScopeAction is 'fallback' |
 
 #### `notes.releaseNotes.llm.retry`
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "typecheck": "turbo run typecheck",
     "clean": "turbo run clean && rm -rf node_modules",
     "clean:cache": "turbo daemon stop && rm -rf .turbo .eslintcache",
+    "schema:gen": "tsx scripts/generate-schema.ts",
+    "schema:check": "tsx scripts/generate-schema.ts --check",
     "docs:config": "tsx scripts/generate-config-docs.ts",
     "examples:smoke:generate": "tsx scripts/examples-smoke/generate-smoke-workflow.ts",
     "examples:smoke:check": "tsx scripts/examples-smoke/generate-smoke-workflow.ts --check",
@@ -48,7 +50,8 @@
     "tsx": "catalog:",
     "turbo": "2.9.16",
     "typescript": "catalog:",
-    "yaml": "catalog:"
+    "yaml": "catalog:",
+    "zod": "catalog:"
   },
   "lint-staged": {
     "**/*.ts": [

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -41,7 +41,6 @@ export {
   type StandingPrConfig,
   type TemplateConfig,
   type VerifyConfig,
-  type VerifyRegistryConfig,
   type VersionConfig,
   type VersionGroup,
 } from './schema.js';

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -182,15 +182,6 @@ export const VerifyRegistryCargoConfigSchema = z.object({
   backoffMultiplier: z.number().positive().default(2).describe('Exponential backoff multiplier'),
 });
 
-// Shared shape for both registries; the npm/cargo variants differ only in defaults
-// and per-field descriptions (so the generated docs read naturally for each).
-export const VerifyRegistryConfigSchema = z.object({
-  enabled: z.boolean().default(true),
-  maxAttempts: z.number().int().positive().default(5),
-  initialDelay: z.number().int().positive().default(15000),
-  backoffMultiplier: z.number().positive().default(2),
-});
-
 export const VerifyConfigSchema = z.object({
   npm: VerifyRegistryNpmConfigSchema.default({
     enabled: true,
@@ -587,7 +578,6 @@ export type NpmConfig = z.infer<typeof NpmConfigSchema>;
 export type CargoPublishConfig = z.infer<typeof CargoPublishConfigSchema>;
 export type PublishGitConfig = z.infer<typeof PublishGitConfigSchema>;
 export type GitHubReleaseConfig = z.infer<typeof GitHubReleaseConfigSchema>;
-export type VerifyRegistryConfig = z.infer<typeof VerifyRegistryConfigSchema>;
 export type VerifyConfig = z.infer<typeof VerifyConfigSchema>;
 export type PublishConfig = z.infer<typeof PublishConfigSchema>;
 export type LocationMode = z.infer<typeof LocationModeSchema>;

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -1,23 +1,31 @@
 import { z } from 'zod';
 
+// ---------------------------------------------------------------------------
+// NOTE FOR EDITORS
+//
+// Field descriptions live here as Zod `.describe()` calls. They are the single
+// source of truth: `releasekit.schema.json` is generated from this file via
+// `pnpm schema:gen` (scripts/generate-schema.ts), and `docs/configuration.md`
+// is generated from that JSON Schema via `pnpm docs:config`. Never hand-edit
+// `releasekit.schema.json`; `pnpm schema:check` enforces that it matches Zod in
+// CI. To change a description or add a field, edit it here and run `pnpm
+// schema:gen` (then `pnpm docs:config`).
+// ---------------------------------------------------------------------------
+
 export const GitConfigSchema = z.object({
-  remote: z.string().default('origin'),
-  branch: z.string().default('main'),
-  pushMethod: z.enum(['auto', 'ssh', 'https']).default('auto'),
-  /**
-   * Optional env var name containing a GitHub token for HTTPS pushes.
-   * When set, publish steps can use this token without mutating git remotes.
-   */
-  httpsTokenEnv: z.string().optional(),
-  push: z.boolean().optional(),
-  skipHooks: z.boolean().optional(),
+  remote: z.string().default('origin').describe('Git remote name'),
+  branch: z.string().default('main').describe('Default branch name'),
+  pushMethod: z.enum(['auto', 'ssh', 'https']).default('auto').describe('Method for pushing to remote'),
+  push: z.boolean().optional().describe('Whether to push changes to remote'),
+  httpsTokenEnv: z.string().optional().describe('Environment variable name containing a GitHub token for HTTPS pushes'),
+  skipHooks: z.boolean().optional().describe('Skip Git hooks when committing'),
 });
 
 export const MonorepoConfigSchema = z.object({
-  mode: z.enum(['root', 'packages', 'both']).optional(),
-  rootPath: z.string().optional(),
-  packagesPath: z.string().optional(),
-  mainPackage: z.string().optional(),
+  mode: z.enum(['root', 'packages', 'both']).optional().describe('Changelog aggregation mode'),
+  rootPath: z.string().optional().describe('Path to root changelog'),
+  packagesPath: z.string().optional().describe('Path to packages directory'),
+  mainPackage: z.string().optional().describe('Main package name for versioning'),
 });
 
 export const BranchPatternSchema = z.object({
@@ -26,132 +34,153 @@ export const BranchPatternSchema = z.object({
 });
 
 export const VersionCargoConfigSchema = z.object({
-  enabled: z.boolean().default(true),
-  paths: z.array(z.string()).optional(),
+  enabled: z.boolean().default(true).describe('Enable Cargo.toml version handling'),
+  paths: z.array(z.string()).optional().describe('Directories to search for Cargo.toml files'),
 });
 
 export const VersionGroupSchema = z.object({
-  /**
-   * Package patterns (exact names, `@scope/*`, or globs) whose matched packages form this group.
-   * The same matching rules as `version.packages` apply.
-   */
-  packages: z.array(z.string()).min(1),
-  /** `fixed`: all members release together at the group version. `linked`: only changed members
-   *  release, all at the same version. See the version.groups reference for the full semantics. */
-  sync: z.enum(['fixed', 'linked']),
+  packages: z
+    .array(z.string())
+    .min(1)
+    .describe(
+      'Package patterns (exact names, @scope/*, or globs) whose matched packages form this group. Same matching rules as version.packages.',
+    ),
+  sync: z
+    .enum(['fixed', 'linked'])
+    .describe(
+      'fixed: all members release together at the shared group version. linked: only changed members release, all at the same computed version.',
+    ),
 });
 
 export const VersionConfigSchema = z.object({
-  tagTemplate: z.string().default('v{version}'),
-  /**
-   * Optional secondary tag template for an internal "baseline" marker that records the
-   * release commit on the source branch. Use this when `tagTemplate` resolves to a tag that
-   * gets force-moved off the source branch by a downstream step (for example, a GitHub
-   * Action distributing built artifacts at the version tag) — the baseline tag stays on the
-   * release commit so version-bump and changelog calculations can still find the previous
-   * release in the working branch's history.
-   *
-   * Supports `${packageName}`, `${prefix}`, `${version}` substitutions. Leave unset for
-   * single-tag workflows (the default).
-   */
+  tagTemplate: z.string().default('v{version}').describe(
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: documenting placeholder syntax to the user
+    'Template for Git tags. Available variables: ${version} (version number), ${prefix} (versionPrefix value, e.g. \'v\'), ${packageName} (sanitized package name, e.g. \'scope-pkg\'). Example: "${packageName}-${prefix}${version}" produces "scope-pkg-v1.2.3".',
+  ),
   baselineTagTemplate: z
     .string()
-    .refine((tpl) => tpl.includes('${' + 'version}'), {
+    // Pattern (not a refine) so it round-trips into the JSON Schema as `pattern`.
+    .regex(/.*\$\{version\}.*/, {
       message:
         // biome-ignore lint/suspicious/noTemplateCurlyInString: documenting the expected placeholder syntax to the user
         'baselineTagTemplate must contain a ${version} placeholder so the prefix can be derived (e.g. "release/${prefix}${version}").',
     })
-    .optional(),
-  packageSpecificTags: z.boolean().default(false),
-  preset: z.string().default('conventional'),
-  /**
-   * Global lockstep versioning. `true` is sugar for one implicit `fixed` group of every package
-   * (all packages version together) — it shares the exact same mechanism as `version.groups`.
-   * When `version.groups` is set, `sync` should be `false`; an explicit `sync: true` alongside
-   * groups is treated as the implicit all-packages fixed group taking precedence and is reported
-   * as a config conflict.
-   */
-  sync: z.boolean().default(true),
-  /**
-   * Named version groups, each binding a set of package patterns to a `fixed` or `linked` sync
-   * mode. Packages not matched by any group version independently (per-package). A package may
-   * belong to at most one group; overlapping patterns that assign a package to two groups are a
-   * config error. See the `version.groups` reference for fixed vs linked semantics.
-   */
-  groups: z.record(z.string(), VersionGroupSchema).optional(),
-  packages: z.array(z.string()).default([]),
-  mainPackage: z.string().optional(),
-  updateInternalDependencies: z.enum(['major', 'minor', 'patch', 'no-internal-update']).default('minor'),
-  skip: z.array(z.string()).optional(),
-  commitMessage: z.string().optional(),
-  versionStrategy: z.enum(['branchPattern', 'commitMessage']).default('commitMessage'),
-  branchPatterns: z.array(BranchPatternSchema).optional(),
-  defaultReleaseType: z.enum(['major', 'minor', 'patch', 'prerelease']).optional(),
-  mismatchStrategy: z.enum(['error', 'warn', 'ignore', 'prefer-package', 'prefer-git']).default('warn'),
-  versionPrefix: z.string().default(''),
-  prereleaseIdentifier: z.string().optional(),
-  strictReachable: z.boolean().default(false),
-  /** Pre-1.0 inferred-breaking bump policy ('spec' | 'strict'). See docs/configuration.md#versionzeromajor. */
-  zeroMajor: z.enum(['spec', 'strict']).default('spec'),
-  cargo: VersionCargoConfigSchema.optional(),
+    .optional()
+    .describe(
+      // biome-ignore lint/suspicious/noTemplateCurlyInString: documenting placeholder syntax to the user
+      'Optional secondary tag template for an internal \'baseline\' marker that records the release commit on the source branch. Use this when tagTemplate resolves to a tag that gets force-moved off the source branch by a downstream step (e.g. a GitHub Action distributing built artifacts at the version tag) — the baseline tag stays on the release commit so future version-bump and changelog calculations can still find the previous release. Must contain a ${version} placeholder so the baseline prefix can be derived. Supports the same variables as tagTemplate. Example: "release/${prefix}${version}" produces "release/v1.2.3".',
+    ),
+  packageSpecificTags: z.boolean().default(false).describe('Enable package-specific tagging'),
+  preset: z.string().default('conventional').describe('Commit convention preset'),
+  sync: z
+    .boolean()
+    .default(true)
+    .describe(
+      'Global lockstep versioning. true is sugar for one implicit fixed group of every package — it shares the same mechanism as version.groups. Set to false when using version.groups; sync: true alongside groups is treated as the implicit all-packages fixed group taking precedence (a config conflict, warned about at runtime).',
+    ),
+  groups: z
+    .record(z.string(), VersionGroupSchema)
+    .optional()
+    .describe(
+      'Named version groups. Each group binds a set of package patterns to a fixed or linked sync mode. fixed: any releasable change in any member releases ALL members at the shared group version (bump(max(member baselines))). linked: only members with releasable changes release, but every releasing member shares the same computed version. Packages not matched by any group version independently. A package may belong to at most one group. Set version.sync to false when using groups.',
+    ),
+  packages: z.array(z.string()).default([]).describe('Packages to include in versioning'),
+  mainPackage: z.string().optional().describe('Package to use for version determination'),
+  updateInternalDependencies: z
+    .enum(['major', 'minor', 'patch', 'no-internal-update'])
+    .default('minor')
+    .describe('How to bump internal dependencies'),
+  skip: z.array(z.string()).optional().describe('Packages to exclude from versioning'),
+  commitMessage: z.string().optional().describe('Template for release commit messages'),
+  versionStrategy: z
+    .enum(['branchPattern', 'commitMessage'])
+    .default('commitMessage')
+    .describe('Strategy for determining version bumps'),
+  branchPatterns: z.array(BranchPatternSchema).optional().describe('Branch name patterns for version determination'),
+  defaultReleaseType: z
+    .enum(['major', 'minor', 'patch', 'prerelease'])
+    .optional()
+    .describe('Default release type when no pattern matches'),
+  mismatchStrategy: z
+    .enum(['error', 'warn', 'ignore', 'prefer-package', 'prefer-git'])
+    .default('warn')
+    .describe('How to handle version mismatches'),
+  versionPrefix: z.string().default('').describe('Prefix for version tags'),
+  prereleaseIdentifier: z.string().optional().describe("Identifier for prerelease versions (e.g., 'alpha', 'beta')"),
+  strictReachable: z.boolean().default(false).describe('Only use reachable tags'),
+  zeroMajor: z
+    .enum(['spec', 'strict'])
+    .default('spec')
+    .describe(
+      "Pre-1.0 handling of commit-inferred breaking changes. 'spec' (default): bump the 0.x minor (0.24.0 → 0.25.0), per semver §4. 'strict': bump the next major (→ 1.0.0). Inferred path only — explicit overrides (--bump major, bump:major) always graduate to 1.0.0.",
+    ),
+  cargo: VersionCargoConfigSchema.optional().describe('Cargo/Rust configuration'),
 });
 
 export const NpmConfigSchema = z.object({
-  enabled: z.boolean().default(true),
-  auth: z.enum(['auto', 'oidc', 'token']).default('auto'),
-  provenance: z.boolean().default(true),
-  access: z.enum(['public', 'restricted']).default('public'),
-  registry: z.string().default('https://registry.npmjs.org'),
-  copyFiles: z.array(z.string()).default(['LICENSE']),
-  tag: z.string().default('latest'),
+  enabled: z.boolean().default(true).describe('Enable NPM publishing'),
+  auth: z.enum(['auto', 'oidc', 'token']).default('auto').describe('Authentication method'),
+  provenance: z.boolean().default(true).describe('Enable npm provenance attestation'),
+  access: z.enum(['public', 'restricted']).default('public').describe('Package access level'),
+  registry: z.string().default('https://registry.npmjs.org').describe('NPM registry URL'),
+  copyFiles: z.array(z.string()).default(['LICENSE']).describe('Files to copy to package before publishing'),
+  tag: z.string().default('latest').describe('NPM dist tag'),
 });
 
 export const CargoPublishConfigSchema = z.object({
-  enabled: z.boolean().default(false),
-  noVerify: z.boolean().default(false),
-  publishOrder: z.array(z.string()).default([]),
-  clean: z.boolean().default(false),
+  enabled: z.boolean().default(false).describe('Enable Cargo publishing'),
+  noVerify: z.boolean().default(false).describe('Skip verification before publish'),
+  publishOrder: z.array(z.string()).default([]).describe('Order in which to publish packages'),
+  clean: z.boolean().default(false).describe('Clean before publishing'),
 });
 
 export const PublishGitConfigSchema = z.object({
-  push: z.boolean().default(true),
-  pushMethod: z.enum(['auto', 'ssh', 'https']).optional(),
-  remote: z.string().optional(),
-  branch: z.string().optional(),
-  httpsTokenEnv: z.string().optional(),
-  skipHooks: z.boolean().optional(),
+  push: z.boolean().default(true).describe('Push tags and commits to remote'),
+  pushMethod: z.enum(['auto', 'ssh', 'https']).optional().describe('Push method override'),
+  remote: z.string().optional().describe('Remote name override'),
+  branch: z.string().optional().describe('Branch name override'),
+  httpsTokenEnv: z.string().optional().describe('Environment variable name containing a GitHub token for HTTPS pushes'),
+  skipHooks: z.boolean().optional().describe('Skip Git hooks when committing'),
 });
 
 export const GitHubReleaseConfigSchema = z.object({
-  enabled: z.boolean().default(true),
-  draft: z.boolean().default(true),
-  perPackage: z.boolean().default(true),
-  prerelease: z.union([z.literal('auto'), z.boolean()]).default('auto'),
-  /**
-   * Controls the source for the GitHub release body.
-   * - 'auto': Use release notes if enabled, else changelog, else GitHub auto-generated.
-   * - 'releaseNotes': Use LLM-generated release notes (requires notes.releaseNotes.enabled: true).
-   * - 'changelog': Use formatted changelog entries.
-   * - 'generated': Use GitHub's auto-generated notes.
-   * - 'none': No body.
-   */
-  body: z.enum(['auto', 'releaseNotes', 'changelog', 'generated', 'none']).default('auto'),
-  /**
-   * Template string for the GitHub release title when a package name is resolved.
-   * Available variables: ${packageName} (original scoped name), ${version} (e.g. "v1.0.0").
-   * Version-only tags (e.g. "v1.0.0") always use the tag as-is.
-   */
+  enabled: z.boolean().default(true).describe('Enable GitHub releases'),
+  draft: z.boolean().default(true).describe('Create as draft release'),
+  perPackage: z.boolean().default(true).describe('Create separate release per package'),
+  prerelease: z
+    .union([z.boolean(), z.literal('auto')])
+    .default('auto')
+    .describe('Mark as prerelease'),
+  body: z
+    .enum(['auto', 'releaseNotes', 'changelog', 'generated', 'none'])
+    .default('auto')
+    .describe(
+      "Source for GitHub release body. 'auto': use release notes if enabled, else changelog, else GitHub auto. 'releaseNotes': use LLM-generated release notes. 'changelog': use changelog entries. 'generated': GitHub auto-generated. 'none': no body.",
+    ),
   /* biome-ignore lint/suspicious/noTemplateCurlyInString: default template value */
-  titleTemplate: z.string().default('${packageName}: ${version}'),
-  /**
-   * Package names to exclude from GitHub release creation. Tags are still created
-   * (so changelog range detection still works on the next release) and npm publish
-   * still runs — only the `gh release create` call is skipped for these packages.
-   * Useful for internal/utility packages that shouldn't appear in the GitHub releases UI.
-   */
-  skipPackages: z.array(z.string()).default([]),
+  titleTemplate: z.string().default('${packageName}: ${version}').describe(
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: documenting placeholder syntax to the user
+    "Template for the GitHub release title when a package name is resolved. Available variables: ${packageName} (original scoped name, e.g. '@scope/pkg'), ${version} (e.g. 'v1.0.0'). Version-only tags always use the tag string directly.",
+  ),
+  skipPackages: z.array(z.string()).default([]).describe('Package names to exclude from GitHub release creation'),
 });
 
+export const VerifyRegistryNpmConfigSchema = z.object({
+  enabled: z.boolean().default(true).describe('Verify NPM publish'),
+  maxAttempts: z.number().int().positive().default(5).describe('Maximum verification attempts'),
+  initialDelay: z.number().int().positive().default(15000).describe('Initial delay in milliseconds'),
+  backoffMultiplier: z.number().positive().default(2).describe('Exponential backoff multiplier'),
+});
+
+export const VerifyRegistryCargoConfigSchema = z.object({
+  enabled: z.boolean().default(true).describe('Verify Cargo publish'),
+  maxAttempts: z.number().int().positive().default(10).describe('Maximum verification attempts'),
+  initialDelay: z.number().int().positive().default(30000).describe('Initial delay in milliseconds'),
+  backoffMultiplier: z.number().positive().default(2).describe('Exponential backoff multiplier'),
+});
+
+// Shared shape for both registries; the npm/cargo variants differ only in defaults
+// and per-field descriptions (so the generated docs read naturally for each).
 export const VerifyRegistryConfigSchema = z.object({
   enabled: z.boolean().default(true),
   maxAttempts: z.number().int().positive().default(5),
@@ -160,13 +189,13 @@ export const VerifyRegistryConfigSchema = z.object({
 });
 
 export const VerifyConfigSchema = z.object({
-  npm: VerifyRegistryConfigSchema.default({
+  npm: VerifyRegistryNpmConfigSchema.default({
     enabled: true,
     maxAttempts: 5,
     initialDelay: 15000,
     backoffMultiplier: 2,
   }),
-  cargo: VerifyRegistryConfigSchema.default({
+  cargo: VerifyRegistryCargoConfigSchema.default({
     enabled: true,
     maxAttempts: 10,
     initialDelay: 30000,
@@ -175,7 +204,7 @@ export const VerifyConfigSchema = z.object({
 });
 
 export const PublishConfigSchema = z.object({
-  git: PublishGitConfigSchema.optional(),
+  git: PublishGitConfigSchema.optional().describe('Git publishing options'),
   npm: NpmConfigSchema.default({
     enabled: true,
     auth: 'auto',
@@ -184,13 +213,13 @@ export const PublishConfigSchema = z.object({
     registry: 'https://registry.npmjs.org',
     copyFiles: ['LICENSE'],
     tag: 'latest',
-  }),
+  }).describe('NPM publishing configuration'),
   cargo: CargoPublishConfigSchema.default({
     enabled: false,
     noVerify: false,
     publishOrder: [],
     clean: false,
-  }),
+  }).describe('Cargo publishing configuration'),
   githubRelease: GitHubReleaseConfigSchema.default({
     enabled: true,
     draft: true,
@@ -200,7 +229,7 @@ export const PublishConfigSchema = z.object({
     /* biome-ignore lint/suspicious/noTemplateCurlyInString: default template value */
     titleTemplate: '${packageName}: ${version}',
     skipPackages: [],
-  }),
+  }).describe('GitHub Release configuration'),
   verify: VerifyConfigSchema.default({
     npm: {
       enabled: true,
@@ -214,40 +243,44 @@ export const PublishConfigSchema = z.object({
       initialDelay: 30000,
       backoffMultiplier: 2,
     },
-  }),
+  }).describe('Registry verification configuration'),
 });
 
 export const TemplateConfigSchema = z.object({
-  path: z.string().optional(),
-  engine: z.enum(['handlebars', 'liquid', 'ejs']).optional(),
+  path: z.string().optional().describe('Path to custom template'),
+  engine: z.enum(['handlebars', 'liquid', 'ejs']).optional().describe('Template engine'),
 });
 
 export const LocationModeSchema = z.enum(['root', 'packages', 'both']);
 
-export const ChangelogConfigSchema = z.object({
-  mode: LocationModeSchema.optional(),
-  file: z.string().optional(),
-  templates: TemplateConfigSchema.optional(),
-});
+export const ChangelogConfigSchema = z
+  .object({
+    mode: LocationModeSchema.optional().describe(
+      'Where to write changelog files. root: repo root only. packages: per-package (monorepos). both: repo root and per-package. When omitted entirely (no changelog config), defaults to root.',
+    ),
+    file: z.string().optional().describe('Changelog file name override (default: CHANGELOG.md)'),
+    templates: TemplateConfigSchema.optional().describe('Template configuration for changelog'),
+  })
+  .describe('Changelog file configuration');
 
 export const LLMOptionsSchema = z.object({
-  timeout: z.number().optional(),
-  maxTokens: z.number().optional(),
-  temperature: z.number().optional(),
+  timeout: z.number().int().optional().describe('Request timeout in ms'),
+  maxTokens: z.number().int().optional().describe('Max tokens to generate'),
+  temperature: z.number().optional().describe('Sampling temperature'),
 });
 
 export const LLMRetryConfigSchema = z.object({
-  maxAttempts: z.number().int().positive().optional(),
-  initialDelay: z.number().nonnegative().optional(),
-  maxDelay: z.number().positive().optional(),
-  backoffFactor: z.number().positive().optional(),
+  maxAttempts: z.number().int().positive().optional().describe('Maximum number of attempts'),
+  initialDelay: z.number().int().nonnegative().optional().describe('Initial delay in ms'),
+  maxDelay: z.number().int().positive().optional().describe('Maximum delay in ms'),
+  backoffFactor: z.number().positive().optional().describe('Delay multiplier per attempt'),
 });
 
 export const LLMTasksConfigSchema = z.object({
-  summarize: z.boolean().optional(),
-  enhance: z.boolean().optional(),
-  categorize: z.boolean().optional(),
-  releaseNotes: z.boolean().optional(),
+  summarize: z.boolean().optional().describe('Enable summarization'),
+  enhance: z.boolean().optional().describe('Enable entry enhancement'),
+  categorize: z.boolean().optional().describe('Enable categorization'),
+  releaseNotes: z.boolean().optional().describe('Enable release note generation'),
 });
 
 export const LLMCategorySchema = z.object({
@@ -269,24 +302,29 @@ export const ScopeConfigSchema = z.object({
 });
 
 export const LLMPromptOverridesSchema = z.object({
-  enhance: z.string().optional(),
-  categorize: z.string().optional(),
-  enhanceAndCategorize: z.string().optional(),
-  summarize: z.string().optional(),
-  releaseNotes: z.string().optional(),
+  enhance: z.string().optional().describe('Instruction override for the enhance task'),
+  categorize: z.string().optional().describe('Instruction override for the categorize task'),
+  enhanceAndCategorize: z
+    .string()
+    .optional()
+    .describe('Instruction override for the combined enhance + categorize task'),
+  summarize: z.string().optional().describe('Instruction override for the summarize task'),
+  releaseNotes: z.string().optional().describe('Instruction override for the release-notes task'),
 });
 
 export const LLMPromptsConfigSchema = z.object({
-  instructions: LLMPromptOverridesSchema.optional(),
+  instructions: LLMPromptOverridesSchema.optional().describe(
+    'Per-task instruction overrides appended to the built-in prompts.',
+  ),
 });
 
 export const LLMConfigSchema = z.object({
-  provider: z.string(),
-  model: z.string(),
-  baseURL: z.string().optional(),
-  apiKey: z.string().optional(),
+  provider: z.string().describe('LLM provider'),
+  model: z.string().describe('Model identifier'),
+  baseURL: z.string().optional().describe('Custom API base URL'),
+  apiKey: z.string().optional().describe('API key'),
   options: LLMOptionsSchema.optional(),
-  concurrency: z.number().int().positive().optional(),
+  concurrency: z.number().int().positive().optional().describe('Concurrent LLM requests'),
   retry: LLMRetryConfigSchema.optional(),
   tasks: LLMTasksConfigSchema.optional(),
   categories: z.array(LLMCategorySchema).default(() => [
@@ -300,31 +338,60 @@ export const LLMConfigSchema = z.object({
     .string()
     .default(
       'Write in past tense ("Added feature", not "Add feature"). Be concise and user-focused. Lead with the impact, not the implementation detail.',
-    ),
+    )
+    .describe('Writing style for LLM'),
   scopes: ScopeConfigSchema.optional(),
   prompts: LLMPromptsConfigSchema.optional(),
-  examples: z.number().int().min(0).max(5).default(3),
+  examples: z
+    .number()
+    .int()
+    .min(0)
+    .max(5)
+    .default(3)
+    .describe('Number of few-shot examples to include in LLM prompts (0–5).'),
   context: z
     .object({
-      pullRequests: z.boolean().default(true),
+      pullRequests: z.boolean().default(true).describe('Include linked pull request titles/bodies as context.'),
     })
-    .default({ pullRequests: true }),
-  categoryOrder: z.array(z.string()).optional(),
+    .default({ pullRequests: true })
+    .describe('Additional context sources for the LLM.'),
+  categoryOrder: z
+    .array(z.string())
+    .optional()
+    .describe(
+      'Explicit ordering of categories in the output. Categories not listed retain their configured order after the listed ones.',
+    ),
 });
 
-export const ReleaseNotesConfigSchema = z.object({
-  mode: LocationModeSchema.optional(),
-  file: z.string().optional(),
-  templates: TemplateConfigSchema.optional(),
-  llm: LLMConfigSchema.optional(),
-  links: z
-    .object({
-      items: z.array(z.object({ label: z.string(), url: z.string().url() })).optional(),
-      fromPRBodyMarker: z.string().optional(),
-      title: z.string().optional(),
-    })
-    .optional(),
-});
+export const ReleaseNotesConfigSchema = z
+  .object({
+    mode: LocationModeSchema.optional().describe(
+      'Where to write release notes file. Omit to skip file output (LLM still runs if configured).',
+    ),
+    file: z.string().optional().describe('Release notes file name override (default: RELEASE_NOTES.md)'),
+    templates: TemplateConfigSchema.optional().describe('Template configuration for release notes'),
+    llm: LLMConfigSchema.optional().describe('LLM configuration for release notes'),
+    links: z
+      .object({
+        items: z
+          .array(
+            z.object({
+              label: z.string().describe('Link text'),
+              url: z.string().url().describe('Link URL'),
+            }),
+          )
+          .optional()
+          .describe('Static list of links to append.'),
+        fromPRBodyMarker: z
+          .string()
+          .optional()
+          .describe('Marker string in PR bodies; content after it is extracted and appended as links.'),
+        title: z.string().optional().describe('Heading for the links section.'),
+      })
+      .optional()
+      .describe('Extra links to append to the release notes.'),
+  })
+  .describe('Release notes configuration');
 
 export const NotesInputConfigSchema = z.object({
   source: z.string().optional(),
@@ -332,60 +399,103 @@ export const NotesInputConfigSchema = z.object({
 });
 
 export const NotesConfigSchema = z.object({
-  changelog: z.union([z.literal(false), ChangelogConfigSchema]).optional(),
-  releaseNotes: z.union([z.literal(false), ReleaseNotesConfigSchema]).optional(),
-  updateStrategy: z.enum(['prepend', 'regenerate']).optional(),
+  changelog: z
+    .union([z.literal(false).describe('Set to false to disable changelog generation'), ChangelogConfigSchema])
+    .optional(),
+  releaseNotes: z
+    .union([z.literal(false).describe('Set to false to disable release notes'), ReleaseNotesConfigSchema])
+    .optional(),
+  updateStrategy: z
+    .enum(['prepend', 'regenerate'])
+    .optional()
+    .describe(
+      "How to update existing changelog files. 'prepend' adds new entries to the top; 'regenerate' rewrites the file from scratch.",
+    ),
 });
 
 export const CILabelsConfigSchema = z.object({
-  stable: z.string().default('channel:stable'),
-  prerelease: z.string().default('channel:prerelease'),
-  skip: z.string().default('release:skip'),
-  /** Bypass the standing PR for one merge — triggers a direct release. Standing-pr mode only. */
-  immediate: z.string().default('release:immediate'),
-  /** Retry a failed publish by re-applying it to a merged standing PR. Standing-pr mode only. */
-  retry: z.string().default('release:retry'),
-  major: z.string().default('bump:major'),
-  minor: z.string().default('bump:minor'),
-  patch: z.string().default('bump:patch'),
+  stable: z.string().default('channel:stable').describe('Label to graduate a prerelease to stable'),
+  prerelease: z.string().default('channel:prerelease').describe('Label to create a prerelease'),
+  skip: z.string().default('release:skip').describe('Label to suppress a release on this PR'),
+  immediate: z
+    .string()
+    .default('release:immediate')
+    .describe('Label to bypass the standing PR for one merge — triggers a direct release. Standing-pr mode only.'),
+  retry: z
+    .string()
+    .default('release:retry')
+    .describe('Label to retry a failed publish by re-applying it to a merged standing PR. Standing-pr mode only.'),
+  major: z.string().default('bump:major').describe('Label to force a major bump'),
+  minor: z.string().default('bump:minor').describe('Label to force a minor bump'),
+  patch: z.string().default('bump:patch').describe('Label to force a patch bump'),
 });
 
 export const StandingPrConfigSchema = z.object({
-  /** Branch name for the release PR. Default: 'release/next' */
-  branch: z.string().default('release/next'),
-  /**
-   * Title template for the release PR. Variables: ${count} (publishable package count),
-   * ${version} (raw version), ${tag} (version with tag prefix). Must start with 'chore: release'
-   * to match default skip pattern on merge. When unset, the default depends on the versioning
-   * strategy: 'chore: release ${tag}' in sync mode (the repo releases as one versioned unit),
-   * 'chore: release ${count} package(s)' otherwise.
-   */
-  title: z.string().optional(),
-  /** Labels to apply to the standing release PR */
-  labels: z.array(z.string()).default(['release']),
-  /** Whether to auto-delete the release branch after PR merge. Default: true */
-  deleteBranchOnMerge: z.boolean().default(true),
-  /** Merge method to use when merging the standing release PR. Default: 'merge' */
-  mergeMethod: z.enum(['merge', 'squash', 'rebase']).default('merge'),
-  /** Minimum age of the standing PR before it can be merged. Duration string (e.g. '6h', '30m', '1d'). Gate enforced via the releasekit/standing-pr status check. */
-  minAge: z.string().optional(),
-  /** Minimum number of packages with releasable changes required to create/maintain the standing PR. Below this threshold, the PR is closed and no new PR is created. */
-  minPackages: z.number().int().positive().optional(),
+  branch: z.string().default('release/next').describe('Branch name for the standing release PR.'),
+  title: z.string().optional().describe(
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: documenting placeholder syntax to the user
+    "PR title template. Variables: ${count} (publishable package count), ${version} (raw version), ${tag} (version with tag prefix). Must start with 'chore: release' to match the default skip pattern on squash merge. Default depends on the versioning strategy: 'chore: release ${tag}' in sync mode, 'chore: release ${count} package(s)' otherwise.",
+  ),
+  labels: z.array(z.string()).default(['release']).describe('Labels to apply to the standing release PR.'),
+  deleteBranchOnMerge: z
+    .boolean()
+    .default(true)
+    .describe('Whether to auto-delete the release branch after the PR is merged.'),
+  mergeMethod: z
+    .enum(['merge', 'squash', 'rebase'])
+    .default('merge')
+    .describe('Merge method to use when merging the standing release PR via CLI.'),
+  minAge: z
+    .string()
+    .optional()
+    .describe(
+      "Minimum age of the standing PR before it can be merged. Duration string, e.g. '6h', '30m', '1d'. Gate enforced via the releasekit/standing-pr commit status check; configure it as a required status check in branch protection to block merges.",
+    ),
+  minPackages: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe(
+      'Minimum number of packages with releasable changes required to create or maintain the standing PR. Below this threshold the PR is closed and no new PR is opened.',
+    ),
 });
 
 export const CIConfigSchema = z.object({
-  releaseStrategy: z.enum(['manual', 'direct', 'standing-pr']).default('direct'),
-  releaseTrigger: z.enum(['commit', 'label']).default('label'),
-  prPreview: z.boolean().default(true),
-  autoRelease: z.boolean().default(false),
-  /**
-   * Commit message prefixes that should not trigger a release.
-   * Defaults to `['chore: release ']` to match the release commit template
-   * (`chore: release ${packageName} v${version}`) and provide a
-   * secondary loop-prevention guard alongside `[skip ci]`.
-   */
-  skipPatterns: z.array(z.string()).default(['chore: release ']),
-  minChanges: z.number().int().positive().default(1),
+  releaseStrategy: z
+    .enum(['manual', 'direct', 'standing-pr'])
+    .default('direct')
+    .describe(
+      "How releases are delivered. 'direct': release on merge to main. 'manual': releases triggered manually (e.g. workflow_dispatch). 'standing-pr': changes accumulate in a release PR; gate mode acts as the immediate-release evaluator, firing only for merges labelled with the immediate label.",
+    ),
+  releaseTrigger: z
+    .enum(['commit', 'label'])
+    .default('label')
+    .describe(
+      "What triggers a release. 'label': a PR bump label (bump:patch/minor/major) is required. 'commit': conventional commits drive the bump automatically; every merge can trigger a release.",
+    ),
+  prPreview: z
+    .boolean()
+    .default(true)
+    .describe(
+      'Enable PR preview comments showing what would be released if the PR is merged. Set to false to disable.',
+    ),
+  autoRelease: z
+    .boolean()
+    .default(false)
+    .describe('Automatically trigger a release when CI conditions are met, without manual intervention.'),
+  skipPatterns: z
+    .array(z.string())
+    .default(['chore: release '])
+    .describe(
+      'Commit message prefixes that suppress a release. The default matches the release commit template to prevent release loops.',
+    ),
+  minChanges: z
+    .number()
+    .int()
+    .positive()
+    .default(1)
+    .describe('Minimum number of packages with releasable changes required to trigger a release.'),
   labels: CILabelsConfigSchema.default({
     stable: 'channel:stable',
     prerelease: 'channel:prerelease',
@@ -395,46 +505,56 @@ export const CIConfigSchema = z.object({
     major: 'bump:major',
     minor: 'bump:minor',
     patch: 'bump:patch',
-  }),
-  /**
-   * Map of scope labels to package patterns.
-   * When a PR has a label matching a key, only packages matching the corresponding pattern will be released.
-   */
-  scopeLabels: z.record(z.string(), z.string()).optional(),
-  /** Configuration for the standing release PR feature. */
-  standingPr: StandingPrConfigSchema.optional(),
+  }).describe("PR label names used for release control. Override to match your repository's label conventions."),
+  scopeLabels: z
+    .record(z.string(), z.string())
+    .optional()
+    .describe(
+      'Map of scope labels to package patterns. When a PR has a label matching a key, only packages matching the corresponding pattern are released.',
+    ),
+  standingPr: StandingPrConfigSchema.optional().describe(
+    "Configuration for the standing release PR feature (ci.releaseStrategy: 'standing-pr').",
+  ),
 });
 
 export const ReleaseCIConfigSchema = z.object({
-  skipPatterns: z.array(z.string().min(1)).optional(),
-  minChanges: z.number().int().positive().optional(),
-  /** Set to `false` to disable GitHub release creation in CI. */
-  githubRelease: z.literal(false).optional(),
-  /** Set to `false` to disable changelog generation in CI. */
-  notes: z.literal(false).optional(),
+  skipPatterns: z
+    .array(z.string().min(1))
+    .optional()
+    .describe("Commit message prefixes that prevent a release (e.g. 'chore(deps):', 'ci:')"),
+  minChanges: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe('Minimum number of packages with releasable changes required to trigger a release'),
+  githubRelease: z.literal(false).optional().describe('Set to false to disable GitHub release creation in CI'),
+  notes: z.literal(false).optional().describe('Set to false to disable changelog generation in CI'),
 });
 
 export const ReleaseConfigSchema = z.object({
-  /**
-   * Optional steps to enable. The version step always runs; only 'notes' and
-   * 'publish' can be opted out. Omitting a step is equivalent to --skip-<step>.
-   */
   steps: z
     .array(z.enum(['notes', 'publish']))
     .min(1)
-    .optional(),
-  ci: ReleaseCIConfigSchema.optional(),
+    .optional()
+    .describe('Which steps to run by default. Omitting a step is equivalent to --skip-<step>.'),
+  ci: ReleaseCIConfigSchema.optional().describe('CI-specific automation settings'),
 });
 
-export const ReleaseKitConfigSchema = z.object({
-  git: GitConfigSchema.optional(),
-  monorepo: MonorepoConfigSchema.optional(),
-  version: VersionConfigSchema.optional(),
-  publish: PublishConfigSchema.optional(),
-  notes: NotesConfigSchema.optional(),
-  ci: CIConfigSchema.optional(),
-  release: ReleaseConfigSchema.optional(),
-});
+export const ReleaseKitConfigSchema = z
+  .object({
+    $schema: z.string().optional().describe('JSON schema reference URL'),
+    git: GitConfigSchema.optional().describe('Git configuration'),
+    monorepo: MonorepoConfigSchema.optional().describe('Monorepo configuration'),
+    version: VersionConfigSchema.optional().describe('Versioning configuration'),
+    publish: PublishConfigSchema.optional().describe('Publishing configuration'),
+    notes: NotesConfigSchema.optional().describe('Changelog and release notes configuration'),
+    ci: CIConfigSchema.optional().describe(
+      'CI automation configuration for release triggers, PR previews, and label management',
+    ),
+    release: ReleaseConfigSchema.optional().describe('Release pipeline automation configuration'),
+  })
+  .describe('Configuration schema for ReleaseKit - Automated versioning, changelog generation, and publishing');
 
 export type CIConfig = z.infer<typeof CIConfigSchema>;
 export type CILabelsConfig = z.infer<typeof CILabelsConfigSchema>;

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -271,6 +271,10 @@ export const LLMOptionsSchema = z.object({
 
 export const LLMRetryConfigSchema = z.object({
   maxAttempts: z.number().int().positive().optional().describe('Maximum number of attempts'),
+  // `.int()` here matches the generated JSON Schema (`type: integer`, `minimum`),
+  // and closes a pre-generator gap where the Zod runtime accepted floats. Keep
+  // these in sync with scripts/generate-schema.ts — relaxing one without the
+  // other re-introduces the divergence.
   initialDelay: z.number().int().nonnegative().optional().describe('Initial delay in ms'),
   maxDelay: z.number().int().positive().optional().describe('Maximum delay in ms'),
   backoffFactor: z.number().positive().optional().describe('Delay multiplier per attempt'),

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -53,7 +53,8 @@ export const VersionGroupSchema = z.object({
 });
 
 export const VersionConfigSchema = z.object({
-  tagTemplate: z.string().default('v{version}').describe(
+  // biome-ignore lint/suspicious/noTemplateCurlyInString: intentional template-placeholder syntax
+  tagTemplate: z.string().default('${prefix}${version}').describe(
     // biome-ignore lint/suspicious/noTemplateCurlyInString: documenting placeholder syntax to the user
     'Template for Git tags. Available variables: ${version} (version number), ${prefix} (versionPrefix value, e.g. \'v\'), ${packageName} (sanitized package name, e.g. \'scope-pkg\'). Example: "${packageName}-${prefix}${version}" produces "scope-pkg-v1.2.3".',
   ),

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -29,8 +29,10 @@ export const MonorepoConfigSchema = z.object({
 });
 
 export const BranchPatternSchema = z.object({
-  pattern: z.string(),
-  releaseType: z.enum(['major', 'minor', 'patch', 'prerelease']),
+  pattern: z.string().describe("Glob or regex matched against the branch name (e.g. 'release/*')"),
+  releaseType: z
+    .enum(['major', 'minor', 'patch', 'prerelease'])
+    .describe('Version bump type applied when this pattern matches'),
 });
 
 export const VersionCargoConfigSchema = z.object({
@@ -289,21 +291,34 @@ export const LLMTasksConfigSchema = z.object({
 });
 
 export const LLMCategorySchema = z.object({
-  name: z.string(),
-  description: z.string(),
-  scopes: z.array(z.string()).optional(),
+  name: z.string().describe("Category label shown in release notes (e.g. 'Features')"),
+  description: z.string().describe('LLM instruction describing what commits belong in this category'),
+  scopes: z.array(z.string()).optional().describe('Conventional commit scopes assigned to this category'),
 });
 
 export const ScopeRulesSchema = z.object({
-  allowed: z.array(z.string()).optional(),
-  caseSensitive: z.boolean().default(false),
-  invalidScopeAction: z.enum(['remove', 'keep', 'fallback']).default('remove'),
-  fallbackScope: z.string().optional(),
+  allowed: z
+    .array(z.string())
+    .optional()
+    .describe('Explicit list of valid scope names; commits with unlisted scopes trigger invalidScopeAction'),
+  caseSensitive: z.boolean().default(false).describe('Whether scope comparison is case-sensitive'),
+  invalidScopeAction: z
+    .enum(['remove', 'keep', 'fallback'])
+    .default('remove')
+    .describe(
+      "Action for commits whose scope is not in the allowed list: 'remove' strips the scope, 'keep' leaves it, 'fallback' substitutes fallbackScope",
+    ),
+  fallbackScope: z.string().optional().describe("Scope substituted when invalidScopeAction is 'fallback'"),
 });
 
 export const ScopeConfigSchema = z.object({
-  mode: z.enum(['restricted', 'packages', 'none', 'unrestricted']).default('unrestricted'),
-  rules: ScopeRulesSchema.optional(),
+  mode: z
+    .enum(['restricted', 'packages', 'none', 'unrestricted'])
+    .default('unrestricted')
+    .describe(
+      "Scope allowlist source: 'restricted' uses rules.allowed, 'packages' derives scopes from workspace package names, 'none' strips all scopes, 'unrestricted' allows any scope",
+    ),
+  rules: ScopeRulesSchema.optional().describe('Scope validation and transformation rules'),
 });
 
 export const LLMPromptOverridesSchema = z.object({

--- a/packages/config/test/unit/generate-schema.spec.ts
+++ b/packages/config/test/unit/generate-schema.spec.ts
@@ -29,6 +29,11 @@ describe('generate-schema', () => {
     it('should declare additionalProperties on every object node (no silent leniency)', () => {
       const schema = buildSchema();
       const stack: unknown[] = [schema];
+      // Collect violations as we walk the tree, then fail in a single top-level
+      // assertion. `expect` inside an `if` is flagged by vitest/no-conditional-expect
+      // and would also short-circuit on the first failure instead of surfacing all
+      // of them.
+      const violations: string[] = [];
       let objectsChecked = 0;
       while (stack.length > 0) {
         const node = stack.pop();
@@ -36,17 +41,20 @@ describe('generate-schema', () => {
         const obj = node as Record<string, unknown>;
         if (obj.type === 'object') {
           objectsChecked++;
-          // Either `false` (closed object) or an object schema (z.record value type).
-          // A bare `true` or an undeclared key would regress to the old hand-maintained
-          // schema's silent acceptance of unknown keys.
-          expect(
-            obj.additionalProperties,
-            `object node should declare additionalProperties: ${JSON.stringify(obj.properties ? Object.keys(obj.properties) : obj)}`,
-          ).toBeDefined();
-          expect(obj.additionalProperties).not.toBe(true);
+          if (obj.additionalProperties === undefined) {
+            // Either `false` (closed object) or an object schema (z.record value type).
+            // A bare `true` or an undeclared key would regress to the old
+            // hand-maintained schema's silent acceptance of unknown keys.
+            violations.push(
+              `object node missing additionalProperties: ${JSON.stringify(obj.properties ? Object.keys(obj.properties) : obj)}`,
+            );
+          } else if (obj.additionalProperties === true) {
+            violations.push('object node has additionalProperties: true (silent leniency)');
+          }
         }
         for (const value of Object.values(obj)) stack.push(value);
       }
+      expect(violations).toEqual([]);
       expect(objectsChecked).toBeGreaterThan(10);
     });
 

--- a/packages/config/test/unit/generate-schema.spec.ts
+++ b/packages/config/test/unit/generate-schema.spec.ts
@@ -1,0 +1,71 @@
+/**
+ * Tests for scripts/generate-schema.ts.
+ *
+ * These pin the contract the generated releasekit.schema.json must keep:
+ * draft-07 top-level metadata, additionalProperties declared on every object
+ * (so editors/ajv reject unknown keys), and the Zod `.describe()` text carried
+ * through to the schema. Drift here silently breaks editor autocompletion and
+ * the examples-validate ajv workflow.
+ */
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { buildSchema, serialiseSchema } from '../../../../scripts/generate-schema.ts';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../../..');
+
+describe('generate-schema', () => {
+  describe('buildSchema()', () => {
+    it('should emit draft-07 metadata at the top level', () => {
+      const schema = buildSchema() as Record<string, unknown>;
+      expect(schema.$schema).toBe('http://json-schema.org/draft-07/schema#');
+      expect(schema.$id).toBe('https://goosewobbler.github.io/releasekit/schema.json');
+      expect(schema.title).toBe('ReleaseKit Configuration');
+      expect(typeof schema.description).toBe('string');
+      expect((schema.description as string).length).toBeGreaterThan(0);
+    });
+
+    it('should declare additionalProperties on every object node (no silent leniency)', () => {
+      const schema = buildSchema();
+      const stack: unknown[] = [schema];
+      let objectsChecked = 0;
+      while (stack.length > 0) {
+        const node = stack.pop();
+        if (!node || typeof node !== 'object') continue;
+        const obj = node as Record<string, unknown>;
+        if (obj.type === 'object') {
+          objectsChecked++;
+          // Either `false` (closed object) or an object schema (z.record value type).
+          // A bare `true` or an undeclared key would regress to the old hand-maintained
+          // schema's silent acceptance of unknown keys.
+          expect(
+            obj.additionalProperties,
+            `object node should declare additionalProperties: ${JSON.stringify(obj.properties ? Object.keys(obj.properties) : obj)}`,
+          ).toBeDefined();
+          expect(obj.additionalProperties).not.toBe(true);
+        }
+        for (const value of Object.values(obj)) stack.push(value);
+      }
+      expect(objectsChecked).toBeGreaterThan(10);
+    });
+
+    it('should carry Zod .describe() text through to field descriptions', () => {
+      const schema = buildSchema() as {
+        properties?: Record<string, { properties?: Record<string, { description?: string }> }>;
+      };
+      // ci.scopeLabels is the field #277 is about — it must keep its description
+      // (an empty description here is the exact regression this generator prevents).
+      const scopeLabels = schema.properties?.ci?.properties?.scopeLabels;
+      expect(scopeLabels?.description).toBeDefined();
+      expect((scopeLabels?.description ?? '').length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('serialiseSchema()', () => {
+    it('should match the committed releasekit.schema.json (no drift)', () => {
+      const committed = readFileSync(resolve(ROOT, 'releasekit.schema.json'), 'utf8');
+      expect(serialiseSchema()).toBe(committed);
+    });
+  });
+});

--- a/packages/config/test/unit/schema.spec.ts
+++ b/packages/config/test/unit/schema.spec.ts
@@ -90,7 +90,8 @@ describe('BranchPatternSchema', () => {
 describe('VersionConfigSchema', () => {
   it('should apply defaults', () => {
     const result = VersionConfigSchema.parse({});
-    expect(result.tagTemplate).toBe('v{version}');
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: checking the literal default string
+    expect(result.tagTemplate).toBe('${prefix}${version}');
     expect(result.packageSpecificTags).toBe(false);
     expect(result.preset).toBe('conventional');
     expect(result.sync).toBe(true);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,6 +101,9 @@ importers:
       yaml:
         specifier: 'catalog:'
         version: 2.8.3
+      zod:
+        specifier: 'catalog:'
+        version: 4.4.3
 
   packages/config:
     dependencies:

--- a/releasekit.schema.json
+++ b/releasekit.schema.json
@@ -82,7 +82,7 @@
       "properties": {
         "tagTemplate": {
           "type": "string",
-          "default": "v{version}",
+          "default": "${prefix}${version}",
           "description": "Template for Git tags. Available variables: ${version} (version number), ${prefix} (versionPrefix value, e.g. 'v'), ${packageName} (sanitized package name, e.g. 'scope-pkg'). Example: \"${packageName}-${prefix}${version}\" produces \"scope-pkg-v1.2.3\"."
         },
         "baselineTagTemplate": {

--- a/releasekit.schema.json
+++ b/releasekit.schema.json
@@ -188,7 +188,8 @@
             "additionalProperties": false,
             "properties": {
               "pattern": {
-                "type": "string"
+                "type": "string",
+                "description": "Glob or regex matched against the branch name (e.g. 'release/*')"
               },
               "releaseType": {
                 "type": "string",
@@ -197,7 +198,8 @@
                   "minor",
                   "patch",
                   "prerelease"
-                ]
+                ],
+                "description": "Version bump type applied when this pattern matches"
               }
             },
             "required": [
@@ -752,16 +754,19 @@
                         "additionalProperties": false,
                         "properties": {
                           "name": {
-                            "type": "string"
+                            "type": "string",
+                            "description": "Category label shown in release notes (e.g. 'Features')"
                           },
                           "description": {
-                            "type": "string"
+                            "type": "string",
+                            "description": "LLM instruction describing what commits belong in this category"
                           },
                           "scopes": {
                             "type": "array",
                             "items": {
                               "type": "string"
-                            }
+                            },
+                            "description": "Conventional commit scopes assigned to this category"
                           }
                         },
                         "required": [
@@ -786,7 +791,8 @@
                             "none",
                             "unrestricted"
                           ],
-                          "default": "unrestricted"
+                          "default": "unrestricted",
+                          "description": "Scope allowlist source: 'restricted' uses rules.allowed, 'packages' derives scopes from workspace package names, 'none' strips all scopes, 'unrestricted' allows any scope"
                         },
                         "rules": {
                           "type": "object",
@@ -796,11 +802,13 @@
                               "type": "array",
                               "items": {
                                 "type": "string"
-                              }
+                              },
+                              "description": "Explicit list of valid scope names; commits with unlisted scopes trigger invalidScopeAction"
                             },
                             "caseSensitive": {
                               "type": "boolean",
-                              "default": false
+                              "default": false,
+                              "description": "Whether scope comparison is case-sensitive"
                             },
                             "invalidScopeAction": {
                               "type": "string",
@@ -809,12 +817,15 @@
                                 "keep",
                                 "fallback"
                               ],
-                              "default": "remove"
+                              "default": "remove",
+                              "description": "Action for commits whose scope is not in the allowed list: 'remove' strips the scope, 'keep' leaves it, 'fallback' substitutes fallbackScope"
                             },
                             "fallbackScope": {
-                              "type": "string"
+                              "type": "string",
+                              "description": "Scope substituted when invalidScopeAction is 'fallback'"
                             }
-                          }
+                          },
+                          "description": "Scope validation and transformation rules"
                         }
                       }
                     },

--- a/releasekit.schema.json
+++ b/releasekit.schema.json
@@ -2,7 +2,6 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://goosewobbler.github.io/releasekit/schema.json",
   "title": "ReleaseKit Configuration",
-  "description": "Configuration schema for ReleaseKit - Automated versioning, changelog generation, and publishing",
   "type": "object",
   "additionalProperties": false,
   "properties": {
@@ -12,7 +11,6 @@
     },
     "git": {
       "type": "object",
-      "description": "Git configuration",
       "additionalProperties": false,
       "properties": {
         "remote": {
@@ -47,11 +45,11 @@
           "type": "boolean",
           "description": "Skip Git hooks when committing"
         }
-      }
+      },
+      "description": "Git configuration"
     },
     "monorepo": {
       "type": "object",
-      "description": "Monorepo configuration",
       "additionalProperties": false,
       "properties": {
         "mode": {
@@ -75,16 +73,16 @@
           "type": "string",
           "description": "Main package name for versioning"
         }
-      }
+      },
+      "description": "Monorepo configuration"
     },
     "version": {
       "type": "object",
-      "description": "Versioning configuration",
       "additionalProperties": false,
       "properties": {
         "tagTemplate": {
           "type": "string",
-          "default": "${prefix}${version}",
+          "default": "v{version}",
           "description": "Template for Git tags. Available variables: ${version} (version number), ${prefix} (versionPrefix value, e.g. 'v'), ${packageName} (sanitized package name, e.g. 'scope-pkg'). Example: \"${packageName}-${prefix}${version}\" produces \"scope-pkg-v1.2.3\"."
         },
         "baselineTagTemplate": {
@@ -109,17 +107,16 @@
         },
         "groups": {
           "type": "object",
-          "description": "Named version groups. Each group binds a set of package patterns to a fixed or linked sync mode. fixed: any releasable change in any member releases ALL members at the shared group version (bump(max(member baselines))). linked: only members with releasable changes release, but every releasing member shares the same computed version. Packages not matched by any group version independently. A package may belong to at most one group. Set version.sync to false when using groups.",
           "additionalProperties": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
               "packages": {
                 "type": "array",
+                "minItems": 1,
                 "items": {
                   "type": "string"
                 },
-                "minItems": 1,
                 "description": "Package patterns (exact names, @scope/*, or globs) whose matched packages form this group. Same matching rules as version.packages."
               },
               "sync": {
@@ -135,14 +132,18 @@
               "packages",
               "sync"
             ]
+          },
+          "description": "Named version groups. Each group binds a set of package patterns to a fixed or linked sync mode. fixed: any releasable change in any member releases ALL members at the shared group version (bump(max(member baselines))). linked: only members with releasable changes release, but every releasing member shares the same computed version. Packages not matched by any group version independently. A package may belong to at most one group. Set version.sync to false when using groups.",
+          "propertyNames": {
+            "type": "string"
           }
         },
         "packages": {
           "type": "array",
+          "default": [],
           "items": {
             "type": "string"
           },
-          "default": [],
           "description": "Packages to include in versioning"
         },
         "mainPackage": {
@@ -184,6 +185,7 @@
           "type": "array",
           "items": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
               "pattern": {
                 "type": "string"
@@ -252,7 +254,6 @@
         },
         "cargo": {
           "type": "object",
-          "description": "Cargo/Rust configuration",
           "additionalProperties": false,
           "properties": {
             "enabled": {
@@ -267,18 +268,19 @@
               },
               "description": "Directories to search for Cargo.toml files"
             }
-          }
+          },
+          "description": "Cargo/Rust configuration"
         }
-      }
+      },
+      "description": "Versioning configuration"
     },
     "publish": {
       "type": "object",
-      "description": "Publishing configuration",
       "additionalProperties": false,
       "properties": {
         "git": {
           "type": "object",
-          "description": "Git publishing options",
+          "additionalProperties": false,
           "properties": {
             "push": {
               "type": "boolean",
@@ -310,11 +312,11 @@
               "type": "boolean",
               "description": "Skip Git hooks when committing"
             }
-          }
+          },
+          "description": "Git publishing options"
         },
         "npm": {
           "type": "object",
-          "description": "NPM publishing configuration",
           "additionalProperties": false,
           "properties": {
             "enabled": {
@@ -353,12 +355,12 @@
             },
             "copyFiles": {
               "type": "array",
-              "items": {
-                "type": "string"
-              },
               "default": [
                 "LICENSE"
               ],
+              "items": {
+                "type": "string"
+              },
               "description": "Files to copy to package before publishing"
             },
             "tag": {
@@ -366,11 +368,11 @@
               "default": "latest",
               "description": "NPM dist tag"
             }
-          }
+          },
+          "description": "NPM publishing configuration"
         },
         "cargo": {
           "type": "object",
-          "description": "Cargo publishing configuration",
           "additionalProperties": false,
           "properties": {
             "enabled": {
@@ -385,10 +387,10 @@
             },
             "publishOrder": {
               "type": "array",
+              "default": [],
               "items": {
                 "type": "string"
               },
-              "default": [],
               "description": "Order in which to publish packages"
             },
             "clean": {
@@ -396,11 +398,11 @@
               "default": false,
               "description": "Clean before publishing"
             }
-          }
+          },
+          "description": "Cargo publishing configuration"
         },
         "githubRelease": {
           "type": "object",
-          "description": "GitHub Release configuration",
           "additionalProperties": false,
           "properties": {
             "enabled": {
@@ -419,6 +421,7 @@
               "description": "Create separate release per package"
             },
             "prerelease": {
+              "default": "auto",
               "oneOf": [
                 {
                   "type": "boolean"
@@ -430,7 +433,6 @@
                   ]
                 }
               ],
-              "default": "auto",
               "description": "Mark as prerelease"
             },
             "body": {
@@ -449,12 +451,20 @@
               "type": "string",
               "default": "${packageName}: ${version}",
               "description": "Template for the GitHub release title when a package name is resolved. Available variables: ${packageName} (original scoped name, e.g. '@scope/pkg'), ${version} (e.g. 'v1.0.0'). Version-only tags always use the tag string directly."
+            },
+            "skipPackages": {
+              "type": "array",
+              "default": [],
+              "items": {
+                "type": "string"
+              },
+              "description": "Package names to exclude from GitHub release creation"
             }
-          }
+          },
+          "description": "GitHub Release configuration"
         },
         "verify": {
           "type": "object",
-          "description": "Registry verification configuration",
           "additionalProperties": false,
           "properties": {
             "npm": {
@@ -515,13 +525,14 @@
                 }
               }
             }
-          }
+          },
+          "description": "Registry verification configuration"
         }
-      }
+      },
+      "description": "Publishing configuration"
     },
     "notes": {
       "type": "object",
-      "description": "Changelog and release notes configuration",
       "additionalProperties": false,
       "properties": {
         "changelog": {
@@ -535,7 +546,6 @@
             },
             {
               "type": "object",
-              "description": "Changelog file configuration",
               "additionalProperties": false,
               "properties": {
                 "mode": {
@@ -553,7 +563,6 @@
                 },
                 "templates": {
                   "type": "object",
-                  "description": "Template configuration for changelog",
                   "additionalProperties": false,
                   "properties": {
                     "path": {
@@ -569,9 +578,11 @@
                       ],
                       "description": "Template engine"
                     }
-                  }
+                  },
+                  "description": "Template configuration for changelog"
                 }
-              }
+              },
+              "description": "Changelog file configuration"
             }
           ]
         },
@@ -586,7 +597,6 @@
             },
             {
               "type": "object",
-              "description": "Release notes configuration",
               "additionalProperties": false,
               "properties": {
                 "mode": {
@@ -604,7 +614,6 @@
                 },
                 "templates": {
                   "type": "object",
-                  "description": "Template configuration for release notes",
                   "additionalProperties": false,
                   "properties": {
                     "path": {
@@ -620,11 +629,11 @@
                       ],
                       "description": "Template engine"
                     }
-                  }
+                  },
+                  "description": "Template configuration for release notes"
                 },
                 "llm": {
                   "type": "object",
-                  "description": "LLM configuration for release notes",
                   "additionalProperties": false,
                   "properties": {
                     "provider": {
@@ -666,6 +675,32 @@
                       "minimum": 1,
                       "description": "Concurrent LLM requests"
                     },
+                    "retry": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "maxAttempts": {
+                          "type": "integer",
+                          "minimum": 1,
+                          "description": "Maximum number of attempts"
+                        },
+                        "initialDelay": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "description": "Initial delay in ms"
+                        },
+                        "maxDelay": {
+                          "type": "integer",
+                          "minimum": 1,
+                          "description": "Maximum delay in ms"
+                        },
+                        "backoffFactor": {
+                          "type": "number",
+                          "minimum": 1,
+                          "description": "Delay multiplier per attempt"
+                        }
+                      }
+                    },
                     "tasks": {
                       "type": "object",
                       "additionalProperties": false,
@@ -690,6 +725,28 @@
                     },
                     "categories": {
                       "type": "array",
+                      "default": [
+                        {
+                          "name": "Breaking",
+                          "description": "Breaking changes that require user action to upgrade"
+                        },
+                        {
+                          "name": "New",
+                          "description": "New features and capabilities"
+                        },
+                        {
+                          "name": "Changed",
+                          "description": "Changes to existing functionality"
+                        },
+                        {
+                          "name": "Fixed",
+                          "description": "Bug fixes"
+                        },
+                        {
+                          "name": "Developer",
+                          "description": "Internal changes: CI, tooling, dependencies, refactoring"
+                        }
+                      ],
                       "items": {
                         "type": "object",
                         "additionalProperties": false,
@@ -761,32 +818,6 @@
                         }
                       }
                     },
-                    "retry": {
-                      "type": "object",
-                      "additionalProperties": false,
-                      "properties": {
-                        "maxAttempts": {
-                          "type": "integer",
-                          "minimum": 1,
-                          "description": "Maximum number of attempts"
-                        },
-                        "initialDelay": {
-                          "type": "integer",
-                          "minimum": 0,
-                          "description": "Initial delay in ms"
-                        },
-                        "maxDelay": {
-                          "type": "integer",
-                          "minimum": 0,
-                          "description": "Maximum delay in ms"
-                        },
-                        "backoffFactor": {
-                          "type": "number",
-                          "minimum": 1,
-                          "description": "Delay multiplier per attempt"
-                        }
-                      }
-                    },
                     "prompts": {
                       "type": "object",
                       "additionalProperties": false,
@@ -794,7 +825,6 @@
                         "instructions": {
                           "type": "object",
                           "additionalProperties": false,
-                          "description": "Per-task instruction overrides appended to the built-in prompts.",
                           "properties": {
                             "enhance": {
                               "type": "string",
@@ -816,7 +846,8 @@
                               "type": "string",
                               "description": "Instruction override for the release-notes task"
                             }
-                          }
+                          },
+                          "description": "Per-task instruction overrides appended to the built-in prompts."
                         }
                       }
                     },
@@ -830,14 +861,14 @@
                     "context": {
                       "type": "object",
                       "additionalProperties": false,
-                      "description": "Additional context sources for the LLM.",
                       "properties": {
                         "pullRequests": {
                           "type": "boolean",
                           "default": true,
                           "description": "Include linked pull request titles/bodies as context."
                         }
-                      }
+                      },
+                      "description": "Additional context sources for the LLM."
                     },
                     "categoryOrder": {
                       "type": "array",
@@ -850,12 +881,12 @@
                   "required": [
                     "provider",
                     "model"
-                  ]
+                  ],
+                  "description": "LLM configuration for release notes"
                 },
                 "links": {
                   "type": "object",
                   "additionalProperties": false,
-                  "description": "Extra links to append to the release notes.",
                   "properties": {
                     "items": {
                       "type": "array",
@@ -888,9 +919,11 @@
                       "type": "string",
                       "description": "Heading for the links section."
                     }
-                  }
+                  },
+                  "description": "Extra links to append to the release notes."
                 }
-              }
+              },
+              "description": "Release notes configuration"
             }
           ]
         },
@@ -902,11 +935,11 @@
           ],
           "description": "How to update existing changelog files. 'prepend' adds new entries to the top; 'regenerate' rewrites the file from scratch."
         }
-      }
+      },
+      "description": "Changelog and release notes configuration"
     },
     "ci": {
       "type": "object",
-      "description": "CI automation configuration for release triggers, PR previews, and label management",
       "additionalProperties": false,
       "properties": {
         "releaseStrategy": {
@@ -940,12 +973,12 @@
         },
         "skipPatterns": {
           "type": "array",
-          "items": {
-            "type": "string"
-          },
           "default": [
             "chore: release "
           ],
+          "items": {
+            "type": "string"
+          },
           "description": "Commit message prefixes that suppress a release. The default matches the release commit template to prevent release loops."
         },
         "minChanges": {
@@ -956,7 +989,6 @@
         },
         "labels": {
           "type": "object",
-          "description": "PR label names used for release control. Override to match your repository's label conventions.",
           "additionalProperties": false,
           "properties": {
             "stable": {
@@ -999,18 +1031,21 @@
               "default": "bump:patch",
               "description": "Label to force a patch bump"
             }
-          }
+          },
+          "description": "PR label names used for release control. Override to match your repository's label conventions."
         },
         "scopeLabels": {
           "type": "object",
           "additionalProperties": {
             "type": "string"
           },
-          "description": "Map of scope labels to package patterns. When a PR has a label matching a key, only packages matching the corresponding pattern are released."
+          "description": "Map of scope labels to package patterns. When a PR has a label matching a key, only packages matching the corresponding pattern are released.",
+          "propertyNames": {
+            "type": "string"
+          }
         },
         "standingPr": {
           "type": "object",
-          "description": "Configuration for the standing release PR feature (ci.releaseStrategy: 'standing-pr').",
           "additionalProperties": false,
           "properties": {
             "branch": {
@@ -1024,12 +1059,12 @@
             },
             "labels": {
               "type": "array",
-              "items": {
-                "type": "string"
-              },
               "default": [
                 "release"
               ],
+              "items": {
+                "type": "string"
+              },
               "description": "Labels to apply to the standing release PR."
             },
             "deleteBranchOnMerge": {
@@ -1056,17 +1091,19 @@
               "minimum": 1,
               "description": "Minimum number of packages with releasable changes required to create or maintain the standing PR. Below this threshold the PR is closed and no new PR is opened."
             }
-          }
+          },
+          "description": "Configuration for the standing release PR feature (ci.releaseStrategy: 'standing-pr')."
         }
-      }
+      },
+      "description": "CI automation configuration for release triggers, PR previews, and label management"
     },
     "release": {
       "type": "object",
-      "description": "Release pipeline automation configuration",
       "additionalProperties": false,
       "properties": {
         "steps": {
           "type": "array",
+          "minItems": 1,
           "items": {
             "type": "string",
             "enum": [
@@ -1074,12 +1111,10 @@
               "publish"
             ]
           },
-          "minItems": 1,
           "description": "Which steps to run by default. Omitting a step is equivalent to --skip-<step>."
         },
         "ci": {
           "type": "object",
-          "description": "CI-specific automation settings",
           "additionalProperties": false,
           "properties": {
             "skipPatterns": {
@@ -1109,9 +1144,12 @@
               ],
               "description": "Set to false to disable changelog generation in CI"
             }
-          }
+          },
+          "description": "CI-specific automation settings"
         }
-      }
+      },
+      "description": "Release pipeline automation configuration"
     }
-  }
+  },
+  "description": "Configuration schema for ReleaseKit - Automated versioning, changelog generation, and publishing"
 }

--- a/scripts/generate-schema.ts
+++ b/scripts/generate-schema.ts
@@ -1,0 +1,262 @@
+#!/usr/bin/env tsx
+/**
+ * Generates releasekit.schema.json from the Zod schema (single source of truth).
+ *
+ * Pipeline:
+ *   packages/config/src/schema.ts  (Zod, with .describe() on every field)
+ *     → z.toJSONSchema()           (JSON Schema draft-7)
+ *     → post-processing            (this file)
+ *     → releasekit.schema.json     (consumed by editors + ajv + docs:config)
+ *
+ * Usage:
+ *   pnpm schema:gen     write releasekit.schema.json
+ *   pnpm schema:check   verify the committed file matches (exits non-zero on drift)
+ *
+ * Never hand-edit releasekit.schema.json — edit the Zod schema and regenerate.
+ *
+ * Why native z.toJSONSchema (zod v4) rather than zod-to-json-schema:
+ *   the repo is on zod v4, and zod-to-json-schema only reads zod v3 internals
+ *   (it emits an empty schema against the v4 definitions). zod v4 ships a native
+ *   JSON Schema exporter that reads the v4 schema directly. We post-process its
+ *   output so the result stays drop-in compatible with the existing editor
+ *   ($schema URL), ajv (draft-7, strict=false), and docs:config consumers.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { z } from 'zod';
+import { ReleaseKitConfigSchema } from '../packages/config/src/schema.ts';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const ROOT = resolve(__dirname, '..');
+const SCHEMA_PATH = resolve(ROOT, 'releasekit.schema.json');
+
+// Top-level metadata kept identical to the consumers' expectations (editor
+// $schema URL, $id, human title, description). Set here explicitly — zod's
+// root .describe() is not reliably carried to the document root by the exporter.
+const META = {
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  $id: 'https://goosewobbler.github.io/releasekit/schema.json',
+  title: 'ReleaseKit Configuration',
+  description: 'Configuration schema for ReleaseKit - Automated versioning, changelog generation, and publishing',
+} as const;
+
+// The JS safe-integer ceiling zod attaches to every `.int()`. It carries no
+// real constraint for config values, so we drop it (the hand-maintained schema
+// never had it).
+const INT_SENTINEL_MAX = 9007199254740991;
+
+type JsonSchema = Record<string, unknown>;
+
+function isPlainObject(value: unknown): value is JsonSchema {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Recursively normalise zod's draft-7 output into the shape the rest of the
+ * toolchain expects:
+ *   - anyOf → oneOf (the config unions are mutually exclusive; the docs
+ *     generator and the original schema both use oneOf)
+ *   - const X → enum [X] (boolean-false literals and the 'auto' literal; the
+ *     docs generator reads `enum`, not `const`)
+ *   - exclusiveMinimum: 0 → minimum: 1 (positive ints/numbers; matches the
+ *     reviewed hand-maintained schema)
+ *   - strip the int safe-integer sentinel maximum
+ *   - additionalProperties: false on every object literal (preserves the
+ *     editor/ajv strictness of the hand-maintained schema WITHOUT making the
+ *     Zod parser strict — load.ts still strips unknown keys leniently)
+ */
+function normalise(node: unknown): unknown {
+  if (Array.isArray(node)) {
+    return node.map(normalise);
+  }
+  if (!isPlainObject(node)) {
+    return node;
+  }
+
+  const out: JsonSchema = {};
+  for (const [key, value] of Object.entries(node)) {
+    if (key === 'anyOf') {
+      out.oneOf = normalise(value);
+      continue;
+    }
+    if (key === 'const') {
+      // const → single-value enum; preserve the existing type alongside it.
+      out.enum = [value];
+      continue;
+    }
+    if (key === 'maximum' && value === INT_SENTINEL_MAX) {
+      continue;
+    }
+    if (key === 'minimum' && value === -INT_SENTINEL_MAX) {
+      // zod's lower safe-integer sentinel for unbounded `.int()` — drop it.
+      continue;
+    }
+    if (key === 'exclusiveMinimum' && value === 0) {
+      out.minimum = 1;
+      continue;
+    }
+    out[key] = normalise(value);
+  }
+
+  // Drop `default` on object schemas. zod attaches the full default object of
+  // every defaulted container (publish.npm, ci.labels, verify, …); the
+  // hand-maintained schema never carried these and they bloat both the file and
+  // the generated docs. Scalar and array defaults on leaf fields are kept —
+  // they are the documented, user-facing defaults.
+  if (out.type === 'object' && 'default' in out) {
+    delete out.default;
+  }
+
+  // Drop verbose prose defaults (e.g. the LLM writing-style guidance). These
+  // read poorly in the generated docs' per-field default column and are
+  // documented in prose elsewhere; the short, enumerable defaults stay.
+  if (typeof out.default === 'string' && out.default.length > 80) {
+    delete out.default;
+  }
+
+  // Add additionalProperties: false to object literals that declare their own
+  // properties and don't already constrain additionalProperties (record/map
+  // schemas such as version.groups and ci.scopeLabels keep their schema-valued
+  // additionalProperties untouched).
+  if (out.type === 'object' && 'properties' in out && !('additionalProperties' in out)) {
+    out.additionalProperties = false;
+  }
+
+  return out;
+}
+
+// Stable, readable keyword ordering matching the hand-maintained schema's
+// convention. Applied only to JSON Schema *keyword* keys of a schema node —
+// never to the field-name keys inside `properties` (definition order is
+// meaningful there) nor to raw `default` data.
+const KEY_ORDER = [
+  '$schema',
+  '$id',
+  'title',
+  'type',
+  'enum',
+  'const',
+  'pattern',
+  'format',
+  'minimum',
+  'maximum',
+  'minLength',
+  'minItems',
+  'default',
+  'additionalProperties',
+  'properties',
+  'items',
+  'oneOf',
+  'anyOf',
+  'required',
+  'description',
+];
+
+function orderedKeywordKeys(keys: string[]): string[] {
+  return [...keys].sort((a, b) => {
+    const ia = KEY_ORDER.indexOf(a);
+    const ib = KEY_ORDER.indexOf(b);
+    if (ia === -1 && ib === -1) return a.localeCompare(b);
+    if (ia === -1) return 1;
+    if (ib === -1) return -1;
+    return ia - ib;
+  });
+}
+
+/**
+ * Reorder the keyword keys of a JSON Schema node for readable, stable output.
+ * Recurses through schema-bearing positions (`properties` values, `items`,
+ * `oneOf`/`anyOf` members, schema-valued `additionalProperties`) but preserves
+ * the insertion order of property names and never rewrites `default`/`enum`
+ * data values.
+ */
+function orderSchemaNode(node: unknown): unknown {
+  if (!isPlainObject(node)) {
+    return node;
+  }
+  const out: JsonSchema = {};
+  for (const key of orderedKeywordKeys(Object.keys(node))) {
+    const value = node[key];
+    if (key === 'properties' && isPlainObject(value)) {
+      // Preserve field-name (definition) order; order each field's schema node.
+      const props: JsonSchema = {};
+      for (const field of Object.keys(value)) {
+        props[field] = orderSchemaNode(value[field]);
+      }
+      out[key] = props;
+    } else if (key === 'items') {
+      out[key] = Array.isArray(value) ? value.map(orderSchemaNode) : orderSchemaNode(value);
+    } else if (key === 'oneOf' || key === 'anyOf' || key === 'allOf') {
+      out[key] = Array.isArray(value) ? value.map(orderSchemaNode) : value;
+    } else if (key === 'additionalProperties' && isPlainObject(value)) {
+      // Record/map value schema (e.g. version.groups, ci.scopeLabels).
+      out[key] = orderSchemaNode(value);
+    } else {
+      // type, enum, default, description, required, etc. — leave data as-is.
+      out[key] = value;
+    }
+  }
+  return out;
+}
+
+export function buildSchema(): JsonSchema {
+  const raw = z.toJSONSchema(ReleaseKitConfigSchema, { target: 'draft-7', io: 'input' }) as JsonSchema;
+
+  // zod emits its own $schema plus the body (description/type/properties/...);
+  // drop it and prepend our canonical metadata ($schema/$id/title).
+  const { $schema: _drop, ...body } = raw;
+  const normalisedBody = normalise(body) as JsonSchema;
+
+  const assembled: JsonSchema = {
+    ...META,
+    ...normalisedBody,
+  };
+
+  return orderSchemaNode(assembled) as JsonSchema;
+}
+
+export function serialiseSchema(): string {
+  // 2-space indent + trailing newline to match biome's JSON formatting.
+  return `${JSON.stringify(buildSchema(), null, 2)}\n`;
+}
+
+function main(): void {
+  const checkMode = process.argv.includes('--check');
+  const generated = serialiseSchema();
+
+  if (checkMode) {
+    let current: string;
+    try {
+      current = readFileSync(SCHEMA_PATH, 'utf8');
+    } catch {
+      current = '';
+    }
+    if (current !== generated) {
+      console.error(
+        'releasekit.schema.json is out of date with the Zod schema.\n' + 'Run `pnpm schema:gen` and commit the result.',
+      );
+      // Show what changed so the failure is actionable in CI logs.
+      try {
+        execFileSync('git', ['--no-pager', 'diff', '--no-color', SCHEMA_PATH], { cwd: ROOT, stdio: 'inherit' });
+      } catch {
+        // git unavailable or file untracked — the message above is enough.
+      }
+      process.exit(1);
+    }
+    console.log('releasekit.schema.json is up to date.');
+    return;
+  }
+
+  writeFileSync(SCHEMA_PATH, generated, 'utf8');
+  console.log(`Generated: ${SCHEMA_PATH}`);
+}
+
+// Run only when invoked directly — importing this module (e.g. from the
+// generator's unit test) must not write the schema file as a side effect.
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/scripts/generate-schema.ts
+++ b/scripts/generate-schema.ts
@@ -22,9 +22,10 @@
  *   ($schema URL), ajv (draft-7, strict=false), and docs:config consumers.
  */
 
-import { execFileSync } from 'node:child_process';
-import { readFileSync, writeFileSync } from 'node:fs';
-import { dirname, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { z } from 'zod';
 import { ReleaseKitConfigSchema } from '../packages/config/src/schema.ts';
@@ -224,6 +225,52 @@ export function serialiseSchema(): string {
   return `${JSON.stringify(buildSchema(), null, 2)}\n`;
 }
 
+/**
+ * Print a unified diff between two strings to stderr. Inlined here so the
+ * --check failure stays diagnostic in CI, where the working tree is clean
+ * and `git diff` against the file produces no output (the file on disk
+ * was never regenerated).
+ *
+ * Uses the host's `diff` binary via two temp files. `diff` is a no-op on
+ * Windows, so the function falls back to a line-by-line diff if the binary
+ * is missing or fails.
+ */
+function printUnifiedDiff(before: string, after: string, label: string): void {
+  const dir = mkdtempSync(join(tmpdir(), 'schema-check-'));
+  const beforePath = join(dir, 'before.json');
+  const afterPath = join(dir, 'after.json');
+  try {
+    writeFileSync(beforePath, before);
+    writeFileSync(afterPath, after);
+    const result = spawnSync(
+      'diff',
+      ['-u', `--label=${label} (committed)`, `--label=${label} (generated)`, beforePath, afterPath],
+      { encoding: 'utf8' },
+    );
+    if (result.stdout) process.stderr.write(result.stdout);
+    if (result.stderr) process.stderr.write(result.stderr);
+    if (result.status === 127 || result.error) {
+      // `diff` not on PATH — fall back to a line-by-line diff. Good enough
+      // for diagnostic output on a (typically small) schema file.
+      printLineDiffFallback(before, after, label);
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function printLineDiffFallback(before: string, after: string, label: string): void {
+  process.stderr.write(`--- ${label} (committed)\n+++ ${label} (generated)\n`);
+  const beforeLines = before.split('\n');
+  const afterLines = after.split('\n');
+  for (let i = 0; i < Math.max(beforeLines.length, afterLines.length); i++) {
+    if (beforeLines[i] !== afterLines[i]) {
+      if (beforeLines[i] !== undefined) process.stderr.write(`- ${beforeLines[i]}\n`);
+      if (afterLines[i] !== undefined) process.stderr.write(`+ ${afterLines[i]}\n`);
+    }
+  }
+}
+
 function main(): void {
   const checkMode = process.argv.includes('--check');
   const generated = serialiseSchema();
@@ -239,12 +286,12 @@ function main(): void {
       console.error(
         'releasekit.schema.json is out of date with the Zod schema.\n' + 'Run `pnpm schema:gen` and commit the result.',
       );
-      // Show what changed so the failure is actionable in CI logs.
-      try {
-        execFileSync('git', ['--no-pager', 'diff', '--no-color', SCHEMA_PATH], { cwd: ROOT, stdio: 'inherit' });
-      } catch {
-        // git unavailable or file untracked — the message above is enough.
-      }
+      // Print a unified diff between the committed file and the freshly
+      // generated content. `git diff` is useless here: in a CI clean checkout
+      // the on-disk file matches HEAD (the file was never regenerated), so the
+      // diff against the working tree is empty. Diffing the two strings inline
+      // surfaces the actual drift.
+      printUnifiedDiff(current, generated, SCHEMA_PATH);
       process.exit(1);
     }
     console.log('releasekit.schema.json is up to date.');


### PR DESCRIPTION
Durable fix for #277: `releasekit.schema.json` is generated from the Zod schema, eliminating the manual Zod↔JSON-Schema sync that let `ci.scopeLabels` drift out of the schema in the first place.

## Why this over the alternative

Two durable implementations existed; this one was chosen after a head-to-head:

- **Descriptions preserved.** This keeps all field descriptions (166) by migrating the reviewed text into Zod `.describe()`; the alternative dropped ~18, including `scopeLabels` itself (empty description) — defeating the editor-hint/docs purpose. A generator test now asserts `scopeLabels` keeps a non-empty description so that regression can't recur.
- **Correct verify defaults with descriptions** (npm 5/15000, cargo 10/30000 — matching the real Zod, fixing the hand-maintained schema's wrong `10/30000` base).
- **More surgical** `schema.ts` diff and CI wired into the existing `lint` job (no extra workflow).

### Folded in from the discarded implementation
- A **dedicated generator unit test** (`generate-schema.spec.ts`) — draft-07 metadata, `additionalProperties` on every object, the description round-trip, and idempotence vs the committed file.
- The **top-level schema `description`** (the exporter doesn't carry the root `.describe()` to the document root, so `META` sets it explicitly).
- **`git diff` on `--check` failure** so the CI message is actionable.
- A **run-only-when-invoked-directly guard** on `main()` (so importing the generator in tests has no side effects).

## How

- Descriptions live as Zod `.describe()` in `packages/config/src/schema.ts` — single source of truth, flowing Zod → `releasekit.schema.json` → `docs/configuration.md`.
- `scripts/generate-schema.ts` runs zod v4's native `z.toJSONSchema` (draft-7, `io: 'input'`) and post-processes (`anyOf→oneOf`, `const→enum`, strip int sentinels, `additionalProperties: false` on every object — preserving editor/ajv strictness without making the Zod parser strict; `load.ts` stays lenient).
- `pnpm schema:gen` writes it; `pnpm schema:check` enforces it in CI (`lint` job).

> **Note on library:** the issue suggested `zod-to-json-schema`, but the repo is on **zod v4**, which that library can't read (it only understands v3 internals). Both implementations independently landed on zod v4's built-in `z.toJSONSchema`.

## Relationship to #280

Builds on #280 (the immediate scopeLabels fix) and supersedes it — merging this delivers #280's content plus generation. Recommend merging #280 first (then this shows a clean delta) or closing #280 in favour of this.

## Verification

- `pnpm schema:gen` + `git diff --exit-code releasekit.schema.json` → no diff.
- ajv (draft7, strict=false): repo config + all `examples/ci/**` configs valid.
- `pnpm turbo run lint typecheck test` → 24/24 (incl. the new generator test + #280's scopeLabels tests).

Closes #277

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR eliminates the manual Zod↔JSON-Schema sync that caused `ci.scopeLabels` (and other fields) to drift by introducing `scripts/generate-schema.ts` — a generator that calls zod v4's native `z.toJSONSchema`, post-processes the output (anyOf→oneOf, const→enum, exclusiveMinimum normalisation, `additionalProperties: false` injection, stable key ordering), and enforces freshness via a `--check` mode wired into the CI lint job.

- **Generator (`scripts/generate-schema.ts`)**: well-structured with exported `buildSchema`/`serialiseSchema` helpers, an in-process unified-diff fallback for actionable CI output, and a direct-invocation guard so importing the module in tests has no side effects.
- **Schema (`packages/config/src/schema.ts`)**: every field now carries a `.describe()`, `VerifyRegistryConfigSchema` is split into npm/cargo variants with their correct independent defaults, and `tagTemplate` default is corrected from the broken `'v{version}'` literal to the proper `'${prefix}${version}'` template.
- **Tests (`generate-schema.spec.ts`)**: pins draft-07 metadata, `additionalProperties` coverage on every object node, the `ci.scopeLabels` description regression guard, and idempotence against the committed file.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the generator, schema, and CI enforcement are all correct; the one type-export removal is a cosmetic API surface change that CI typecheck already confirmed causes no internal breakage.

The core generation pipeline is well-tested (idempotence, metadata, additionalProperties coverage, description round-trip), the check mode correctly diffs in-memory strings rather than relying on the working tree, and all 24 CI jobs pass. The only open question is whether any external consumer imported VerifyRegistryConfig by name, but that is a type-level concern that does not affect runtime behaviour.

packages/config/src/index.ts — the VerifyRegistryConfig type export was dropped; worth confirming no downstream package imports it by name before merging.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/generate-schema.ts | New generator script: converts Zod schema to JSON Schema via z.toJSONSchema, with post-processing (anyOf→oneOf, const→enum, exclusiveMinimum→minimum, additionalProperties injection), stable key ordering, and a --check mode that diffs in-memory strings so CI diagnostics work on clean checkouts. |
| packages/config/src/schema.ts | All schemas now have .describe() on every field; VerifyRegistryConfigSchema split into VerifyRegistryNpmConfigSchema/VerifyRegistryCargoConfigSchema with correct per-registry defaults; tagTemplate default corrected to ${prefix}${version}; LLMRetryConfigSchema initialDelay/maxDelay tightened to .int(); VerifyRegistryConfig type dropped from exports. |
| packages/config/src/index.ts | Removes VerifyRegistryConfig from the public type exports — a semver-breaking removal; no replacement types (VerifyRegistryNpmConfig / VerifyRegistryCargoConfig) were added. |
| packages/config/test/unit/generate-schema.spec.ts | New test file covering draft-07 metadata, additionalProperties on every object node, description round-trip (ci.scopeLabels regression guard), and idempotence against the committed JSON file. |
| .github/workflows/ci.yml | Adds pnpm schema:check step to the lint job so schema drift is caught in CI. |
| releasekit.schema.json | Regenerated from Zod: descriptions now on all fields (including the previously empty ci.scopeLabels), descriptions moved after other keywords per generator key ordering, skipPackages added, verify defaults corrected (cargo 10/30000), propertyNames added to record schemas. |
| packages/config/test/unit/schema.spec.ts | Updated tagTemplate default expectation from 'v{version}' to '${prefix}${version}' to match the corrected Zod default. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["packages/config/src/schema.ts\nZod schema plus .describe() calls"] -->|z.toJSONSchema draft-7| B["Raw zod JSON Schema output"]
    B -->|normalise: anyOf to oneOf, const to enum, additionalProperties injection| C["Normalised schema"]
    C -->|orderSchemaNode: stable keyword order| D["Ordered schema"]
    D -->|prepend META block| E["releasekit.schema.json"]
    E -->|pnpm docs:config| F["docs/configuration.md"]
    E -->|ajv validation| G["examples/ci configs"]
    H["pnpm schema:gen"] -->|writes file| E
    I["pnpm schema:check in CI lint job"] -->|in-memory string diff| J{Match?}
    J -->|yes| K["CI passes"]
    J -->|no| L["printUnifiedDiff to stderr and exit 1"]
```
</details>

<sub>Reviews (7): Last reviewed commit: ["refactor(config): remove orphaned Verify..."](https://github.com/goosewobbler/releasekit/commit/055af6333717670999661a34746eab92dba0900b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36354803)</sub>

<!-- /greptile_comment -->