### PR TITLE
fix(notes): strip code fences before parsing structured LLM output

### DIFF
--- a/packages/notes/src/llm/ollama.ts
+++ b/packages/notes/src/llm/ollama.ts
@@ -1,6 +1,7 @@
 import { debug } from '@releasekit/core';
 import type { CompleteOptions } from '../core/types.js';
 import { LLMError } from '../errors/index.js';
+import { extractJsonFromResponse } from '../utils/json.js';
 import { BaseLLMProvider } from './base.js';
 import { LLM_DEFAULTS } from './defaults.js';
 import type { CompleteResult, LLMMessage } from './messages.js';
@@ -110,7 +111,9 @@ export class OllamaProvider extends BaseLLMProvider {
 
       if (options?.schema) {
         try {
-          const structured = JSON.parse(content);
+          // Strip markdown code fences / preamble first — cloud-hosted models (e.g. via ollama.com)
+          // often wrap schema-constrained output in a ```json fence despite the `format` request.
+          const structured = JSON.parse(extractJsonFromResponse(content));
           return { content, structured };
         } catch (e) {
           debug(`Ollama: failed to parse structured response: ${e instanceof Error ? e.message : String(e)}`);

--- a/packages/notes/src/llm/openai.ts
+++ b/packages/notes/src/llm/openai.ts
@@ -2,6 +2,7 @@ import { debug } from '@releasekit/core';
 import OpenAI from 'openai';
 import type { CompleteOptions } from '../core/types.js';
 import { LLMError } from '../errors/index.js';
+import { extractJsonFromResponse } from '../utils/json.js';
 import { BaseLLMProvider } from './base.js';
 import { LLM_DEFAULTS } from './defaults.js';
 import type { CompleteResult, LLMMessage } from './messages.js';
@@ -77,7 +78,9 @@ export class OpenAIProvider extends BaseLLMProvider {
 
       if (options?.schema) {
         try {
-          const structured = JSON.parse(content);
+          // Strip markdown code fences / preamble first — some models (and openai-compatible
+          // backends) wrap schema-constrained output in a ```json fence rather than returning raw JSON.
+          const structured = JSON.parse(extractJsonFromResponse(content));
           return { content, structured };
         } catch (e) {
           debug(`OpenAI: failed to parse structured response: ${e instanceof Error ? e.message : String(e)}`);

--- a/packages/notes/test/unit/llm/ollama.spec.ts
+++ b/packages/notes/test/unit/llm/ollama.spec.ts
@@ -21,7 +21,6 @@ describe('OllamaProvider', () => {
   });
 
   it('should parse structured output wrapped in a markdown code fence', async () => {
-    // Regression for #289: cloud-hosted models often wrap schema output in ```json … ``` fences.
     mockFetch('```json\n{ "entries": [{ "category": "New" }] }\n```');
     const provider = new OllamaProvider({ model: 'test-model', apiKey: 'k' });
 

--- a/packages/notes/test/unit/llm/ollama.spec.ts
+++ b/packages/notes/test/unit/llm/ollama.spec.ts
@@ -1,0 +1,41 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { OllamaProvider } from '../../../src/llm/ollama.js';
+
+function mockFetch(content: string) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ message: { role: 'assistant', content }, done: true }),
+    }),
+  );
+}
+
+describe('OllamaProvider', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('should parse structured output wrapped in a markdown code fence', async () => {
+    // Regression for #289: cloud-hosted models often wrap schema output in ```json … ``` fences.
+    mockFetch('```json\n{ "entries": [{ "category": "New" }] }\n```');
+    const provider = new OllamaProvider({ model: 'test-model', apiKey: 'k' });
+
+    const result = await provider.complete([{ role: 'user', content: 'hi' }], { schema: { type: 'object' } });
+
+    expect(result.structured).toEqual({ entries: [{ category: 'New' }] });
+  });
+
+  it('should still parse plain (unfenced) JSON structured output', async () => {
+    mockFetch('{ "ok": true }');
+    const provider = new OllamaProvider({ model: 'test-model', apiKey: 'k' });
+
+    const result = await provider.complete([{ role: 'user', content: 'hi' }], { schema: { type: 'object' } });
+
+    expect(result.structured).toEqual({ ok: true });
+  });
+});

--- a/packages/notes/test/unit/llm/openai.spec.ts
+++ b/packages/notes/test/unit/llm/openai.spec.ts
@@ -25,4 +25,13 @@ describe('OpenAIProvider', () => {
 
     expect(result.structured).toEqual({ entries: [{ category: 'Fixed' }] });
   });
+
+  it('should still parse plain (unfenced) JSON structured output', async () => {
+    createMock.mockResolvedValue({ choices: [{ message: { content: '{ "ok": true }' } }] });
+    const provider = new OpenAIProvider({ model: 'gpt-4o-mini', apiKey: 'k' });
+
+    const result = await provider.complete([{ role: 'user', content: 'hi' }], { schema: { type: 'object' } });
+
+    expect(result.structured).toEqual({ ok: true });
+  });
 });

