### PR TITLE
fix(publish): match sanitized "name@v" tags so notes attach for scoped packages

### DIFF
--- a/packages/publish/src/stages/github-release.ts
+++ b/packages/publish/src/stages/github-release.ts
@@ -76,10 +76,12 @@ interface TagResolution {
   version: string;
 }
 
-/** Match a tag against a list of package names, handling two formats:
- *  - Raw:       "@scope/pkg@v1.0.0"   (separator: @, no tagTemplate)
- *  - Sanitized: "scope-pkg-v1.0.0"    (separator: -, tagTemplate uses ${packageName})
+/** Match a tag against a list of package names, handling three formats:
+ *  - Raw:           "@scope/pkg@v1.0.0"  (unsanitized name, "@" separator — no tagTemplate)
+ *  - Sanitized "@": "scope-pkg@v1.0.0"   (sanitized name, "@" separator — tagTemplate "${packageName}@v${version}")
+ *  - Sanitized "-": "scope-pkg-v1.0.0"   (sanitized name, "-" separator — tagTemplate "${packageName}-${version}")
  *
+ *  Checked in that order; for unscoped names the sanitized-"@" form collapses to the raw form.
  *  Sorts by sanitized name length (longest first) to resolve prefix ambiguity.
  */
 function resolveTagPackage(tag: string, packageNames: string[]): TagResolution | null {

--- a/packages/publish/src/stages/github-release.ts
+++ b/packages/publish/src/stages/github-release.ts
@@ -85,11 +85,25 @@ interface TagResolution {
 function resolveTagPackage(tag: string, packageNames: string[]): TagResolution | null {
   const sorted = [...packageNames].sort((a, b) => sanitizePackageName(b).length - sanitizePackageName(a).length);
   for (const packageName of sorted) {
+    // Raw, unsanitized name: "@scope/pkg@v1.0.0"
     const atPrefix = `${packageName}@`;
     if (tag.startsWith(atPrefix)) {
       return { packageName, version: tag.slice(atPrefix.length) };
     }
-    const dashPrefix = `${sanitizePackageName(packageName)}-`;
+    const sanitized = sanitizePackageName(packageName);
+    // Sanitized name + "@" separator: "scope-pkg@v1.0.0". Produced when `tagTemplate` is
+    // "${packageName}@v${version}" and the name is scoped — the template sanitizes the name into
+    // the tag, so neither the raw-"@" nor the sanitized-"-" branch matches it. (For unscoped names
+    // `sanitized` equals `packageName`, so this collapses to `atPrefix` above.)
+    const sanitizedAtPrefix = `${sanitized}@`;
+    if (sanitizedAtPrefix !== atPrefix && tag.startsWith(sanitizedAtPrefix)) {
+      const versionPart = tag.slice(sanitizedAtPrefix.length);
+      if (/^v?\d/.test(versionPart)) {
+        return { packageName, version: versionPart };
+      }
+    }
+    // Sanitized name + "-" separator: "scope-pkg-v1.0.0"
+    const dashPrefix = `${sanitized}-`;
     if (tag.startsWith(dashPrefix)) {
       const versionPart = tag.slice(dashPrefix.length);
       if (/^v?\d/.test(versionPart)) {

--- a/packages/publish/test/unit/stages/github-release.spec.ts
+++ b/packages/publish/test/unit/stages/github-release.spec.ts
@@ -337,6 +337,35 @@ describe('github-release stage', () => {
     expect(args[args.indexOf('--title') + 1]).toBe('@releasekit/version: v0.4.1');
   });
 
+  it('should match a sanitized "name@vX.Y.Z" tag to release notes keyed by scoped package name', async () => {
+    // Regression for #288: tagTemplate "${packageName}@v${version}" sanitizes a scoped name into
+    // the tag (e.g. wdio-tauri-plugin@v1.1.0). Previously neither the raw-"@" nor the sanitized-"-"
+    // branch matched it, so notes silently fell back to GitHub auto-generated notes.
+    const { execCommand } = await import('../../../src/utils/exec.js');
+
+    const ctx = createContext({
+      input: { dryRun: false, updates: [], changelogs: [], tags: ['wdio-tauri-plugin@v1.1.0'] },
+      output: {
+        dryRun: false,
+        git: { committed: true, tags: ['wdio-tauri-plugin@v1.1.0'], pushed: true },
+        npm: [],
+        cargo: [],
+        verification: [],
+        githubReleases: [],
+      },
+      releaseNotes: { '@wdio/tauri-plugin': 'LLM-enhanced release notes' },
+    });
+
+    await runGithubReleaseStage(ctx);
+
+    const args = vi.mocked(execCommand).mock.calls[0]?.[1] as string[];
+    expect(args).toContain('--notes');
+    expect(args[args.indexOf('--notes') + 1]).toBe('LLM-enhanced release notes');
+    expect(args).not.toContain('--generate-notes');
+    // Title resolves via the original (unsanitized) scoped name
+    expect(args[args.indexOf('--title') + 1]).toBe('@wdio/tauri-plugin: v1.1.0');
+  });
+
   it('should always use --generate-notes when body is generated', async () => {
     const { execCommand } = await import('../../../src/utils/exec.js');
     const config = getDefaultConfig();


### PR DESCRIPTION
## Summary

`resolveTagPackage` only recognized raw `@scope/pkg@v…` and sanitized `scope-pkg-v…` tag shapes. With `tagTemplate: "${packageName}@v${version}"` and a **scoped** package, ReleaseKit generates `scope-pkg@v…` (sanitized name + `@` separator) — a shape it then couldn't match back, so per-package release notes silently fell back to GitHub's auto-generated notes.

This adds the sanitized-`@` prefix as a third recognized shape, with the same version guard as the dash branch. Unscoped names collapse to the existing raw-`@` branch, so they're unaffected.

## Context

Observed in the [webdriverio/desktop-mobile release run](https://github.com/webdriverio/desktop-mobile/actions/runs/27469532901/job/81197798707): the two **scoped** packages warned `Release notes configured but no content found for tag … falling back to GitHub auto-generated notes`, while the **unscoped** crate (whose name survives sanitization) did not — pinpointing the scoped-tag gap.

## Testing

- New regression test: `wdio-tauri-plugin@v1.1.0` resolves to `@wdio/tauri-plugin`; existing raw-`@` and sanitized-`-` shapes still resolve.
- `lint typecheck test` pass for `@releasekit/publish`.

Closes #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a silent fallback to GitHub auto-generated release notes for scoped npm packages when `tagTemplate` uses the `${packageName}@v${version}` form. `resolveTagPackage` previously only recognised raw `@scope/pkg@v…` and sanitized `scope-pkg-v…` tags; the third shape `scope-pkg@v…` (sanitized name, `@` separator) produced by that template was unmatched.

- Adds a third match branch in `resolveTagPackage` for sanitized-name + `@` separator, guarded by a version-format regex identical to the existing dash branch, and only attempted when the sanitized name differs from the original (i.e., scoped packages).
- Updates the JSDoc to document all three formats and adds a regression test that reproduces the `@wdio/tauri-plugin` scenario from the linked webdriverio/desktop-mobile run.
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a minimal, well-guarded addition to a single matching function with no effect on unscoped packages or the existing dash/raw branches.

The fix is tightly scoped: the new branch only fires when the sanitized name differs from the original name (ruling out unscoped packages) and when the version part looks like a version string. Existing branches are structurally unchanged. The regression test directly reproduces the reported failure scenario and the JSDoc now accurately describes all three formats.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/publish/src/stages/github-release.ts | Adds a third match branch in resolveTagPackage for sanitized-name + "@" tags; JSDoc updated to document all three formats. Logic is correct for scoped/unscoped packages and prefix ambiguity. |
| packages/publish/test/unit/stages/github-release.spec.ts | Adds a focused regression test for the sanitized "@" tag shape using the wdio-tauri-plugin scenario; existing tests for raw-"@" and sanitized-"-" shapes remain in place. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["resolveTagPackage(tag, packageNames)"] --> B["Sort by sanitized name length (longest first)"]
    B --> C["For each packageName"]
    C --> D{"tag starts with\npackageName + '@'\n(raw prefix)"}
    D -- Yes --> E["Return { packageName, version }"]
    D -- No --> F["sanitized = sanitizePackageName(packageName)"]
    F --> G{"sanitizedAtPrefix ≠ atPrefix\nAND tag starts with\nsanitized + '@'"}
    G -- Yes --> H{"versionPart matches /^v?\\d/"}
    H -- Yes --> I["Return { packageName, version }"]
    H -- No --> J["Try dash branch"]
    G -- No --> J
    J --> K{"tag starts with\nsanitized + '-'"}
    K -- Yes --> L{"versionPart matches /^v?\\d/"}
    L -- Yes --> M["Return { packageName, version }"]
    L -- No --> N["Next package"]
    K -- No --> N
    N --> C
    C -- exhausted --> O["Return null"]

    style I fill:#90EE90
    style E fill:#90EE90
    style M fill:#90EE90
    style O fill:#FFB6C1
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/publish/src/stages/github-release.ts`, line 79-84 ([link](https://github.com/goosewobbler/releasekit/blob/b03c4a3fa9a4a53865752b14b91065ddc9ade3cf/packages/publish/src/stages/github-release.ts#L79-L84)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Stale JSDoc — new third format not listed**

   The block comment above `resolveTagPackage` still says the function handles "two formats" and only lists the raw `@scope/pkg@v…` and sanitized `scope-pkg-v…` shapes. The new `scope-pkg@v…` shape is now a first-class branch but is invisible to anyone reading only the contract comment.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fpublish%2Fsrc%2Fstages%2Fgithub-release.ts%0ALine%3A%2079-84%0A%0AComment%3A%0A**Stale%20JSDoc%20%E2%80%94%20new%20third%20format%20not%20listed**%0A%0AThe%20block%20comment%20above%20%60resolveTagPackage%60%20still%20says%20the%20function%20handles%20%22two%20formats%22%20and%20only%20lists%20the%20raw%20%60%40scope%2Fpkg%40v%E2%80%A6%60%20and%20sanitized%20%60scope-pkg-v%E2%80%A6%60%20shapes.%20The%20new%20%60scope-pkg%40v%E2%80%A6%60%20shape%20is%20now%20a%20first-class%20branch%20but%20is%20invisible%20to%20anyone%20reading%20only%20the%20contract%20comment.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=goosewobbler%2Freleasekit&pr=294&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fpublish%2Fsrc%2Fstages%2Fgithub-release.ts%0ALine%3A%2079-84%0A%0AComment%3A%0A**Stale%20JSDoc%20%E2%80%94%20new%20third%20format%20not%20listed**%0A%0AThe%20block%20comment%20above%20%60resolveTagPackage%60%20still%20says%20the%20function%20handles%20%22two%20formats%22%20and%20only%20lists%20the%20raw%20%60%40scope%2Fpkg%40v%E2%80%A6%60%20and%20sanitized%20%60scope-pkg-v%E2%80%A6%60%20shapes.%20The%20new%20%60scope-pkg%40v%E2%80%A6%60%20shape%20is%20now%20a%20first-class%20branch%20but%20is%20invisible%20to%20anyone%20reading%20only%20the%20contract%20comment.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=294&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["docs(publish): list the sanitized-&quot;@&quot; ta..."](https://github.com/goosewobbler/releasekit/commit/d908304be35300bb5b7a959e83513596de750cee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37439904)</sub>

<!-- /greptile_comment -->