### PR TITLE
docs: position releasekit as registry-agnostic (npm, crates.io, pub.dev)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ AI context file for the ReleaseKit monorepo.
 
 ## Project Overview
 
-ReleaseKit is release tooling for JavaScript and Rust monorepos: semantic versioning from Conventional Commits, changelog/release-notes generation (optionally LLM-enhanced), and publishing to npm / crates.io with git tags and GitHub Releases. It ships as four npm packages, a unified `releasekit` CLI, and a composite GitHub Action.
+ReleaseKit is release tooling for polyglot projects and monorepos: semantic versioning from Conventional Commits, changelog/release-notes generation (optionally LLM-enhanced), and publishing with git tags and GitHub Releases. Publish targets today are npm (JS/TS), crates.io (Rust), and pub.dev (Dart/Flutter); the pipeline is registry-agnostic and more ecosystems can be added. It ships as four npm packages, a unified `releasekit` CLI, and a composite GitHub Action.
 
 This repo **dogfoods itself**: releases run in standing-PR mode with sync versioning (see `releasekit.config.json`). The standing release PR lives on `release/next`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ packages/
 ├── config/    # Config loading, Zod schemas, JSONC parsing
 ├── version/   # Version calculation, bump strategies (sync/single/async)
 ├── notes/     # Changelog + release notes, LLM enhancement, templates
-├── publish/   # npm/cargo/pub publish pipeline, git tags, GitHub Releases
+├── publish/   # Multi-registry publish pipeline, git tags, GitHub Releases
 └── release/   # Orchestrator: unified CLI, standing-pr, preview, gate, failure report
 
 docs/               # User docs (see "Documentation rules")

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ packages/
 ├── config/    # Config loading, Zod schemas, JSONC parsing
 ├── version/   # Version calculation, bump strategies (sync/single/async)
 ├── notes/     # Changelog + release notes, LLM enhancement, templates
