### PR TITLE
test(harness): multi-registry e2e covering npm + cargo manifests

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "test:action": "node scripts/test-harness/index.mjs",
     "test:action:preview": "node scripts/test-harness/index.mjs preview",
     "test:action:release": "node scripts/test-harness/index.mjs release --bump patch",
+    "test:harness:multi": "node scripts/test-harness/index.mjs release-multi",
     "lint": "biome check . && eslint --cache \"packages/**/*.ts\"",
     "lint:fix": "biome check --write .",
     "format": "biome format --write .",

--- a/scripts/test-harness/index.mjs
+++ b/scripts/test-harness/index.mjs
@@ -12,14 +12,17 @@
  *   pnpm test:harness           # Run preview mode (default)
  *   pnpm test:harness:preview   # Run preview mode explicitly
  *   pnpm test:harness:release   # Run release mode with patch bump
+ *   pnpm test:harness:multi     # Run release mode with npm + cargo, verify both manifests bumped
  *
  * The harness defaults to running in "CI simulation" mode where:
  * - Only the test project's node_modules are available in NODE_PATH
  * - This mimics the actual CI environment where the action's node_modules aren't available
  */
+import fs from 'node:fs';
+import path from 'node:path';
 import { getRemoteRefs, verifyTags, verifyVersionCommit } from './mock-git.mjs';
 import { parseInputs, runActionLocal } from './run-action-local.mjs';
-import { cleanupTestProject, createTestProject } from './test-project.mjs';
+import { cleanupTestProject, createMultiRegistryTestProject, createTestProject } from './test-project.mjs';
 
 const args = process.argv.slice(2);
 const mode = args[0] || 'preview';
