### PR TITLE
fix(notes): add an output flag so frontmatter templates don't leak into the GitHub body

### DIFF
--- a/packages/notes/docs/templates.md
+++ b/packages/notes/docs/templates.md
@@ -80,7 +80,8 @@ A release-notes template that adds frontmatter for the in-repo file but not the 
 title: {{ versions[0].version }}
 date: {{ versions[0].date }}
 ---
-{% endif %}{% for v in versions %}{{ v.summary }}{% endfor %}
+{% endif %}{% for v in versions %}{% for entry in v.entries %}- {{ entry.description }}
+{% endfor %}{% endfor %}
 ```
 
 ### Version context

--- a/packages/notes/docs/templates.md
+++ b/packages/notes/docs/templates.md
@@ -71,6 +71,17 @@ The outermost template (`document`) receives:
 | `unreleased` | `TemplateContext \| undefined` | Unreleased changes, if any |
 | `compareUrls` | `Record<string, string> \| undefined` | Map of version → compare URL for all versions |
 | `perPackage` | `boolean \| undefined` | `true` when rendered inline for a single package (e.g. GitHub release body). Use this to suppress document-level headings that are redundant when the content is embedded in a release that already shows the package name and version. |
+| `output` | `'file' \| 'release' \| undefined` | Which release-notes destination this render targets: `'file'` (an in-repo per-version file) or `'release'` (the GitHub release body). Branch on it to emit content that only suits one — most importantly, docs-site **YAML frontmatter**, which would render as literal text in a GitHub release. |
+
+A release-notes template that adds frontmatter for the in-repo file but not the GitHub release body:
+
+```liquid
+{% if output == "file" %}---
+title: {{ versions[0].version }}
+date: {{ versions[0].date }}
+---
+{% endif %}{% for v in versions %}{{ v.summary }}{% endfor %}
+```
 
 ### Version context
 

--- a/packages/notes/src/core/pipeline.ts
+++ b/packages/notes/src/core/pipeline.ts
@@ -489,7 +489,7 @@ export async function runPipeline(
       const renderContent = (ctx: TemplateContext): string => {
         if (releaseNotesConfig.templates?.path) {
           const templatePath = path.resolve(releaseNotesConfig.templates.path);
-          const docCtx = { ...createDocumentContext([ctx], undefined), perPackage: true };
+          const docCtx = { ...createDocumentContext([ctx], undefined), perPackage: true, output: 'file' as const };
           return renderTemplate(templatePath, docCtx, releaseNotesConfig.templates.engine as TemplateEngine | undefined)
             .content;
         }
@@ -520,7 +520,7 @@ export async function runPipeline(
       if (releaseNotesConfig.templates?.path) {
         try {
           const templatePath = path.resolve(releaseNotesConfig.templates.path);
-          const docCtx = { ...createDocumentContext([ctx], undefined), perPackage: true };
+          const docCtx = { ...createDocumentContext([ctx], undefined), perPackage: true, output: 'release' as const };
           const rendered = renderTemplate(
             templatePath,
             docCtx,

--- a/packages/notes/src/core/types.ts
+++ b/packages/notes/src/core/types.ts
@@ -79,6 +79,10 @@ export interface DocumentContext {
    *  Templates can use this to suppress document-level headings that are redundant
    *  when the content is embedded in a release that already shows the package/version. */
   perPackage?: boolean;
+  /** Which release-notes destination this render targets: `'file'` (an in-repo per-version file)
+   *  or `'release'` (the GitHub release body). Templates can branch on it — e.g. emit docs-site
+   *  YAML frontmatter only for `'file'`, since it would render as literal text in a GitHub release. */
+  output?: 'file' | 'release';
 }
 
 export interface LLMOptions {

--- a/packages/notes/test/integration/llm-pipeline.spec.ts
+++ b/packages/notes/test/integration/llm-pipeline.spec.ts
@@ -335,7 +335,7 @@ describe('Pipeline: releaseNotes in output', () => {
     expect(fileContent).toContain('perPackage=true');
   });
 
-  it('should keep frontmatter out of the GitHub release body via the output flag (#297)', async () => {
+  it('should keep frontmatter out of the GitHub release body via the output flag', async () => {
     // A template that emits frontmatter only for file output. The same template also feeds the
     // GitHub release body, where YAML frontmatter would otherwise render as literal text.
     const templatePath = path.join(tmpDir, 'release.liquid');

--- a/packages/notes/test/integration/llm-pipeline.spec.ts
+++ b/packages/notes/test/integration/llm-pipeline.spec.ts
@@ -334,6 +334,36 @@ describe('Pipeline: releaseNotes in output', () => {
     expect(fileContent).toContain('version: 2.0.0');
     expect(fileContent).toContain('perPackage=true');
   });
+
+  it('should keep frontmatter out of the GitHub release body via the output flag (#297)', async () => {
+    // A template that emits frontmatter only for file output. The same template also feeds the
+    // GitHub release body, where YAML frontmatter would otherwise render as literal text.
+    const templatePath = path.join(tmpDir, 'release.liquid');
+    fs.writeFileSync(
+      templatePath,
+      '{% if output == "file" %}---\nversion: {{ versions[0].version }}\n---\n{% endif %}Notes for {{ versions[0].version }}',
+    );
+
+    const config = {
+      changelog: false as const,
+      releaseNotes: {
+        file: { dir: path.join(tmpDir, 'notes') },
+        templates: { path: templatePath, engine: 'liquid' as const },
+      },
+    };
+
+    const result = await runPipeline(sampleInput, config, false);
+
+    // File render (output: 'file') includes the frontmatter…
+    const fileContent = fs.readFileSync(result.files[0] as string, 'utf-8');
+    expect(fileContent).toContain('---');
+    expect(fileContent).toContain('version: 2.0.0');
+    expect(fileContent).toContain('Notes for 2.0.0');
+
+    // …but the GitHub release body render (output: 'release') does not.
+    expect(result.releaseNotes?.['my-lib']).toContain('Notes for 2.0.0');
+    expect(result.releaseNotes?.['my-lib']).not.toContain('---');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/notes/test/integration/llm-pipeline.spec.ts
+++ b/packages/notes/test/integration/llm-pipeline.spec.ts
@@ -355,6 +355,7 @@ describe('Pipeline: releaseNotes in output', () => {
     const result = await runPipeline(sampleInput, config, false);
 
     // File render (output: 'file') includes the frontmatter…
+    expect(result.files.length).toBeGreaterThan(0);
     const fileContent = fs.readFileSync(result.files[0] as string, 'utf-8');
     expect(fileContent).toContain('---');
     expect(fileContent).toContain('version: 2.0.0');


### PR DESCRIPTION
## Summary

Resolves the caveat deferred from #296 (now merged). A single `releaseNotes.templates` feeds two destinations with opposite formatting needs:

- **versioned file** (`pipeline.ts` `renderContent`) — where a docs-site **frontmatter** template belongs
- **GitHub release body** (`releaseNotesResult`) — where YAML frontmatter renders as literal text

The template couldn't tell them apart, so a frontmatter template leaked into the release body when no LLM prose was present.

This exposes **`output: 'file' | 'release'`** on the template document context (next to the existing `perPackage` flag). The file render passes `'file'`, the release-body render `'release'`, so a template guards frontmatter with `{% if output == "file" %}`.

## Testing

- New integration test: a template that emits frontmatter only for `output == "file"` → the per-version file contains the frontmatter, the GitHub-release-body content does not.
- Documented `output` in the templates guide with a frontmatter example.
- `@releasekit/notes` lint + typecheck + test pass.

Closes #297

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR exposes an `output: 'file' | 'release'` flag on the `DocumentContext` passed to Liquid/Nunjucks templates, letting a single template guard frontmatter that belongs only in the versioned in-repo file and must not appear in the GitHub release body.

- **`types.ts`**: Adds the optional `output` field to `DocumentContext` with a JSDoc that explains the two values.
- **`pipeline.ts`**: The two existing template render sites now inject `output: 'file'` (versioned-file path) and `output: 'release'` (GitHub release-body path) respectively, closing the leak without altering any other logic.
- **`llm-pipeline.spec.ts`**: New integration test verifies that a frontmatter-guarded template writes `---` to the file but not to `result.releaseNotes`, and the `result.files.length > 0` guard (flagged in a previous review) is present.
</details>

<h3>Confidence Score: 5/5</h3>

The change is safe to merge — it adds a read-only context field with no effect on callers that don't use it, and the two mutated render sites each receive the correct value.

The fix is minimal and surgical: two lines in pipeline.ts inject a discriminant that was simply missing, the type change is purely additive, and the integration test exercises both render paths end-to-end. No existing behaviour is altered for projects that don't use a template.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/notes/src/core/types.ts | Adds `output?: 'file' | 'release'` to `DocumentContext`; minimal, well-documented type extension with no breaking changes. |
| packages/notes/src/core/pipeline.ts | Both template render sites now carry the correct `output` discriminant — `'file'` for versioned-file renders, `'release'` for the GitHub release-body render. Logic is accurate and the asymmetric content-precedence (template > LLM for file; LLM > template for release) remains intentional. |
| packages/notes/test/integration/llm-pipeline.spec.ts | New integration test covers the exact bug scenario; includes the `result.files.length > 0` guard (addressing previous review feedback) before dereferencing `result.files[0]`. |
| packages/notes/docs/templates.md | Documents the new `output` context variable with description and a Liquid frontmatter-guard example using valid `versions[0].version` / `versions[0].date` fields. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[runPipeline] --> B{releaseNotes.file configured?}
    B -- yes --> C[renderContent per ctx]
    C --> D{template configured?}
    D -- yes --> E["renderTemplate(templatePath, docCtx\n+ output: 'file')"]
    D -- no --> F{ctx.enhanced.releaseNotes?}
    F -- yes --> G[use LLM prose]
    F -- no --> H[formatVersion default]
    E & G & H --> I[writeVersionedNotes → files]

    A --> J{for each ctx}
    J --> K{ctx.enhanced.releaseNotes?}
    K -- yes --> L[releaseNotesResult = LLM prose]
    K -- no --> M{template configured?}
    M -- yes --> N["renderTemplate(templatePath, docCtx\n+ output: 'release')"]
    M -- no --> O[formatted changelog fallback]
    N & O --> P[releaseNotesResult]
    L --> P
```
</details>

<sub>Reviews (3): Last reviewed commit: ["test(notes): drop the #297 citation from..."](https://github.com/goosewobbler/releasekit/commit/269621cb9ed83dc72d6a8a3717bdb9153dda785f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37530752)</sub>

<!-- /greptile_comment -->