### PR TITLE
feat(publish): add pub.dev (Dart/Flutter) as a first-class registry

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -258,7 +258,7 @@ Publish packages to registries with git tagging and GitHub releases. Reads a ver
 |---|---|---|---|
 | `--input <path>` | string | stdin | Path to version output JSON |
 | `--config <path>` | string | auto-discovered | Path to releasekit config |
-| `--registry <type>` | `npm` \| `cargo` \| `all` | `all` | Registry to publish to |
+| `--registry <type>` | `npm` \| `cargo` \| `pub` \| `all` | `all` | Registry to publish to |
 | `--npm-auth <method>` | `oidc` \| `token` \| `auto` | `auto` | NPM auth method |
 | `--dry-run` | boolean | `false` | Simulate all operations |
 | `--skip-git` | boolean | `false` | Skip git commit/tag/push |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -76,6 +76,7 @@ Versioning configuration.
 | `prereleaseIdentifier` | string | — | Identifier for prerelease versions (e.g., 'alpha', 'beta') |
 | `strictReachable` | boolean | `false` | Only use reachable tags |
 | `zeroMajor` | `"spec"` \| `"strict"` | `"spec"` | Pre-1.0 handling of commit-inferred breaking changes. 'spec' (default): bump the 0.x minor (0.24.0 → 0.25.0), per semver §4. 'strict': bump the next major (→ 1.0.0). Inferred path only — explicit overrides (--bump major, bump:major) always graduate to 1.0.0. |
+| `pub` | object | — | Dart/Flutter pub configuration |
 
 ### `version.zeroMajor`
 
@@ -183,6 +184,15 @@ Cargo publishing configuration.
 | `publishOrder` | `string[]` | `[]` | Order in which to publish packages |
 | `clean` | boolean | `false` | Clean before publishing |
 
+### `publish.pub`
+
+Dart/Flutter publishing configuration via pub.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | boolean | `false` | Enable Dart publishing to pub.dev |
+| `publishOrder` | `string[]` | `[]` | Order in which to publish Dart packages |
+
 ### `publish.githubRelease`
 
 GitHub Release configuration.
@@ -216,6 +226,15 @@ Registry verification configuration.
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `enabled` | boolean | `true` | Verify Cargo publish |
+| `maxAttempts` | integer | `10` | Maximum verification attempts |
+| `initialDelay` | integer | `30000` | Initial delay in milliseconds |
+| `backoffMultiplier` | number | `2` | Exponential backoff multiplier |
+
+#### `publish.verify.pub`
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | boolean | `true` | Verify Dart pub publish |
 | `maxAttempts` | integer | `10` | Maximum verification attempts |
 | `initialDelay` | integer | `30000` | Initial delay in milliseconds |
 | `backoffMultiplier` | number | `2` | Exponential backoff multiplier |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -190,8 +190,8 @@ Dart/Flutter publishing configuration via pub.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `enabled` | boolean | `false` | Enable Dart publishing to pub.dev |
-| `publishOrder` | `string[]` | `[]` | Order in which to publish Dart packages |
+| `enabled` | boolean | `false` |  |
+| `publishOrder` | `string[]` | `[]` |  |
 
 ### `publish.githubRelease`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -190,8 +190,8 @@ Dart/Flutter publishing configuration via pub.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `enabled` | boolean | `false` |  |
-| `publishOrder` | `string[]` | `[]` |  |
+| `enabled` | boolean | `false` | Enable pub.dev publishing |
+| `publishOrder` | `string[]` | `[]` | Order in which to publish packages |
 
 ### `publish.githubRelease`
 

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -29,6 +29,7 @@
     "jsonc-parser": "catalog:",
     "minimatch": "catalog:",
     "smol-toml": "catalog:",