--- a/packages/notes/test/unit/llm/openai.spec.ts
+++ b/packages/notes/test/unit/llm/openai.spec.ts
@@ -1,0 +1,28 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { OpenAIProvider } from '../../../src/llm/openai.js';
+
+const { createMock } = vi.hoisted(() => ({ createMock: vi.fn() }));
+
+vi.mock('openai', () => ({
+  default: class MockOpenAI {
+    chat = { completions: { create: createMock } };
+  },
+}));
+
+describe('OpenAIProvider', () => {
+  beforeEach(() => {
+    createMock.mockReset();
+  });
+
+  it('should parse structured output wrapped in a markdown code fence', async () => {
+    // Regression for #289: some models / openai-compatible backends wrap JSON in ```json fences.
+    createMock.mockResolvedValue({
+      choices: [{ message: { content: '```json\n{ "entries": [{ "category": "Fixed" }] }\n```' } }],
+    });
+    const provider = new OpenAIProvider({ model: 'gpt-4o-mini', apiKey: 'k' });
+
+    const result = await provider.complete([{ role: 'user', content: 'hi' }], { schema: { type: 'object' } });
+
+    expect(result.structured).toEqual({ entries: [{ category: 'Fixed' }] });
+  });
+});

--- a/packages/notes/test/unit/llm/openai.spec.ts
+++ b/packages/notes/test/unit/llm/openai.spec.ts
@@ -15,7 +15,6 @@ describe('OpenAIProvider', () => {
   });
 
   it('should parse structured output wrapped in a markdown code fence', async () => {
-    // Regression for #289: some models / openai-compatible backends wrap JSON in ```json fences.
     createMock.mockResolvedValue({
       choices: [{ message: { content: '```json\n{ "entries": [{ "category": "Fixed" }] }\n```' } }],
     });


### PR DESCRIPTION
## Summary

The Ollama (`ollama.ts:113`) and OpenAI (`openai.ts:80`) providers ran a raw `JSON.parse` on schema-constrained responses. Cloud-hosted and openai-compatible models routinely wrap that JSON in a ```` ```json … ``` ```` markdown fence (observed with `minimax-m2.7:cloud` via `ollama.com` in the desktop-mobile run), so the parse threw, the provider returned text with **no `structured` field**, and a misleading `failed to parse structured response` debug fired.

This runs the response through the existing `extractJsonFromResponse` util before parsing — it strips fences + preamble — so `structured` is populated for fenced output and the debug only fires on genuinely malformed JSON. The task-layer fallback is retained as defense in depth.

## Testing

- New `OllamaProvider` / `OpenAIProvider` unit tests: fenced ```` ```json ```` response yields parsed `structured`; plain JSON still parses.
- `@releasekit/notes` lint + typecheck + test pass.

Closes #289

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a `JSON.parse` failure in the Ollama and OpenAI providers that occurred when cloud-hosted or OpenAI-compatible models wrapped schema-constrained output in a ` ```json ``` ` markdown fence instead of returning raw JSON. The fix routes the raw response through the existing `extractJsonFromResponse` utility before parsing, which strips fences and preamble text.

- **`ollama.ts` / `openai.ts`**: Both `complete()` methods now call `extractJsonFromResponse(content)` before `JSON.parse` when a `schema` option is present; the surrounding try/catch error fallback is unchanged.
- **`ollama.spec.ts` / `openai.spec.ts`**: New unit tests added for both providers covering the fenced case and the plain-JSON case, verifying `structured` is correctly populated in both scenarios.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a targeted defensive improvement to JSON parsing with no behavioural changes on the happy path.

The fix is minimal and well-contained: it adds one pre-processing step before an existing JSON.parse call, the original try/catch error fallback is fully preserved, and both new test files cover the fenced and unfenced paths for each provider. No data model, API contract, or error surface changes.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/notes/src/llm/ollama.ts | Routes raw content through extractJsonFromResponse before JSON.parse in the structured-output path; logic and error handling are correct. |
| packages/notes/src/llm/openai.ts | Same fence-stripping fix applied symmetrically; no other changes. |
| packages/notes/test/unit/llm/ollama.spec.ts | New spec covering fenced and unfenced JSON paths for OllamaProvider; both cases verified correctly. |
| packages/notes/test/unit/llm/openai.spec.ts | New spec covering fenced and unfenced JSON paths for OpenAIProvider; both cases verified correctly. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Provider as OllamaProvider / OpenAIProvider
    participant API as Remote Model API
    participant Util as extractJsonFromResponse
    participant Parse as JSON.parse

    Provider->>API: "complete(messages, {schema})"
    API-->>Provider: raw content (may be fenced)
    Provider->>Util: extractJsonFromResponse(content)
    Note over Util: strip ```json fence & preamble<br/>extract first { } or [ ] span
    Util-->>Provider: cleaned JSON string
    Provider->>Parse: JSON.parse(cleaned)
    alt parse succeeds
        Parse-->>Provider: structured object
        Provider-->>Provider: "return { content, structured }"
    else parse fails
        Parse-->>Provider: SyntaxError
        Provider-->>Provider: "debug log + return { content }"
    end
```
</details>

<sub>Reviews (3): Last reviewed commit: ["test(notes): drop the #289 citation comm..."](https://github.com/goosewobbler/releasekit/commit/5881da621a7e41c26bbfc8be4f89cb7ca45632a8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37530126)</sub>

<!-- /greptile_comment -->