### PR TITLE
fix(publish): skip non-package.json manifests in npm-publish without a confusing log

### DIFF
--- a/packages/publish/src/stages/npm-publish.ts
+++ b/packages/publish/src/stages/npm-publish.ts
@@ -50,6 +50,17 @@ export async function runNpmPublishStage(ctx: PipelineContext): Promise<void> {
         skipped: false,
       };
 
+      // Only npm packages have a package.json; cargo (Cargo.toml) and pub (pubspec.yaml) manifests
+      // flow through here too. Skip non-package.json manifests up front so we never JSON.parse a
+      // TOML/YAML file and emit a confusing "Failed to read package.json" debug.
+      if (!update.filePath.endsWith('package.json')) {
+        result.skipped = true;
+        result.success = true;
+        result.reason = 'Not an npm package';
+        ctx.output.npm.push(result);
+        continue;
+      }
+
       // Check if package is private
       const pkgJsonPath = path.resolve(cwd, update.filePath);
       let pkgJson: any = {};
@@ -69,15 +80,8 @@ export async function runNpmPublishStage(ctx: PipelineContext): Promise<void> {
           continue;
         }
       } catch (error) {
+        // A genuinely unreadable/malformed package.json — log and continue with empty metadata.
         debug(`Failed to read package.json: ${error}`);
-        // If we can't read package.json, it might be a Cargo.toml package
-        if (update.filePath.endsWith('Cargo.toml')) {
-          result.skipped = true;
-          result.success = true;
-          result.reason = 'Not an npm package';
-          ctx.output.npm.push(result);
-          continue;
-        }
       }
 
       // Check if already published

--- a/packages/publish/test/unit/stages/npm-publish.spec.ts
+++ b/packages/publish/test/unit/stages/npm-publish.spec.ts
@@ -19,6 +19,14 @@ vi.mock('../../../src/utils/auth.js', () => ({
   detectNpmAuth: vi.fn().mockReturnValue('token'),
 }));
 
+// Spy on `debug` (everything else from core stays real) to assert the absence of the misleading
+// "Failed to read package.json" log for non-npm manifests.
+const { debugMock } = vi.hoisted(() => ({ debugMock: vi.fn() }));
+vi.mock('@releasekit/core', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@releasekit/core')>()),
+  debug: debugMock,
+}));
+
 function createContext(cwd: string, overrides?: Partial<PipelineContext>): PipelineContext {
   return {
     input: {
@@ -126,6 +134,28 @@ describe('npm-publish stage', () => {
     expect(execCommand).not.toHaveBeenCalled();
     expect(ctx.output.npm[0]?.skipped).toBe(true);
     expect(ctx.output.npm[0]?.reason).toContain('private');
+  });
+
+  it('should skip non-package.json manifests (Cargo.toml) without trying to read them', async () => {
+    const { execCommand } = await import('../../../src/utils/exec.js');
+    const dir = createTmpDir();
+
+    // No Cargo.toml is created on disk: the guard must skip before any read attempt.
+    const ctx = createContext(dir, {
+      input: {
+        dryRun: false,
+        updates: [{ packageName: 'my-crate', newVersion: '1.0.0', filePath: 'crates/my-crate/Cargo.toml' }],
+        changelogs: [],
+        tags: [],
+      },
+    });
+    await runNpmPublishStage(ctx);
+
+    expect(ctx.output.npm[0]?.skipped).toBe(true);
+    expect(ctx.output.npm[0]?.reason).toBe('Not an npm package');
+    expect(execCommand).not.toHaveBeenCalled();
+    // Regression: no confusing "Failed to read package.json" for a non-npm manifest.
+    expect(debugMock).not.toHaveBeenCalledWith(expect.stringContaining('Failed to read package.json'));
   });
 
   it('should use correct cwd for npm vs pnpm', async () => {


### PR DESCRIPTION
## Summary

During publish, `npm-publish.ts` read each version update's `filePath` as `package.json` to check `private`. For Rust-only crates the manifest is a `Cargo.toml` (and pub packages a `pubspec.yaml`), so `JSON.parse` threw on its first line (`[package]`) and emitted a misleading `Failed to read package.json: SyntaxError: Unexpected token 'p', "[package]…` before the `catch` recognised it as non-npm and skipped it.

This adds an up-front guard: any update whose `filePath` isn't a `package.json` is skipped as "Not an npm package" without attempting a read/parse. The `catch` is retained only for a genuinely malformed `package.json`.

## Testing

- New test: a `Cargo.toml` update is skipped as "Not an npm package", no publish command runs, and **no** `Failed to read package.json` debug is emitted (the manifest is never read — the test doesn't even create the file).
- `@releasekit/publish` lint + typecheck + test pass.

Closes #290

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds an early `endsWith('package.json')` guard in `runNpmPublishStage` so non-npm manifests (`Cargo.toml`, `pubspec.yaml`) are skipped before any filesystem read, eliminating the misleading `Failed to read package.json` debug line that previously appeared for every Rust/Dart package in the release set.

- `npm-publish.ts`: the new guard sets `skipped = true` and `continue`s immediately for any `filePath` that isn't a `package.json`; the old `endsWith('Cargo.toml')` check inside the `catch` block (which silently left `pubspec.yaml` unhandled) is removed, and the retained `catch` is scoped solely to genuinely malformed `package.json` files.
- `npm-publish.spec.ts`: a new test asserts that a `Cargo.toml` update is skipped without touching the filesystem or calling `execCommand`, and verifies via a hoisted `debugMock` that the confusing log is never emitted.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge. The guard is a pure early-exit addition that cannot affect existing package.json paths.

The change is narrow and well-targeted: a single endsWith check added before the filesystem read, with the old Cargo.toml-specific catch fallback removed. The fix also closes an unaddressed gap — the old catch only handled Cargo.toml, silently leaving pubspec.yaml to fall through to the npm publish path with empty metadata. The new test correctly verifies both the skip outcome and the absence of the misleading debug log using a hoisted mock. No existing code paths are altered.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/publish/src/stages/npm-publish.ts | Adds a clean early-exit guard for non-package.json manifests; removes the Cargo.toml-only catch fallback that left pubspec.yaml silently unhandled. |
| packages/publish/test/unit/stages/npm-publish.spec.ts | Adds a well-targeted regression test using a hoisted debugMock to assert the absence of the misleading log; mock teardown via vi.clearAllMocks() in beforeEach is correct. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[for each update] --> B{filePath ends with package.json?}
    B -- No --> C[skipped=true, reason='Not an npm package', push result, continue]
    B -- Yes --> D[readFileSync + JSON.parse]
    D -- success --> E{pkgJson.private?}
    D -- error --> F[debug 'Failed to read package.json', continue with empty pkgJson]
    E -- Yes --> G[skipped=true, reason='Package is private', push result, continue]
    E -- No --> H[execCommandSafe: npm view, check already published]
    F --> H
    H -- already published --> I[skipped=true, reason='Already published', push result, continue]
    H -- not published --> J[execCommand: npm publish with retry]
    J -- success --> K[success=true, push result]
    J -- EPUBLISHCONFLICT --> I
    J -- permanent error --> L[throw PublishError, fail-fast]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(publish): skip non-package.json mani..."](https://github.com/goosewobbler/releasekit/commit/4895c152d94e2eebfbbc5dccc240fb1cdafda2f4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37530298)</sub>

<!-- /greptile_comment -->