+    "yaml": "catalog:",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -14,6 +14,7 @@ export {
 export { deepMerge, mergeGitConfig } from './merge.js';
 export { filterPackagesByConfig } from './packageFiltering.js';
 export { parseJsonc } from './parse.js';
+export { isPubspecYaml, type PubspecManifest, parsePubspec } from './pubspec.js';
 export {
   type CargoPublishConfig,
   type ChangelogConfig,
@@ -31,6 +32,7 @@ export {
   type NpmConfig,
   type PublishConfig,
   type PublishGitConfig,
+  type PubPublishConfig,
   type ReleaseCIConfig,
   type ReleaseConfig,
   type ReleaseKitConfig,

--- a/packages/config/src/pubspec.ts
+++ b/packages/config/src/pubspec.ts
@@ -9,9 +9,9 @@ export interface PubspecManifest {
   [key: string]: unknown;
 }
 
-export function parsePubspec(pubspecPath: string): PubspecManifest {
-  const content = fs.readFileSync(pubspecPath, 'utf-8');
-  return yaml.parse(content) as PubspecManifest;
+export function parsePubspec(pubspecPath: string, content?: string): PubspecManifest {
+  const src = content ?? fs.readFileSync(pubspecPath, 'utf-8');
+  return yaml.parse(src) as PubspecManifest;
 }
 
 export function isPubspecYaml(filePath: string): boolean {

--- a/packages/config/src/pubspec.ts
+++ b/packages/config/src/pubspec.ts
@@ -12,7 +12,10 @@ export interface PubspecManifest {
 
 export function parsePubspec(pubspecPath: string, content?: string): PubspecManifest {
   const src = content ?? fs.readFileSync(pubspecPath, 'utf-8');
-  return yaml.parse(src) as PubspecManifest;
+  // yaml.parse returns null for an empty or comment-only document; normalise to an
+  // empty manifest so callers get clear "missing name/version" errors rather than a
+  // cryptic "Cannot read properties of null".
+  return (yaml.parse(src) ?? {}) as PubspecManifest;
 }
 
 export function isPubspecYaml(filePath: string): boolean {

--- a/packages/config/src/pubspec.ts
+++ b/packages/config/src/pubspec.ts
@@ -5,6 +5,7 @@ import * as yaml from 'yaml';
 export interface PubspecManifest {
   name?: string;
   version?: string;
+  publish_to?: string;
   environment?: Record<string, unknown>;
   [key: string]: unknown;
 }

--- a/packages/config/src/pubspec.ts
+++ b/packages/config/src/pubspec.ts
@@ -1,0 +1,19 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as yaml from 'yaml';
+
+export interface PubspecManifest {
+  name?: string;
+  version?: string;
+  environment?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+export function parsePubspec(pubspecPath: string): PubspecManifest {
+  const content = fs.readFileSync(pubspecPath, 'utf-8');
+  return yaml.parse(content) as PubspecManifest;
+}
+
+export function isPubspecYaml(filePath: string): boolean {
+  return path.basename(filePath) === 'pubspec.yaml';
+}

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -40,6 +40,11 @@ export const VersionCargoConfigSchema = z.object({
   paths: z.array(z.string()).optional().describe('Directories to search for Cargo.toml files'),
 });
 
+export const VersionPubConfigSchema = z.object({
+  enabled: z.boolean().default(true),
+  paths: z.array(z.string()).optional(),
+});
+
 export const VersionGroupSchema = z.object({
   packages: z
     .array(z.string())
@@ -118,6 +123,7 @@ export const VersionConfigSchema = z.object({
       "Pre-1.0 handling of commit-inferred breaking changes. 'spec' (default): bump the 0.x minor (0.24.0 → 0.25.0), per semver §4. 'strict': bump the next major (→ 1.0.0). Inferred path only — explicit overrides (--bump major, bump:major) always graduate to 1.0.0.",
     ),
   cargo: VersionCargoConfigSchema.optional().describe('Cargo/Rust configuration'),
+  pub: VersionPubConfigSchema.optional().describe('Dart/Flutter pub configuration'),
 });
 
 export const NpmConfigSchema = z.object({
@@ -135,6 +141,11 @@ export const CargoPublishConfigSchema = z.object({
   noVerify: z.boolean().default(false).describe('Skip verification before publish'),
   publishOrder: z.array(z.string()).default([]).describe('Order in which to publish packages'),
   clean: z.boolean().default(false).describe('Clean before publishing'),
+});
+
+export const PubPublishConfigSchema = z.object({
+  enabled: z.boolean().default(false),
+  publishOrder: z.array(z.string()).default([]),
 });
 
 export const PublishGitConfigSchema = z.object({
@@ -195,6 +206,12 @@ export const VerifyConfigSchema = z.object({
     initialDelay: 30000,
     backoffMultiplier: 2,
   }),
+  pub: VerifyRegistryConfigSchema.default({
+    enabled: true,
+    maxAttempts: 10,
+    initialDelay: 30000,
+    backoffMultiplier: 2,
+  }),
 });
 
 export const PublishConfigSchema = z.object({
@@ -214,6 +231,10 @@ export const PublishConfigSchema = z.object({
     publishOrder: [],
     clean: false,
   }).describe('Cargo publishing configuration'),
+  pub: PubPublishConfigSchema.default({
+    enabled: false,
+    publishOrder: [],
+  }).describe('Dart/Flutter publishing configuration via pub'),
   githubRelease: GitHubReleaseConfigSchema.default({
     enabled: true,
     draft: true,
@@ -232,6 +253,12 @@ export const PublishConfigSchema = z.object({
       backoffMultiplier: 2,
     },
     cargo: {
+      enabled: true,
+      maxAttempts: 10,
+      initialDelay: 30000,
+      backoffMultiplier: 2,
+    },
+    pub: {
       enabled: true,
       maxAttempts: 10,
       initialDelay: 30000,
@@ -576,6 +603,7 @@ export type VersionConfig = z.infer<typeof VersionConfigSchema>;
 export type VersionGroup = z.infer<typeof VersionGroupSchema>;
 export type NpmConfig = z.infer<typeof NpmConfigSchema>;
 export type CargoPublishConfig = z.infer<typeof CargoPublishConfigSchema>;
+export type PubPublishConfig = z.infer<typeof PubPublishConfigSchema>;
 export type PublishGitConfig = z.infer<typeof PublishGitConfigSchema>;
 export type GitHubReleaseConfig = z.infer<typeof GitHubReleaseConfigSchema>;
 export type VerifyConfig = z.infer<typeof VerifyConfigSchema>;

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -41,8 +41,8 @@ export const VersionCargoConfigSchema = z.object({
 });
 
 export const VersionPubConfigSchema = z.object({
-  enabled: z.boolean().default(true),
-  paths: z.array(z.string()).optional(),
+  enabled: z.boolean().default(true).describe('Enable pubspec.yaml version handling'),
+  paths: z.array(z.string()).optional().describe('Directories to search for pubspec.yaml files'),
 });
 
 export const VersionGroupSchema = z.object({
@@ -144,8 +144,8 @@ export const CargoPublishConfigSchema = z.object({
 });
 
 export const PubPublishConfigSchema = z.object({
-  enabled: z.boolean().default(false),
-  publishOrder: z.array(z.string()).default([]),
+  enabled: z.boolean().default(false).describe('Enable pub.dev publishing'),
+  publishOrder: z.array(z.string()).default([]).describe('Order in which to publish packages'),
 });
 
 export const PublishGitConfigSchema = z.object({

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -193,6 +193,13 @@ export const VerifyRegistryCargoConfigSchema = z.object({
   backoffMultiplier: z.number().positive().default(2).describe('Exponential backoff multiplier'),
 });
 
+export const VerifyRegistryPubConfigSchema = z.object({
+  enabled: z.boolean().default(true).describe('Verify Dart pub publish'),
+  maxAttempts: z.number().int().positive().default(10).describe('Maximum verification attempts'),
+  initialDelay: z.number().int().positive().default(30000).describe('Initial delay in milliseconds'),
+  backoffMultiplier: z.number().positive().default(2).describe('Exponential backoff multiplier'),
+});
+
 export const VerifyConfigSchema = z.object({
   npm: VerifyRegistryNpmConfigSchema.default({
     enabled: true,
@@ -206,7 +213,7 @@ export const VerifyConfigSchema = z.object({
     initialDelay: 30000,
     backoffMultiplier: 2,
   }),
-  pub: VerifyRegistryConfigSchema.default({
+  pub: VerifyRegistryPubConfigSchema.default({
     enabled: true,
     maxAttempts: 10,
     initialDelay: 30000,

--- a/packages/config/test/unit/pubspec.spec.ts
+++ b/packages/config/test/unit/pubspec.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { isPubspecYaml, parsePubspec } from '../../src/pubspec.js';
+
+describe('parsePubspec', () => {
+  it('should parse name, version and publish_to from content', () => {
+    const result = parsePubspec('pubspec.yaml', 'name: my_pkg\nversion: 1.2.3\npublish_to: none\n');
+    expect(result).toMatchObject({ name: 'my_pkg', version: '1.2.3', publish_to: 'none' });
+  });
+
+  it('should return an empty manifest for an empty document', () => {
+    expect(parsePubspec('pubspec.yaml', '')).toEqual({});
+  });
+
+  it('should return an empty manifest for a comment-only document', () => {
+    expect(parsePubspec('pubspec.yaml', '# just a comment\n')).toEqual({});
+  });
+});
+
+describe('isPubspecYaml', () => {
+  it('should return true for pubspec.yaml paths', () => {
+    expect(isPubspecYaml('pubspec.yaml')).toBe(true);
+    expect(isPubspecYaml('/a/b/pubspec.yaml')).toBe(true);
+  });
+
+  it('should return false for other files', () => {
+    expect(isPubspecYaml('package.json')).toBe(false);
+    expect(isPubspecYaml('pubspec.yml')).toBe(false);
+  });
+});

--- a/packages/notes/package.json
+++ b/packages/notes/package.json
@@ -69,6 +69,7 @@
     "minimatch": "catalog:",
     "openai": "^6.42.0",
     "smol-toml": "catalog:",
+    "yaml": "catalog:",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/packages/notes/package.json
+++ b/packages/notes/package.json
@@ -69,7 +69,6 @@
     "minimatch": "catalog:",
     "openai": "^6.42.0",
     "smol-toml": "catalog:",
-    "yaml": "catalog:",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/packages/publish/package.json
+++ b/packages/publish/package.json
@@ -65,6 +65,7 @@
     "minimatch": "catalog:",
     "semver": "catalog:",
     "smol-toml": "catalog:",
+    "yaml": "catalog:",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/packages/publish/src/command.ts
+++ b/packages/publish/src/command.ts
@@ -11,7 +11,7 @@ export function createPublishCommand(): Command {
     .description('Publish packages to registries with git tagging and GitHub releases')
     .option('--input <path>', 'Path to version output JSON (default: stdin)')
     .option('--config <path>', 'Path to releasekit config')
-    .option('--registry <type>', 'Registry to publish to (npm, cargo, all)', 'all')
+    .option('--registry <type>', 'Registry to publish to (npm, cargo, pub, all)', 'all')
     .option('--npm-auth <method>', 'NPM auth method (oidc, token, auto)', 'auto')
     .option('--dry-run', 'Simulate all operations', false)
     .option('--skip-git', 'Skip git commit/tag/push', false)

--- a/packages/publish/src/errors/index.ts
+++ b/packages/publish/src/errors/index.ts
@@ -45,6 +45,8 @@ export enum PublishErrorCode {
   NPM_AUTH_ERROR = 'NPM_AUTH_ERROR',
   CARGO_PUBLISH_ERROR = 'CARGO_PUBLISH_ERROR',
   CARGO_AUTH_ERROR = 'CARGO_AUTH_ERROR',
+  PUB_PUBLISH_ERROR = 'PUB_PUBLISH_ERROR',
+  PUBSPEC_YAML_ERROR = 'PUBSPEC_YAML_ERROR',
   VERIFICATION_FAILED = 'VERIFICATION_FAILED',
   GITHUB_RELEASE_ERROR = 'GITHUB_RELEASE_ERROR',
   FILE_COPY_ERROR = 'FILE_COPY_ERROR',
@@ -64,6 +66,9 @@ export function createPublishError(code: PublishErrorCode, details?: string): Pu
     [PublishErrorCode.NPM_AUTH_ERROR]: 'NPM authentication failed',
     [PublishErrorCode.CARGO_PUBLISH_ERROR]: 'Failed to publish to crates.io',
     [PublishErrorCode.CARGO_AUTH_ERROR]: 'Cargo authentication failed',
+    [PublishErrorCode.PUB_PUBLISH_ERROR]: 'Failed to publish to pub.dev',
+
+    [PublishErrorCode.PUBSPEC_YAML_ERROR]: 'Failed to update pubspec.yaml',
     [PublishErrorCode.VERIFICATION_FAILED]: 'Package verification failed',
     [PublishErrorCode.GITHUB_RELEASE_ERROR]: 'Failed to create GitHub release',
     [PublishErrorCode.FILE_COPY_ERROR]: 'Failed to copy files',
@@ -117,6 +122,17 @@ export function createPublishError(code: PublishErrorCode, details?: string): Pu
     [PublishErrorCode.CARGO_AUTH_ERROR]: [
       'Set CARGO_REGISTRY_TOKEN environment variable',
       'Generate a token at https://crates.io/settings/tokens',
+    ],
+    [PublishErrorCode.PUB_PUBLISH_ERROR]: [
+      'Check pub.dev registry availability',
+      'Verify package name ownership on pub.dev',
+      'Ensure pubspec.yaml metadata is complete (description, homepage, etc.)',
+      'Configure automated publishing via OIDC at https://pub.dev/publishers',
+      'Or set PUB_TOKEN environment variable for token-based auth',
+    ],
+    [PublishErrorCode.PUBSPEC_YAML_ERROR]: [
+      'Ensure pubspec.yaml exists and is valid YAML',
+      'Check that the name and version fields are present',
     ],
     [PublishErrorCode.VERIFICATION_FAILED]: [
       'Registry propagation may take longer than expected',

--- a/packages/publish/src/errors/index.ts
+++ b/packages/publish/src/errors/index.ts
@@ -46,6 +46,7 @@ export enum PublishErrorCode {
   CARGO_PUBLISH_ERROR = 'CARGO_PUBLISH_ERROR',
   CARGO_AUTH_ERROR = 'CARGO_AUTH_ERROR',
   PUB_PUBLISH_ERROR = 'PUB_PUBLISH_ERROR',
+  PUB_AUTH_ERROR = 'PUB_AUTH_ERROR',
   PUBSPEC_YAML_ERROR = 'PUBSPEC_YAML_ERROR',
   VERIFICATION_FAILED = 'VERIFICATION_FAILED',
   GITHUB_RELEASE_ERROR = 'GITHUB_RELEASE_ERROR',
@@ -67,6 +68,7 @@ export function createPublishError(code: PublishErrorCode, details?: string): Pu
     [PublishErrorCode.CARGO_PUBLISH_ERROR]: 'Failed to publish to crates.io',
     [PublishErrorCode.CARGO_AUTH_ERROR]: 'Cargo authentication failed',
     [PublishErrorCode.PUB_PUBLISH_ERROR]: 'Failed to publish to pub.dev',
+    [PublishErrorCode.PUB_AUTH_ERROR]: 'Pub.dev authentication failed',
 
     [PublishErrorCode.PUBSPEC_YAML_ERROR]: 'Failed to update pubspec.yaml',
     [PublishErrorCode.VERIFICATION_FAILED]: 'Package verification failed',
@@ -129,6 +131,11 @@ export function createPublishError(code: PublishErrorCode, details?: string): Pu
       'Ensure pubspec.yaml metadata is complete (description, homepage, etc.)',
       'Configure automated publishing via OIDC at https://pub.dev/publishers',
       'Or set PUB_TOKEN environment variable for token-based auth',
+    ],
+    [PublishErrorCode.PUB_AUTH_ERROR]: [
+      'Set the PUB_TOKEN environment variable for token-based auth',
+      'Configure automated publishing via OIDC at https://pub.dev/publishers',
+      'Ensure the Dart SDK is installed and `dart pub token add` can run',
     ],
     [PublishErrorCode.PUBSPEC_YAML_ERROR]: [
       'Ensure pubspec.yaml exists and is valid YAML',

--- a/packages/publish/src/pipeline/index.ts
+++ b/packages/publish/src/pipeline/index.ts
@@ -6,6 +6,7 @@ import { preparePushSetup, pushPackageTag, runGitPushStage } from '../stages/git
 import { runGithubReleaseStage } from '../stages/github-release.js';
 import { runNpmPublishStage } from '../stages/npm-publish.js';
 import { runPrepareStage } from '../stages/prepare.js';
+import { runPubPublishStage } from '../stages/pub-publish.js';
 import { runVerifyStage } from '../stages/verify.js';
 import type { PipelineContext, PublishCliOptions, PublishConfig, PublishOutput } from '../types.js';
 import { detectPackageManager } from '../utils/package-manager.js';
@@ -21,6 +22,8 @@ function inferStageName(error: unknown): string {
       NPM_AUTH_ERROR: 'npm-publish',
       CARGO_PUBLISH_ERROR: 'cargo-publish',
       CARGO_AUTH_ERROR: 'cargo-publish',
+      PUB_PUBLISH_ERROR: 'pub-publish',
+      PUBSPEC_YAML_ERROR: 'prepare',
       VERIFICATION_FAILED: 'verify',
       GIT_PUSH_ERROR: 'git-push',
       GITHUB_RELEASE_ERROR: 'github-release',
@@ -49,6 +52,7 @@ export async function runPipeline(
       git: { committed: false, tags: [], pushed: false },
       npm: [],
       cargo: [],
+      pub: [],
       verification: [],
       githubReleases: [],
       publishSucceeded: false,
@@ -86,6 +90,9 @@ export async function runPipeline(
         if (options.registry === 'all' || options.registry === 'cargo') {
           await runCargoPublishStage(ctx);
         }
+        if (options.registry === 'all' || options.registry === 'pub') {
+          await runPubPublishStage(ctx);
+        }
       } else if (!options.skipPublish) {
         // Per-package mode: for each update, publish → verify → push its tag.
         // Uses a single-update context so existing stage logic is fully reused.
@@ -101,6 +108,7 @@ export async function runPipeline(
               git: ctx.output.git, // shared so pushPackageTag accumulates into ctx.output.git
               npm: [],
               cargo: [],
+              pub: [],
               verification: [],
               githubReleases: [],
               publishSucceeded: false,
@@ -115,6 +123,10 @@ export async function runPipeline(
             await runCargoPublishStage(singleCtx);
             ctx.output.cargo.push(...singleCtx.output.cargo);
           }
+          if (options.registry === 'all' || options.registry === 'pub') {
+            await runPubPublishStage(singleCtx);
+            ctx.output.pub.push(...singleCtx.output.pub);
+          }
 
           if (!options.skipVerification) {
             await runVerifyStage(singleCtx);
@@ -123,7 +135,9 @@ export async function runPipeline(
 
           // Compute publish success for this package before pushing its tag
           singleCtx.output.publishSucceeded =
-            singleCtx.output.npm.every((r) => r.success) && singleCtx.output.cargo.every((r) => r.success);
+            singleCtx.output.npm.every((r) => r.success) &&
+            singleCtx.output.cargo.every((r) => r.success) &&
+            singleCtx.output.pub.every((r) => r.success);
 
           // Push tag after publish/verify — only push if publish succeeded (commit is ready regardless).
           if (!options.skipGit && update.tag && singleCtx.output.publishSucceeded) {
@@ -136,7 +150,9 @@ export async function runPipeline(
       // Only relevant for batch mode; per-package mode sets publishSucceeded per-loop but doesn't accumulate.
       if (!perPackageMode) {
         ctx.output.publishSucceeded =
-          ctx.output.npm.every((r) => r.success) && ctx.output.cargo.every((r) => r.success);
+          ctx.output.npm.every((r) => r.success) &&
+          ctx.output.cargo.every((r) => r.success) &&
+          ctx.output.pub.every((r) => r.success);
       } else {
         // In per-package mode every singleCtx succeeded (stages throw on failure), so the overall run succeeded.
         ctx.output.publishSucceeded = true;

--- a/packages/publish/src/pipeline/index.ts
+++ b/packages/publish/src/pipeline/index.ts
@@ -23,6 +23,7 @@ function inferStageName(error: unknown): string {
       CARGO_PUBLISH_ERROR: 'cargo-publish',
       CARGO_AUTH_ERROR: 'cargo-publish',
       PUB_PUBLISH_ERROR: 'pub-publish',
+      PUB_AUTH_ERROR: 'pub-publish',
       PUBSPEC_YAML_ERROR: 'prepare',
       VERIFICATION_FAILED: 'verify',
       GIT_PUSH_ERROR: 'git-push',

--- a/packages/publish/src/stages/pub-publish.ts
+++ b/packages/publish/src/stages/pub-publish.ts
@@ -10,6 +10,18 @@ import { classifyPublishError, withPublishRetry } from '../utils/publish-retry.j
 
 const ALREADY_PUBLISHED_PATTERN = /already published|version already exists/i;
 
+/** Hosts that mean "publish to pub.dev" (the default when `publish_to` is unset). */
+const PUB_DEV_HOSTS = ['https://pub.dev', 'https://pub.dartlang.org'];
+
+/**
+ * Whether a package's `publish_to` targets pub.dev. `dart pub publish` honours a custom
+ * `publish_to` (a private registry), but the pub.dev REST API checks here only make sense
+ * for pub.dev, so they are skipped for custom servers.
+ */
+function targetsPubDev(publishTo: string | undefined): boolean {
+  return !publishTo || PUB_DEV_HOSTS.includes(publishTo.replace(/\/+$/, ''));
+}
+
 /** Bounded auto-retry for transient registry blips: initial attempt + 2 retries. */
 const PUBLISH_RETRY = { maxAttempts: 3, initialDelay: 1000 } as const;
 
@@ -61,8 +73,8 @@ export async function runPubPublishStage(ctx: PipelineContext): Promise<void> {
       skipped: false,
     };
 
-    // Check if already published via the pub.dev API
-    if (await isPubPackagePublished(pkg.name, pkg.version)) {
+    // Check if already published via the pub.dev API (pub.dev targets only)
+    if (targetsPubDev(pkg.publishTo) && (await isPubPackagePublished(pkg.name, pkg.version))) {
       result.alreadyPublished = true;
       result.skipped = true;
       result.success = true;
@@ -122,6 +134,7 @@ interface PubPackageInfo {
   dir: string;
   pubspecPath: string;
   command: 'dart' | 'flutter';
+  publishTo: string | undefined;
 }
 
 function findPubPackages(
@@ -150,6 +163,7 @@ function findPubPackages(
         dir: update.dir,
         pubspecPath,
         command: detectPubCommand(pubspec.environment as Record<string, unknown> | undefined),
+        publishTo: pubspec.publish_to,
       });
     } catch (error) {
       throw createPublishError(

--- a/packages/publish/src/stages/pub-publish.ts
+++ b/packages/publish/src/stages/pub-publish.ts
@@ -34,13 +34,19 @@ export async function runPubPublishStage(ctx: PipelineContext): Promise<void> {
     return;
   }
 
-  // If PUB_TOKEN is set, configure it before publishing; otherwise assume OIDC automated publishing
+  // If PUB_TOKEN is set, configure it before publishing; otherwise assume OIDC automated publishing.
+  // Wrap the token setup so a failure here is attributed to auth (with remediation hints) rather
+  // than surfacing as a raw exec error against an unknown stage.
   if (hasPubTokenAuth() && !dryRun) {
-    await execCommand('dart', ['pub', 'token', 'add', 'https://pub.dev', '--env-var', 'PUB_TOKEN'], {
-      cwd,
-      dryRun: false,
-      label: 'dart pub token add',
-    });
+    try {
+      await execCommand('dart', ['pub', 'token', 'add', 'https://pub.dev', '--env-var', 'PUB_TOKEN'], {
+        cwd,
+        dryRun: false,
+        label: 'dart pub token add',
+      });
+    } catch (error) {
+      throw createPublishError(PublishErrorCode.PUB_AUTH_ERROR, error instanceof Error ? error.message : String(error));
+    }
   }
 
   // Apply explicit publish order if configured

--- a/packages/publish/src/stages/pub-publish.ts
+++ b/packages/publish/src/stages/pub-publish.ts
@@ -145,8 +145,11 @@ function findPubPackages(
         pubspecPath,
         command: detectPubCommand(pubspec.environment as Record<string, unknown> | undefined),
       });
-    } catch {
-      // Skip unparseable pubspec.yaml
+    } catch (error) {
+      throw createPublishError(
+        PublishErrorCode.PUBSPEC_YAML_ERROR,
+        `${pubspecPath}: ${error instanceof Error ? error.message : String(error)}`,
+      );
     }
   }
 

--- a/packages/publish/src/stages/pub-publish.ts
+++ b/packages/publish/src/stages/pub-publish.ts
@@ -5,7 +5,7 @@ import { createPublishError, PublishErrorCode } from '../errors/index.js';
 import type { PipelineContext, PublishResult } from '../types.js';
 import { hasPubTokenAuth } from '../utils/auth.js';
 import { execCommand } from '../utils/exec.js';
-import { isPubPackagePublished, parsePubspec } from '../utils/pub.js';
+import { detectPubCommand, isPubPackagePublished, parsePubspec } from '../utils/pub.js';
 import { classifyPublishError, withPublishRetry } from '../utils/publish-retry.js';
 
 const ALREADY_PUBLISHED_PATTERN = /already published|version already exists/i;
@@ -138,13 +138,12 @@ function findPubPackages(
         continue;
       }
 
-      const env = pubspec.environment as Record<string, unknown> | undefined;
       packages.push({
         name: pubspec.name,
         version: update.newVersion,
         dir: update.dir,
         pubspecPath,
-        command: env && 'flutter' in env ? 'flutter' : 'dart',
+        command: detectPubCommand(pubspec.environment as Record<string, unknown> | undefined),
       });
     } catch {
       // Skip unparseable pubspec.yaml

--- a/packages/publish/src/stages/pub-publish.ts
+++ b/packages/publish/src/stages/pub-publish.ts
@@ -122,12 +122,14 @@ function findPubPackages(
   _cwd: string,
 ): PubPackageInfo[] {
   const packages: PubPackageInfo[] = [];
+  const seen = new Set<string>();
 
   for (const update of updates) {
     const pubspecPath = path.join(update.dir, 'pubspec.yaml');
-    if (!fs.existsSync(pubspecPath)) {
+    if (!fs.existsSync(pubspecPath) || seen.has(pubspecPath)) {
       continue;
     }
+    seen.add(pubspecPath);
 
     try {
       const pubspec = parsePubspec(pubspecPath);

--- a/packages/publish/src/stages/pub-publish.ts
+++ b/packages/publish/src/stages/pub-publish.ts
@@ -134,7 +134,7 @@ function findPubPackages(
 
     try {
       const pubspec = parsePubspec(pubspecPath);
-      if (!pubspec.name) {
+      if (!pubspec.name || pubspec.publish_to === 'none') {
         continue;
       }
 

--- a/packages/publish/src/stages/pub-publish.ts
+++ b/packages/publish/src/stages/pub-publish.ts
@@ -1,0 +1,174 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { debug, success, warn } from '@releasekit/core';
+import { createPublishError, PublishErrorCode } from '../errors/index.js';
+import type { PipelineContext, PublishResult } from '../types.js';
+import { hasPubTokenAuth } from '../utils/auth.js';
+import { execCommand } from '../utils/exec.js';
+import { detectPubCommand, isPubPackagePublished, parsePubspec } from '../utils/pub.js';
+import { classifyPublishError, withPublishRetry } from '../utils/publish-retry.js';
+
+const ALREADY_PUBLISHED_PATTERN = /already published|version already exists/i;
+
+/** Bounded auto-retry for transient registry blips: initial attempt + 2 retries. */
+const PUBLISH_RETRY = { maxAttempts: 3, initialDelay: 1000 } as const;
+
+/** Error strategy: FAIL-FAST. First publish failure aborts the stage. */
+export async function runPubPublishStage(ctx: PipelineContext): Promise<void> {
+  const { input, config, cliOptions, cwd } = ctx;
+  const dryRun = cliOptions.dryRun;
+
+  if (!config.pub.enabled) {
+    debug('Pub publishing disabled in config');
+    return;
+  }
+
+  // If PUB_TOKEN is set, configure it before publishing; otherwise assume OIDC automated publishing
+  if (hasPubTokenAuth() && !dryRun) {
+    await execCommand('dart', ['pub', 'token', 'add', 'https://pub.dev', '--env-var', 'PUB_TOKEN'], {
+      cwd,
+      dryRun: false,
+      label: 'dart pub token add',
+    });
+  }
+
+  // Find Dart packages to publish
+  const packages = findPubPackages(
+    input.updates.map((u) => ({ dir: path.dirname(path.resolve(cwd, u.filePath)), ...u })),
+    cwd,
+  );
+
+  if (packages.length === 0) {
+    debug('No Dart packages found to publish');
+    return;
+  }
+
+  // Apply explicit publish order if configured
+  const ordered = orderPubPackages(packages, config.pub.publishOrder);
+
+  for (const pkg of ordered) {
+    const result: PublishResult = {
+      packageName: pkg.name,
+      version: pkg.version,
+      registry: 'pub',
+      success: false,
+      skipped: false,
+    };
+
+    // Check if already published via the pub.dev API
+    if (await isPubPackagePublished(pkg.name, pkg.version)) {
+      result.alreadyPublished = true;
+      result.skipped = true;
+      result.success = true;
+      result.reason = 'Already published on pub.dev';
+      ctx.output.pub.push(result);
+      warn(`${pkg.name}@${pkg.version} is already published on pub.dev, skipping`);
+      continue;
+    }
+
+    const cmd = detectPubCommand(pkg.pubspecPath);
+    const publishArgs = ['pub', 'publish', '--force'];
+
+    try {
+      await withPublishRetry(
+        () =>
+          execCommand(cmd, publishArgs, {
+            cwd: pkg.dir,
+            dryRun,
+            label: `${cmd} pub publish ${pkg.name}@${pkg.version}`,
+            timeout: 10 * 60 * 1000, // 10 minutes timeout
+          }),
+        {
+          ...PUBLISH_RETRY,
+          label: `${pkg.name}@${pkg.version}`,
+          shouldRetry: (error) =>
+            !ALREADY_PUBLISHED_PATTERN.test(String(error)) && classifyPublishError(error) === 'transient',
+          onAttempt: (attempt) => {
+            result.attempts = attempt;
+          },
+        },
+      );
+      result.success = true;
+      if (!dryRun) {
+        success(`Published ${pkg.name}@${pkg.version} to pub.dev`);
+      }
+      ctx.output.pub.push(result);
+    } catch (error) {
+      if (ALREADY_PUBLISHED_PATTERN.test(String(error))) {
+        result.alreadyPublished = true;
+        result.skipped = true;
+        result.success = true;
+        result.reason = 'Already published on pub.dev (detected from publish error)';
+        ctx.output.pub.push(result);
+        warn(`${pkg.name}@${pkg.version} is already published on pub.dev, skipping`);
+        continue;
+      }
+      result.reason = error instanceof Error ? error.message : String(error);
+      ctx.output.pub.push(result);
+      throw createPublishError(PublishErrorCode.PUB_PUBLISH_ERROR, `${pkg.name}@${pkg.version}: ${result.reason}`);
+    }
+  }
+}
+
+interface PubPackageInfo {
+  name: string;
+  version: string;
+  dir: string;
+  pubspecPath: string;
+}
+
+function findPubPackages(
+  updates: Array<{ packageName: string; newVersion: string; filePath: string; dir: string }>,
+  _cwd: string,
+): PubPackageInfo[] {
+  const packages: PubPackageInfo[] = [];
+
+  for (const update of updates) {
+    const pubspecPath = path.join(update.dir, 'pubspec.yaml');
+    if (!fs.existsSync(pubspecPath)) {
+      continue;
+    }
+
+    try {
+      const pubspec = parsePubspec(pubspecPath);
+      if (!pubspec.name) {
+        continue;
+      }
+
+      packages.push({
+        name: pubspec.name,
+        version: update.newVersion,
+        dir: update.dir,
+        pubspecPath,
+      });
+    } catch {
+      // Skip unparseable pubspec.yaml
+    }
+  }
+
+  return packages;
+}
+
+function orderPubPackages(packages: PubPackageInfo[], explicitOrder: string[]): PubPackageInfo[] {
+  if (explicitOrder.length === 0) {
+    return packages;
+  }
+
+  const ordered: PubPackageInfo[] = [];
+  const byName = new Map(packages.map((p) => [p.name, p]));
+
+  for (const name of explicitOrder) {
+    const pkg = byName.get(name);
+    if (pkg) {
+      ordered.push(pkg);
+      byName.delete(name);
+    }
+  }
+
+  // Append remaining packages not in explicit order
+  for (const pkg of byName.values()) {
+    ordered.push(pkg);
+  }
+
+  return ordered;
+}

--- a/packages/publish/src/stages/pub-publish.ts
+++ b/packages/publish/src/stages/pub-publish.ts
@@ -5,7 +5,7 @@ import { createPublishError, PublishErrorCode } from '../errors/index.js';
 import type { PipelineContext, PublishResult } from '../types.js';
 import { hasPubTokenAuth } from '../utils/auth.js';
 import { execCommand } from '../utils/exec.js';
-import { detectPubCommand, isPubPackagePublished, parsePubspec } from '../utils/pub.js';
+import { isPubPackagePublished, parsePubspec } from '../utils/pub.js';
 import { classifyPublishError, withPublishRetry } from '../utils/publish-retry.js';
 
 const ALREADY_PUBLISHED_PATTERN = /already published|version already exists/i;
@@ -66,7 +66,7 @@ export async function runPubPublishStage(ctx: PipelineContext): Promise<void> {
       continue;
     }
 
-    const cmd = detectPubCommand(pkg.pubspecPath);
+    const cmd = pkg.command;
     const publishArgs = ['pub', 'publish', '--force'];
 
     try {
@@ -115,6 +115,7 @@ interface PubPackageInfo {
   version: string;
   dir: string;
   pubspecPath: string;
+  command: 'dart' | 'flutter';
 }
 
 function findPubPackages(
@@ -137,11 +138,13 @@ function findPubPackages(
         continue;
       }
 
+      const env = pubspec.environment as Record<string, unknown> | undefined;
       packages.push({
         name: pubspec.name,
         version: update.newVersion,
         dir: update.dir,
         pubspecPath,
+        command: env && 'flutter' in env ? 'flutter' : 'dart',
       });
     } catch {
       // Skip unparseable pubspec.yaml

--- a/packages/publish/src/stages/pub-publish.ts
+++ b/packages/publish/src/stages/pub-publish.ts
@@ -23,15 +23,6 @@ export async function runPubPublishStage(ctx: PipelineContext): Promise<void> {
     return;
   }
 
-  // If PUB_TOKEN is set, configure it before publishing; otherwise assume OIDC automated publishing
-  if (hasPubTokenAuth() && !dryRun) {
-    await execCommand('dart', ['pub', 'token', 'add', 'https://pub.dev', '--env-var', 'PUB_TOKEN'], {
-      cwd,
-      dryRun: false,
-      label: 'dart pub token add',
-    });
-  }
-
   // Find Dart packages to publish
   const packages = findPubPackages(
     input.updates.map((u) => ({ dir: path.dirname(path.resolve(cwd, u.filePath)), ...u })),
@@ -41,6 +32,15 @@ export async function runPubPublishStage(ctx: PipelineContext): Promise<void> {
   if (packages.length === 0) {
     debug('No Dart packages found to publish');
     return;
+  }
+
+  // If PUB_TOKEN is set, configure it before publishing; otherwise assume OIDC automated publishing
+  if (hasPubTokenAuth() && !dryRun) {
+    await execCommand('dart', ['pub', 'token', 'add', 'https://pub.dev', '--env-var', 'PUB_TOKEN'], {
+      cwd,
+      dryRun: false,
+      label: 'dart pub token add',
+    });
   }
 
   // Apply explicit publish order if configured

--- a/packages/publish/src/stages/verify.ts
+++ b/packages/publish/src/stages/verify.ts
@@ -3,6 +3,7 @@ import type { PipelineContext, VerificationResult } from '../types.js';
 import { CRATES_IO_API_TIMEOUT_MS, CRATES_IO_USER_AGENT } from '../utils/cargo.js';
 import { execCommandSafe } from '../utils/exec.js';
 import { buildViewCommand } from '../utils/package-manager.js';
+import { PUB_DEV_API_TIMEOUT_MS, PUB_DEV_USER_AGENT } from '../utils/pub.js';
 import { withRetry } from '../utils/retry.js';
 
 export async function runVerifyStage(ctx: PipelineContext): Promise<void> {
@@ -106,6 +107,66 @@ export async function runVerifyStage(ctx: PipelineContext): Promise<void> {
         const reason = error instanceof Error ? error.message : String(error);
         warn(
           `Failed to verify ${crate.packageName}@${crate.version} on crates.io after ${result.attempts} attempts: ${reason}`,
+        );
+      }
+
+      ctx.output.verification.push(result);
+    }
+  }
+
+  // Verify Dart packages on pub.dev
+  if (config.verify.pub.enabled) {
+    const published = output.pub.filter((r) => r.success && !r.skipped && !r.alreadyPublished);
+
+    for (const pkg of published) {
+      const result: VerificationResult = {
+        packageName: pkg.packageName,
+        version: pkg.version,
+        registry: 'pub',
+        verified: false,
+        attempts: 0,
+      };
+
+      if (cliOptions.dryRun) {
+        info(`[DRY RUN] Would verify ${pkg.packageName}@${pkg.version} on pub.dev`);
+        result.verified = true;
+        ctx.output.verification.push(result);
+        continue;
+      }
+
+      try {
+        await withRetry(
+          async () => {
+            result.attempts++;
+            const response = await fetch(`https://pub.dev/api/packages/${pkg.packageName}/versions/${pkg.version}`, {
+              signal: AbortSignal.timeout(PUB_DEV_API_TIMEOUT_MS),
+              headers: { 'User-Agent': PUB_DEV_USER_AGENT },
+            });
+
+            if (response.status === 403) {
+              throw Object.assign(
+                new Error(
+                  `pub.dev API rejected request for ${pkg.packageName}@${pkg.version} (403 Forbidden) — check User-Agent policy`,
+                ),
+                { fatal: true },
+              );
+            }
+
+            if (!response.ok) {
+              throw new Error(`${pkg.packageName}@${pkg.version} not yet available on pub.dev`);
+            }
+
+            debug(`Verified ${pkg.packageName}@${pkg.version} on pub.dev`);
+          },
+          config.verify.pub,
+          (error) => !(error instanceof Error && (error as any).fatal),
+        );
+        result.verified = true;
+        success(`Verified ${pkg.packageName}@${pkg.version} on pub.dev`);
+      } catch (error) {
+        const reason = error instanceof Error ? error.message : String(error);
+        warn(
+          `Failed to verify ${pkg.packageName}@${pkg.version} on pub.dev after ${result.attempts} attempts: ${reason}`,
         );
       }
 

--- a/packages/publish/src/types.ts
+++ b/packages/publish/src/types.ts
@@ -19,6 +19,11 @@ export interface CargoConfig {
   clean: boolean;
 }
 
+export interface PubConfig {
+  enabled: boolean;
+  publishOrder: string[];
+}
+
 export interface GitConfig {
   push: boolean;
   pushMethod: 'auto' | 'ssh' | 'https';
@@ -51,11 +56,13 @@ export interface VerifyRegistryConfig {
 export interface VerifyConfig {
   npm: VerifyRegistryConfig;
   cargo: VerifyRegistryConfig;
+  pub: VerifyRegistryConfig;
 }
 
 export interface PublishConfig {
   npm: NpmConfig;
   cargo: CargoConfig;
+  pub: PubConfig;
   git: GitConfig;
   githubRelease: GitHubReleaseConfig;
   verify: VerifyConfig;
@@ -64,7 +71,7 @@ export interface PublishConfig {
 export interface PublishCliOptions {
   input?: string;
   config?: string;
-  registry: 'npm' | 'cargo' | 'all';
+  registry: 'npm' | 'cargo' | 'pub' | 'all';
   npmAuth: 'auto' | 'oidc' | 'token';
   dryRun: boolean;
   skipGit: boolean;
@@ -83,7 +90,7 @@ export interface PublishCliOptions {
 export interface PublishResult {
   packageName: string;
   version: string;
-  registry: 'npm' | 'cargo';
+  registry: 'npm' | 'cargo' | 'pub';
   success: boolean;
   skipped: boolean;
   reason?: string;
@@ -100,7 +107,7 @@ export interface PublishResult {
 export interface VerificationResult {
   packageName: string;
   version: string;
-  registry: 'npm' | 'cargo';
+  registry: 'npm' | 'cargo' | 'pub';
   verified: boolean;
   attempts: number;
 }
@@ -125,6 +132,7 @@ export interface PublishOutput {
   git: GitResult;
   npm: PublishResult[];
   cargo: PublishResult[];
+  pub: PublishResult[];
   verification: VerificationResult[];
   githubReleases: GitHubReleaseResult[];
   publishSucceeded: boolean;
@@ -160,6 +168,10 @@ export function getDefaultConfig(): PublishConfig {
       publishOrder: [],
       clean: false,
     },
+    pub: {
+      enabled: false,
+      publishOrder: [],
+    },
     git: {
       push: true,
       pushMethod: 'auto',
@@ -191,6 +203,12 @@ export function getDefaultConfig(): PublishConfig {
         initialDelay: 30000,
         backoffMultiplier: 2,
       },
+      pub: {
+        enabled: true,
+        maxAttempts: 10,
+        initialDelay: 30000,
+        backoffMultiplier: 2,
+      },
     },
   };
 }
@@ -215,6 +233,10 @@ export function toPublishConfig(config: BasePublishConfig | undefined): PublishC
       noVerify: config.cargo?.noVerify ?? defaults.cargo.noVerify,
       publishOrder: config.cargo?.publishOrder ?? defaults.cargo.publishOrder,
       clean: config.cargo?.clean ?? defaults.cargo.clean,
+    },
+    pub: {
+      enabled: config.pub?.enabled ?? defaults.pub.enabled,
+      publishOrder: config.pub?.publishOrder ?? defaults.pub.publishOrder,
     },
     git: config.git
       ? {
@@ -247,6 +269,12 @@ export function toPublishConfig(config: BasePublishConfig | undefined): PublishC
         maxAttempts: config.verify?.cargo?.maxAttempts ?? defaults.verify.cargo.maxAttempts,
         initialDelay: config.verify?.cargo?.initialDelay ?? defaults.verify.cargo.initialDelay,
         backoffMultiplier: config.verify?.cargo?.backoffMultiplier ?? defaults.verify.cargo.backoffMultiplier,
+      },
+      pub: {
+        enabled: config.verify?.pub?.enabled ?? defaults.verify.pub.enabled,
+        maxAttempts: config.verify?.pub?.maxAttempts ?? defaults.verify.pub.maxAttempts,
+        initialDelay: config.verify?.pub?.initialDelay ?? defaults.verify.pub.initialDelay,
+        backoffMultiplier: config.verify?.pub?.backoffMultiplier ?? defaults.verify.pub.backoffMultiplier,
       },
     },
   };

--- a/packages/publish/src/utils/auth.ts
+++ b/packages/publish/src/utils/auth.ts
@@ -14,6 +14,11 @@ export function hasCargoAuth(): boolean {
   return !!process.env.CARGO_REGISTRY_TOKEN;
 }
 
+/** Returns true if PUB_TOKEN is set (token auth). Without it, OIDC automated publishing is assumed. */
+export function hasPubTokenAuth(): boolean {
+  return !!process.env.PUB_TOKEN;
+}
+
 export async function detectGitPushMethod(remote: string, cwd: string): Promise<'ssh' | 'https'> {
   const result = await execCommand('git', ['remote', 'get-url', remote], { cwd });
   const url = result.stdout.trim();

--- a/packages/publish/src/utils/pub.ts
+++ b/packages/publish/src/utils/pub.ts
@@ -8,17 +8,8 @@ export { parsePubspec };
 export const PUB_DEV_USER_AGENT = 'releasekit/publish (https://github.com/goosewobbler/releasekit)';
 export const PUB_DEV_API_TIMEOUT_MS = 30_000;
 
-export function detectPubCommand(pubspecPath: string): 'dart' | 'flutter' {
-  try {
-    const pubspec = parsePubspec(pubspecPath);
-    const env = pubspec.environment as Record<string, unknown> | undefined;
-    if (env && 'flutter' in env) {
-      return 'flutter';
-    }
-  } catch {
-    // Fall through to default
-  }
-  return 'dart';
+export function detectPubCommand(environment: Record<string, unknown> | undefined): 'dart' | 'flutter' {
+  return environment && 'flutter' in environment ? 'flutter' : 'dart';
 }
 
 export async function isPubPackagePublished(name: string, version: string): Promise<boolean> {

--- a/packages/publish/src/utils/pub.ts
+++ b/packages/publish/src/utils/pub.ts
@@ -1,0 +1,40 @@
+import type { PubspecManifest } from '@releasekit/config';
+import { parsePubspec } from '@releasekit/config';
+import { debug } from '@releasekit/core';
+
+export type { PubspecManifest };
+export { parsePubspec };
+
+export const PUB_DEV_USER_AGENT = 'releasekit/publish (https://github.com/goosewobbler/releasekit)';
+export const PUB_DEV_API_TIMEOUT_MS = 30_000;
+
+export function detectPubCommand(pubspecPath: string): 'dart' | 'flutter' {
+  try {
+    const pubspec = parsePubspec(pubspecPath);
+    const env = pubspec.environment as Record<string, unknown> | undefined;
+    if (env && 'flutter' in env) {
+      return 'flutter';
+    }
+  } catch {
+    // Fall through to default
+  }
+  return 'dart';
+}
+
+export async function isPubPackagePublished(name: string, version: string): Promise<boolean> {
+  try {
+    const response = await fetch(`https://pub.dev/api/packages/${name}/versions/${version}`, {
+      signal: AbortSignal.timeout(PUB_DEV_API_TIMEOUT_MS),
+      headers: { 'User-Agent': PUB_DEV_USER_AGENT },
+    });
+    if (response.status === 200) return true;
+    if (response.status === 404) return false;
+    debug(`pub.dev published-check returned ${response.status} for ${name}@${version}, will attempt publish`);
+    return false;
+  } catch (error) {
+    debug(
+      `pub.dev published-check failed for ${name}@${version} (${error instanceof Error ? error.message : String(error)}), will attempt publish`,
+    );
+    return false;
+  }
+}

--- a/packages/publish/test/unit/stages/pub-publish.spec.ts
+++ b/packages/publish/test/unit/stages/pub-publish.spec.ts
@@ -182,6 +182,27 @@ describe('pub-publish stage', () => {
     expect(ctx.output.pub).toHaveLength(1);
   });
 
+  it('should skip the pub.dev published-check for a custom publish_to but still publish', async () => {
+    const { execCommand } = await import('../../../src/utils/exec.js');
+    const fetchMock = vi.fn().mockResolvedValue({ status: 404 } as Response);
+    vi.stubGlobal('fetch', fetchMock);
+
+    const dir = createTmpDir();
+    const pkgDir = path.join(dir, 'packages', 'my_package');
+    fs.mkdirSync(pkgDir, { recursive: true });
+    writePubspec(pkgDir, 'my_package', '0.5.0', 'publish_to: https://my-registry.example.com\n');
+
+    const ctx = createContext(dir);
+    await runPubPublishStage(ctx);
+
+    // pub.dev API must not be queried for a custom registry
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    const publishCalls = vi.mocked(execCommand).mock.calls.filter((c) => (c[1] as string[]).includes('publish'));
+    expect(publishCalls).toHaveLength(1);
+    expect(ctx.output.pub[0]?.success).toBe(true);
+  });
+
   it('should skip packages without pubspec.yaml', async () => {
     const { execCommand } = await import('../../../src/utils/exec.js');
     const dir = createTmpDir();

--- a/packages/publish/test/unit/stages/pub-publish.spec.ts
+++ b/packages/publish/test/unit/stages/pub-publish.spec.ts
@@ -156,6 +156,32 @@ describe('pub-publish stage', () => {
     expect(ctx.output.pub[0]?.success).toBe(true);
   });
 
+  it('should publish a package only once when multiple updates share the same dir', async () => {
+    const { execCommand } = await import('../../../src/utils/exec.js');
+    const dir = createTmpDir();
+    const pkgDir = path.join(dir, 'packages', 'my_package');
+    fs.mkdirSync(pkgDir, { recursive: true });
+    writePubspec(pkgDir, 'my_package');
+    fs.writeFileSync(path.join(pkgDir, 'package.json'), '{"name":"my_package"}');
+
+    const ctx = createContext(dir, {
+      input: {
+        dryRun: false,
+        updates: [
+          { packageName: 'my_package', newVersion: '0.5.0', filePath: 'packages/my_package/package.json' },
+          { packageName: 'my_package', newVersion: '0.5.0', filePath: 'packages/my_package/pubspec.yaml' },
+        ],
+        changelogs: [],
+        tags: [],
+      },
+    });
+    await runPubPublishStage(ctx);
+
+    const publishCalls = vi.mocked(execCommand).mock.calls.filter((c) => (c[1] as string[]).includes('publish'));
+    expect(publishCalls).toHaveLength(1);
+    expect(ctx.output.pub).toHaveLength(1);
+  });
+
   it('should skip packages without pubspec.yaml', async () => {
     const { execCommand } = await import('../../../src/utils/exec.js');
     const dir = createTmpDir();

--- a/packages/publish/test/unit/stages/pub-publish.spec.ts
+++ b/packages/publish/test/unit/stages/pub-publish.spec.ts
@@ -1,0 +1,290 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getDefaultConfig } from '../../../src/config.js';
+import { runPubPublishStage } from '../../../src/stages/pub-publish.js';
+import type { PipelineContext } from '../../../src/types.js';
+
+vi.mock('../../../src/utils/exec.js', async () => {
+  const actual = await vi.importActual<typeof import('../../../src/utils/exec.js')>('../../../src/utils/exec.js');
+  return {
+    ...actual,
+    execCommand: vi.fn().mockResolvedValue({ stdout: '', stderr: '', exitCode: 0 }),
+  };
+});
+
+vi.mock('../../../src/utils/auth.js', () => ({
+  hasCargoAuth: vi.fn().mockReturnValue(true),
+  hasPubTokenAuth: vi.fn().mockReturnValue(false),
+}));
+
+function createContext(cwd: string, overrides?: Partial<PipelineContext>): PipelineContext {
+  const config = getDefaultConfig();
+  config.pub.enabled = true;
+  return {
+    input: {
+      dryRun: false,
+      updates: [{ packageName: 'my_package', newVersion: '0.5.0', filePath: 'packages/my_package/pubspec.yaml' }],
+      changelogs: [],
+      tags: [],
+    },
+    config,
+    cliOptions: {
+      registry: 'all',
+      npmAuth: 'auto',
+      dryRun: false,
+      skipGit: false,
+      skipPublish: false,
+      skipGithubRelease: false,
+      skipVerification: false,
+      json: false,
+      verbose: false,
+    },
+    cwd,
+    packageManager: 'pnpm',
+    output: {
+      dryRun: false,
+      git: { committed: false, tags: [], pushed: false },
+      npm: [],
+      cargo: [],
+      pub: [],
+      verification: [],
+      githubReleases: [],
+      publishSucceeded: false,
+    },
+    ...overrides,
+  };
+}
+
+function writePubspec(dir: string, name: string, version = '0.5.0', extraFields = '') {
+  fs.writeFileSync(
+    path.join(dir, 'pubspec.yaml'),
+    `name: ${name}\nversion: ${version}\nenvironment:\n  sdk: ">=3.0.0 <4.0.0"\n${extraFields}`,
+  );
+}
+
+describe('pub-publish stage', () => {
+  const tmpDirs: string[] = [];
+
+  function createTmpDir(): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'releasekit-pub-test-'));
+    tmpDirs.push(dir);
+    return dir;
+  }
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const { execCommand } = await import('../../../src/utils/exec.js');
+    const { hasPubTokenAuth } = await import('../../../src/utils/auth.js');
+    vi.mocked(execCommand).mockResolvedValue({ stdout: '', stderr: '', exitCode: 0 });
+    vi.mocked(hasPubTokenAuth).mockReturnValue(false);
+    // pub.dev published-check defaults to "not published"
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ status: 404 } as Response));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    for (const dir of tmpDirs) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+    tmpDirs.length = 0;
+  });
+
+  it('should skip when pub disabled', async () => {
+    const { execCommand } = await import('../../../src/utils/exec.js');
+    const dir = createTmpDir();
+    const config = getDefaultConfig();
+    // pub.enabled defaults to false
+    const ctx = createContext(dir, { config });
+
+    await runPubPublishStage(ctx);
+
+    expect(execCommand).not.toHaveBeenCalled();
+  });
+
+  it('should publish a dart package', async () => {
+    const { execCommand } = await import('../../../src/utils/exec.js');
+    const dir = createTmpDir();
+    const pkgDir = path.join(dir, 'packages', 'my_package');
+    fs.mkdirSync(pkgDir, { recursive: true });
+    writePubspec(pkgDir, 'my_package');
+
+    const ctx = createContext(dir);
+    await runPubPublishStage(ctx);
+
+    const publishCalls = vi.mocked(execCommand).mock.calls.filter((c) => (c[1] as string[]).includes('publish'));
+    expect(publishCalls).toHaveLength(1);
+    expect(publishCalls[0]?.[0]).toBe('dart');
+    expect(publishCalls[0]?.[1]).toContain('--force');
+
+    expect(ctx.output.pub).toHaveLength(1);
+    expect(ctx.output.pub[0]?.success).toBe(true);
+    expect(ctx.output.pub[0]?.registry).toBe('pub');
+  });
+
+  it('should use flutter command when pubspec has flutter environment key', async () => {
+    const { execCommand } = await import('../../../src/utils/exec.js');
+    const dir = createTmpDir();
+    const pkgDir = path.join(dir, 'packages', 'my_package');
+    fs.mkdirSync(pkgDir, { recursive: true });
+    writePubspec(pkgDir, 'my_package', '0.5.0', '  flutter: ">=3.0.0"\n');
+
+    const ctx = createContext(dir);
+    await runPubPublishStage(ctx);
+
+    const publishCalls = vi.mocked(execCommand).mock.calls.filter((c) => (c[1] as string[]).includes('publish'));
+    expect(publishCalls[0]?.[0]).toBe('flutter');
+  });
+
+  it('should skip packages already published on pub.dev', async () => {
+    const { execCommand } = await import('../../../src/utils/exec.js');
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ status: 200 } as Response));
+
+    const dir = createTmpDir();
+    const pkgDir = path.join(dir, 'packages', 'my_package');
+    fs.mkdirSync(pkgDir, { recursive: true });
+    writePubspec(pkgDir, 'my_package');
+
+    const ctx = createContext(dir);
+    await runPubPublishStage(ctx);
+
+    const publishCalls = vi.mocked(execCommand).mock.calls.filter((c) => (c[1] as string[]).includes('publish'));
+    expect(publishCalls).toHaveLength(0);
+    expect(ctx.output.pub[0]?.alreadyPublished).toBe(true);
+    expect(ctx.output.pub[0]?.skipped).toBe(true);
+    expect(ctx.output.pub[0]?.success).toBe(true);
+  });
+
+  it('should skip packages without pubspec.yaml', async () => {
+    const { execCommand } = await import('../../../src/utils/exec.js');
+    const dir = createTmpDir();
+    const pkgDir = path.join(dir, 'packages', 'js-only');
+    fs.mkdirSync(pkgDir, { recursive: true });
+    fs.writeFileSync(path.join(pkgDir, 'package.json'), '{"name":"js-only"}');
+
+    const ctx = createContext(dir, {
+      input: {
+        dryRun: false,
+        updates: [{ packageName: 'js-only', newVersion: '1.0.0', filePath: 'packages/js-only/package.json' }],
+        changelogs: [],
+        tags: [],
+      },
+    });
+    await runPubPublishStage(ctx);
+
+    const publishCalls = vi.mocked(execCommand).mock.calls.filter((c) => (c[1] as string[]).includes('publish'));
+    expect(publishCalls).toHaveLength(0);
+    expect(ctx.output.pub).toHaveLength(0);
+  });
+
+  it('should configure PUB_TOKEN when hasPubTokenAuth returns true', async () => {
+    const { execCommand, hasPubTokenAuth } = await Promise.all([
+      import('../../../src/utils/exec.js'),
+      import('../../../src/utils/auth.js'),
+    ]).then(([exec, auth]) => ({ execCommand: exec.execCommand, hasPubTokenAuth: auth.hasPubTokenAuth }));
+
+    vi.mocked(hasPubTokenAuth).mockReturnValue(true);
+
+    const dir = createTmpDir();
+    const pkgDir = path.join(dir, 'packages', 'my_package');
+    fs.mkdirSync(pkgDir, { recursive: true });
+    writePubspec(pkgDir, 'my_package');
+
+    const ctx = createContext(dir);
+    await runPubPublishStage(ctx);
+
+    const tokenCalls = vi
+      .mocked(execCommand)
+      .mock.calls.filter((c) => c[0] === 'dart' && (c[1] as string[]).includes('token'));
+    expect(tokenCalls).toHaveLength(1);
+    expect(tokenCalls[0]?.[1]).toContain('https://pub.dev');
+    expect(tokenCalls[0]?.[1]).toContain('PUB_TOKEN');
+  });
+
+  it('should not configure token when hasPubTokenAuth returns false', async () => {
+    const { execCommand } = await import('../../../src/utils/exec.js');
+    const dir = createTmpDir();
+    const pkgDir = path.join(dir, 'packages', 'my_package');
+    fs.mkdirSync(pkgDir, { recursive: true });
+    writePubspec(pkgDir, 'my_package');
+
+    const ctx = createContext(dir);
+    await runPubPublishStage(ctx);
+
+    const tokenCalls = vi
+      .mocked(execCommand)
+      .mock.calls.filter((c) => c[0] === 'dart' && (c[1] as string[]).includes('token'));
+    expect(tokenCalls).toHaveLength(0);
+  });
+
+  it('should respect publishOrder config', async () => {
+    const { execCommand } = await import('../../../src/utils/exec.js');
+    const dir = createTmpDir();
+
+    const pkgADir = path.join(dir, 'packages', 'pkg_a');
+    const pkgBDir = path.join(dir, 'packages', 'pkg_b');
+    fs.mkdirSync(pkgADir, { recursive: true });
+    fs.mkdirSync(pkgBDir, { recursive: true });
+    writePubspec(pkgADir, 'pkg_a');
+    writePubspec(pkgBDir, 'pkg_b');
+
+    const config = getDefaultConfig();
+    config.pub.enabled = true;
+    config.pub.publishOrder = ['pkg_b', 'pkg_a'];
+
+    const ctx = createContext(dir, {
+      config,
+      input: {
+        dryRun: false,
+        updates: [
+          { packageName: 'pkg_a', newVersion: '1.0.0', filePath: 'packages/pkg_a/pubspec.yaml' },
+          { packageName: 'pkg_b', newVersion: '1.0.0', filePath: 'packages/pkg_b/pubspec.yaml' },
+        ],
+        changelogs: [],
+        tags: [],
+      },
+    });
+
+    await runPubPublishStage(ctx);
+
+    const publishCalls = vi.mocked(execCommand).mock.calls.filter((c) => (c[1] as string[]).includes('publish'));
+    expect(publishCalls).toHaveLength(2);
+    // pkg_b should come before pkg_a
+    const cwds = publishCalls.map((c) => (c[2] as { cwd?: string })?.cwd ?? '');
+    expect(cwds[0]).toContain('pkg_b');
+    expect(cwds[1]).toContain('pkg_a');
+  });
+
+  it('should throw and record failure result when publish fails', async () => {
+    const { execCommand } = await import('../../../src/utils/exec.js');
+    vi.mocked(execCommand).mockRejectedValue(new Error('publish failed: connection timeout'));
+
+    const dir = createTmpDir();
+    const pkgDir = path.join(dir, 'packages', 'my_package');
+    fs.mkdirSync(pkgDir, { recursive: true });
+    writePubspec(pkgDir, 'my_package');
+
+    const ctx = createContext(dir);
+
+    await expect(runPubPublishStage(ctx)).rejects.toThrow();
+    expect(ctx.output.pub[0]?.success).toBe(false);
+  });
+
+  it('should send User-Agent header in pub.dev published-check', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ status: 404 } as Response);
+    vi.stubGlobal('fetch', fetchMock);
+
+    const dir = createTmpDir();
+    const pkgDir = path.join(dir, 'packages', 'my_package');
+    fs.mkdirSync(pkgDir, { recursive: true });
+    writePubspec(pkgDir, 'my_package');
+
+    const ctx = createContext(dir);
+    await runPubPublishStage(ctx);
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect((init?.headers as Record<string, string>)?.['User-Agent']).toMatch(/releasekit/);
+  });
+});

--- a/packages/publish/test/unit/stages/pub-publish.spec.ts
+++ b/packages/publish/test/unit/stages/pub-publish.spec.ts
@@ -282,6 +282,33 @@ describe('pub-publish stage', () => {
     expect(cwds[1]).toContain('pkg_a');
   });
 
+  it('should wrap dart pub token add failures as PUB_AUTH_ERROR', async () => {
+    const { execCommand, hasPubTokenAuth } = await Promise.all([
+      import('../../../src/utils/exec.js'),
+      import('../../../src/utils/auth.js'),
+    ]).then(([exec, auth]) => ({ execCommand: exec.execCommand, hasPubTokenAuth: auth.hasPubTokenAuth }));
+
+    vi.mocked(hasPubTokenAuth).mockReturnValue(true);
+    vi.mocked(execCommand).mockImplementation((cmd, args) => {
+      if (cmd === 'dart' && (args as string[]).includes('token')) {
+        return Promise.reject(new Error('dart: command not found'));
+      }
+      return Promise.resolve({ stdout: '', stderr: '', exitCode: 0 });
+    });
+
+    const dir = createTmpDir();
+    const pkgDir = path.join(dir, 'packages', 'my_package');
+    fs.mkdirSync(pkgDir, { recursive: true });
+    writePubspec(pkgDir, 'my_package');
+
+    const ctx = createContext(dir);
+
+    await expect(runPubPublishStage(ctx)).rejects.toMatchObject({ code: 'PUB_AUTH_ERROR' });
+
+    const publishCalls = vi.mocked(execCommand).mock.calls.filter((c) => (c[1] as string[]).includes('publish'));
+    expect(publishCalls).toHaveLength(0);
+  });
+
   it('should throw and record failure result when publish fails', async () => {
     const { execCommand } = await import('../../../src/utils/exec.js');
     vi.mocked(execCommand).mockRejectedValue(new Error('publish failed: connection timeout'));

--- a/packages/publish/test/unit/stages/verify.spec.ts
+++ b/packages/publish/test/unit/stages/verify.spec.ts
@@ -36,6 +36,7 @@ function createContext(overrides?: Partial<PipelineContext>): PipelineContext {
     packageManager: 'pnpm',
     output: {
       dryRun: false,
+      publishSucceeded: true,
       git: { committed: false, tags: [], pushed: false },
       npm: [{ packageName: '@test/pkg', version: '1.0.0', registry: 'npm', success: true, skipped: false }],
       cargo: [],
@@ -50,6 +51,7 @@ function createContext(overrides?: Partial<PipelineContext>): PipelineContext {
 function cargoOutput(overrides?: object) {
   return {
     dryRun: false,
+    publishSucceeded: true,
     git: { committed: false, tags: [], pushed: false },
     npm: [],
     cargo: [
@@ -71,6 +73,7 @@ function cargoOutput(overrides?: object) {
 function pubOutput(overrides?: object) {
   return {
     dryRun: false,
+    publishSucceeded: true,
     git: { committed: false, tags: [], pushed: false },
     npm: [],
     cargo: [],
@@ -113,6 +116,7 @@ describe('verify stage', () => {
     const ctx = createContext({
       output: {
         dryRun: false,
+        publishSucceeded: true,
         git: { committed: false, tags: [], pushed: false },
         npm: [
           {
@@ -140,6 +144,7 @@ describe('verify stage', () => {
     const ctx = createContext({
       output: {
         dryRun: false,
+        publishSucceeded: true,
         git: { committed: false, tags: [], pushed: false },
         npm: [
           {

--- a/packages/publish/test/unit/stages/verify.spec.ts
+++ b/packages/publish/test/unit/stages/verify.spec.ts
@@ -14,6 +14,8 @@ function createContext(overrides?: Partial<PipelineContext>): PipelineContext {
   config.verify.npm.maxAttempts = 2;
   config.verify.cargo.initialDelay = 1;
   config.verify.cargo.maxAttempts = 2;
+  config.verify.pub.initialDelay = 1;
+  config.verify.pub.maxAttempts = 2;
 
   return {
     input: { dryRun: false, updates: [], changelogs: [], tags: [] },
@@ -37,6 +39,7 @@ function createContext(overrides?: Partial<PipelineContext>): PipelineContext {
       git: { committed: false, tags: [], pushed: false },
       npm: [{ packageName: '@test/pkg', version: '1.0.0', registry: 'npm', success: true, skipped: false }],
       cargo: [],
+      pub: [],
       verification: [],
       githubReleases: [],
     },
@@ -54,6 +57,28 @@ function cargoOutput(overrides?: object) {
         packageName: 'my-crate',
         version: '0.5.0',
         registry: 'cargo' as const,
+        success: true,
+        skipped: false,
+        ...overrides,
+      },
+    ],
+    pub: [],
+    verification: [],
+    githubReleases: [],
+  };
+}
+
+function pubOutput(overrides?: object) {
+  return {
+    dryRun: false,
+    git: { committed: false, tags: [], pushed: false },
+    npm: [],
+    cargo: [],
+    pub: [
+      {
+        packageName: 'my_package',
+        version: '1.0.0',
+        registry: 'pub' as const,
         success: true,
         skipped: false,
         ...overrides,
@@ -100,6 +125,7 @@ describe('verify stage', () => {
           },
         ],
         cargo: [],
+        pub: [],
         verification: [],
         githubReleases: [],
       },
@@ -126,6 +152,7 @@ describe('verify stage', () => {
           },
         ],
         cargo: [],
+        pub: [],
         verification: [],
         githubReleases: [],
       },
@@ -234,6 +261,106 @@ describe('verify stage', () => {
 
       expect(fetchMock).not.toHaveBeenCalled();
       expect(ctx.output.verification).toHaveLength(0);
+    });
+  });
+
+  describe('pub.dev verification', () => {
+    it('should verify a published package when pub.dev returns 200', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ status: 200, ok: true } as Response));
+      const ctx = createContext({ output: pubOutput() });
+
+      await runVerifyStage(ctx);
+
+      expect(ctx.output.verification).toHaveLength(1);
+      expect(ctx.output.verification[0]?.verified).toBe(true);
+      expect(ctx.output.verification[0]?.registry).toBe('pub');
+    });
+
+    it('should retry when pub.dev returns 404 then succeed on 200', async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce({ status: 404, ok: false } as Response)
+        .mockResolvedValue({ status: 200, ok: true } as Response);
+      vi.stubGlobal('fetch', fetchMock);
+      const ctx = createContext({ output: pubOutput() });
+
+      await runVerifyStage(ctx);
+
+      expect(ctx.output.verification[0]?.verified).toBe(true);
+      expect(ctx.output.verification[0]?.attempts).toBeGreaterThan(1);
+    });
+
+    it('should fail fast on 403 without exhausting retries and surface the reason', async () => {
+      const fetchMock = vi.fn().mockResolvedValue({ status: 403, ok: false } as Response);
+      vi.stubGlobal('fetch', fetchMock);
+      const warnSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const ctx = createContext({ output: pubOutput() });
+
+      await runVerifyStage(ctx);
+
+      expect(ctx.output.verification[0]?.verified).toBe(false);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const warnCalls = warnSpy.mock.calls.map((c) => c.join(' '));
+      expect(warnCalls.some((msg) => msg.includes('403'))).toBe(true);
+      warnSpy.mockRestore();
+    });
+
+    it('should send User-Agent header in pub.dev verification request', async () => {
+      const fetchMock = vi.fn().mockResolvedValue({ status: 200, ok: true } as Response);
+      vi.stubGlobal('fetch', fetchMock);
+      const ctx = createContext({ output: pubOutput() });
+
+      await runVerifyStage(ctx);
+
+      expect(fetchMock).toHaveBeenCalledOnce();
+      const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      expect((init?.headers as Record<string, string>)?.['User-Agent']).toMatch(/releasekit/);
+    });
+
+    it('should skip verification for skipped pub packages', async () => {
+      const fetchMock = vi.fn();
+      vi.stubGlobal('fetch', fetchMock);
+      const ctx = createContext({ output: pubOutput({ skipped: true }) });
+
+      await runVerifyStage(ctx);
+
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(ctx.output.verification).toHaveLength(0);
+    });
+
+    it('should skip pub verification when verify.pub.enabled is false', async () => {
+      const fetchMock = vi.fn();
+      vi.stubGlobal('fetch', fetchMock);
+      const ctx = createContext({ output: pubOutput() });
+      ctx.config.verify.pub.enabled = false;
+
+      await runVerifyStage(ctx);
+
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('should handle dry run for pub packages', async () => {
+      const fetchMock = vi.fn();
+      vi.stubGlobal('fetch', fetchMock);
+      const ctx = createContext({
+        output: pubOutput(),
+        cliOptions: {
+          registry: 'all',
+          npmAuth: 'auto',
+          dryRun: true,
+          skipGit: false,
+          skipPublish: false,
+          skipGithubRelease: false,
+          skipVerification: false,
+          json: false,
+          verbose: false,
+        },
+      });
+
+      await runVerifyStage(ctx);
+
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(ctx.output.verification[0]?.verified).toBe(true);
     });
   });
 });

--- a/packages/release/docs/ci-setup.md
+++ b/packages/release/docs/ci-setup.md
@@ -626,6 +626,54 @@ ReleaseKit detects OIDC availability automatically (`npm-auth: auto`). To force 
 
 ---
 
+## pub.dev Publishing (Dart / Flutter)
+
+ReleaseKit publishes Dart and Flutter packages to pub.dev. Set `publish.pub.enabled: true` in your config and, if the repo contains Flutter packages, ReleaseKit detects them automatically from the `environment.flutter` key in `pubspec.yaml`.
+
+### OIDC automated publishing (recommended)
+
+pub.dev supports automated publishing without a token if you configure a publisher on the pub.dev package admin page:
+
+1. Go to the package page on pub.dev → **Admin** → **Automated publishing**.
+2. Enable **GitHub Actions publishing** and set the repository, workflow file, and (optionally) environment.
+3. No secret is required — the workflow gets `id-token: write` permission and pub.dev validates the OIDC token at publish time.
+
+```yaml
+permissions:
+  contents: write
+  id-token: write   # required for pub.dev OIDC publishing
+```
+
+ReleaseKit will run `dart pub publish --force` (or `flutter pub publish --force` for Flutter packages) directly. No credential setup step is needed.
+
+### Token-based publishing
+
+If OIDC is not configured, set the `PUB_TOKEN` environment variable. ReleaseKit will run `dart pub token add https://pub.dev --env-var PUB_TOKEN` before publishing.
+
+```yaml
+- run: pnpm exec releasekit release
+  env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    PUB_TOKEN: ${{ secrets.PUB_TOKEN }}
+```
+
+### Config
+
+```json
+{
+  "publish": {
+    "pub": {
+      "enabled": true,
+      "publishOrder": ["my_core_package", "my_app_package"]
+    }
+  }
+}
+```
+
+`publishOrder` is optional — use it to control the sequence when packages within the same release have inter-dependencies.
+
+---
+
 ## Prerelease Workflow
 
 ```yaml

--- a/packages/release/package.json
+++ b/packages/release/package.json
@@ -66,6 +66,7 @@
     "minimatch": "catalog:",
     "semver": "catalog:",
     "smol-toml": "catalog:",
+    "yaml": "catalog:",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/packages/version/package.json
+++ b/packages/version/package.json
@@ -74,6 +74,7 @@
     "minimatch": "^10.2.5",
     "semver": "catalog:",
     "smol-toml": "catalog:",
+    "yaml": "catalog:",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/packages/version/src/package/packageManagement.ts
+++ b/packages/version/src/package/packageManagement.ts
@@ -5,6 +5,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { isCargoToml, updateCargoVersion } from '../cargo/cargoHandler.js';
+import { isPubspecYaml, updatePubVersion } from '../pub/pubHandler.js';
 import type { PkgJson } from '../types.js';
 import { addPackageUpdate, recordPendingWrite } from '../utils/jsonOutput.js';
 import { log } from '../utils/logging.js';
@@ -117,6 +118,12 @@ export function updatePackageVersion(packagePath: string, version: string, dryRu
   // Handle Cargo.toml files separately
   if (isCargoToml(packagePath)) {
     updateCargoVersion(packagePath, version, dryRun);
+    return;
+  }
+
+  // Handle pubspec.yaml files separately
+  if (isPubspecYaml(packagePath)) {
+    updatePubVersion(packagePath, version, dryRun);
     return;
   }
 

--- a/packages/version/src/package/packageProcessor.ts
+++ b/packages/version/src/package/packageProcessor.ts
@@ -344,6 +344,39 @@ export class PackageProcessor {
         log(`Cargo disabled for ${name}`, 'debug');
       }
 
+      // Check if Dart/pubspec.yaml handling is enabled (default to true if not specified)
+      const pubEnabled = this.fullConfig.pub?.enabled !== false;
+      log(`Pub enabled for ${name}: ${pubEnabled}, config: ${JSON.stringify(this.fullConfig.pub)}`, 'debug');
+
+      if (pubEnabled) {
+        const dartPaths = this.fullConfig.pub?.paths;
+        log(`Pub paths config for ${name}: ${JSON.stringify(dartPaths)}`, 'debug');
+
+        if (dartPaths && dartPaths.length > 0) {
+          for (const dartPath of dartPaths) {
+            const resolvedPubspecPath = path.resolve(pkgPath, dartPath, 'pubspec.yaml');
+            log(`Checking pub path for ${name}: ${resolvedPubspecPath}`, 'debug');
+            if (fs.existsSync(resolvedPubspecPath)) {
+              log(`Found pubspec.yaml for ${name} at ${resolvedPubspecPath}, updating...`, 'debug');
+              updatePackageVersion(resolvedPubspecPath, nextVersion, this.dryRun);
+            } else {
+              log(`pubspec.yaml not found at ${resolvedPubspecPath}`, 'debug');
+            }
+          }
+        } else {
+          const pubspecPath = path.join(pkgPath, 'pubspec.yaml');
+          log(`Checking default pub path for ${name}: ${pubspecPath}`, 'debug');
+          if (fs.existsSync(pubspecPath)) {
+            log(`Found pubspec.yaml for ${name} at ${pubspecPath}, updating...`, 'debug');
+            updatePackageVersion(pubspecPath, nextVersion, this.dryRun);
+          } else {
+            log(`pubspec.yaml not found for ${name} at ${pubspecPath}`, 'debug');
+          }
+        }
+      } else {
+        log(`Pub disabled for ${name}`, 'debug');
+      }
+
       // Create package-specific tag (using the updated formatTag function with package name)
       const packageTag = formatTag(
         nextVersion,

--- a/packages/version/src/pub/pubHandler.ts
+++ b/packages/version/src/pub/pubHandler.ts
@@ -55,7 +55,7 @@ export function updatePubVersion(pubspecPath: string, version: string, dryRun = 
 
     // Replace the entire version line. Flutter build numbers (e.g. `1.0.0+1`) are
     // intentionally dropped — ReleaseKit manages the SemVer portion only.
-    const updatedContent = content.replace(/^(version:\s*).*$/m, `$1${version}`);
+    const updatedContent = content.replace(/^(version:\s*)\S+(\s+#.*)?$/m, `$1${version}$2`);
 
     if (updatedContent === content && !/^version:\s*/m.test(content)) {
       throw new Error(`No version field found in ${pubspecPath}`);

--- a/packages/version/src/pub/pubHandler.ts
+++ b/packages/version/src/pub/pubHandler.ts
@@ -46,7 +46,7 @@ export function getPubInfo(pubspecPath: string): PubInfo {
 export function updatePubVersion(pubspecPath: string, version: string, dryRun = false): void {
   try {
     const content = fs.readFileSync(pubspecPath, 'utf-8');
-    const pubspec = parsePubspec(pubspecPath);
+    const pubspec = parsePubspec(pubspecPath, content);
     const packageName = pubspec.name;
 
     if (!packageName) {

--- a/packages/version/src/pub/pubHandler.ts
+++ b/packages/version/src/pub/pubHandler.ts
@@ -53,8 +53,13 @@ export function updatePubVersion(pubspecPath: string, version: string, dryRun = 
       throw new Error(`No package name found in ${pubspecPath}`);
     }
 
-    // Replace the version line, preserving all other content and formatting
+    // Replace the entire version line. Flutter build numbers (e.g. `1.0.0+1`) are
+    // intentionally dropped — ReleaseKit manages the SemVer portion only.
     const updatedContent = content.replace(/^(version:\s*).*$/m, `$1${version}`);
+
+    if (updatedContent === content && !/^version:\s*/m.test(content)) {
+      throw new Error(`No version field found in ${pubspecPath}`);
+    }
 
     if (dryRun) {
       recordPendingWrite(pubspecPath, updatedContent);

--- a/packages/version/src/pub/pubHandler.ts
+++ b/packages/version/src/pub/pubHandler.ts
@@ -1,0 +1,77 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { isPubspecYaml, parsePubspec } from '@releasekit/config';
+import { addPackageUpdate, recordPendingWrite } from '../utils/jsonOutput.js';
+import { log } from '../utils/logging.js';
+
+export { isPubspecYaml };
+
+export interface PubInfo {
+  name: string;
+  version: string;
+  path: string;
+  dir: string;
+}
+
+export function getPubInfo(pubspecPath: string): PubInfo {
+  if (!fs.existsSync(pubspecPath)) {
+    log(`pubspec.yaml not found at: ${pubspecPath}`, 'error');
+    throw new Error(`pubspec.yaml not found at: ${pubspecPath}`);
+  }
+
+  try {
+    const pubspec = parsePubspec(pubspecPath);
+
+    if (!pubspec.name) {
+      log(`Package name not found in: ${pubspecPath}`, 'error');
+      throw new Error(`Package name not found in: ${pubspecPath}`);
+    }
+
+    return {
+      name: pubspec.name,
+      version: pubspec.version ?? '0.0.0',
+      path: pubspecPath,
+      dir: path.dirname(pubspecPath),
+    };
+  } catch (error) {
+    log(`Error reading pubspec.yaml: ${pubspecPath}`, 'error');
+    if (error instanceof Error) {
+      log(error.message, 'error');
+      throw error;
+    }
+    throw new Error(`Failed to process pubspec.yaml at ${pubspecPath}`);
+  }
+}
+
+export function updatePubVersion(pubspecPath: string, version: string, dryRun = false): void {
+  try {
+    const content = fs.readFileSync(pubspecPath, 'utf-8');
+    const pubspec = parsePubspec(pubspecPath);
+    const packageName = pubspec.name;
+
+    if (!packageName) {
+      throw new Error(`No package name found in ${pubspecPath}`);
+    }
+
+    // Replace the version line, preserving all other content and formatting
+    const updatedContent = content.replace(/^(version:\s*).*$/m, `$1${version}`);
+
+    if (dryRun) {
+      recordPendingWrite(pubspecPath, updatedContent);
+    } else {
+      fs.writeFileSync(pubspecPath, updatedContent);
+    }
+
+    addPackageUpdate(packageName, version, pubspecPath);
+    log(
+      `${dryRun ? '[DRY RUN] Would update' : 'Updated'} pubspec.yaml at ${pubspecPath} to version ${version}`,
+      'success',
+    );
+  } catch (error) {
+    log(`Failed to update pubspec.yaml at ${pubspecPath}`, 'error');
+    if (error instanceof Error) {
+      log(error.message, 'error');
+    }
+    throw error;
+  }
+}

--- a/packages/version/src/pub/pubHandler.ts
+++ b/packages/version/src/pub/pubHandler.ts
@@ -57,7 +57,7 @@ export function updatePubVersion(pubspecPath: string, version: string, dryRun = 
     // intentionally dropped — ReleaseKit manages the SemVer portion only.
     const updatedContent = content.replace(/^(version:\s*)\S+(\s+#.*)?$/m, `$1${version}$2`);
 
-    if (updatedContent === content && !/^version:\s*/m.test(content)) {
+    if (updatedContent === content && !pubspec.version) {
       throw new Error(`No version field found in ${pubspecPath}`);
     }
 

--- a/packages/version/src/pub/pubHandler.ts
+++ b/packages/version/src/pub/pubHandler.ts
@@ -53,11 +53,16 @@ export function updatePubVersion(pubspecPath: string, version: string, dryRun = 
       throw new Error(`No package name found in ${pubspecPath}`);
     }
 
-    // Replace the entire version line. Flutter build numbers (e.g. `1.0.0+1`) are
-    // intentionally dropped — ReleaseKit manages the SemVer portion only.
-    const updatedContent = content.replace(/^(version:\s*)\S+(\s+#.*)?$/m, `$1${version}$2`);
+    // Replace the version line, preserving an optional inline comment and tolerating
+    // trailing whitespace. Flutter build numbers (e.g. `1.0.0+1`) are intentionally
+    // dropped — ReleaseKit manages the SemVer portion only.
+    const updatedContent = content.replace(/^(version:[ \t]*)\S.*?([ \t]*#[^\n]*)?[ \t]*$/m, `$1${version}$2`);
 
-    if (updatedContent === content && !pubspec.version) {
+    // A no-op replacement is only legitimate when the file is already at the target
+    // version. Otherwise either there is no version field, or the parser found one the
+    // regex could not rewrite (an unusually-formatted line) — refuse rather than record
+    // a bump that never touched the file and let a stale version reach pub.dev.
+    if (updatedContent === content && pubspec.version !== version) {
       throw new Error(`No version field found in ${pubspecPath}`);
     }
 

--- a/packages/version/src/types.ts
+++ b/packages/version/src/types.ts
@@ -95,6 +95,10 @@ export interface Config extends VersionConfigBase {
     enabled?: boolean;
     paths?: string[];
   };
+  pub?: {
+    enabled?: boolean;
+    paths?: string[];
+  };
 }
 
 export interface BranchPattern {
@@ -180,5 +184,6 @@ export function toVersionConfig(config: VersionConfig | undefined, gitConfig?: G
     prereleaseIdentifier: config.prereleaseIdentifier,
     baseBranch: gitConfig?.branch,
     cargo: config.cargo,
+    pub: config.pub,
   };
 }

--- a/packages/version/test/unit/pub/pubHandler.spec.ts
+++ b/packages/version/test/unit/pub/pubHandler.spec.ts
@@ -154,6 +154,12 @@ describe('Pub Handler', () => {
       expect(() => updatePubVersion(mockPubspecPath, '2.0.0')).toThrow('No package name found in');
     });
 
+    it('should throw if pubspec.yaml has no version field', () => {
+      vi.mocked(fs.readFileSync, { partial: true }).mockReturnValue('name: test_package\n');
+
+      expect(() => updatePubVersion(mockPubspecPath, '2.0.0')).toThrow('No version field found in');
+    });
+
     it('should handle errors when updating pubspec.yaml', () => {
       vi.mocked(fs.readFileSync, { partial: true }).mockImplementation(() => {
         throw new Error('Read error');

--- a/packages/version/test/unit/pub/pubHandler.spec.ts
+++ b/packages/version/test/unit/pub/pubHandler.spec.ts
@@ -1,0 +1,167 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getPubInfo, isPubspecYaml, updatePubVersion } from '../../../src/pub/pubHandler.js';
+import * as jsonOutput from '../../../src/utils/jsonOutput.js';
+import * as logging from '../../../src/utils/logging.js';
+
+vi.mock('node:fs');
+vi.mock('../../../src/utils/jsonOutput.js');
+vi.mock('../../../src/utils/logging.js');
+vi.mock('@releasekit/config', () => ({
+  parsePubspec: vi.fn(),
+  isPubspecYaml: vi.fn((filePath: string) => path.basename(filePath) === 'pubspec.yaml'),
+}));
+
+import { parsePubspec } from '@releasekit/config';
+
+describe('Pub Handler', () => {
+  const mockPubspecPath = path.join('test', 'fixtures', 'dart-package', 'pubspec.yaml');
+
+  const mockPubspecContent = 'name: test_package\nversion: 1.0.0\nenvironment:\n  sdk: ">=3.0.0 <4.0.0"\n';
+
+  const mockPubspecData = {
+    name: 'test_package',
+    version: '1.0.0',
+    environment: { sdk: '>=3.0.0 <4.0.0' },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(fs.existsSync, { partial: true }).mockReturnValue(true);
+    vi.mocked(fs.readFileSync, { partial: true }).mockReturnValue(mockPubspecContent);
+    vi.mocked(parsePubspec, { partial: true }).mockReturnValue({ ...mockPubspecData });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('isPubspecYaml', () => {
+    it('should return true for pubspec.yaml files', () => {
+      expect(isPubspecYaml('pubspec.yaml')).toBe(true);
+      expect(isPubspecYaml('/path/to/pubspec.yaml')).toBe(true);
+      expect(isPubspecYaml('project/pubspec.yaml')).toBe(true);
+    });
+
+    it('should return false for non-pubspec.yaml files', () => {
+      expect(isPubspecYaml('package.json')).toBe(false);
+      expect(isPubspecYaml('/path/to/Cargo.toml')).toBe(false);
+      expect(isPubspecYaml('pubspec.yml')).toBe(false);
+    });
+  });
+
+  describe('getPubInfo', () => {
+    it('should get pub info from pubspec.yaml', () => {
+      const info = getPubInfo(mockPubspecPath);
+
+      expect(fs.existsSync).toHaveBeenCalledWith(mockPubspecPath);
+      expect(parsePubspec).toHaveBeenCalledWith(mockPubspecPath);
+
+      expect(info).toEqual({
+        name: 'test_package',
+        version: '1.0.0',
+        path: mockPubspecPath,
+        dir: path.dirname(mockPubspecPath),
+      });
+    });
+
+    it('should use 0.0.0 as fallback when version is absent', () => {
+      vi.mocked(parsePubspec, { partial: true }).mockReturnValue({ name: 'test_package' });
+
+      const info = getPubInfo(mockPubspecPath);
+
+      expect(info.version).toBe('0.0.0');
+    });
+
+    it('should throw if pubspec.yaml does not exist', () => {
+      vi.mocked(fs.existsSync, { partial: true }).mockReturnValue(false);
+
+      expect(() => getPubInfo(mockPubspecPath)).toThrow(`pubspec.yaml not found at: ${mockPubspecPath}`);
+
+      expect(logging.log).toHaveBeenCalledWith(expect.stringContaining('pubspec.yaml not found at:'), 'error');
+    });
+
+    it('should throw if package name not found', () => {
+      vi.mocked(parsePubspec, { partial: true }).mockReturnValue({});
+
+      expect(() => getPubInfo(mockPubspecPath)).toThrow('Package name not found in:');
+
+      expect(logging.log).toHaveBeenCalledWith(expect.stringContaining('Package name not found in:'), 'error');
+    });
+
+    it('should handle errors when reading pubspec.yaml', () => {
+      const mockError = new Error('Read error');
+      vi.mocked(parsePubspec, { partial: true }).mockImplementation(() => {
+        throw mockError;
+      });
+
+      expect(() => getPubInfo(mockPubspecPath)).toThrow();
+
+      expect(logging.log).toHaveBeenCalledWith(expect.stringContaining('Error reading pubspec.yaml:'), 'error');
+    });
+  });
+
+  describe('updatePubVersion', () => {
+    it('should update the version in pubspec.yaml', () => {
+      vi.mocked(jsonOutput.addPackageUpdate, { partial: true }).mockImplementation(() => {});
+
+      updatePubVersion(mockPubspecPath, '2.0.0');
+
+      expect(fs.readFileSync).toHaveBeenCalledWith(mockPubspecPath, 'utf-8');
+      expect(fs.writeFileSync).toHaveBeenCalledWith(mockPubspecPath, expect.stringContaining('version: 2.0.0'));
+      expect(jsonOutput.addPackageUpdate).toHaveBeenCalledWith('test_package', '2.0.0', mockPubspecPath);
+      expect(logging.log).toHaveBeenCalledWith(expect.stringContaining('Updated pubspec.yaml at'), 'success');
+    });
+
+    it('should preserve surrounding file content when updating version', () => {
+      vi.mocked(jsonOutput.addPackageUpdate, { partial: true }).mockImplementation(() => {});
+
+      updatePubVersion(mockPubspecPath, '2.0.0');
+
+      const [, writtenContent] = vi.mocked(fs.writeFileSync).mock.calls[0] as [string, string];
+      expect(writtenContent).toContain('name: test_package');
+      expect(writtenContent).toContain('version: 2.0.0');
+      expect(writtenContent).toContain('sdk: ">=3.0.0 <4.0.0"');
+    });
+
+    it('should not write to disk when dryRun is true', () => {
+      vi.mocked(jsonOutput.addPackageUpdate, { partial: true }).mockImplementation(() => {});
+
+      updatePubVersion(mockPubspecPath, '2.0.0', true);
+
+      expect(fs.writeFileSync).not.toHaveBeenCalled();
+      expect(jsonOutput.recordPendingWrite).toHaveBeenCalledWith(
+        mockPubspecPath,
+        expect.stringContaining('version: 2.0.0'),
+      );
+      expect(jsonOutput.addPackageUpdate).toHaveBeenCalledWith('test_package', '2.0.0', mockPubspecPath);
+      expect(logging.log).toHaveBeenCalledWith(expect.stringContaining('[DRY RUN] Would update'), 'success');
+    });
+
+    it('should write to disk when dryRun is false', () => {
+      vi.mocked(jsonOutput.addPackageUpdate, { partial: true }).mockImplementation(() => {});
+
+      updatePubVersion(mockPubspecPath, '2.0.0', false);
+
+      expect(fs.writeFileSync).toHaveBeenCalledWith(mockPubspecPath, expect.any(String));
+      expect(jsonOutput.addPackageUpdate).toHaveBeenCalledWith('test_package', '2.0.0', mockPubspecPath);
+    });
+
+    it('should throw if package name is missing', () => {
+      vi.mocked(parsePubspec, { partial: true }).mockReturnValue({});
+
+      expect(() => updatePubVersion(mockPubspecPath, '2.0.0')).toThrow('No package name found in');
+    });
+
+    it('should handle errors when updating pubspec.yaml', () => {
+      vi.mocked(fs.readFileSync, { partial: true }).mockImplementation(() => {
+        throw new Error('Read error');
+      });
+
+      expect(() => updatePubVersion(mockPubspecPath, '2.0.0')).toThrow();
+
+      expect(logging.log).toHaveBeenCalledWith(expect.stringContaining('Failed to update pubspec.yaml at'), 'error');
+    });
+  });
+});

--- a/packages/version/test/unit/pub/pubHandler.spec.ts
+++ b/packages/version/test/unit/pub/pubHandler.spec.ts
@@ -171,6 +171,36 @@ describe('Pub Handler', () => {
       expect(() => updatePubVersion(mockPubspecPath, '2.0.0')).toThrow('No version field found in');
     });
 
+    it('should update a version line with trailing whitespace instead of silently no-opping', () => {
+      vi.mocked(fs.readFileSync, { partial: true }).mockReturnValue('name: test_package\nversion: 1.0.0  \n');
+      vi.mocked(jsonOutput.addPackageUpdate, { partial: true }).mockImplementation(() => {});
+
+      updatePubVersion(mockPubspecPath, '2.0.0');
+
+      const [, writtenContent] = vi.mocked(fs.writeFileSync).mock.calls[0] as [string, string];
+      expect(writtenContent).toContain('version: 2.0.0');
+      expect(writtenContent).not.toContain('1.0.0');
+    });
+
+    it('should preserve an inline comment on the version line', () => {
+      vi.mocked(fs.readFileSync, { partial: true }).mockReturnValue('name: test_package\nversion: 1.0.0 # current\n');
+      vi.mocked(jsonOutput.addPackageUpdate, { partial: true }).mockImplementation(() => {});
+
+      updatePubVersion(mockPubspecPath, '2.0.0');
+
+      const [, writtenContent] = vi.mocked(fs.writeFileSync).mock.calls[0] as [string, string];
+      expect(writtenContent).toContain('version: 2.0.0 # current');
+    });
+
+    it('should not throw when the file is already at the target version', () => {
+      vi.mocked(fs.readFileSync, { partial: true }).mockReturnValue('name: test_package\nversion: 2.0.0\n');
+      vi.mocked(parsePubspec, { partial: true }).mockReturnValue({ name: 'test_package', version: '2.0.0' });
+      vi.mocked(jsonOutput.addPackageUpdate, { partial: true }).mockImplementation(() => {});
+
+      expect(() => updatePubVersion(mockPubspecPath, '2.0.0')).not.toThrow();
+      expect(jsonOutput.addPackageUpdate).toHaveBeenCalledWith('test_package', '2.0.0', mockPubspecPath);
+    });
+
     it('should handle errors when updating pubspec.yaml', () => {
       vi.mocked(fs.readFileSync, { partial: true }).mockImplementation(() => {
         throw new Error('Read error');

--- a/packages/version/test/unit/pub/pubHandler.spec.ts
+++ b/packages/version/test/unit/pub/pubHandler.spec.ts
@@ -156,6 +156,17 @@ describe('Pub Handler', () => {
 
     it('should throw if pubspec.yaml has no version field', () => {
       vi.mocked(fs.readFileSync, { partial: true }).mockReturnValue('name: test_package\n');
+      vi.mocked(parsePubspec, { partial: true }).mockReturnValue({ name: 'test_package' });
+
+      expect(() => updatePubVersion(mockPubspecPath, '2.0.0')).toThrow('No version field found in');
+    });
+
+    it('should throw if pubspec.yaml has a bare version key with null value', () => {
+      vi.mocked(fs.readFileSync, { partial: true }).mockReturnValue('name: test_package\nversion:\n');
+      vi.mocked(parsePubspec, { partial: true }).mockReturnValue({
+        name: 'test_package',
+        version: null as unknown as string,
+      });
 
       expect(() => updatePubVersion(mockPubspecPath, '2.0.0')).toThrow('No version field found in');
     });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -217,6 +217,9 @@ importers:
       smol-toml:
         specifier: 'catalog:'
         version: 1.6.1
+      yaml:
+        specifier: 'catalog:'
+        version: 2.8.3
       zod:
         specifier: 'catalog:'
         version: 4.4.3
@@ -269,6 +272,9 @@ importers:
       smol-toml:
         specifier: 'catalog:'
         version: 1.6.1
+      yaml:
+        specifier: 'catalog:'
+        version: 2.8.3
       zod:
         specifier: 'catalog:'
         version: 4.4.3
@@ -345,6 +351,9 @@ importers:
       smol-toml:
         specifier: 'catalog:'
         version: 1.6.1
+      yaml:
+        specifier: 'catalog:'
+        version: 2.8.3
       zod:
         specifier: 'catalog:'
         version: 4.4.3
@@ -424,6 +433,9 @@ importers:
       smol-toml:
         specifier: 'catalog:'
         version: 1.6.1
+      yaml:
+        specifier: 'catalog:'
+        version: 2.8.3
       zod:
         specifier: 'catalog:'
         version: 4.4.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -217,9 +217,6 @@ importers:
       smol-toml:
         specifier: 'catalog:'
         version: 1.6.1
-      yaml:
-        specifier: 'catalog:'
-        version: 2.8.3
       zod:
         specifier: 'catalog:'
         version: 4.4.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,6 +119,9 @@ importers:
       smol-toml:
         specifier: 'catalog:'
         version: 1.6.1
+      yaml:
+        specifier: 'catalog:'
+        version: 2.8.3
       zod:
         specifier: 'catalog:'
         version: 4.4.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -217,6 +217,9 @@ importers:
       smol-toml:
         specifier: 'catalog:'
         version: 1.6.1
+      yaml:
+        specifier: 'catalog:'
+        version: 2.8.3
       zod:
         specifier: 'catalog:'
         version: 4.4.3

--- a/releasekit.schema.json
+++ b/releasekit.schema.json
@@ -2,7 +2,6 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://goosewobbler.github.io/releasekit/schema.json",
   "title": "ReleaseKit Configuration",
-  "description": "Configuration schema for ReleaseKit - Automated versioning, changelog generation, and publishing",
   "type": "object",
   "additionalProperties": false,
   "properties": {
@@ -12,7 +11,6 @@
     },
     "git": {
       "type": "object",
-      "description": "Git configuration",
       "additionalProperties": false,
       "properties": {
         "remote": {
@@ -47,11 +45,11 @@
           "type": "boolean",
           "description": "Skip Git hooks when committing"
         }
-      }
+      },
+      "description": "Git configuration"
     },
     "monorepo": {
       "type": "object",
-      "description": "Monorepo configuration",
       "additionalProperties": false,
       "properties": {
         "mode": {
@@ -75,11 +73,11 @@
           "type": "string",
           "description": "Main package name for versioning"
         }
-      }
+      },
+      "description": "Monorepo configuration"
     },
     "version": {
       "type": "object",
-      "description": "Versioning configuration",
       "additionalProperties": false,
       "properties": {
         "tagTemplate": {
@@ -90,7 +88,7 @@
         "baselineTagTemplate": {
           "type": "string",
           "pattern": ".*\\$\\{version\\}.*",
-          "description": "Optional secondary tag template for an internal 'baseline' marker that records the release commit on the source branch. Use this when tagTemplate resolves to a tag that gets force-moved off the source branch by a downstream step (e.g. a GitHub Action distributing built artifacts at the version tag) \u2014 the baseline tag stays on the release commit so future version-bump and changelog calculations can still find the previous release. Must contain a ${version} placeholder so the baseline prefix can be derived. Supports the same variables as tagTemplate. Example: \"release/${prefix}${version}\" produces \"release/v1.2.3\"."
+          "description": "Optional secondary tag template for an internal 'baseline' marker that records the release commit on the source branch. Use this when tagTemplate resolves to a tag that gets force-moved off the source branch by a downstream step (e.g. a GitHub Action distributing built artifacts at the version tag) — the baseline tag stays on the release commit so future version-bump and changelog calculations can still find the previous release. Must contain a ${version} placeholder so the baseline prefix can be derived. Supports the same variables as tagTemplate. Example: \"release/${prefix}${version}\" produces \"release/v1.2.3\"."
         },
         "packageSpecificTags": {
           "type": "boolean",
@@ -105,21 +103,20 @@
         "sync": {
           "type": "boolean",
           "default": true,
-          "description": "Global lockstep versioning. true is sugar for one implicit fixed group of every package \u2014 it shares the same mechanism as version.groups. Set to false when using version.groups; sync: true alongside groups is treated as the implicit all-packages fixed group taking precedence (a config conflict, warned about at runtime)."
+          "description": "Global lockstep versioning. true is sugar for one implicit fixed group of every package — it shares the same mechanism as version.groups. Set to false when using version.groups; sync: true alongside groups is treated as the implicit all-packages fixed group taking precedence (a config conflict, warned about at runtime)."
         },
         "groups": {
           "type": "object",
-          "description": "Named version groups. Each group binds a set of package patterns to a fixed or linked sync mode. fixed: any releasable change in any member releases ALL members at the shared group version (bump(max(member baselines))). linked: only members with releasable changes release, but every releasing member shares the same computed version. Packages not matched by any group version independently. A package may belong to at most one group. Set version.sync to false when using groups.",
           "additionalProperties": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
               "packages": {
                 "type": "array",
+                "minItems": 1,
                 "items": {
                   "type": "string"
                 },
-                "minItems": 1,
                 "description": "Package patterns (exact names, @scope/*, or globs) whose matched packages form this group. Same matching rules as version.packages."
               },
               "sync": {
@@ -135,14 +132,18 @@
               "packages",
               "sync"
             ]
+          },
+          "description": "Named version groups. Each group binds a set of package patterns to a fixed or linked sync mode. fixed: any releasable change in any member releases ALL members at the shared group version (bump(max(member baselines))). linked: only members with releasable changes release, but every releasing member shares the same computed version. Packages not matched by any group version independently. A package may belong to at most one group. Set version.sync to false when using groups.",
+          "propertyNames": {
+            "type": "string"
           }
         },
         "packages": {
           "type": "array",
+          "default": [],
           "items": {
             "type": "string"
           },
-          "default": [],
           "description": "Packages to include in versioning"
         },
         "mainPackage": {
@@ -184,9 +185,11 @@
           "type": "array",
           "items": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
               "pattern": {
-                "type": "string"
+                "type": "string",
+                "description": "Glob or regex matched against the branch name (e.g. 'release/*')"
               },
               "releaseType": {
                 "type": "string",
@@ -195,7 +198,8 @@
                   "minor",
                   "patch",
                   "prerelease"
-                ]
+                ],
+                "description": "Version bump type applied when this pattern matches"
               }
             },
             "required": [
@@ -248,11 +252,10 @@
             "strict"
           ],
           "default": "spec",
-          "description": "Pre-1.0 handling of commit-inferred breaking changes. 'spec' (default): bump the 0.x minor (0.24.0 \u2192 0.25.0), per semver \u00a74. 'strict': bump the next major (\u2192 1.0.0). Inferred path only \u2014 explicit overrides (--bump major, bump:major) always graduate to 1.0.0."
+          "description": "Pre-1.0 handling of commit-inferred breaking changes. 'spec' (default): bump the 0.x minor (0.24.0 → 0.25.0), per semver §4. 'strict': bump the next major (→ 1.0.0). Inferred path only — explicit overrides (--bump major, bump:major) always graduate to 1.0.0."
         },
         "cargo": {
           "type": "object",
-          "description": "Cargo/Rust configuration",
           "additionalProperties": false,
           "properties": {
             "enabled": {
@@ -267,37 +270,36 @@
               },
               "description": "Directories to search for Cargo.toml files"
             }
-          }
+          },
+          "description": "Cargo/Rust configuration"
         },
         "pub": {
           "type": "object",
-          "description": "Dart/Flutter pub configuration",
           "additionalProperties": false,
           "properties": {
             "enabled": {
               "type": "boolean",
-              "default": true,
-              "description": "Enable pubspec.yaml version handling"
+              "default": true
             },
             "paths": {
               "type": "array",
               "items": {
                 "type": "string"
-              },
-              "description": "Directories to search for pubspec.yaml files"
+              }
             }
-          }
+          },
+          "description": "Dart/Flutter pub configuration"
         }
-      }
+      },
+      "description": "Versioning configuration"
     },
     "publish": {
       "type": "object",
-      "description": "Publishing configuration",
       "additionalProperties": false,
       "properties": {
         "git": {
           "type": "object",
-          "description": "Git publishing options",
+          "additionalProperties": false,
           "properties": {
             "push": {
               "type": "boolean",
@@ -329,11 +331,11 @@
               "type": "boolean",
               "description": "Skip Git hooks when committing"
             }
-          }
+          },
+          "description": "Git publishing options"
         },
         "npm": {
           "type": "object",
-          "description": "NPM publishing configuration",
           "additionalProperties": false,
           "properties": {
             "enabled": {
@@ -372,12 +374,12 @@
             },
             "copyFiles": {
               "type": "array",
-              "items": {
-                "type": "string"
-              },
               "default": [
                 "LICENSE"
               ],
+              "items": {
+                "type": "string"
+              },
               "description": "Files to copy to package before publishing"
             },
             "tag": {
@@ -385,11 +387,11 @@
               "default": "latest",
               "description": "NPM dist tag"
             }
-          }
+          },
+          "description": "NPM publishing configuration"
         },
         "cargo": {
           "type": "object",
-          "description": "Cargo publishing configuration",
           "additionalProperties": false,
           "properties": {
             "enabled": {
@@ -404,10 +406,10 @@
             },
             "publishOrder": {
               "type": "array",
+              "default": [],
               "items": {
                 "type": "string"
               },
-              "default": [],
               "description": "Order in which to publish packages"
             },
             "clean": {
@@ -415,11 +417,29 @@
               "default": false,
               "description": "Clean before publishing"
             }
-          }
+          },
+          "description": "Cargo publishing configuration"
+        },
+        "pub": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": false
+            },
+            "publishOrder": {
+              "type": "array",
+              "default": [],
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "description": "Dart/Flutter publishing configuration via pub"
         },
         "githubRelease": {
           "type": "object",
-          "description": "GitHub Release configuration",
           "additionalProperties": false,
           "properties": {
             "enabled": {
@@ -438,6 +458,7 @@
               "description": "Create separate release per package"
             },
             "prerelease": {
+              "default": "auto",
               "oneOf": [
                 {
                   "type": "boolean"
@@ -449,7 +470,6 @@
                   ]
                 }
               ],
-              "default": "auto",
               "description": "Mark as prerelease"
             },
             "body": {
@@ -468,12 +488,20 @@
               "type": "string",
               "default": "${packageName}: ${version}",
               "description": "Template for the GitHub release title when a package name is resolved. Available variables: ${packageName} (original scoped name, e.g. '@scope/pkg'), ${version} (e.g. 'v1.0.0'). Version-only tags always use the tag string directly."
+            },
+            "skipPackages": {
+              "type": "array",
+              "default": [],
+              "items": {
+                "type": "string"
+              },
+              "description": "Package names to exclude from GitHub release creation"
             }
-          }
+          },
+          "description": "GitHub Release configuration"
         },
         "verify": {
           "type": "object",
-          "description": "Registry verification configuration",
           "additionalProperties": false,
           "properties": {
             "npm": {
@@ -563,33 +591,14 @@
                 }
               }
             }
-          }
-        },
-        "pub": {
-          "type": "object",
-          "description": "Dart/Flutter publishing configuration via pub",
-          "additionalProperties": false,
-          "properties": {
-            "enabled": {
-              "type": "boolean",
-              "default": false,
-              "description": "Enable Dart publishing to pub.dev"
-            },
-            "publishOrder": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "default": [],
-              "description": "Order in which to publish Dart packages"
-            }
-          }
+          },
+          "description": "Registry verification configuration"
         }
-      }
+      },
+      "description": "Publishing configuration"
     },
     "notes": {
       "type": "object",
-      "description": "Changelog and release notes configuration",
       "additionalProperties": false,
       "properties": {
         "changelog": {
@@ -603,7 +612,6 @@
             },
             {
               "type": "object",
-              "description": "Changelog file configuration",
               "additionalProperties": false,
               "properties": {
                 "mode": {
@@ -621,7 +629,6 @@
                 },
                 "templates": {
                   "type": "object",
-                  "description": "Template configuration for changelog",
                   "additionalProperties": false,
                   "properties": {
                     "path": {
@@ -637,9 +644,11 @@
                       ],
                       "description": "Template engine"
                     }
-                  }
+                  },
+                  "description": "Template configuration for changelog"
                 }
-              }
+              },
+              "description": "Changelog file configuration"
             }
           ]
         },
@@ -654,7 +663,6 @@
             },
             {
               "type": "object",
-              "description": "Release notes configuration",
               "additionalProperties": false,
               "properties": {
                 "mode": {
@@ -672,7 +680,6 @@
                 },
                 "templates": {
                   "type": "object",
-                  "description": "Template configuration for release notes",
                   "additionalProperties": false,
                   "properties": {
                     "path": {
@@ -688,11 +695,11 @@
                       ],
                       "description": "Template engine"
                     }
-                  }
+                  },
+                  "description": "Template configuration for release notes"
                 },
                 "llm": {
                   "type": "object",
-                  "description": "LLM configuration for release notes",
                   "additionalProperties": false,
                   "properties": {
                     "provider": {
@@ -734,6 +741,32 @@
                       "minimum": 1,
                       "description": "Concurrent LLM requests"
                     },
+                    "retry": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "maxAttempts": {
+                          "type": "integer",
+                          "minimum": 1,
+                          "description": "Maximum number of attempts"
+                        },
+                        "initialDelay": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "description": "Initial delay in ms"
+                        },
+                        "maxDelay": {
+                          "type": "integer",
+                          "minimum": 1,
+                          "description": "Maximum delay in ms"
+                        },
+                        "backoffFactor": {
+                          "type": "number",
+                          "minimum": 1,
+                          "description": "Delay multiplier per attempt"
+                        }
+                      }
+                    },
                     "tasks": {
                       "type": "object",
                       "additionalProperties": false,
@@ -758,21 +791,46 @@
                     },
                     "categories": {
                       "type": "array",
+                      "default": [
+                        {
+                          "name": "Breaking",
+                          "description": "Breaking changes that require user action to upgrade"
+                        },
+                        {
+                          "name": "New",
+                          "description": "New features and capabilities"
+                        },
+                        {
+                          "name": "Changed",
+                          "description": "Changes to existing functionality"
+                        },
+                        {
+                          "name": "Fixed",
+                          "description": "Bug fixes"
+                        },
+                        {
+                          "name": "Developer",
+                          "description": "Internal changes: CI, tooling, dependencies, refactoring"
+                        }
+                      ],
                       "items": {
                         "type": "object",
                         "additionalProperties": false,
                         "properties": {
                           "name": {
-                            "type": "string"
+                            "type": "string",
+                            "description": "Category label shown in release notes (e.g. 'Features')"
                           },
                           "description": {
-                            "type": "string"
+                            "type": "string",
+                            "description": "LLM instruction describing what commits belong in this category"
                           },
                           "scopes": {
                             "type": "array",
                             "items": {
                               "type": "string"
-                            }
+                            },
+                            "description": "Conventional commit scopes assigned to this category"
                           }
                         },
                         "required": [
@@ -797,7 +855,8 @@
                             "none",
                             "unrestricted"
                           ],
-                          "default": "unrestricted"
+                          "default": "unrestricted",
+                          "description": "Scope allowlist source: 'restricted' uses rules.allowed, 'packages' derives scopes from workspace package names, 'none' strips all scopes, 'unrestricted' allows any scope"
                         },
                         "rules": {
                           "type": "object",
@@ -807,11 +866,13 @@
                               "type": "array",
                               "items": {
                                 "type": "string"
-                              }
+                              },
+                              "description": "Explicit list of valid scope names; commits with unlisted scopes trigger invalidScopeAction"
                             },
                             "caseSensitive": {
                               "type": "boolean",
-                              "default": false
+                              "default": false,
+                              "description": "Whether scope comparison is case-sensitive"
                             },
                             "invalidScopeAction": {
                               "type": "string",
@@ -820,38 +881,15 @@
                                 "keep",
                                 "fallback"
                               ],
-                              "default": "remove"
+                              "default": "remove",
+                              "description": "Action for commits whose scope is not in the allowed list: 'remove' strips the scope, 'keep' leaves it, 'fallback' substitutes fallbackScope"
                             },
                             "fallbackScope": {
-                              "type": "string"
+                              "type": "string",
+                              "description": "Scope substituted when invalidScopeAction is 'fallback'"
                             }
-                          }
-                        }
-                      }
-                    },
-                    "retry": {
-                      "type": "object",
-                      "additionalProperties": false,
-                      "properties": {
-                        "maxAttempts": {
-                          "type": "integer",
-                          "minimum": 1,
-                          "description": "Maximum number of attempts"
-                        },
-                        "initialDelay": {
-                          "type": "integer",
-                          "minimum": 0,
-                          "description": "Initial delay in ms"
-                        },
-                        "maxDelay": {
-                          "type": "integer",
-                          "minimum": 0,
-                          "description": "Maximum delay in ms"
-                        },
-                        "backoffFactor": {
-                          "type": "number",
-                          "minimum": 1,
-                          "description": "Delay multiplier per attempt"
+                          },
+                          "description": "Scope validation and transformation rules"
                         }
                       }
                     },
@@ -862,7 +900,6 @@
                         "instructions": {
                           "type": "object",
                           "additionalProperties": false,
-                          "description": "Per-task instruction overrides appended to the built-in prompts.",
                           "properties": {
                             "enhance": {
                               "type": "string",
@@ -884,7 +921,8 @@
                               "type": "string",
                               "description": "Instruction override for the release-notes task"
                             }
-                          }
+                          },
+                          "description": "Per-task instruction overrides appended to the built-in prompts."
                         }
                       }
                     },
@@ -893,19 +931,19 @@
                       "minimum": 0,
                       "maximum": 5,
                       "default": 3,
-                      "description": "Number of few-shot examples to include in LLM prompts (0\u20135)."
+                      "description": "Number of few-shot examples to include in LLM prompts (0–5)."
                     },
                     "context": {
                       "type": "object",
                       "additionalProperties": false,
-                      "description": "Additional context sources for the LLM.",
                       "properties": {
                         "pullRequests": {
                           "type": "boolean",
                           "default": true,
                           "description": "Include linked pull request titles/bodies as context."
                         }
-                      }
+                      },
+                      "description": "Additional context sources for the LLM."
                     },
                     "categoryOrder": {
                       "type": "array",
@@ -918,12 +956,12 @@
                   "required": [
                     "provider",
                     "model"
-                  ]
+                  ],
+                  "description": "LLM configuration for release notes"
                 },
                 "links": {
                   "type": "object",
                   "additionalProperties": false,
-                  "description": "Extra links to append to the release notes.",
                   "properties": {
                     "items": {
                       "type": "array",
@@ -956,9 +994,11 @@
                       "type": "string",
                       "description": "Heading for the links section."
                     }
-                  }
+                  },
+                  "description": "Extra links to append to the release notes."
                 }
-              }
+              },
+              "description": "Release notes configuration"
             }
           ]
         },
@@ -970,11 +1010,11 @@
           ],
           "description": "How to update existing changelog files. 'prepend' adds new entries to the top; 'regenerate' rewrites the file from scratch."
         }
-      }
+      },
+      "description": "Changelog and release notes configuration"
     },
     "ci": {
       "type": "object",
-      "description": "CI automation configuration for release triggers, PR previews, and label management",
       "additionalProperties": false,
       "properties": {
         "releaseStrategy": {
@@ -1008,12 +1048,12 @@
         },
         "skipPatterns": {
           "type": "array",
-          "items": {
-            "type": "string"
-          },
           "default": [
             "chore: release "
           ],
+          "items": {
+            "type": "string"
+          },
           "description": "Commit message prefixes that suppress a release. The default matches the release commit template to prevent release loops."
         },
         "minChanges": {
@@ -1024,7 +1064,6 @@
         },
         "labels": {
           "type": "object",
-          "description": "PR label names used for release control. Override to match your repository's label conventions.",
           "additionalProperties": false,
           "properties": {
             "stable": {
@@ -1045,7 +1084,7 @@
             "immediate": {
               "type": "string",
               "default": "release:immediate",
-              "description": "Label to bypass the standing PR for one merge \u2014 triggers a direct release. Standing-pr mode only."
+              "description": "Label to bypass the standing PR for one merge — triggers a direct release. Standing-pr mode only."
             },
             "retry": {
               "type": "string",
@@ -1067,18 +1106,21 @@
               "default": "bump:patch",
               "description": "Label to force a patch bump"
             }
-          }
+          },
+          "description": "PR label names used for release control. Override to match your repository's label conventions."
         },
         "scopeLabels": {
           "type": "object",
           "additionalProperties": {
             "type": "string"
           },
-          "description": "Map of scope labels to package patterns. When a PR has a label matching a key, only packages matching the corresponding pattern are released."
+          "description": "Map of scope labels to package patterns. When a PR has a label matching a key, only packages matching the corresponding pattern are released.",
+          "propertyNames": {
+            "type": "string"
+          }
         },
         "standingPr": {
           "type": "object",
-          "description": "Configuration for the standing release PR feature (ci.releaseStrategy: 'standing-pr').",
           "additionalProperties": false,
           "properties": {
             "branch": {
@@ -1092,12 +1134,12 @@
             },
             "labels": {
               "type": "array",
-              "items": {
-                "type": "string"
-              },
               "default": [
                 "release"
               ],
+              "items": {
+                "type": "string"
+              },
               "description": "Labels to apply to the standing release PR."
             },
             "deleteBranchOnMerge": {
@@ -1124,17 +1166,19 @@
               "minimum": 1,
               "description": "Minimum number of packages with releasable changes required to create or maintain the standing PR. Below this threshold the PR is closed and no new PR is opened."
             }
-          }
+          },
+          "description": "Configuration for the standing release PR feature (ci.releaseStrategy: 'standing-pr')."
         }
-      }
+      },
+      "description": "CI automation configuration for release triggers, PR previews, and label management"
     },
     "release": {
       "type": "object",
-      "description": "Release pipeline automation configuration",
       "additionalProperties": false,
       "properties": {
         "steps": {
           "type": "array",
+          "minItems": 1,
           "items": {
             "type": "string",
             "enum": [
@@ -1142,12 +1186,10 @@
               "publish"
             ]
           },
-          "minItems": 1,
           "description": "Which steps to run by default. Omitting a step is equivalent to --skip-<step>."
         },
         "ci": {
           "type": "object",
-          "description": "CI-specific automation settings",
           "additionalProperties": false,
           "properties": {
             "skipPatterns": {
@@ -1177,9 +1219,12 @@
               ],
               "description": "Set to false to disable changelog generation in CI"
             }
-          }
+          },
+          "description": "CI-specific automation settings"
         }
-      }
+      },
+      "description": "Release pipeline automation configuration"
     }
-  }
+  },
+  "description": "Configuration schema for ReleaseKit - Automated versioning, changelog generation, and publishing"
 }

--- a/releasekit.schema.json
+++ b/releasekit.schema.json
@@ -2,6 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://goosewobbler.github.io/releasekit/schema.json",
   "title": "ReleaseKit Configuration",
+  "description": "Configuration schema for ReleaseKit - Automated versioning, changelog generation, and publishing",
   "type": "object",
   "additionalProperties": false,
   "properties": {
@@ -11,6 +12,7 @@
     },
     "git": {
       "type": "object",
+      "description": "Git configuration",
       "additionalProperties": false,
       "properties": {
         "remote": {
@@ -45,11 +47,11 @@
           "type": "boolean",
           "description": "Skip Git hooks when committing"
         }
-      },
-      "description": "Git configuration"
+      }
     },
     "monorepo": {
       "type": "object",
+      "description": "Monorepo configuration",
       "additionalProperties": false,
       "properties": {
         "mode": {
@@ -73,11 +75,11 @@
           "type": "string",
           "description": "Main package name for versioning"
         }
-      },
-      "description": "Monorepo configuration"
+      }
     },
     "version": {
       "type": "object",
+      "description": "Versioning configuration",
       "additionalProperties": false,
       "properties": {
         "tagTemplate": {
@@ -88,7 +90,7 @@
         "baselineTagTemplate": {
           "type": "string",
           "pattern": ".*\\$\\{version\\}.*",
-          "description": "Optional secondary tag template for an internal 'baseline' marker that records the release commit on the source branch. Use this when tagTemplate resolves to a tag that gets force-moved off the source branch by a downstream step (e.g. a GitHub Action distributing built artifacts at the version tag) — the baseline tag stays on the release commit so future version-bump and changelog calculations can still find the previous release. Must contain a ${version} placeholder so the baseline prefix can be derived. Supports the same variables as tagTemplate. Example: \"release/${prefix}${version}\" produces \"release/v1.2.3\"."
+          "description": "Optional secondary tag template for an internal 'baseline' marker that records the release commit on the source branch. Use this when tagTemplate resolves to a tag that gets force-moved off the source branch by a downstream step (e.g. a GitHub Action distributing built artifacts at the version tag) \u2014 the baseline tag stays on the release commit so future version-bump and changelog calculations can still find the previous release. Must contain a ${version} placeholder so the baseline prefix can be derived. Supports the same variables as tagTemplate. Example: \"release/${prefix}${version}\" produces \"release/v1.2.3\"."
         },
         "packageSpecificTags": {
           "type": "boolean",
@@ -103,20 +105,21 @@
         "sync": {
           "type": "boolean",
           "default": true,
-          "description": "Global lockstep versioning. true is sugar for one implicit fixed group of every package — it shares the same mechanism as version.groups. Set to false when using version.groups; sync: true alongside groups is treated as the implicit all-packages fixed group taking precedence (a config conflict, warned about at runtime)."
+          "description": "Global lockstep versioning. true is sugar for one implicit fixed group of every package \u2014 it shares the same mechanism as version.groups. Set to false when using version.groups; sync: true alongside groups is treated as the implicit all-packages fixed group taking precedence (a config conflict, warned about at runtime)."
         },
         "groups": {
           "type": "object",
+          "description": "Named version groups. Each group binds a set of package patterns to a fixed or linked sync mode. fixed: any releasable change in any member releases ALL members at the shared group version (bump(max(member baselines))). linked: only members with releasable changes release, but every releasing member shares the same computed version. Packages not matched by any group version independently. A package may belong to at most one group. Set version.sync to false when using groups.",
           "additionalProperties": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
               "packages": {
                 "type": "array",
-                "minItems": 1,
                 "items": {
                   "type": "string"
                 },
+                "minItems": 1,
                 "description": "Package patterns (exact names, @scope/*, or globs) whose matched packages form this group. Same matching rules as version.packages."
               },
               "sync": {
@@ -132,18 +135,14 @@
               "packages",
               "sync"
             ]
-          },
-          "description": "Named version groups. Each group binds a set of package patterns to a fixed or linked sync mode. fixed: any releasable change in any member releases ALL members at the shared group version (bump(max(member baselines))). linked: only members with releasable changes release, but every releasing member shares the same computed version. Packages not matched by any group version independently. A package may belong to at most one group. Set version.sync to false when using groups.",
-          "propertyNames": {
-            "type": "string"
           }
         },
         "packages": {
           "type": "array",
-          "default": [],
           "items": {
             "type": "string"
           },
+          "default": [],
           "description": "Packages to include in versioning"
         },
         "mainPackage": {
@@ -185,11 +184,9 @@
           "type": "array",
           "items": {
             "type": "object",
-            "additionalProperties": false,
             "properties": {
               "pattern": {
-                "type": "string",
-                "description": "Glob or regex matched against the branch name (e.g. 'release/*')"
+                "type": "string"
               },
               "releaseType": {
                 "type": "string",
@@ -198,8 +195,7 @@
                   "minor",
                   "patch",
                   "prerelease"
-                ],
-                "description": "Version bump type applied when this pattern matches"
+                ]
               }
             },
             "required": [
@@ -252,10 +248,11 @@
             "strict"
           ],
           "default": "spec",
-          "description": "Pre-1.0 handling of commit-inferred breaking changes. 'spec' (default): bump the 0.x minor (0.24.0 → 0.25.0), per semver §4. 'strict': bump the next major (→ 1.0.0). Inferred path only — explicit overrides (--bump major, bump:major) always graduate to 1.0.0."
+          "description": "Pre-1.0 handling of commit-inferred breaking changes. 'spec' (default): bump the 0.x minor (0.24.0 \u2192 0.25.0), per semver \u00a74. 'strict': bump the next major (\u2192 1.0.0). Inferred path only \u2014 explicit overrides (--bump major, bump:major) always graduate to 1.0.0."
         },
         "cargo": {
           "type": "object",
+          "description": "Cargo/Rust configuration",
           "additionalProperties": false,
           "properties": {
             "enabled": {
@@ -270,19 +267,37 @@
               },
               "description": "Directories to search for Cargo.toml files"
             }
-          },
-          "description": "Cargo/Rust configuration"
+          }
+        },
+        "pub": {
+          "type": "object",
+          "description": "Dart/Flutter pub configuration",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": true,
+              "description": "Enable pubspec.yaml version handling"
+            },
+            "paths": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Directories to search for pubspec.yaml files"
+            }
+          }
         }
-      },
-      "description": "Versioning configuration"
+      }
     },
     "publish": {
       "type": "object",
+      "description": "Publishing configuration",
       "additionalProperties": false,
       "properties": {
         "git": {
           "type": "object",
-          "additionalProperties": false,
+          "description": "Git publishing options",
           "properties": {
             "push": {
               "type": "boolean",
@@ -314,11 +329,11 @@
               "type": "boolean",
               "description": "Skip Git hooks when committing"
             }
-          },
-          "description": "Git publishing options"
+          }
         },
         "npm": {
           "type": "object",
+          "description": "NPM publishing configuration",
           "additionalProperties": false,
           "properties": {
             "enabled": {
@@ -357,12 +372,12 @@
             },
             "copyFiles": {
               "type": "array",
-              "default": [
-                "LICENSE"
-              ],
               "items": {
                 "type": "string"
               },
+              "default": [
+                "LICENSE"
+              ],
               "description": "Files to copy to package before publishing"
             },
             "tag": {
@@ -370,11 +385,11 @@
               "default": "latest",
               "description": "NPM dist tag"
             }
-          },
-          "description": "NPM publishing configuration"
+          }
         },
         "cargo": {
           "type": "object",
+          "description": "Cargo publishing configuration",
           "additionalProperties": false,
           "properties": {
             "enabled": {
@@ -389,10 +404,10 @@
             },
             "publishOrder": {
               "type": "array",
-              "default": [],
               "items": {
                 "type": "string"
               },
+              "default": [],
               "description": "Order in which to publish packages"
             },
             "clean": {
@@ -400,11 +415,11 @@
               "default": false,
               "description": "Clean before publishing"
             }
-          },
-          "description": "Cargo publishing configuration"
+          }
         },
         "githubRelease": {
           "type": "object",
+          "description": "GitHub Release configuration",
           "additionalProperties": false,
           "properties": {
             "enabled": {
@@ -423,7 +438,6 @@
               "description": "Create separate release per package"
             },
             "prerelease": {
-              "default": "auto",
               "oneOf": [
                 {
                   "type": "boolean"
@@ -435,6 +449,7 @@
                   ]
                 }
               ],
+              "default": "auto",
               "description": "Mark as prerelease"
             },
             "body": {
@@ -453,20 +468,12 @@
               "type": "string",
               "default": "${packageName}: ${version}",
               "description": "Template for the GitHub release title when a package name is resolved. Available variables: ${packageName} (original scoped name, e.g. '@scope/pkg'), ${version} (e.g. 'v1.0.0'). Version-only tags always use the tag string directly."
-            },
-            "skipPackages": {
-              "type": "array",
-              "default": [],
-              "items": {
-                "type": "string"
-              },
-              "description": "Package names to exclude from GitHub release creation"
             }
-          },
-          "description": "GitHub Release configuration"
+          }
         },
         "verify": {
           "type": "object",
+          "description": "Registry verification configuration",
           "additionalProperties": false,
           "properties": {
             "npm": {
@@ -526,15 +533,63 @@
                   "description": "Exponential backoff multiplier"
                 }
               }
+            },
+            "pub": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "default": true,
+                  "description": "Verify Dart pub publish"
+                },
+                "maxAttempts": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "default": 10,
+                  "description": "Maximum verification attempts"
+                },
+                "initialDelay": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "default": 30000,
+                  "description": "Initial delay in milliseconds"
+                },
+                "backoffMultiplier": {
+                  "type": "number",
+                  "minimum": 1,
+                  "default": 2,
+                  "description": "Exponential backoff multiplier"
+                }
+              }
             }
-          },
-          "description": "Registry verification configuration"
+          }
+        },
+        "pub": {
+          "type": "object",
+          "description": "Dart/Flutter publishing configuration via pub",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": false,
+              "description": "Enable Dart publishing to pub.dev"
+            },
+            "publishOrder": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": [],
+              "description": "Order in which to publish Dart packages"
+            }
+          }
         }
-      },
-      "description": "Publishing configuration"
+      }
     },
     "notes": {
       "type": "object",
+      "description": "Changelog and release notes configuration",
       "additionalProperties": false,
       "properties": {
         "changelog": {
@@ -548,6 +603,7 @@
             },
             {
               "type": "object",
+              "description": "Changelog file configuration",
               "additionalProperties": false,
               "properties": {
                 "mode": {
@@ -565,6 +621,7 @@
                 },
                 "templates": {
                   "type": "object",
+                  "description": "Template configuration for changelog",
                   "additionalProperties": false,
                   "properties": {
                     "path": {
@@ -580,11 +637,9 @@
                       ],
                       "description": "Template engine"
                     }
-                  },
-                  "description": "Template configuration for changelog"
+                  }
                 }
-              },
-              "description": "Changelog file configuration"
+              }
             }
           ]
         },
@@ -599,6 +654,7 @@
             },
             {
               "type": "object",
+              "description": "Release notes configuration",
               "additionalProperties": false,
               "properties": {
                 "mode": {
@@ -616,6 +672,7 @@
                 },
                 "templates": {
                   "type": "object",
+                  "description": "Template configuration for release notes",
                   "additionalProperties": false,
                   "properties": {
                     "path": {
@@ -631,11 +688,11 @@
                       ],
                       "description": "Template engine"
                     }
-                  },
-                  "description": "Template configuration for release notes"
+                  }
                 },
                 "llm": {
                   "type": "object",
+                  "description": "LLM configuration for release notes",
                   "additionalProperties": false,
                   "properties": {
                     "provider": {
@@ -677,32 +734,6 @@
                       "minimum": 1,
                       "description": "Concurrent LLM requests"
                     },
-                    "retry": {
-                      "type": "object",
-                      "additionalProperties": false,
-                      "properties": {
-                        "maxAttempts": {
-                          "type": "integer",
-                          "minimum": 1,
-                          "description": "Maximum number of attempts"
-                        },
-                        "initialDelay": {
-                          "type": "integer",
-                          "minimum": 0,
-                          "description": "Initial delay in ms"
-                        },
-                        "maxDelay": {
-                          "type": "integer",
-                          "minimum": 1,
-                          "description": "Maximum delay in ms"
-                        },
-                        "backoffFactor": {
-                          "type": "number",
-                          "minimum": 1,
-                          "description": "Delay multiplier per attempt"
-                        }
-                      }
-                    },
                     "tasks": {
                       "type": "object",
                       "additionalProperties": false,
@@ -727,46 +758,21 @@
                     },
                     "categories": {
                       "type": "array",
-                      "default": [
-                        {
-                          "name": "Breaking",
-                          "description": "Breaking changes that require user action to upgrade"
-                        },
-                        {
-                          "name": "New",
-                          "description": "New features and capabilities"
-                        },
-                        {
-                          "name": "Changed",
-                          "description": "Changes to existing functionality"
-                        },
-                        {
-                          "name": "Fixed",
-                          "description": "Bug fixes"
-                        },
-                        {
-                          "name": "Developer",
-                          "description": "Internal changes: CI, tooling, dependencies, refactoring"
-                        }
-                      ],
                       "items": {
                         "type": "object",
                         "additionalProperties": false,
                         "properties": {
                           "name": {
-                            "type": "string",
-                            "description": "Category label shown in release notes (e.g. 'Features')"
+                            "type": "string"
                           },
                           "description": {
-                            "type": "string",
-                            "description": "LLM instruction describing what commits belong in this category"
+                            "type": "string"
                           },
                           "scopes": {
                             "type": "array",
                             "items": {
                               "type": "string"
-                            },
-                            "description": "Conventional commit scopes assigned to this category"
+                            }
                           }
                         },
                         "required": [
@@ -791,8 +797,7 @@
                             "none",
                             "unrestricted"
                           ],
-                          "default": "unrestricted",
-                          "description": "Scope allowlist source: 'restricted' uses rules.allowed, 'packages' derives scopes from workspace package names, 'none' strips all scopes, 'unrestricted' allows any scope"
+                          "default": "unrestricted"
                         },
                         "rules": {
                           "type": "object",
@@ -802,13 +807,11 @@
                               "type": "array",
                               "items": {
                                 "type": "string"
-                              },
-                              "description": "Explicit list of valid scope names; commits with unlisted scopes trigger invalidScopeAction"
+                              }
                             },
                             "caseSensitive": {
                               "type": "boolean",
-                              "default": false,
-                              "description": "Whether scope comparison is case-sensitive"
+                              "default": false
                             },
                             "invalidScopeAction": {
                               "type": "string",
@@ -817,15 +820,38 @@
                                 "keep",
                                 "fallback"
                               ],
-                              "default": "remove",
-                              "description": "Action for commits whose scope is not in the allowed list: 'remove' strips the scope, 'keep' leaves it, 'fallback' substitutes fallbackScope"
+                              "default": "remove"
                             },
                             "fallbackScope": {
-                              "type": "string",
-                              "description": "Scope substituted when invalidScopeAction is 'fallback'"
+                              "type": "string"
                             }
-                          },
-                          "description": "Scope validation and transformation rules"
+                          }
+                        }
+                      }
+                    },
+                    "retry": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "maxAttempts": {
+                          "type": "integer",
+                          "minimum": 1,
+                          "description": "Maximum number of attempts"
+                        },
+                        "initialDelay": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "description": "Initial delay in ms"
+                        },
+                        "maxDelay": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "description": "Maximum delay in ms"
+                        },
+                        "backoffFactor": {
+                          "type": "number",
+                          "minimum": 1,
+                          "description": "Delay multiplier per attempt"
                         }
                       }
                     },
@@ -836,6 +862,7 @@
                         "instructions": {
                           "type": "object",
                           "additionalProperties": false,
+                          "description": "Per-task instruction overrides appended to the built-in prompts.",
                           "properties": {
                             "enhance": {
                               "type": "string",
@@ -857,8 +884,7 @@
                               "type": "string",
                               "description": "Instruction override for the release-notes task"
                             }
-                          },
-                          "description": "Per-task instruction overrides appended to the built-in prompts."
+                          }
                         }
                       }
                     },
@@ -867,19 +893,19 @@
                       "minimum": 0,
                       "maximum": 5,
                       "default": 3,
-                      "description": "Number of few-shot examples to include in LLM prompts (0–5)."
+                      "description": "Number of few-shot examples to include in LLM prompts (0\u20135)."
                     },
                     "context": {
                       "type": "object",
                       "additionalProperties": false,
+                      "description": "Additional context sources for the LLM.",
                       "properties": {
                         "pullRequests": {
                           "type": "boolean",
                           "default": true,
                           "description": "Include linked pull request titles/bodies as context."
                         }
-                      },
-                      "description": "Additional context sources for the LLM."
+                      }
                     },
                     "categoryOrder": {
                       "type": "array",
@@ -892,12 +918,12 @@
                   "required": [
                     "provider",
                     "model"
-                  ],
-                  "description": "LLM configuration for release notes"
+                  ]
                 },
                 "links": {
                   "type": "object",
                   "additionalProperties": false,
+                  "description": "Extra links to append to the release notes.",
                   "properties": {
                     "items": {
                       "type": "array",
@@ -930,11 +956,9 @@
                       "type": "string",
                       "description": "Heading for the links section."
                     }
-                  },
-                  "description": "Extra links to append to the release notes."
+                  }
                 }
-              },
-              "description": "Release notes configuration"
+              }
             }
           ]
         },
@@ -946,11 +970,11 @@
           ],
           "description": "How to update existing changelog files. 'prepend' adds new entries to the top; 'regenerate' rewrites the file from scratch."
         }
-      },
-      "description": "Changelog and release notes configuration"
+      }
     },
     "ci": {
       "type": "object",
+      "description": "CI automation configuration for release triggers, PR previews, and label management",
       "additionalProperties": false,
       "properties": {
         "releaseStrategy": {
@@ -984,12 +1008,12 @@
         },
         "skipPatterns": {
           "type": "array",
-          "default": [
-            "chore: release "
-          ],
           "items": {
             "type": "string"
           },
+          "default": [
+            "chore: release "
+          ],
           "description": "Commit message prefixes that suppress a release. The default matches the release commit template to prevent release loops."
         },
         "minChanges": {
@@ -1000,6 +1024,7 @@
         },
         "labels": {
           "type": "object",
+          "description": "PR label names used for release control. Override to match your repository's label conventions.",
           "additionalProperties": false,
           "properties": {
             "stable": {
@@ -1020,7 +1045,7 @@
             "immediate": {
               "type": "string",
               "default": "release:immediate",
-              "description": "Label to bypass the standing PR for one merge — triggers a direct release. Standing-pr mode only."
+              "description": "Label to bypass the standing PR for one merge \u2014 triggers a direct release. Standing-pr mode only."
             },
             "retry": {
               "type": "string",
@@ -1042,21 +1067,18 @@
               "default": "bump:patch",
               "description": "Label to force a patch bump"
             }
-          },
-          "description": "PR label names used for release control. Override to match your repository's label conventions."
+          }
         },
         "scopeLabels": {
           "type": "object",
           "additionalProperties": {
             "type": "string"
           },
-          "description": "Map of scope labels to package patterns. When a PR has a label matching a key, only packages matching the corresponding pattern are released.",
-          "propertyNames": {
-            "type": "string"
-          }
+          "description": "Map of scope labels to package patterns. When a PR has a label matching a key, only packages matching the corresponding pattern are released."
         },
         "standingPr": {
           "type": "object",
+          "description": "Configuration for the standing release PR feature (ci.releaseStrategy: 'standing-pr').",
           "additionalProperties": false,
           "properties": {
             "branch": {
@@ -1070,12 +1092,12 @@
             },
             "labels": {
               "type": "array",
-              "default": [
-                "release"
-              ],
               "items": {
                 "type": "string"
               },
+              "default": [
+                "release"
+              ],
               "description": "Labels to apply to the standing release PR."
             },
             "deleteBranchOnMerge": {
@@ -1102,19 +1124,17 @@
               "minimum": 1,
               "description": "Minimum number of packages with releasable changes required to create or maintain the standing PR. Below this threshold the PR is closed and no new PR is opened."
             }
-          },
-          "description": "Configuration for the standing release PR feature (ci.releaseStrategy: 'standing-pr')."
+          }
         }
-      },
-      "description": "CI automation configuration for release triggers, PR previews, and label management"
+      }
     },
     "release": {
       "type": "object",
+      "description": "Release pipeline automation configuration",
       "additionalProperties": false,
       "properties": {
         "steps": {
           "type": "array",
-          "minItems": 1,
           "items": {
             "type": "string",
             "enum": [
@@ -1122,10 +1142,12 @@
               "publish"
             ]
           },
+          "minItems": 1,
           "description": "Which steps to run by default. Omitting a step is equivalent to --skip-<step>."
         },
         "ci": {
           "type": "object",
+          "description": "CI-specific automation settings",
           "additionalProperties": false,
           "properties": {
             "skipPatterns": {
@@ -1155,12 +1177,9 @@
               ],
               "description": "Set to false to disable changelog generation in CI"
             }
-          },
-          "description": "CI-specific automation settings"
+          }
         }
-      },
-      "description": "Release pipeline automation configuration"
+      }
     }
-  },
-  "description": "Configuration schema for ReleaseKit - Automated versioning, changelog generation, and publishing"
+  }
 }

--- a/releasekit.schema.json
+++ b/releasekit.schema.json
@@ -279,13 +279,15 @@
           "properties": {
             "enabled": {
               "type": "boolean",
-              "default": true
+              "default": true,
+              "description": "Enable pubspec.yaml version handling"
             },
             "paths": {
               "type": "array",
               "items": {
                 "type": "string"
-              }
+              },
+              "description": "Directories to search for pubspec.yaml files"
             }
           },
           "description": "Dart/Flutter pub configuration"
@@ -426,14 +428,16 @@
           "properties": {
             "enabled": {
               "type": "boolean",
-              "default": false
+              "default": false,
+              "description": "Enable pub.dev publishing"
             },
             "publishOrder": {
               "type": "array",
               "default": [],
               "items": {
                 "type": "string"
-              }
+              },
+              "description": "Order in which to publish packages"
             }
           },
           "description": "Dart/Flutter publishing configuration via pub"

--- a/scripts/generate-config-docs.ts
+++ b/scripts/generate-config-docs.ts
@@ -254,6 +254,14 @@ function renderPublish(prop: SchemaProperty): void {
     emitBlank();
   }
 
+  const pub = prop.properties?.pub;
+  if (pub) {
+    emit('### `publish.pub`', '');
+    emit(ensurePeriod(pub.description), '');
+    emit(propsTable(pub.properties ?? {}));
+    emitBlank();
+  }
+
   const gh = prop.properties?.githubRelease;
   if (gh) {
     emit('### `publish.githubRelease`', '');
@@ -279,6 +287,13 @@ function renderPublish(prop: SchemaProperty): void {
     if (verifyCargo) {
       emit('#### `publish.verify.cargo`', '');
       emit(propsTable(verifyCargo.properties ?? {}));
+      emitBlank();
+    }
+
+    const verifyPub = verify.properties?.pub;
+    if (verifyPub) {
+      emit('#### `publish.verify.pub`', '');
+      emit(propsTable(verifyPub.properties ?? {}));
       emitBlank();
     }
   }


### PR DESCRIPTION
Closes #285.

## Summary

- **Version stage**: detects `pubspec.yaml` alongside `package.json`/`Cargo.toml` and bumps the `version:` field via regex (preserves comments and formatting). Gated by `version.pub.enabled` (default `true`); supports `version.pub.paths` for packages with multiple pubspecs.
- **Publish stage**: runs `dart pub publish --force` (or `flutter pub publish --force` for packages with `environment.flutter`). Auth via OIDC (no setup required) or `PUB_TOKEN` env var — mirrors cargo-publish: fail-fast, `withPublishRetry` for transient errors, pre-publish skip when already published.
- **Verify stage**: polls `https://pub.dev/api/packages/{name}/versions/{version}` with exponential backoff (`maxAttempts=10`, `initialDelay=30s`). 403 is fatal (same pattern as crates.io).
- **Config**: new `publish.pub` (`enabled`/`publishOrder`) and `version.pub` (`enabled`/`paths`) keys in Zod schemas and JSON schema. `--registry pub` added to the publish CLI.
- **Docs**: `docs/cli.md` updated, `ci-setup.md` gains a pub.dev OIDC + token auth section, `docs/configuration.md` regenerated.
- **Tests**: 13 unit tests for `pubHandler`, 10 for `pub-publish` stage, 7 for pub.dev verify polling.

## Test plan

- [ ] `pnpm turbo run lint typecheck test` passes (24/24 tasks)
- [ ] Verify `pubspec.yaml` version bump works in a real Dart package
- [ ] Verify OIDC publish path (no `PUB_TOKEN`) works end-to-end
- [ ] Verify `PUB_TOKEN` path runs `dart pub token add` before publishing
- [ ] Verify `flutter pub publish --force` is used for Flutter packages
- [ ] Verify already-published packages are skipped gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds pub.dev (Dart/Flutter) as a first-class registry, implementing version bumping, publishing, and post-publish verification in parallel with the existing npm and cargo pipelines.

- **Version stage**: `pubHandler.ts` detects `pubspec.yaml` and updates the `version:` field via a regex that preserves inline comments, with a guard that throws on missing/null version fields rather than silently recording a false bump.
- **Publish stage**: `pub-publish.ts` finds pub packages from version-stage updates, optionally configures `PUB_TOKEN` via `dart pub token add`, detects Flutter packages via `environment.flutter`, and handles already-published packages both via pre-publish API check and post-error pattern matching. Duplicate publishes for the same directory are guarded by a `seen` set.
- **Verify stage**: Polls `https://pub.dev/api/packages/{name}/versions/{version}` with exponential backoff, matching the existing 403-fatal-error pattern from the crates.io implementation.
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge; all previously flagged issues (duplicate publishes, silent no-op on missing version, missing PUB_AUTH_ERROR stage mapping) are addressed and covered by the new unit tests.

The implementation follows the established npm/cargo patterns closely, the error-handling guards are thorough, and 30 new unit tests cover the major code paths including edge cases. The two findings are minor: a CRLF edge case that's extremely unlikely in Dart projects and a cosmetic inconsistency in how the already-published pattern is matched against error strings.

No files require special attention beyond the two minor notes on `pubHandler.ts` and `pub-publish.ts`.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/version/src/pub/pubHandler.ts | New pub version handler; regex-based version replacement is correct for LF files but silently changes CRLF line endings on the version line; no-op guard handles null/missing version correctly |
| packages/publish/src/stages/pub-publish.ts | New pub publish stage; dedup via `seen` set addresses previous duplicate-publish concern; token auth, dry-run, publishOrder, and already-published detection all handled correctly |
| packages/publish/src/pipeline/index.ts | pub stage integrated into both batch and per-package modes; PUB_AUTH_ERROR correctly mapped to 'pub-publish' stage; publishSucceeded check updated for all three registries |
| packages/publish/src/stages/verify.ts | pub.dev verification added with 403-fatal pattern matching existing cargo implementation; warn-on-failure (no throw) is consistent with npm/cargo behavior |
| packages/config/src/pubspec.ts | New helper; normalises null YAML documents to empty object; re-exported cleanly from config/index.ts |
| packages/publish/src/utils/pub.ts | New utility; `detectPubCommand` correctly checks `environment.flutter`; `isPubPackagePublished` properly handles non-200/404 responses as "attempt publish" |
| packages/version/src/package/packageProcessor.ts | pub handling wired in alongside cargo; `pub?.enabled !== false` correctly defaults to enabled; supports both explicit `paths` and auto-detected `pubspec.yaml` at package root |
| packages/config/src/schema.ts | New Zod schemas for `VersionPubConfig`, `PubPublishConfig`, `VerifyRegistryPubConfig`; defaults match stated intent (version enabled by default, publish requires opt-in) |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant PP as packageProcessor
    participant PH as pubHandler
    participant Pipeline as pipeline/index
    participant PPS as pub-publish stage
    participant PUB as pub.dev API
    participant VS as verify stage

    PP->>PH: updatePubVersion(pubspecPath, newVersion)
    PH->>PH: regex replace version: field
    PH-->>PP: addPackageUpdate(name, version, path)

    Pipeline->>PPS: runPubPublishStage(ctx)
    PPS->>PPS: findPubPackages(updates) [dedup via seen set]
    alt PUB_TOKEN set
        PPS->>PPS: dart pub token add https://pub.dev --env-var PUB_TOKEN
    end
    loop each package
        PPS->>PUB: "GET /api/packages/{name}/versions/{ver}"
        alt already published (200)
            PPS-->>Pipeline: "skip, success=true"
        else not published (404)
            PPS->>PPS: dart/flutter pub publish --force [withPublishRetry]
            PPS-->>Pipeline: "success=true"
        end
    end

    VS->>PUB: "GET /api/packages/{name}/versions/{ver} [withRetry]"
    alt 403
        PUB-->>VS: fatal error, stop retrying
    else 200
        PUB-->>VS: "verified=true"
    else 404
        PUB-->>VS: retry with backoff
    end
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/publish/src/pipeline/index.ts`, line 14-32 ([link](https://github.com/goosewobbler/releasekit/blob/b3bc2668d2acd68ed2e594adc1cd1cbdb2e6ded2/packages/publish/src/pipeline/index.ts#L14-L32)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`PUB_AUTH_ERROR` missing from stage name map**

   `PUB_AUTH_ERROR` is not added to the `codeToStage` lookup. When `dart pub token add` fails and throws a `PUB_AUTH_ERROR`, `inferStageName` falls through to `'unknown'` instead of `'pub-publish'`. The resulting `PipelineError` will have the wrong `stageName`, so any tooling or output that surfaces the stage name (e.g. CI summary, structured JSON output) will show `"unknown"` rather than `"pub-publish"` — making auth failures harder to diagnose.

   Compare: `NPM_AUTH_ERROR: 'npm-publish'` and `CARGO_AUTH_ERROR: 'cargo-publish'` are both mapped; `PUB_AUTH_ERROR` is the only auth error code without a mapping.

   

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fpublish%2Fsrc%2Fpipeline%2Findex.ts%0ALine%3A%2014-32%0A%0AComment%3A%0A**%60PUB_AUTH_ERROR%60%20missing%20from%20stage%20name%20map**%0A%0A%60PUB_AUTH_ERROR%60%20is%20not%20added%20to%20the%20%60codeToStage%60%20lookup.%20When%20%60dart%20pub%20token%20add%60%20fails%20and%20throws%20a%20%60PUB_AUTH_ERROR%60%2C%20%60inferStageName%60%20falls%20through%20to%20%60'unknown'%60%20instead%20of%20%60'pub-publish'%60.%20The%20resulting%20%60PipelineError%60%20will%20have%20the%20wrong%20%60stageName%60%2C%20so%20any%20tooling%20or%20output%20that%20surfaces%20the%20stage%20name%20%28e.g.%20CI%20summary%2C%20structured%20JSON%20output%29%20will%20show%20%60%22unknown%22%60%20rather%20than%20%60%22pub-publish%22%60%20%E2%80%94%20making%20auth%20failures%20harder%20to%20diagnose.%0A%0ACompare%3A%20%60NPM_AUTH_ERROR%3A%20'npm-publish'%60%20and%20%60CARGO_AUTH_ERROR%3A%20'cargo-publish'%60%20are%20both%20mapped%3B%20%60PUB_AUTH_ERROR%60%20is%20the%20only%20auth%20error%20code%20without%20a%20mapping.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20PUB_PUBLISH_ERROR%3A%20'pub-publish'%2C%0A%20%20%20%20%20%20PUB_AUTH_ERROR%3A%20'pub-publish'%2C%0A%20%20%20%20%20%20PUBSPEC_YAML_ERROR%3A%20'prepare'%2C%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=goosewobbler%2Freleasekit&pr=286&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fpublish%2Fsrc%2Fpipeline%2Findex.ts%0ALine%3A%2014-32%0A%0AComment%3A%0A**%60PUB_AUTH_ERROR%60%20missing%20from%20stage%20name%20map**%0A%0A%60PUB_AUTH_ERROR%60%20is%20not%20added%20to%20the%20%60codeToStage%60%20lookup.%20When%20%60dart%20pub%20token%20add%60%20fails%20and%20throws%20a%20%60PUB_AUTH_ERROR%60%2C%20%60inferStageName%60%20falls%20through%20to%20%60'unknown'%60%20instead%20of%20%60'pub-publish'%60.%20The%20resulting%20%60PipelineError%60%20will%20have%20the%20wrong%20%60stageName%60%2C%20so%20any%20tooling%20or%20output%20that%20surfaces%20the%20stage%20name%20%28e.g.%20CI%20summary%2C%20structured%20JSON%20output%29%20will%20show%20%60%22unknown%22%60%20rather%20than%20%60%22pub-publish%22%60%20%E2%80%94%20making%20auth%20failures%20harder%20to%20diagnose.%0A%0ACompare%3A%20%60NPM_AUTH_ERROR%3A%20'npm-publish'%60%20and%20%60CARGO_AUTH_ERROR%3A%20'cargo-publish'%60%20are%20both%20mapped%3B%20%60PUB_AUTH_ERROR%60%20is%20the%20only%20auth%20error%20code%20without%20a%20mapping.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20PUB_PUBLISH_ERROR%3A%20'pub-publish'%2C%0A%20%20%20%20%20%20PUB_AUTH_ERROR%3A%20'pub-publish'%2C%0A%20%20%20%20%20%20PUBSPEC_YAML_ERROR%3A%20'prepare'%2C%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=286&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (16): Last reviewed commit: ["fix(publish): guard null pubspec parse a..."](https://github.com/goosewobbler/releasekit/commit/04cdae977eb4fe132a9c88a0036c367e5f3c896d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37197609)</sub>

<!-- /greptile_comment -->