### PR TITLE
fix(version): aggregate graduation changelog from the last stable tag

### DIFF
--- a/packages/version/src/git/tagsAndBranches.ts
+++ b/packages/version/src/git/tagsAndBranches.ts
@@ -141,8 +141,7 @@ export async function lastMergeBranchName(branches: string[], baseBranch: string
  * List a package's tags (those matching its tag template), most-recently-created first.
  *
  * Returns an empty array when package-specific tags are disabled (callers fall back to the global
- * tag series) or when nothing matches. Shared by the latest-tag and latest-stable-tag lookups, and
- * by the notes-backfill enumeration (#293).
+ * tag series) or when nothing matches. Shared by the latest-tag and latest-stable-tag lookups.
  */
 export async function listPackageTags(
   packageName: string,
@@ -248,7 +247,7 @@ export async function getLatestTagForPackage(
  * Most recent *stable* (non-prerelease) tag for a package, or '' if none.
  *
  * Used when a prerelease graduates to stable: the changelog should aggregate everything since the
- * last stable release, not since the most recent (prerelease) tag. (#291)
+ * last stable release, not since the most recent (prerelease) tag.
  */
 export async function getLatestStableTagForPackage(
   packageName: string,
@@ -274,7 +273,7 @@ export async function getLatestStableTagForPackage(
 
 /**
  * Most recent *stable* tag across the global (non-package-specific) tag series, or '' if none.
- * Stable counterpart of {@link getLatestTag} for sync/global graduation. (#291)
+ * Stable counterpart of {@link getLatestTag} for sync/global graduation.
  */
 export async function getLatestStableTag(versionPrefix?: string): Promise<string> {
   try {

--- a/packages/version/src/git/tagsAndBranches.ts
+++ b/packages/version/src/git/tagsAndBranches.ts
@@ -2,6 +2,7 @@ import { getSemverTags } from 'git-semver-tags';
 import semver from 'semver';
 import { escapeRegExp } from '../utils/formatting.js';
 import { log } from '../utils/logging.js';
+import { isStableTag } from '../utils/versionUtils.js';
 import { execAsync, execSync } from './commandExecutor.js';
 
 /**
@@ -143,85 +144,92 @@ export async function lastMergeBranchName(branches: string[], baseBranch: string
  * @param options Additional options including tag templates
  * @returns The latest tag for the package or empty string if none found
  */
+/**
+ * List a package's tags (those matching its tag template), most-recently-created first.
+ *
+ * Returns an empty array when package-specific tags are disabled (callers fall back to the global
+ * tag series) or when nothing matches. Shared by the latest-tag and latest-stable-tag lookups, and
+ * by the notes-backfill enumeration (#293).
+ */
+export async function listPackageTags(
+  packageName: string,
+  versionPrefix?: string,
+  options?: TagSearchOptions,
+): Promise<string[]> {
+  const packageSpecificTags = options?.packageSpecificTags ?? false;
+  const tagTemplate =
+    options?.tagTemplate || (packageSpecificTags ? `\${packageName}@\${prefix}\${version}` : `\${prefix}\${version}`);
+
+  // Strip @ prefix from package names for tag matching (e.g., @releasekit/version -> releasekit-version)
+  const sanitizedPackageName = packageName.startsWith('@') ? packageName.slice(1).replace(/\//g, '-') : packageName;
+  const escapedPackageName = escapeRegExp(sanitizedPackageName);
+  const escapedPrefix = versionPrefix ? escapeRegExp(versionPrefix) : '';
+
+  log(
+    `Looking for tags for package ${packageName} with prefix ${versionPrefix || 'none'}, packageSpecificTags: ${packageSpecificTags}`,
+    'debug',
+  );
+
+  // Only package-specific tags are listed here; global tags go through getLatestTag/getSemverTags.
+  if (!packageSpecificTags) {
+    log(`Package-specific tags disabled for ${packageName}, falling back to global tags`, 'debug');
+    return [];
+  }
+
+  // Get ALL git tags (not just semver ones, which git-semver-tags can't see), sorted by creatordate
+  // descending so the most recently created tag comes first. This ensures a stable patch release
+  // (e.g. v0.2.1) created after a prerelease (e.g. v0.3.0-next.4) is correctly identified as latest.
+  let allTags: string[] = [];
+  try {
+    const { execSync } = await import('./commandExecutor.js');
+    const tagsOutput = execSync('git', ['tag', '--sort=-creatordate'], { cwd: process.cwd() });
+    allTags = tagsOutput
+      .toString()
+      .trim()
+      .split('\n')
+      .filter((tag) => tag.length > 0);
+  } catch (err) {
+    log(`Error getting tags: ${err instanceof Error ? err.message : String(err)}`, 'error');
+  }
+
+  log(`Retrieved ${allTags.length} tags`, 'debug');
+
+  // Build a regex from the tag template, replacing template variables with capture groups.
+  const packageTagPattern = escapeRegExp(tagTemplate)
+    .replace(/\\\$\\\{packageName\\\}/g, `(?:${escapedPackageName})`)
+    .replace(/\\\$\\\{prefix\\\}/g, `(?:${escapedPrefix})`)
+    .replace(/\\\$\\\{version\\\}/g, '(?:[0-9]+\\.[0-9]+\\.[0-9]+(?:-[a-zA-Z0-9.-]+)?)');
+
+  log(`Using package tag pattern: ${packageTagPattern}`, 'debug');
+
+  const packageTagRegex = new RegExp(`^${packageTagPattern}$`);
+  // allTags is already sorted by --sort=-creatordate, so the filtered list preserves that order.
+  const packageTags = allTags.filter((tag) => packageTagRegex.test(tag));
+
+  log(`Found ${packageTags.length} matching tags for ${packageName}`, 'debug');
+  if (packageTags.length === 0) {
+    if (allTags.length > 0) {
+      log(`Available tags: ${allTags.join(', ')}`, 'debug');
+    } else {
+      log('No tags available in the repository', 'debug');
+    }
+  }
+  return packageTags;
+}
+
 export async function getLatestTagForPackage(
   packageName: string,
   versionPrefix?: string,
   options?: TagSearchOptions,
 ): Promise<string> {
   try {
-    const packageSpecificTags = options?.packageSpecificTags ?? false;
-    const tagTemplate =
-      options?.tagTemplate || (packageSpecificTags ? `\${packageName}@\${prefix}\${version}` : `\${prefix}\${version}`);
-
-    // Strip @ prefix from package names for tag matching (e.g., @releasekit/version -> releasekit-version)
-    const sanitizedPackageName = packageName.startsWith('@') ? packageName.slice(1).replace(/\//g, '-') : packageName;
-    // Escape package name for regex
-    const escapedPackageName = escapeRegExp(sanitizedPackageName);
-    const escapedPrefix = versionPrefix ? escapeRegExp(versionPrefix) : '';
-
-    log(
-      `Looking for tags for package ${packageName} with prefix ${versionPrefix || 'none'}, packageSpecificTags: ${packageSpecificTags}`,
-      'debug',
-    );
-
-    // Instead of using the package option which requires lerna mode,
-    // get all tags and filter manually for the package
-    // For package-specific tags, we need ALL git tags (not just semver ones)
-    // which git-semver-tags doesn't recognize, so we use git tag -l
-    let allTags: string[] = [];
-    try {
-      const { execSync } = await import('./commandExecutor.js');
-      // Sort by creatordate descending so the most recently created tag comes first.
-      // This ensures that a stable patch release (e.g. v0.2.1) created after a prerelease
-      // (e.g. v0.3.0-next.4) is correctly identified as the latest tag for the package.
-      const tagsOutput = execSync('git', ['tag', '--sort=-creatordate'], { cwd: process.cwd() });
-      allTags = tagsOutput
-        .toString()
-        .trim()
-        .split('\n')
-        .filter((tag) => tag.length > 0);
-    } catch (err) {
-      log(`Error getting tags: ${err instanceof Error ? err.message : String(err)}`, 'error');
+    const packageTags = await listPackageTags(packageName, versionPrefix, options);
+    if (packageTags.length > 0) {
+      log(`Found ${packageTags.length} package tags using configured pattern`, 'debug');
+      log(`Using most recently created tag: ${packageTags[0]}`, 'debug');
+      return packageTags[0];
     }
-
-    log(`Retrieved ${allTags.length} tags`, 'debug');
-
-    // Only use package-specific tag patterns if explicitly enabled
-    if (packageSpecificTags) {
-      // Create a regex pattern based on the tagTemplate
-      // First, replace template variables with regex capture groups
-      const packageTagPattern = escapeRegExp(tagTemplate)
-        .replace(/\\\$\\\{packageName\\\}/g, `(?:${escapedPackageName})`)
-        .replace(/\\\$\\\{prefix\\\}/g, `(?:${escapedPrefix})`)
-        .replace(/\\\$\\\{version\\\}/g, '(?:[0-9]+\\.[0-9]+\\.[0-9]+(?:-[a-zA-Z0-9.-]+)?)');
-
-      log(`Using package tag pattern: ${packageTagPattern}`, 'debug');
-
-      const packageTagRegex = new RegExp(`^${packageTagPattern}$`);
-      const packageTags = allTags.filter((tag) => packageTagRegex.test(tag));
-
-      log(`Found ${packageTags.length} matching tags for ${packageName}`, 'debug');
-
-      // If we found tags with the configured pattern, return the most recently created one.
-      // allTags is already sorted by --sort=-creatordate, so packageTags preserves that order.
-      if (packageTags.length > 0) {
-        log(`Found ${packageTags.length} package tags using configured pattern`, 'debug');
-        log(`Using most recently created tag: ${packageTags[0]}`, 'debug');
-
-        return packageTags[0];
-      }
-
-      log('No matching tags found for configured tag pattern', 'debug');
-      if (allTags.length > 0) {
-        log(`Available tags: ${allTags.join(', ')}`, 'debug');
-      } else {
-        log('No tags available in the repository', 'debug');
-      }
-      return '';
-    }
-
-    // Package-specific tags disabled, return empty string to fall back to global tags
-    log(`Package-specific tags disabled for ${packageName}, falling back to global tags`, 'debug');
+    log('No matching tags found for configured tag pattern', 'debug');
     return '';
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
@@ -233,5 +241,63 @@ export async function getLatestTagForPackage(
     }
 
     return ''; // Return empty string on error or no tags
+  }
+}
+
+/**
+ * Most recent *stable* (non-prerelease) tag for a package, or '' if none.
+ *
+ * Used when a prerelease graduates to stable: the changelog should aggregate everything since the
+ * last stable release, not since the most recent (prerelease) tag. (#291)
+ */
+export async function getLatestStableTagForPackage(
+  packageName: string,
+  versionPrefix?: string,
+  options?: TagSearchOptions,
+): Promise<string> {
+  try {
+    const packageTags = await listPackageTags(packageName, versionPrefix, options);
+    const stable = packageTags.find((tag) => isStableTag(tag));
+    if (stable) {
+      log(`Using most recently created stable tag for ${packageName}: ${stable}`, 'debug');
+      return stable;
+    }
+    return '';
+  } catch (error) {
+    log(
+      `Failed to get latest stable tag for package ${packageName}: ${error instanceof Error ? error.message : String(error)}`,
+      'error',
+    );
+    return '';
+  }
+}
+
+/**
+ * Most recent *stable* tag across the global (non-package-specific) tag series, or '' if none.
+ * Stable counterpart of {@link getLatestTag} for sync/global graduation. (#291)
+ */
+export async function getLatestStableTag(versionPrefix?: string): Promise<string> {
+  try {
+    const tags: string[] = await getSemverTags({ tagPrefix: versionPrefix });
+    const stripPrefix = (tag: string) =>
+      versionPrefix && tag.startsWith(versionPrefix) ? tag.slice(versionPrefix.length) : tag;
+
+    const stableTags = tags.filter((tag) => {
+      const cleaned = semver.clean(stripPrefix(tag));
+      return cleaned ? semver.prerelease(cleaned) === null : false;
+    });
+
+    if (stableTags.length === 0) return '';
+
+    // Highest stable version first (mirrors getLatestTag's semantic sort).
+    const sorted = [...stableTags].sort((a, b) => {
+      const va = semver.clean(stripPrefix(a)) || '0.0.0';
+      const vb = semver.clean(stripPrefix(b)) || '0.0.0';
+      return semver.rcompare(va, vb);
+    });
+    return sorted[0] ?? '';
+  } catch (error) {
+    log(`Failed to get latest stable tag: ${error instanceof Error ? error.message : String(error)}`, 'error');
+    return '';
   }
 }

--- a/packages/version/src/git/tagsAndBranches.ts
+++ b/packages/version/src/git/tagsAndBranches.ts
@@ -138,13 +138,6 @@ export async function lastMergeBranchName(branches: string[], baseBranch: string
 }
 
 /**
- * Get the latest semver tag for a specific package
- * @param packageName The name of the package to get tags for
- * @param versionPrefix Optional version prefix (e.g., 'v')
- * @param options Additional options including tag templates
- * @returns The latest tag for the package or empty string if none found
- */
-/**
  * List a package's tags (those matching its tag template), most-recently-created first.
  *
  * Returns an empty array when package-specific tags are disabled (callers fall back to the global
@@ -217,6 +210,13 @@ export async function listPackageTags(
   return packageTags;
 }
 
+/**
+ * Get the latest semver tag for a specific package (most recently created), or '' if none.
+ * @param packageName The name of the package to get tags for
+ * @param versionPrefix Optional version prefix (e.g., 'v')
+ * @param options Additional options including tag templates
+ * @returns The latest tag for the package or empty string if none found
+ */
 export async function getLatestTagForPackage(
   packageName: string,
   versionPrefix?: string,

--- a/packages/version/src/package/packageProcessor.ts
+++ b/packages/version/src/package/packageProcessor.ts
@@ -5,7 +5,7 @@ import type { VersionChangelogEntry } from '@releasekit/core';
 import { shouldProcessPackage } from '@releasekit/core';
 import { extractChangelogEntriesFromCommits, extractRepoLevelChangelogEntries } from '../changelog/commitParser.js';
 import { calculateVersion } from '../core/versionCalculator.js';
-import { getLatestTagForPackage } from '../git/tagsAndBranches.js';
+import { getLatestStableTag, getLatestStableTagForPackage, getLatestTagForPackage } from '../git/tagsAndBranches.js';
 import { verifyTag } from '../git/tagVerification.js';
 import type { Config, VersionConfigBase } from '../types.js';
 import {
@@ -24,6 +24,7 @@ import {
 } from '../utils/jsonOutput.js';
 import { log } from '../utils/logging.js';
 import { getVersionFromManifests } from '../utils/manifestHelpers.js';
+import { isStableTag, isStableVersion } from '../utils/versionUtils.js';
 import { updatePackageVersion } from './packageManagement.js';
 
 type ChangelogEntry = VersionChangelogEntry;
@@ -183,6 +184,21 @@ export class PackageProcessor {
         continue; // No version change calculated for this package
       }
 
+      // When a prerelease graduates to stable, aggregate the changelog from the last *stable* tag
+      // rather than from `latestTag` (the prerelease, which usually holds only the release-prep
+      // commit). `latestTag` still drives version calculation above — it must see the prerelease to
+      // graduate correctly. With no prior stable tag (first stable release), `changelogBaseTag` is
+      // '' and the range falls through to all commits. (#291)
+      let changelogBaseTag = latestTag;
+      if (hasRealTag && latestTag && isStableVersion(nextVersion) && !isStableTag(latestTag)) {
+        changelogBaseTag = this.fullConfig.packageSpecificTags
+          ? await getLatestStableTagForPackage(name, this.versionPrefix, {
+              tagTemplate: this.tagTemplate,
+              packageSpecificTags: true,
+            })
+          : await getLatestStableTag(this.versionPrefix);
+      }
+
       // Generate changelog entries from conventional commits
       let changelogEntries: ChangelogEntry[] = [];
       let revisionRange = 'HEAD';
@@ -191,7 +207,7 @@ export class PackageProcessor {
         // Extract entries from commits between the base ref (or latest tag) and HEAD.
         // baseRef takes precedence — it's a PR base SHA supplied in advisory standing-pr mode
         // so the changelog is scoped to only this PR's commits, not all commits since last tag.
-        const baseForRange = this.fullConfig.baseRef ?? latestTag;
+        const baseForRange = this.fullConfig.baseRef ?? changelogBaseTag;
         if (baseForRange) {
           const verification = verifyTag(baseForRange, pkgPath);
           if (verification.exists && verification.reachable) {
@@ -290,7 +306,7 @@ export class PackageProcessor {
       addChangelogData({
         packageName: name,
         version: nextVersion,
-        previousVersion: latestTag ? displayTag(latestTag, baselineTagPrefix, formattedPrefix) : null,
+        previousVersion: changelogBaseTag ? displayTag(changelogBaseTag, baselineTagPrefix, formattedPrefix) : null,
         revisionRange,
         repoUrl: repoUrl || null,
         entries: changelogEntries,

--- a/packages/version/src/package/packageProcessor.ts
+++ b/packages/version/src/package/packageProcessor.ts
@@ -118,12 +118,18 @@ export class PackageProcessor {
       // Try to get the latest tag specific to this package first
       let latestTagResult = '';
       let hasRealTag = false;
+      // Whether `latestTag` came from this package's own tag series (vs. the global/manifest
+      // fallback below). Decides which stable-tag lookup to use when graduating, since
+      // `packageSpecificTags: true` can still fall back to a global tag for a package without its
+      // own tag history.
+      let usedPackageSpecificTag = false;
       try {
         latestTagResult = await getLatestTagForPackage(name, this.versionPrefix, {
           tagTemplate: this.tagTemplate,
           packageSpecificTags: this.fullConfig.packageSpecificTags,
         });
         hasRealTag = !!latestTagResult;
+        usedPackageSpecificTag = !!latestTagResult;
       } catch (error) {
         // Log the specific error, but continue with fallback
         const errorMessage = error instanceof Error ? error.message : String(error);
@@ -191,7 +197,10 @@ export class PackageProcessor {
       // '' and the range falls through to all commits. (#291)
       let changelogBaseTag = latestTag;
       if (hasRealTag && latestTag && isStableVersion(nextVersion) && !isStableTag(latestTag)) {
-        changelogBaseTag = this.fullConfig.packageSpecificTags
+        // Mirror where `latestTag` came from: a package-specific prerelease graduates against the
+        // last package-specific stable; a global-fallback prerelease graduates against the last
+        // global stable. Using the wrong series would return '' and over-include all commits.
+        changelogBaseTag = usedPackageSpecificTag
           ? await getLatestStableTagForPackage(name, this.versionPrefix, {
               tagTemplate: this.tagTemplate,
               packageSpecificTags: true,

--- a/packages/version/src/package/packageProcessor.ts
+++ b/packages/version/src/package/packageProcessor.ts
@@ -194,12 +194,11 @@ export class PackageProcessor {
       // rather than from `latestTag` (the prerelease, which usually holds only the release-prep
       // commit). `latestTag` still drives version calculation above — it must see the prerelease to
       // graduate correctly. With no prior stable tag (first stable release), `changelogBaseTag` is
-      // '' and the range falls through to all commits. (#291)
+      // '' and the range falls through to all commits.
       let changelogBaseTag = latestTag;
       if (hasRealTag && latestTag && isStableVersion(nextVersion) && !isStableTag(latestTag)) {
-        // Mirror where `latestTag` came from: a package-specific prerelease graduates against the
-        // last package-specific stable; a global-fallback prerelease graduates against the last
-        // global stable. Using the wrong series would return '' and over-include all commits.
+        // Follow latestTag's source (package series vs global) — the other lookup returns '' here
+        // and would over-include every commit.
         changelogBaseTag = usedPackageSpecificTag
           ? await getLatestStableTagForPackage(name, this.versionPrefix, {
               tagTemplate: this.tagTemplate,

--- a/packages/version/src/utils/versionUtils.ts
+++ b/packages/version/src/utils/versionUtils.ts
@@ -20,7 +20,10 @@ export function isStableVersion(version: string): boolean {
 
 /** True when a tag's embedded version is a stable release (no semver prerelease segment). */
 export function isStableTag(tag: string): boolean {
-  const match = tag.match(/\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?/);
+  // Bounded quantifiers (not `\d+`) so a long run of digits in a tag name can't trigger polynomial
+  // backtracking on this uncontrolled input (CodeQL js/polynomial-redos). Real semver components
+  // never approach 16 digits, and prerelease identifiers never approach 256 chars.
+  const match = tag.match(/\d{1,16}\.\d{1,16}\.\d{1,16}(?:-[0-9A-Za-z.-]{1,256})?/);
   return match ? semver.prerelease(match[0]) === null : false;
 }
 

--- a/packages/version/src/utils/versionUtils.ts
+++ b/packages/version/src/utils/versionUtils.ts
@@ -13,6 +13,17 @@ import { log } from './logging.js';
 // Standard bump types
 export const STANDARD_BUMP_TYPES = ['major', 'minor', 'patch'] as const;
 
+/** True when a version string is a valid, stable release (no semver prerelease segment). */
+export function isStableVersion(version: string): boolean {
+  return semver.valid(version) !== null && semver.prerelease(version) === null;
+}
+
+/** True when a tag's embedded version is a stable release (no semver prerelease segment). */
+export function isStableTag(tag: string): boolean {
+  const match = tag.match(/\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?/);
+  return match ? semver.prerelease(match[0]) === null : false;
+}
+
 /**
  * Extract version from a package.json file
  */

--- a/packages/version/test/unit/git/tagsAndBranches.spec.ts
+++ b/packages/version/test/unit/git/tagsAndBranches.spec.ts
@@ -2,9 +2,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { execAsync, execSync } from '../../../src/git/commandExecutor.js';
 import {
   getCommitsLength,
+  getLatestStableTagForPackage,
   getLatestTag,
   getLatestTagForPackage,
   lastMergeBranchName,
+  listPackageTags,
 } from '../../../src/git/tagsAndBranches.js';
 import { log } from '../../../src/utils/logging.js';
 
@@ -739,6 +741,43 @@ describe('tagsAndBranches', () => {
         // Verify - should return first (chronological) when versions are identical
         expect(result).toBe('v1.0.0');
       });
+    });
+  });
+
+  describe('listPackageTags', () => {
+    it('should return matching package tags newest-first and an empty list when none match', async () => {
+      mockGitTags(['pkg@v1.1.0', 'pkg@v1.0.0', 'other@v9.9.9']);
+
+      const result = await listPackageTags('pkg', 'v', { packageSpecificTags: true });
+
+      expect(result).toEqual(['pkg@v1.1.0', 'pkg@v1.0.0']);
+    });
+
+    it('should return an empty list when package-specific tags are disabled', async () => {
+      mockGitTags(['v1.0.0', 'v1.1.0']);
+
+      const result = await listPackageTags('pkg', 'v', { packageSpecificTags: false });
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('getLatestStableTagForPackage', () => {
+    it('should skip prerelease tags and return the most recent stable tag', async () => {
+      // Newest tag is a prerelease; the stable lookup must skip it and return the last stable.
+      mockGitTags(['pkg@v1.1.0-next.0', 'pkg@v1.0.0', 'pkg@v0.9.0']);
+
+      const result = await getLatestStableTagForPackage('pkg', 'v', { packageSpecificTags: true });
+
+      expect(result).toBe('pkg@v1.0.0');
+    });
+
+    it('should return an empty string when only prerelease tags exist', async () => {
+      mockGitTags(['pkg@v1.0.0-next.1', 'pkg@v1.0.0-next.0']);
+
+      const result = await getLatestStableTagForPackage('pkg', 'v', { packageSpecificTags: true });
+
+      expect(result).toBe('');
     });
   });
 });

--- a/packages/version/test/unit/package/packageProcessor.spec.ts
+++ b/packages/version/test/unit/package/packageProcessor.spec.ts
@@ -398,6 +398,47 @@ describe('Package Processor', () => {
       expect(calls[0][0]).toMatchObject({ previousVersion: 'v1.0.0' });
     });
 
+    it('should aggregate the changelog from the last stable tag when a prerelease graduates (#291)', async () => {
+      // latestTag is a prerelease; releasing stable 1.1.0 must base the range and previousVersion on
+      // the last *stable* tag, not the prerelease (which holds only the release-prep commit).
+      vi.spyOn(gitTags, 'getLatestTagForPackage').mockResolvedValue('package-a@v1.1.0-next.0');
+      vi.spyOn(gitTags, 'getLatestStableTagForPackage').mockResolvedValue('package-a@v1.0.0');
+      vi.spyOn(formatting, 'displayTag').mockImplementation((tag) => tag);
+      vi.spyOn(calculator, 'calculateVersion').mockResolvedValue('1.1.0');
+      vi.spyOn(versionCalculatorModule, 'calculateVersion').mockResolvedValue('1.1.0');
+
+      const processor = new PackageProcessor({
+        ...defaultOptions,
+        fullConfig: { ...mockConfig, packageSpecificTags: true, writeChangelog: false },
+      });
+
+      await processor.processPackages([mockPackages[0]]);
+
+      expect(gitTags.getLatestStableTagForPackage).toHaveBeenCalled();
+      const calls = vi.mocked(jsonOutput.addChangelogData).mock.calls;
+      expect(calls.length).toBeGreaterThan(0);
+      expect(calls[0][0]).toMatchObject({ previousVersion: 'package-a@v1.0.0' });
+    });
+
+    it('should not use the stable base when releasing a prerelease (no graduation)', async () => {
+      vi.spyOn(gitTags, 'getLatestTagForPackage').mockResolvedValue('package-a@v1.1.0-next.0');
+      vi.spyOn(gitTags, 'getLatestStableTagForPackage').mockResolvedValue('package-a@v1.0.0');
+      vi.spyOn(formatting, 'displayTag').mockImplementation((tag) => tag);
+      vi.spyOn(calculator, 'calculateVersion').mockResolvedValue('1.1.0-next.1');
+      vi.spyOn(versionCalculatorModule, 'calculateVersion').mockResolvedValue('1.1.0-next.1');
+
+      const processor = new PackageProcessor({
+        ...defaultOptions,
+        fullConfig: { ...mockConfig, packageSpecificTags: true, writeChangelog: false },
+      });
+
+      await processor.processPackages([mockPackages[0]]);
+
+      expect(gitTags.getLatestStableTagForPackage).not.toHaveBeenCalled();
+      const calls = vi.mocked(jsonOutput.addChangelogData).mock.calls;
+      expect(calls[0][0]).toMatchObject({ previousVersion: 'package-a@v1.1.0-next.0' });
+    });
+
     it('should emit repo-level entries as sharedEntries, not in individual package changelogs', async () => {
       const repoLevelEntry = { type: 'chore', description: 'Update CI workflow' };
       const pkgAEntry = { type: 'added', description: 'New feature in pkg-a' };

--- a/packages/version/test/unit/package/packageProcessor.spec.ts
+++ b/packages/version/test/unit/package/packageProcessor.spec.ts
@@ -398,7 +398,7 @@ describe('Package Processor', () => {
       expect(calls[0][0]).toMatchObject({ previousVersion: 'v1.0.0' });
     });
 
-    it('should aggregate the changelog from the last stable tag when a prerelease graduates (#291)', async () => {
+    it('should aggregate the changelog from the last stable tag when a prerelease graduates', async () => {
       // latestTag is a prerelease; releasing stable 1.1.0 must base the range and previousVersion on
       // the last *stable* tag, not the prerelease (which holds only the release-prep commit).
       vi.spyOn(gitTags, 'getLatestTagForPackage').mockResolvedValue('package-a@v1.1.0-next.0');
@@ -439,7 +439,7 @@ describe('Package Processor', () => {
       expect(calls[0][0]).toMatchObject({ previousVersion: 'package-a@v1.1.0-next.0' });
     });
 
-    it('should graduate against the global stable tag when packageSpecificTags is off (#291)', async () => {
+    it('should graduate against the global stable tag when packageSpecificTags is off', async () => {
       // No package-specific tags → latestTag comes from the injected global lookup. A global
       // prerelease graduating to stable must range from the last *global* stable tag. No manifest
       // is found, so the global-tag fallback path is exercised.
@@ -470,7 +470,7 @@ describe('Package Processor', () => {
       expect(calls[0][0]).toMatchObject({ previousVersion: 'v1.0.0' });
     });
 
-    it('should graduate against the global stable tag when packageSpecificTags is on but the package has no tags (#291)', async () => {
+    it('should graduate against the global stable tag when packageSpecificTags is on but the package has no tags', async () => {
       // The mismatch case: packageSpecificTags is true but the package has no tag history, so
       // latestTag falls back to the global tag. The stable base must follow that fallback (global)
       // rather than the empty package series, which would over-include every commit.

--- a/packages/version/test/unit/package/packageProcessor.spec.ts
+++ b/packages/version/test/unit/package/packageProcessor.spec.ts
@@ -439,6 +439,68 @@ describe('Package Processor', () => {
       expect(calls[0][0]).toMatchObject({ previousVersion: 'package-a@v1.1.0-next.0' });
     });
 
+    it('should graduate against the global stable tag when packageSpecificTags is off (#291)', async () => {
+      // No package-specific tags → latestTag comes from the injected global lookup. A global
+      // prerelease graduating to stable must range from the last *global* stable tag. No manifest
+      // is found, so the global-tag fallback path is exercised.
+      vi.spyOn(gitTags, 'getLatestTagForPackage').mockResolvedValue('');
+      vi.spyOn(gitTags, 'getLatestStableTag').mockResolvedValue('v1.0.0');
+      vi.spyOn(gitTags, 'getLatestStableTagForPackage').mockResolvedValue('');
+      vi.spyOn(manifestHelpers, 'getVersionFromManifests').mockReturnValue({
+        version: null,
+        manifestFound: false,
+        manifestPath: '',
+        manifestType: null,
+      });
+      vi.spyOn(formatting, 'displayTag').mockImplementation((tag) => tag);
+      vi.spyOn(calculator, 'calculateVersion').mockResolvedValue('1.1.0');
+      vi.spyOn(versionCalculatorModule, 'calculateVersion').mockResolvedValue('1.1.0');
+
+      const processor = new PackageProcessor({
+        ...defaultOptions,
+        getLatestTag: vi.fn().mockResolvedValue('v1.1.0-next.0'),
+        fullConfig: { ...mockConfig, packageSpecificTags: false, writeChangelog: false },
+      });
+
+      await processor.processPackages([mockPackages[1]]);
+
+      expect(gitTags.getLatestStableTag).toHaveBeenCalled();
+      expect(gitTags.getLatestStableTagForPackage).not.toHaveBeenCalled();
+      const calls = vi.mocked(jsonOutput.addChangelogData).mock.calls;
+      expect(calls[0][0]).toMatchObject({ previousVersion: 'v1.0.0' });
+    });
+
+    it('should graduate against the global stable tag when packageSpecificTags is on but the package has no tags (#291)', async () => {
+      // The mismatch case: packageSpecificTags is true but the package has no tag history, so
+      // latestTag falls back to the global tag. The stable base must follow that fallback (global)
+      // rather than the empty package series, which would over-include every commit.
+      vi.spyOn(gitTags, 'getLatestTagForPackage').mockResolvedValue('');
+      vi.spyOn(gitTags, 'getLatestStableTag').mockResolvedValue('v1.0.0');
+      vi.spyOn(gitTags, 'getLatestStableTagForPackage').mockResolvedValue('');
+      vi.spyOn(manifestHelpers, 'getVersionFromManifests').mockReturnValue({
+        version: null,
+        manifestFound: false,
+        manifestPath: '',
+        manifestType: null,
+      });
+      vi.spyOn(formatting, 'displayTag').mockImplementation((tag) => tag);
+      vi.spyOn(calculator, 'calculateVersion').mockResolvedValue('1.1.0');
+      vi.spyOn(versionCalculatorModule, 'calculateVersion').mockResolvedValue('1.1.0');
+
+      const processor = new PackageProcessor({
+        ...defaultOptions,
+        getLatestTag: vi.fn().mockResolvedValue('v1.1.0-next.0'),
+        fullConfig: { ...mockConfig, packageSpecificTags: true, writeChangelog: false },
+      });
+
+      await processor.processPackages([mockPackages[1]]);
+
+      expect(gitTags.getLatestStableTag).toHaveBeenCalled();
+      expect(gitTags.getLatestStableTagForPackage).not.toHaveBeenCalled();
+      const calls = vi.mocked(jsonOutput.addChangelogData).mock.calls;
+      expect(calls[0][0]).toMatchObject({ previousVersion: 'v1.0.0' });
+    });
+
     it('should emit repo-level entries as sharedEntries, not in individual package changelogs', async () => {
       const repoLevelEntry = { type: 'chore', description: 'Update CI workflow' };
       const pkgAEntry = { type: 'added', description: 'New feature in pkg-a' };


### PR DESCRIPTION
## Summary

When a prerelease graduated to stable (e.g. `1.1.0-next.0 → 1.1.0`), the changelog ranged from the **prerelease** tag — usually only the release-prep commit — so all the work done under the prerelease line was dropped from the stable release's notes, and the empty range produced a synthesized `"Project version updated to …"` entry.

This bases the changelog range **and** `previousVersion` on the last **stable** tag when a prerelease graduates. `latestTag` still drives version calculation (it must see the prerelease to graduate correctly). With no prior stable tag the range falls through to all commits — what a first stable release should show.

Extracts a shared `listPackageTags` helper (reused by the notes backfill, #293) and adds `getLatestStableTagForPackage` / `getLatestStableTag` / `isStableTag` / `isStableVersion`.

## Context

This is the **content** half of the empty-notes outcome in the [webdriverio/desktop-mobile run](https://github.com/webdriverio/desktop-mobile/actions/runs/27469532901/job/81197798707); #288 is the **attachment** half. Together they close that loop.

## Testing

- New tests: graduation aggregates from the last stable tag; prerelease→prerelease is unchanged; the stable-tag lookup skips prereleases; `listPackageTags` enumeration.
- Full `lint typecheck test` pass for `@releasekit/version`.

Closes #291

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes the empty/truncated stable-release changelog that occurred when a prerelease graduated (e.g. `1.1.0-next.0 → 1.1.0`): previously the changelog range started at the prerelease tag, capturing only the release-prep commit, and no real entries caused a synthetic `"Project version updated"` note.

- **Core fix** (`packageProcessor.ts`): introduces `changelogBaseTag` — when graduating, the commit range and `previousVersion` are rebased on the last stable tag; a new `usedPackageSpecificTag` flag routes the lookup to either `getLatestStableTagForPackage` (per-package series) or `getLatestStableTag` (global series), correctly handling the edge case where `packageSpecificTags: true` but no package-specific tag history exists.
- **New helpers** (`tagsAndBranches.ts`, `versionUtils.ts`): `listPackageTags` extracts the shared tag-fetching logic; `getLatestStableTagForPackage`, `getLatestStableTag`, `isStableTag`, and `isStableVersion` complete the stable-tag lookup surface.
- **Tests**: four new `packageProcessor` integration tests (graduation, no-graduation, global-tag path, and the `packageSpecificTags: true`-but-no-tags edge case) plus unit tests for `listPackageTags` and `getLatestStableTagForPackage`; all previously-flagged coverage gaps are closed.
</details>


<h3>Confidence Score: 5/5</h3>

This PR is safe to merge. The change is narrowly scoped to graduation detection and the commit-range base selection, and all previously-raised concerns now have test coverage.

The graduation logic is gated by four independent conditions (`hasRealTag`, non-empty `latestTag`, stable `nextVersion`, prerelease `latestTag`), so it only activates on the exact scenario it is meant to fix. The `usedPackageSpecificTag` flag correctly threads through both the package-specific and global fallback paths, and the previously-flagged `packageSpecificTags: true` / no-package-tags edge case now has an explicit test. No data paths outside the graduation scenario are affected.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/version/src/git/tagsAndBranches.ts | Extracts `listPackageTags` helper, adds `getLatestStableTagForPackage` (chronological) and `getLatestStableTag` (semantic-sort, mirroring `getLatestTag`). Each new function is well-guarded with try/catch and the refactor of `getLatestTagForPackage` into a thin wrapper is clean. |
| packages/version/src/package/packageProcessor.ts | Adds `usedPackageSpecificTag` flag and `changelogBaseTag` logic for graduation; correctly guards with `hasRealTag` (excludes manifest-version fallback) and routes to the right stable-tag lookup depending on which tag series `latestTag` came from. `previousVersion` now reflects the stable base. |
| packages/version/src/utils/versionUtils.ts | Adds `isStableVersion` (pure semver check) and `isStableTag` (regex + semver, with bounded quantifiers to avoid ReDoS). Both are straightforward and correct for their intended input shapes. |
| packages/version/test/unit/git/tagsAndBranches.spec.ts | Adds unit tests for `listPackageTags` (matching + disabled path) and `getLatestStableTagForPackage` (skips prerelease, all-prerelease returns empty). Coverage is correct for the new helpers. |
| packages/version/test/unit/package/packageProcessor.spec.ts | Four new integration tests cover: graduation with package-specific tags, prerelease→prerelease (no graduation), global-tag graduation (`packageSpecificTags: false`), and the previously-flagged mismatch case (`packageSpecificTags: true` but no package tags → falls back to global stable tag). All previously-noted coverage gaps are now addressed. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[processPackages] --> B[getLatestTagForPackage]
    B --> C{packageTags found?}
    C -- yes --> D[latestTag = packageTag\nusedPackageSpecificTag = true]
    C -- no --> E{manifest fallback?}
    E -- yes --> F[latestTag = manifest version\nhasRealTag = false]
    E -- no --> G[latestTag = global getLatestTag\nhasRealTag = true]
    D --> H[calculateVersion → nextVersion]
    F --> H
    G --> H
    H --> I{hasRealTag AND latestTag\nAND isStableVersion nextVersion\nAND NOT isStableTag latestTag?}
    I -- no --> J[changelogBaseTag = latestTag]
    I -- yes --> K{usedPackageSpecificTag?}
    K -- yes --> L[getLatestStableTagForPackage\nchronological stable]
    K -- no --> M[getLatestStableTag\nsemantic-sorted stable]
    L --> N[changelogBaseTag = last stable pkg tag]
    M --> O[changelogBaseTag = last stable global tag]
    J --> P[revisionRange = changelogBaseTag..HEAD]
    N --> P
    O --> P
    P --> Q[addChangelogData\npreviousVersion = changelogBaseTag]
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/version/src/git/tagsAndBranches.ts`, line 140-153 ([link](https://github.com/goosewobbler/releasekit/blob/b1a45ea31b70285c8c86e92160753269cee87ec3/packages/version/src/git/tagsAndBranches.ts#L140-L153)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Orphaned JSDoc above `listPackageTags`**

   Two consecutive JSDoc blocks are stacked here: lines 140-146 are the original doc for `getLatestTagForPackage` (which was moved below), and lines 147-153 are the new doc for `listPackageTags`. The first block now documents nothing — TypeScript tooling and IDEs will attach it to `listPackageTags`, producing confusing hover text with the wrong `@returns` description.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fversion%2Fsrc%2Fgit%2FtagsAndBranches.ts%0ALine%3A%20140-153%0A%0AComment%3A%0A**Orphaned%20JSDoc%20above%20%60listPackageTags%60**%0A%0ATwo%20consecutive%20JSDoc%20blocks%20are%20stacked%20here%3A%20lines%20140-146%20are%20the%20original%20doc%20for%20%60getLatestTagForPackage%60%20%28which%20was%20moved%20below%29%2C%20and%20lines%20147-153%20are%20the%20new%20doc%20for%20%60listPackageTags%60.%20The%20first%20block%20now%20documents%20nothing%20%E2%80%94%20TypeScript%20tooling%20and%20IDEs%20will%20attach%20it%20to%20%60listPackageTags%60%2C%20producing%20confusing%20hover%20text%20with%20the%20wrong%20%60%40returns%60%20description.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=goosewobbler%2Freleasekit&pr=295&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fversion%2Fsrc%2Fgit%2FtagsAndBranches.ts%0ALine%3A%20140-153%0A%0AComment%3A%0A**Orphaned%20JSDoc%20above%20%60listPackageTags%60**%0A%0ATwo%20consecutive%20JSDoc%20blocks%20are%20stacked%20here%3A%20lines%20140-146%20are%20the%20original%20doc%20for%20%60getLatestTagForPackage%60%20%28which%20was%20moved%20below%29%2C%20and%20lines%20147-153%20are%20the%20new%20doc%20for%20%60listPackageTags%60.%20The%20first%20block%20now%20documents%20nothing%20%E2%80%94%20TypeScript%20tooling%20and%20IDEs%20will%20attach%20it%20to%20%60listPackageTags%60%2C%20producing%20confusing%20hover%20text%20with%20the%20wrong%20%60%40returns%60%20description.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=295&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (4): Last reviewed commit: ["test(version): drop issue-number suffixe..."](https://github.com/goosewobbler/releasekit/commit/d1c65a8a7da9b8e92758ae0e40ecb3a734e25642) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37439907)</sub>

<!-- /greptile_comment -->