@@ -38,6 +41,66 @@ console.log('');
 
 let projectDir;
 try {
+  if (mode === 'release-multi') {
+    const testProject = createMultiRegistryTestProject();
+    projectDir = testProject.projectDir;
+
+    console.log(`\n--- Running release-multi mode ---`);
+
+    const envVars = {
+      INPUT_MODE: 'release',
+      INPUT_PROJECT_DIR: testProject.projectDir,
+      INPUT_CONFIG: 'releasekit.config.json',
+      INPUT_SKIP_PUBLISH: 'true',
+      INPUT_SKIP_GITHUB_RELEASE: 'true',
+      INPUT_SKIP_VERIFICATION: 'true',
+      INPUT_SKIP_GIT: 'true',
+      INPUT_VERBOSE: 'true',
+      INPUT_BUMP: 'patch',
+    };
+
+    const result = runActionLocal(envVars);
+
+    console.log('\n--- Action Output ---');
+    console.log('Exit code:', result.status);
+    if (result.stdout) {
+      console.log('\nSTDOUT:');
+      console.log(result.stdout);
+    }
+    if (result.stderr) {
+      console.log('\nSTDERR:');
+      console.log(result.stderr);
+    }
+
+    if (result.status !== 0) {
+      console.error(`\n❌ release-multi failed with exit code ${result.status}`);
+      process.exit(1);
+    }
+
+    console.log('\n--- Verifying Multi-Registry Version Bumps ---');
+    const expectedVersion = '1.0.1';
+    for (const pkgSlug of testProject.packages) {
+      const pkgDir = path.join(testProject.projectDir, 'packages', pkgSlug);
+
+      const pkgJsonPath = path.join(pkgDir, 'package.json');
+      const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf-8'));
+      if (pkgJson.version !== expectedVersion) {
+        throw new Error(`${pkgSlug} package.json: expected ${expectedVersion}, got ${pkgJson.version}`);
+      }
+
+      const cargoTomlPath = path.join(pkgDir, 'Cargo.toml');
+      const cargoContent = fs.readFileSync(cargoTomlPath, 'utf-8');
+      const cargoVersionMatch = cargoContent.match(/^version = "([^"]+)"/m);
+      const cargoVersion = cargoVersionMatch?.[1];
+      if (cargoVersion !== expectedVersion) {
+        throw new Error(`${pkgSlug} Cargo.toml: expected ${expectedVersion}, got ${cargoVersion}`);
+      }
+
+      console.log(`✓ ${pkgSlug}: package.json=${pkgJson.version}, Cargo.toml=${cargoVersion}`);
+    }
+
+    console.log(`\n✅ release-multi completed successfully`);
+  } else {
   const testProject = createTestProject();
   projectDir = testProject.projectDir;
 
@@ -132,6 +195,7 @@ try {
   }
 
   console.log(`\n✅ ${mode} completed successfully`);
+  } // end else
 } finally {
   if (projectDir && options.cleanup !== 'false') {
     console.log(`\n--- Cleanup ---`);

--- a/scripts/test-harness/index.mjs
+++ b/scripts/test-harness/index.mjs
@@ -73,8 +73,7 @@ try {
     }
 
     if (result.status !== 0) {
-      console.error(`\n❌ release-multi failed with exit code ${result.status}`);
-      process.exit(1);
+      throw new Error(`release-multi failed with exit code ${result.status}`);
     }
 
     console.log('\n--- Verifying Multi-Registry Version Bumps ---');
@@ -101,101 +100,100 @@ try {
 
     console.log(`\n✅ release-multi completed successfully`);
   } else {
-  const testProject = createTestProject();
-  projectDir = testProject.projectDir;
+    const testProject = createTestProject();
+    projectDir = testProject.projectDir;
 
-  console.log(`\n--- Running ${mode} mode with INPUT_* env vars ---`);
+    console.log(`\n--- Running ${mode} mode with INPUT_* env vars ---`);
 
-  const envVars = {
-    INPUT_MODE: mode,
-    INPUT_PROJECT_DIR: testProject.projectDir,
-    INPUT_CONFIG: 'releasekit.config.json',
-    INPUT_DRY_RUN: 'true',
-    INPUT_SKIP_PUBLISH: 'true',
-    INPUT_SKIP_GITHUB_RELEASE: 'true',
-    INPUT_SKIP_VERIFICATION: 'true',
-    INPUT_SKIP_GIT: 'true',
-  };
+    const envVars = {
+      INPUT_MODE: mode,
+      INPUT_PROJECT_DIR: testProject.projectDir,
+      INPUT_CONFIG: 'releasekit.config.json',
+      INPUT_DRY_RUN: 'true',
+      INPUT_SKIP_PUBLISH: 'true',
+      INPUT_SKIP_GITHUB_RELEASE: 'true',
+      INPUT_SKIP_VERIFICATION: 'true',
+      INPUT_SKIP_GIT: 'true',
+    };
 
-  if (mode === 'release') {
-    envVars.INPUT_VERBOSE = 'true';
-    envVars.INPUT_JSON = 'true';
-    if (options.bump) {
-      envVars.INPUT_BUMP = options.bump;
-    }
-  }
-
-  if (mode === 'preview') {
-    envVars.INPUT_PREVIEW_DRY_RUN = 'true';
-  }
-
-  const parsed = parseInputs(envVars);
-  console.log(`Parsed mode from INPUT_MODE: ${parsed.mode}`);
-
-  if (parsed.mode !== mode) {
-    throw new Error(`Expected mode "${mode}" but parsed as "${parsed.mode}"`);
-  }
-  console.log('✓ INPUT_MODE correctly parsed from env vars');
-
-  const result = runActionLocal(envVars);
-
-  console.log('\n--- Action Output ---');
-  console.log('Exit code:', result.status);
-  if (result.stdout) {
-    console.log('\nSTDOUT:');
-    console.log(result.stdout);
-  }
-  if (result.stderr) {
-    console.log('\nSTDERR:');
-    console.log(result.stderr);
-  }
-
-  if (result.status !== 0) {
-    console.error(`\n❌ ${mode} failed with exit code ${result.status}`);
-    process.exit(1);
-  }
-
-  if (mode === 'release') {
-    console.log('\n--- Verifying Release ---');
-
-    try {
-      verifyVersionCommit(projectDir);
-      console.log('✓ Version commit exists');
-    } catch (_e) {
-      console.warn('⚠ Version commit not found (expected for dry-run without --skip-git)');
+    if (mode === 'release') {
+      envVars.INPUT_VERBOSE = 'true';
+      envVars.INPUT_JSON = 'true';
+      if (options.bump) {
+        envVars.INPUT_BUMP = options.bump;
+      }
     }
 
-    const expectedTags = ['pkg-a@1.0.1', 'pkg-b@1.0.1', 'pkg-c@1.0.1'];
-    try {
-      verifyTags(projectDir, expectedTags);
-      console.log('✓ Tags exist:', expectedTags.join(', '));
-    } catch (_e) {
-      console.warn('⚠ Tags not found (expected for dry-run without --skip-git)');
+    if (mode === 'preview') {
+      envVars.INPUT_PREVIEW_DRY_RUN = 'true';
     }
 
-    const remoteRefs = getRemoteRefs(testProject.remotePath);
-    console.log('Remote refs (should be empty - no actual push):');
-    console.log(`  Branches: ${remoteRefs.branches || '(none)'}`);
-    console.log(`  Tags: ${remoteRefs.tags || '(none)'}`);
+    const parsed = parseInputs(envVars);
+    console.log(`Parsed mode from INPUT_MODE: ${parsed.mode}`);
+
+    if (parsed.mode !== mode) {
+      throw new Error(`Expected mode "${mode}" but parsed as "${parsed.mode}"`);
+    }
+    console.log('✓ INPUT_MODE correctly parsed from env vars');
+
+    const result = runActionLocal(envVars);
+
+    console.log('\n--- Action Output ---');
+    console.log('Exit code:', result.status);
+    if (result.stdout) {
+      console.log('\nSTDOUT:');
+      console.log(result.stdout);
+    }
+    if (result.stderr) {
+      console.log('\nSTDERR:');
+      console.log(result.stderr);
+    }
+
+    if (result.status !== 0) {
+      throw new Error(`${mode} failed with exit code ${result.status}`);
+    }
+
+    if (mode === 'release') {
+      console.log('\n--- Verifying Release ---');
+
+      try {
+        verifyVersionCommit(projectDir);
+        console.log('✓ Version commit exists');
+      } catch (_e) {
+        console.warn('⚠ Version commit not found (expected for dry-run without --skip-git)');
+      }
+
+      const expectedTags = ['pkg-a@1.0.1', 'pkg-b@1.0.1', 'pkg-c@1.0.1'];
+      try {
+        verifyTags(projectDir, expectedTags);
+        console.log('✓ Tags exist:', expectedTags.join(', '));
+      } catch (_e) {
+        console.warn('⚠ Tags not found (expected for dry-run without --skip-git)');
+      }
+
+      const remoteRefs = getRemoteRefs(testProject.remotePath);
+      console.log('Remote refs (should be empty - no actual push):');
+      console.log(`  Branches: ${remoteRefs.branches || '(none)'}`);
+      console.log(`  Tags: ${remoteRefs.tags || '(none)'}`);
+    }
+
+    if (mode === 'preview') {
+      console.log('\n--- Verifying Preview ---');
+      if (result.stdout?.includes('releasekit-preview')) {
+        console.log('✓ Preview markdown generated');
+        console.log('\nPreview content (first 500 chars):');
+        console.log(result.stdout.substring(0, 500));
+      } else {
+        console.warn('⚠ No preview markdown found in output');
+      }
+
+      if (result.stdout?.includes('No release label detected')) {
+        console.log('✓ No release label detected message present');
+      }
+    }
+
+    console.log(`\n✅ ${mode} completed successfully`);
   }
-
-  if (mode === 'preview') {
-    console.log('\n--- Verifying Preview ---');
-    if (result.stdout?.includes('releasekit-preview')) {
-      console.log('✓ Preview markdown generated');
-      console.log('\nPreview content (first 500 chars):');
-      console.log(result.stdout.substring(0, 500));
-    } else {
-      console.warn('⚠ No preview markdown found in output');
-    }
-
-    if (result.stdout?.includes('No release label detected')) {
-      console.log('✓ No release label detected message present');
-    }
-  }
-
-  console.log(`\n✅ ${mode} completed successfully`);
-  } // end else
 } finally {
   if (projectDir && options.cleanup !== 'false') {
     console.log(`\n--- Cleanup ---`);

--- a/scripts/test-harness/test-project.mjs
+++ b/scripts/test-harness/test-project.mjs
@@ -135,3 +135,107 @@ export function cleanupTestProject(projectDir) {
     console.log(`Cleaned up: ${projectDir}`);
   }
 }
+
+export function createMultiRegistryTestProject(_options = {}) {
+  const timestamp = Date.now();
+  const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), `${TEST_PREFIX}-multi-${timestamp}`));
+
+  console.log(`Creating multi-registry test project at: ${projectDir}`);
+
+  const remotePath = path.join(projectDir, 'test-remote.git');
+  createBareRemote(remotePath);
+
+  createMultiRegistryMonorepoStructure(projectDir);
+  initGitRepo(projectDir, remotePath);
+
+  const commits = [
+    'feat(pkg-a): add initial feature',
+    'fix(pkg-b): fix a bug',
+    'docs: update README',
+    'feat(pkg-c): add new feature',
+    'fix(pkg-a): fix another bug',
+    'feat(pkg-b): add feature to pkg-b',
+    'style: format code',
+    'refactor(pkg-c): refactor code',
+    'test(pkg-a): add tests',
+    'chore: update dependencies',
+  ];
+
+  for (const msg of commits) {
+    addConventionalCommit(projectDir, msg);
+  }
+
+  console.log(`Multi-registry test project created with ${commits.length} commits`);
+
+  return {
+    projectDir,
+    remotePath,
+    packages: ['pkg-a', 'pkg-b', 'pkg-c'],
+  };
+}
+
+function createMultiRegistryMonorepoStructure(projectDir) {
+  const rootPackageJson = {
+    name: 'test-monorepo',
+    version: '1.0.0',
+    private: true,
+    scripts: {
+      test: 'echo "test"',
+    },
+  };
+
+  fs.writeFileSync(path.join(projectDir, 'package.json'), JSON.stringify(rootPackageJson, null, 2));
+  fs.writeFileSync(path.join(projectDir, 'pnpm-workspace.yaml'), 'packages:\n  - "packages/*"\n');
+
+  const pkgNames = ['pkg-a', 'pkg-b', 'pkg-c'];
+  const members = pkgNames.map((n) => `    "packages/${n}"`).join(',\n');
+  fs.writeFileSync(path.join(projectDir, 'Cargo.toml'), `[workspace]\nmembers = [\n${members}\n]\nresolver = "2"\n`);
+
+  const packagesDir = path.join(projectDir, 'packages');
+  fs.mkdirSync(packagesDir, { recursive: true });
+
+  const packages = [
+    { name: '@test/pkg-a', slug: 'pkg-a', version: '1.0.0', description: 'Test package A' },
+    { name: '@test/pkg-b', slug: 'pkg-b', version: '1.0.0', description: 'Test package B' },
+    { name: '@test/pkg-c', slug: 'pkg-c', version: '1.0.0', description: 'Test package C' },
+  ];
+
+  for (const pkg of packages) {
+    const pkgDir = path.join(packagesDir, pkg.slug);
+    fs.mkdirSync(pkgDir, { recursive: true });
+
+    fs.writeFileSync(
+      path.join(pkgDir, 'package.json'),
+      JSON.stringify(
+        {
+          name: pkg.name,
+          version: pkg.version,
+          description: pkg.description,
+          main: './dist/index.js',
+          scripts: { build: 'echo "build"' },
+        },
+        null,
+        2,
+      ),
+    );
+
+    fs.writeFileSync(
+      path.join(pkgDir, 'Cargo.toml'),
+      `[package]\nname = "${pkg.slug}"\nversion = "${pkg.version}"\nedition = "2021"\n`,
+    );
+
+    fs.mkdirSync(path.join(pkgDir, 'src'), { recursive: true });
+    fs.writeFileSync(path.join(pkgDir, 'src', 'index.js'), 'export const hello = "world";\n');
+  }
+
+  const releasekitConfig = {
+    version: {
+      preset: 'angular',
+      packages: ['packages/*'],
+    },
+  };
+
+  fs.writeFileSync(path.join(projectDir, 'releasekit.config.json'), JSON.stringify(releasekitConfig, null, 2));
+
+  installDependencies(projectDir);
+}


### PR DESCRIPTION
## Summary

- Adds a `release-multi` mode to the test harness that creates a monorepo where every package has both a `package.json` and a `Cargo.toml`
- Runs `releasekit release` without `--dry-run` (so manifests are actually written to disk), with `--skip-git` and `--skip-publish`
- After the run, asserts both file types contain the bumped version (`1.0.1`) — this is a genuine file-level assertion, not just an exit-code check
- Adds `pnpm test:harness:multi` root script wired to the new mode

Cargo version handling is already on by default (`cargo.enabled !== false`), so no config change is needed — the `Cargo.toml` files just need to exist alongside `package.json`.

**Relationship to #286**: Once the pub.dev PR merges, a `pubspec.yaml` can be added to each test package and the verification loop extended to check the third manifest type.

## Test plan

- [ ] `pnpm build && pnpm test:harness:multi` passes locally
- [ ] CI green
- [ ] Existing `pnpm test:action:release` and `pnpm test:action:preview` still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a `release-multi` mode to the test harness that scaffolds a monorepo with both `package.json` and `Cargo.toml` per package, runs `releasekit release` without `--dry-run` so manifests are actually written, then asserts the bumped version (`1.0.1`) in both file types — a genuine file-level assertion rather than an exit-code check.

- Adds `createMultiRegistryTestProject` in `test-project.mjs` alongside a companion `createMultiRegistryMonorepoStructure` that writes per-package `Cargo.toml` files and a workspace-root `Cargo.toml` with the correct `[workspace]` member list.
- Refactors `index.mjs` to dispatch on `release-multi` vs. the existing modes; the existing `process.exit(1)` paths were converted to `throw` (so the `finally` cleanup block now runs on failure).
- Wires up `pnpm test:harness:multi` in `package.json`.
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge — the changes are confined to the test harness and introduce no risk to production paths.

All changes are test infrastructure only. The new release-multi path is well-isolated, the finally cleanup runs correctly on both success and failure (the old process.exit anti-pattern was fixed as part of this refactor), and the file-level assertions are straightforward. The only nit is a cosmetic improvement to the Cargo.toml version error message.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| package.json | Adds test:harness:multi convenience script wiring the new release-multi mode; clean and consistent with existing harness scripts. |
| scripts/test-harness/index.mjs | Refactors the harness entry-point to dispatch on release-multi, adds file-level assertion of both package.json and Cargo.toml versions; existing paths converted from process.exit to throw which is a correctness improvement. Minor: cargoVersionMatch?.[1] silently produces undefined on a missing version field. |
| scripts/test-harness/test-project.mjs | Adds createMultiRegistryTestProject and its companion structure builder; each per-package Cargo.toml is valid TOML with a [package] section and a version, and the workspace root Cargo.toml correctly lists all members. Code is largely parallel to createTestProject; the duplication is acceptable for test infrastructure. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[pnpm test:harness:multi] --> B{mode === 'release-multi'?}
    B -- yes --> C[createMultiRegistryTestProject]
    C --> D[createBareRemote]
    C --> E[createMultiRegistryMonorepoStructure]
    E --> E1[Write root package.json]
    E --> E2[Write pnpm-workspace.yaml]
    E --> E3[Write root Cargo.toml with members]
    E --> E4[For each pkg: write package.json + Cargo.toml + src/index.js]
    E --> E5[installDependencies]
    C --> F[initGitRepo]
    C --> G[addConventionalCommits x10]
    D & E & F & G --> H[runActionLocal INPUT_MODE=release --skip-git --skip-publish]
    H --> I{exit code === 0?}
    I -- no --> J[throw Error → finally cleanup]
    I -- yes --> K[For each pkg: read package.json + Cargo.toml]
    K --> L{version === '1.0.1'?}
    L -- no --> M[throw Error → finally cleanup]
    L -- yes --> N[Log ✓]
    N --> O[✅ release-multi completed]
    O --> P[finally: cleanupTestProject]
    B -- no --> Q[createTestProject → existing release/preview flow]
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `scripts/test-harness/index.mjs`, line 103-107 ([link](https://github.com/goosewobbler/releasekit/blob/d942737148116c78b5fb666efac81c6f06a93df0/scripts/test-harness/index.mjs#L103-L107)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The `else` block body is not indented relative to the `else` keyword. When the existing code was wrapped in an `else`, the indentation was not updated, making the block boundaries visually ambiguous.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Ftest-harness%2Findex.mjs%0ALine%3A%20103-107%0A%0AComment%3A%0AThe%20%60else%60%20block%20body%20is%20not%20indented%20relative%20to%20the%20%60else%60%20keyword.%20When%20the%20existing%20code%20was%20wrapped%20in%20an%20%60else%60%2C%20the%20indentation%20was%20not%20updated%2C%20making%20the%20block%20boundaries%20visually%20ambiguous.%0A%0A%60%60%60suggestion%0A%20%20%7D%20else%20%7B%0A%20%20%20%20const%20testProject%20%3D%20createTestProject%28%29%3B%0A%20%20%20%20projectDir%20%3D%20testProject.projectDir%3B%0A%0A%20%20%20%20console.log%28%60%5Cn---%20Running%20%24%7Bmode%7D%20mode%20with%20INPUT_*%20env%20vars%20---%60%29%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=goosewobbler%2Freleasekit&pr=287&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Ftest-harness%2Findex.mjs%0ALine%3A%20103-107%0A%0AComment%3A%0AThe%20%60else%60%20block%20body%20is%20not%20indented%20relative%20to%20the%20%60else%60%20keyword.%20When%20the%20existing%20code%20was%20wrapped%20in%20an%20%60else%60%2C%20the%20indentation%20was%20not%20updated%2C%20making%20the%20block%20boundaries%20visually%20ambiguous.%0A%0A%60%60%60suggestion%0A%20%20%7D%20else%20%7B%0A%20%20%20%20const%20testProject%20%3D%20createTestProject%28%29%3B%0A%20%20%20%20projectDir%20%3D%20testProject.projectDir%3B%0A%0A%20%20%20%20console.log%28%60%5Cn---%20Running%20%24%7Bmode%7D%20mode%20with%20INPUT_*%20env%20vars%20---%60%29%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=287&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix(harness): throw instead of process.e..."](https://github.com/goosewobbler/releasekit/commit/d5027d933ff76741bc9b6cb58f4166dd8a58439d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37234833)</sub>

<!-- /greptile_comment -->