-├── publish/   # npm/cargo publish pipeline, git tags, GitHub Releases
+├── publish/   # npm/cargo/pub publish pipeline, git tags, GitHub Releases
 └── release/   # Orchestrator: unified CLI, standing-pr, preview, gate, failure report
 
 docs/               # User docs (see "Documentation rules")

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
 [![Node](https://img.shields.io/node/v/@releasekit/release.svg)](https://www.npmjs.com/package/@releasekit/release)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
 
-Versioning, changelogs, and publishing for JavaScript and Rust monorepos — driven by Conventional Commits, designed for CI.
+Versioning, changelogs, and publishing for whatever you ship — driven by Conventional Commits, built for CI. Releases to npm, crates.io, and pub.dev today, with more ecosystems on the way.
 
 ## Why ReleaseKit
 
-- **One config, two ecosystems** — JavaScript and Rust packages release from the same `releasekit.config.json`, including mixed monorepos.
+- **One config, every ecosystem** — npm (JavaScript/TypeScript), crates.io (Rust), and pub.dev (Dart/Flutter) packages release from the same `releasekit.config.json`, including mixed monorepos. The pipeline is registry-agnostic — new ecosystems plug in without changing your workflow.
 - **Composable, not opinionated** — three independent CLIs (`version`, `notes`, `publish`) you can pipe together, or a unified `release` command if you want the full pipeline.
 - **CI-native** — JSON output, OIDC publishing, PR preview comments, and label- or commit-driven triggers without bolting on extra tools.
 
@@ -52,13 +52,13 @@ See [Getting Started](./docs/getting-started.md) for prerequisites, config optio
 | [@releasekit/release](./packages/release) | [![npm](https://img.shields.io/npm/v/@releasekit/release.svg)](https://www.npmjs.com/package/@releasekit/release) | **Unified CLI** — run version, notes, and publish in a single command |
 | [@releasekit/version](./packages/version) | [![npm](https://img.shields.io/npm/v/@releasekit/version.svg)](https://www.npmjs.com/package/@releasekit/version) | Semantic versioning based on Git history and conventional commits |
 | [@releasekit/notes](./packages/notes) | [![npm](https://img.shields.io/npm/v/@releasekit/notes.svg)](https://www.npmjs.com/package/@releasekit/notes) | Changelog generation with LLM-powered enhancement and flexible templating |
-| [@releasekit/publish](./packages/publish) | [![npm](https://img.shields.io/npm/v/@releasekit/publish.svg)](https://www.npmjs.com/package/@releasekit/publish) | Publish packages to npm and crates.io with git tagging and GitHub releases |
+| [@releasekit/publish](./packages/publish) | [![npm](https://img.shields.io/npm/v/@releasekit/publish.svg)](https://www.npmjs.com/package/@releasekit/publish) | Publish packages to npm, crates.io, and pub.dev with git tagging and GitHub releases |
 
 ## Features
 
-- **Versioning** — derives semver bumps from Conventional Commits; supports JavaScript (`package.json`), Rust (`Cargo.toml`), and monorepos with per-package tags
+- **Versioning** — derives semver bumps from Conventional Commits; supports JavaScript/TypeScript (`package.json`), Rust (`Cargo.toml`), Dart/Flutter (`pubspec.yaml`), and monorepos with per-package tags
 - **Release notes** — generates changelogs from commit history, with optional LLM enhancement (Anthropic, OpenAI, or local models)
-- **Publishing** — pushes to npm (OIDC or token) and crates.io, tags the release, and creates a GitHub Release
+- **Publishing** — pushes to npm (OIDC or token), crates.io, and pub.dev, tags the release, and creates a GitHub Release
 - **CI/CD first** — JSON output for scripting, PR preview comments, and config-driven triggers (commit vs label)
 - **Composable** — use each tool independently or pipe them together
 
@@ -132,7 +132,7 @@ See the [package docs](#documentation) for the full option reference.
 - [@releasekit/release](./packages/release/README.md) — unified pipeline, CI automation, programmatic API
 - [@releasekit/version](./packages/version/README.md) — versioning strategies, JSON output
 - [@releasekit/notes](./packages/notes/README.md) — changelog, release notes, LLM, templates
-- [@releasekit/publish](./packages/publish/README.md) — npm, crates.io, GitHub Releases
+- [@releasekit/publish](./packages/publish/README.md) — npm, crates.io, pub.dev, GitHub Releases
 
 **Help**
 - [Troubleshooting](./docs/troubleshooting.md) — symptom-indexed error guide

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ See the [package docs](#documentation) for the full option reference.
 - [CI setup](./packages/release/docs/ci-setup.md) — GitHub Actions workflows, OIDC, PR preview, prerelease
 - [CI examples](./examples) — runnable, CI-validated workflow + config scenarios (minimal, label-driven, standing-PR, OIDC, monorepo-rust, prerelease)
 - [Rust / Cargo](./docs/rust.md) — Rust crate versioning and crates.io publishing
+- [Dart / pub.dev](./docs/dart.md) — Dart/Flutter versioning and pub.dev publishing
 - [Migration](./docs/migration.md) — from semantic-release or changesets
 
 **Reference**

--- a/docs/dart.md
+++ b/docs/dart.md
@@ -1,0 +1,247 @@
+# Dart / pub.dev Setup
+
+This guide covers configuring releasekit for Dart and Flutter projects that publish to [pub.dev](https://pub.dev). It applies whether you have a single package, a multi-package Dart workspace, or a mixed npm + Dart monorepo.
+
+See [configuration.md](./configuration.md) for the full config reference.
+
+---
+
+## What's supported
+
+- `pubspec.yaml` version bumping driven by conventional commits — **comments and formatting are preserved** (only the `version:` line is rewritten, including any inline comment)
+- Per-package git tags (via `version.packageSpecificTags`)
+- Publishing to pub.dev with `dart pub publish` — or `flutter pub publish` for Flutter packages (auto-detected from a `flutter` SDK constraint in the pubspec's `environment`)
+- **OIDC automated publishing** from GitHub Actions (no secrets) **or** token auth via `PUB_TOKEN`
+- Custom/private registries via `publish_to` in `pubspec.yaml`; packages with `publish_to: none` are skipped automatically
+- Idempotent publish: versions already on pub.dev are skipped both before publish (via the pub.dev REST API) and after (via error pattern matching)
+- Pre-publish verification: polls pub.dev after each publish to confirm the version is visible
+- Explicit publish order override (`publish.pub.publishOrder`)
+- `--force` is passed so publishing is non-interactive in CI
+- Transient registry errors (timeouts, 5xx, connection resets) are auto-retried per package
+
+## What's not supported
+
+- **Automatic dependency-graph ordering** — unlike the Cargo workspace topological sort, releasekit does not infer publish order from Dart path/workspace dependencies. If one package must publish before another, set `publish.pub.publishOrder` explicitly.
+- Automatic package discovery — pubspec directories must be listed in `version.pub.paths` or inferred from `version.packages`.
+
+---
+
+## Quickstart — Dart-only repo
+
+Minimum `releasekit.config.json`:
+
+```json
+{
+  "$schema": "https://goosewobbler.github.io/releasekit/schema.json",
+  "version": {
+    "packages": ["./"],
+    "pub": {
+      "enabled": true
+    }
+  },
+  "publish": {
+    "pub": {
+      "enabled": true
+    }
+  }
+}
+```
+
+`version.pub.enabled` defaults to `true`, so that key is optional but makes intent explicit.
+
+**Important**: `publish.pub.enabled` defaults to `false`. You must set it to `true` explicitly — nothing is published to pub.dev unless you opt in.
+
+Configure authentication via OIDC or `PUB_TOKEN`. See [Auth](#auth) below.
+
+---
+
+## Quickstart — mixed npm + Dart monorepo
+
+Use `version.packages` for npm packages and `version.pub.paths` for Dart packages. Both can coexist:
+
+```json
+{
+  "$schema": "https://goosewobbler.github.io/releasekit/schema.json",
+  "version": {
+    "packages": ["packages/js-lib", "packages/cli"],
+    "pub": {
+      "enabled": true,
+      "paths": ["packages/dart-core", "packages/flutter-widget"]
+    }
+  },
+  "publish": {
+    "npm": {
+      "enabled": true
+    },
+    "pub": {
+      "enabled": true
+    }
+  }
+}
+```
+
+When `version.pub.paths` is omitted, releasekit looks for `pubspec.yaml` files alongside the directories listed in `version.packages`. If your Dart packages live in separate directories not listed there, use `version.pub.paths` to point at them explicitly.
+
+---
+
+## Config reference
+
+### `version.pub`
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | boolean | `true` | Enable `pubspec.yaml` version bumping |
+| `paths` | string[] | — | Directories to search for `pubspec.yaml` files. When omitted, package dirs are inferred from `version.packages` entries that contain a `pubspec.yaml`. |
+
+### `publish.pub`
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | boolean | `false` | Enable publishing to pub.dev. Must be set to `true` explicitly. |
+| `publishOrder` | string[] | `[]` | Explicit package publish order by package name. Packages not listed are appended at the end in discovery order. |
+
+### `publish.verify.pub`
+
+Controls how releasekit polls pub.dev after each publish to confirm the version is visible.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | boolean | `true` | Poll pub.dev after publish to verify the version appears. |
+| `maxAttempts` | integer | `10` | Maximum number of polling attempts. |
+| `initialDelay` | integer (ms) | `30000` | Delay before the first check (30 seconds). |
+| `backoffMultiplier` | number | `2` | Exponential backoff multiplier applied between attempts. |
+
+---
+
+## Auth
+
+pub.dev supports two authentication methods. releasekit picks token auth when `PUB_TOKEN` is set, and otherwise assumes OIDC automated publishing.
+
+### Option 1 — OIDC automated publishing (recommended)
+
+No long-lived secret. pub.dev mints a short-lived token from your GitHub Actions OIDC identity.
+
+1. On pub.dev, open your package → **Admin** → **Automated publishing** → enable **publishing from GitHub Actions**, and set the repository and a tag pattern (e.g. `{{version}}` or `*`).
+2. Give the workflow `id-token: write` permission (see the workflow example below).
+
+When `PUB_TOKEN` is absent, releasekit runs `dart pub publish` directly and pub picks up the ambient OIDC token.
+
+### Option 2 — token (`PUB_TOKEN`)
+
+Set `PUB_TOKEN` to a pub.dev bearer token. Before publishing, releasekit runs:
+
+```bash
+dart pub token add https://pub.dev --env-var PUB_TOKEN
+```
+
+so the publish command authenticates from the env var. Store it as a GitHub Actions secret and reference it as `PUB_TOKEN`:
+
+```yaml
+env:
+  PUB_TOKEN: ${{ secrets.PUB_TOKEN }}
+```
+
+With neither OIDC nor `PUB_TOKEN` configured, `dart pub publish` fails with an authentication error.
+
+---
+
+## Publish ordering
+
+releasekit does **not** infer Dart dependency order automatically. Packages publish in discovery order unless you set `publish.pub.publishOrder`:
+
+```json
+{
+  "publish": {
+    "pub": {
+      "enabled": true,
+      "publishOrder": ["my_core", "my_widgets", "my_app"]
+    }
+  }
+}
+```
+
+Packages listed in `publishOrder` are published in that order; any not listed are appended after. Use this when one package depends on another being available on pub.dev first.
+
+---
+
+## GitHub Actions workflow
+
+A minimal release workflow for a Dart-only repository using OIDC automated publishing:
+
+```yaml
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: read
+  id-token: write # required for pub.dev OIDC automated publishing
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: dart-lang/setup-dart@v1
+
+      # No pnpm/Node setup needed: the bundled goosewobbler/releasekit action brings
+      # its own runtime, and a Dart-only repo has no pnpm-lock.yaml (setting cache: pnpm
+      # would fail with "Dependencies lock file is not found").
+      - name: Run releasekit
+        uses: goosewobbler/releasekit@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # For token auth instead of OIDC, set PUB_TOKEN and drop `id-token: write` above:
+          # PUB_TOKEN: ${{ secrets.PUB_TOKEN }}
+```
+
+`fetch-depth: 0` is required so that releasekit can walk the full commit history to determine the version bump.
+
+For **Flutter** packages, swap (or add) `subosito/flutter-action@v2`, which provides both `flutter` and `dart` on the runner.
+
+---
+
+## Edge cases and troubleshooting
+
+**`dart: command not found`**
+
+The Dart SDK is not pre-installed on GitHub-hosted runners. Add the `dart-lang/setup-dart@v1` step before releasekit runs (see the workflow example above). For Flutter packages, use `subosito/flutter-action@v2` instead — it provides both `flutter` and `dart`.
+
+**Dart vs Flutter**
+
+The publish command is chosen per package: if the pubspec's `environment` includes a `flutter` SDK constraint, releasekit runs `flutter pub publish`; otherwise `dart pub publish`. No configuration is needed.
+
+**Private registries / `publish_to`**
+
+A package with `publish_to: none` is skipped entirely. A package with a custom `publish_to` (a private registry) is published to that server, but the pub.dev idempotency and verification checks are skipped — they only apply to pub.dev targets.
+
+**Publish verification timeout**
+
+pub.dev index propagation can take a little while. If `publish.verify.pub` polls are exhausted before the version appears, increase `maxAttempts` or `initialDelay`:
+
+```json
+{
+  "publish": {
+    "verify": {
+      "pub": {
+        "maxAttempts": 15,
+        "initialDelay": 60000
+      }
+    }
+  }
+}
+```
+
+**Re-running a partially failed release**
+
+Re-running is safe. releasekit checks pub.dev before each publish via the REST API, and also catches the "already published" error from `dart pub publish` itself. Both paths mark the package as skipped rather than failing the pipeline. Transient registry errors are auto-retried per package before the stage fails, so a brief pub.dev blip rarely needs a manual re-run.
+
+**`pubspec.yaml` parse errors**
+
+A malformed or comment-only `pubspec.yaml` produces a clear `PUBSPEC_YAML_ERROR` rather than a cryptic failure. Ensure each package's pubspec has a `name` and `version`.


### PR DESCRIPTION
## Summary

ReleaseKit's purpose is to release *whatever you ship* — the pipeline is registry-agnostic. It now supports **pub.dev** (Dart/Flutter) alongside **npm** (JS/TS) and **crates.io** (Rust), with more ecosystems addable. The README and AGENTS.md still framed it as a "JavaScript and Rust" tool (a closed two-ecosystem list).

This updates the positioning to lead with the release-anything framing and present the three registries as *today's* support rather than the definition:

- **README** — tagline, "One config, every ecosystem" bullet, `@releasekit/publish` table row, Versioning/Publishing feature bullets, and the publish docs link
- **AGENTS.md** — project overview line
- **`docs/dart.md`** — new Dart / pub.dev setup guide mirroring `docs/rust.md` (supported features, Dart-only + mixed-monorepo quickstarts, `version.pub` / `publish.pub` / `publish.verify.pub` reference, OIDC + `PUB_TOKEN` auth, publish ordering, GitHub Actions workflow, troubleshooting), linked from the README next to the Rust guide

Also done in this session (not in this PR): the GitHub repo description was updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This is a documentation-only PR that repositions ReleaseKit as registry-agnostic by updating the README tagline and feature bullets, the AGENTS.md project overview, and adding a new `docs/dart.md` guide for Dart/Flutter + pub.dev support.

- **README.md & AGENTS.md** — "JavaScript and Rust" framing replaced with polyglot/registry-agnostic language across the tagline, feature bullets, package table, and docs links; all occurrences are now consistent.
- **docs/dart.md** — New setup guide covering `pubspec.yaml` versioning, pub.dev publishing, OIDC and token auth, explicit `publishOrder`, a GitHub Actions workflow example, and a troubleshooting section; structure and depth mirror `docs/rust.md`.
</details>

<h3>Confidence Score: 5/5</h3>

Pure documentation change — no executable code modified.

All three files are documentation only. The new dart.md guide is internally consistent and closely mirrors the established rust.md pattern. The README and AGENTS.md updates are complete — every previous reference to 'JavaScript and Rust' has been updated, including the publish/ package comment that was flagged in a prior review cycle.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| AGENTS.md | Project Overview updated from 'JavaScript and Rust' to 'polyglot' framing; publish/ package comment updated from npm/cargo to 'Multi-registry' — both consistent with the new pub.dev support. |
| README.md | Tagline, feature bullets, package table, and docs links all updated to include pub.dev alongside npm and crates.io; changes are internally consistent. |
| docs/dart.md | New 247-line Dart/pub.dev setup guide mirroring docs/rust.md; covers supported features, two quickstarts, full config reference, OIDC + token auth, publish ordering, GitHub Actions workflow, and troubleshooting. Content is internally consistent. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[releasekit release] --> B[version stage]
    B --> B1[Bump package.json\nnpm packages]
    B --> B2[Bump Cargo.toml\nRust crates]
    B --> B3[Bump pubspec.yaml\nDart/Flutter packages]

    A --> C[publish stage]
    C --> C1[npm publish\nOIDC or NPM_TOKEN]
    C --> C2[cargo publish\nCARGO_REGISTRY_TOKEN]
    C --> C3[dart pub publish\nOIDC or PUB_TOKEN]

    C1 --> D1[Verify on npm]
    C2 --> D2[Verify on crates.io]
    C3 --> D3[Verify on pub.dev]

    A --> E[Git tag + GitHub Release]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["docs: make the AGENTS.md publish comment..."](https://github.com/goosewobbler/releasekit/commit/69d6c67511b4351c37d1078c3cc4e5b5b3098929) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37476856)</sub>

<!-- /greptile_comment -->