### PR TITLE
feat(action): add backfill mode to the GitHub Action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ branding:
 
 inputs:
   mode:
-    description: Action mode (release, preview, gate, standing-pr-update, or standing-pr-publish)
+    description: Action mode (release, preview, gate, standing-pr-update, standing-pr-publish, or backfill)
     required: false
     default: preview
   config:
@@ -126,6 +126,35 @@ inputs:
     description: Write GITHUB_STEP_SUMMARY markdown
     required: false
     default: "true"
+
+  package:
+    description: Package to backfill (backfill mode; defaults to the package.json name at `path`)
+    required: false
+  path:
+    description: Package directory to backfill (backfill mode)
+    required: false
+  all:
+    description: Backfill every package in the workspace (backfill mode)
+    required: false
+    default: "false"
+  from:
+    description: Earliest version to backfill, inclusive (backfill mode)
+    required: false
+  to:
+    description: Latest version to backfill, inclusive (backfill mode)
+    required: false
+  update-releases:
+    description: Update matching GitHub release bodies via `gh release edit` (backfill mode)
+    required: false
+    default: "false"
+  only-missing:
+    description: With update-releases, skip releases already carrying releasekit notes (backfill mode)
+    required: false
+    default: "false"
+  apply:
+    description: Apply changes instead of a dry-run preview (backfill mode)
+    required: false
+    default: "false"
 
 outputs:
   success:
@@ -298,6 +327,14 @@ runs:
         INPUT_PREVIEW_DRY_RUN: ${{ inputs.preview-dry-run }}
         INPUT_PREVIEW_TARGET: ${{ inputs.preview-target }}
         INPUT_SUMMARY: ${{ inputs.summary }}
+        INPUT_PACKAGE: ${{ inputs.package }}
+        INPUT_PATH: ${{ inputs.path }}
+        INPUT_ALL: ${{ inputs.all }}
+        INPUT_FROM: ${{ inputs.from }}
+        INPUT_TO: ${{ inputs.to }}
+        INPUT_UPDATE_RELEASES: ${{ inputs.update-releases }}
+        INPUT_ONLY_MISSING: ${{ inputs.only-missing }}
+        INPUT_APPLY: ${{ inputs.apply }}
         GITHUB_TOKEN: ${{ github.token }}
         NPM_TOKEN: ${{ inputs.npm-token }}
         VERBOSE: ${{ inputs.verbose }}

--- a/docs/action.md
+++ b/docs/action.md
@@ -17,6 +17,7 @@ uses: goosewobbler/releasekit@v0
 - `gate`: evaluates merged-PR labels and emits should-release/bump/scope outputs.
 - `standing-pr-update`: creates or refreshes the standing release PR.
 - `standing-pr-publish`: publishes from a merged standing release PR's manifest. Resolution order for which PR: the `pr` input, then the `pull_request` event payload, then the most recently merged standing PR via the GitHub API. Pass `pr` explicitly in dispatch funnels (e.g. `workflow_dispatch` routing for npm OIDC trusted publishing) — re-runs of a stale dispatch can otherwise infer a newer standing PR.
+- `backfill`: regenerates release notes for already-released versions from git history, writing per-version files and/or updating GitHub release bodies. Dry-run unless `apply: true`. Best driven by `workflow_dispatch` for one-off backfills.
 
 ## Requirements
 
@@ -48,7 +49,7 @@ uses: goosewobbler/releasekit@v0
 
 | Input | Default | Description |
 |---|---|---|
-| `mode` | `release` | `release`, `preview`, `gate`, `standing-pr-update`, or `standing-pr-publish` |
+| `mode` | `release` | `release`, `preview`, `gate`, `standing-pr-update`, `standing-pr-publish`, or `backfill` |
 | `config` | - | Path to `releasekit.config.json` |
 | `project-dir` | `.` | Project directory |
 | `dry-run` | `false` | Global dry-run toggle |
@@ -89,6 +90,21 @@ uses: goosewobbler/releasekit@v0
 |---|---|---|
 | `pr` | - | Merged standing PR number (`standing-pr-publish`, when not triggered by a `pull_request` event) |
 | `reconcile` | `false` | `standing-pr-update` only: bypass the skip-pattern guard. Set this for a post-release reconcile run, where HEAD is the just-pushed release commit (which matches the skip pattern). Without it the reconcile run no-ops and the standing PR keeps holding the just-published versions. |
+
+### Backfill mode inputs
+
+| Input | Default | Description |
+|---|---|---|
+| `package` | package.json name at `path` | Package to backfill |
+| `path` | `.` | Package directory |
+| `all` | `false` | Backfill every workspace package (mutually exclusive with `package`) |
+| `from` | - | Earliest version to backfill (inclusive) |
+| `to` | - | Latest version to backfill (inclusive) |
+| `update-releases` | `false` | Update matching GitHub release bodies via `gh release edit` |
+| `only-missing` | `false` | With `update-releases`, skip releases already carrying releasekit notes |
+| `apply` | `false` | Apply changes (default: dry-run preview) |
+
+`update-releases` needs `contents: write` permission and `GITHUB_TOKEN` (for `gh release edit`). Writing per-version files needs `notes.releaseNotes.file.dir` set in your config and, to commit them, a follow-up step.
 
 ## Outputs
 
@@ -183,6 +199,41 @@ jobs:
 
       - run: |
           echo "${{ steps.rk.outputs.preview-markdown }}"
+```
+
+### Backfill mode (update GitHub release bodies)
+
+Run on demand to regenerate notes for past releases. Dry-run by default — flip `apply` to `true` when the preview looks right.
+
+```yaml
+name: Backfill Release Notes
+
+on:
+  workflow_dispatch:
+    inputs:
+      apply:
+        description: Apply changes (off = dry-run preview)
+        type: boolean
+        default: false
+
+jobs:
+  backfill:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: goosewobbler/releasekit@v0
+        with:
+          mode: backfill
+          all: "true"
+          update-releases: "true"
+          only-missing: "true"
+          apply: ${{ inputs.apply }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 ## Versioning and distribution policy

--- a/scripts/run-action.mjs
+++ b/scripts/run-action.mjs
@@ -123,6 +123,23 @@ export function buildGateArgs(input) {
   return args;
 }
 
+export function buildBackfillArgs(input) {
+  const args = ['backfill'];
+
+  // backfill has no --project-dir flag; the runner already spawns the CLI with cwd = projectDir.
+  pushOptionalArg(args, '--config', input.config);
+  pushOptionalArg(args, '--package', input.backfillPackage);
+  pushOptionalArg(args, '--path', input.backfillPath);
+  pushOptionalArg(args, '--from', input.backfillFrom);
+  pushOptionalArg(args, '--to', input.backfillTo);
+  pushBooleanFlag(args, '--all', input.backfillAll);
+  pushBooleanFlag(args, '--update-releases', input.backfillUpdateReleases);
+  pushBooleanFlag(args, '--only-missing', input.backfillOnlyMissing);
+  pushBooleanFlag(args, '--apply', input.backfillApply);
+
+  return args;
+}
+
 export function writeGateOutputs(stdout, verbose = false) {
   const parsed = parseReleaseOutput(stdout, verbose);
   setOutput('should-release', parsed?.shouldRelease ? 'true' : 'false');
@@ -197,9 +214,18 @@ export function parseInputs(env = process.env) {
     previewStable: env.INPUT_PREVIEW_STABLE,
     previewDryRun: env.INPUT_PREVIEW_DRY_RUN,
     previewTarget: normalizeString(env.INPUT_PREVIEW_TARGET),
+
+    backfillPackage: normalizeString(env.INPUT_PACKAGE),
+    backfillPath: normalizeString(env.INPUT_PATH),
+    backfillAll: env.INPUT_ALL,
+    backfillFrom: normalizeString(env.INPUT_FROM),
+    backfillTo: normalizeString(env.INPUT_TO),
+    backfillUpdateReleases: env.INPUT_UPDATE_RELEASES,
+    backfillOnlyMissing: env.INPUT_ONLY_MISSING,
+    backfillApply: env.INPUT_APPLY,
   };
 
-  const validModes = ['release', 'preview', 'gate', 'standing-pr-update', 'standing-pr-publish'];
+  const validModes = ['release', 'preview', 'gate', 'standing-pr-update', 'standing-pr-publish', 'backfill'];
   if (!validModes.includes(input.mode)) {
     throw new Error(`Invalid mode: ${input.mode}. Must be one of: ${validModes.join(', ')}`);
   }
@@ -209,7 +235,7 @@ export function parseInputs(env = process.env) {
 
 export async function runAction(input, options = {}) {
   const mode = input.mode;
-  const validModes = ['release', 'preview', 'gate', 'standing-pr-update', 'standing-pr-publish'];
+  const validModes = ['release', 'preview', 'gate', 'standing-pr-update', 'standing-pr-publish', 'backfill'];
   if (!validModes.includes(mode)) {
     throw new Error(`Invalid mode: ${mode}. Expected one of: ${validModes.join(', ')}.`);
   }
@@ -218,16 +244,15 @@ export async function runAction(input, options = {}) {
     options.cliPath ??
     path.resolve(fileURLToPath(import.meta.url), '..', '..', 'packages', 'release', 'dist', 'cli.js');
 
-  const args =
-    mode === 'release'
-      ? buildReleaseArgs(input)
-      : mode === 'gate'
-        ? buildGateArgs(input)
-        : mode === 'standing-pr-update'
-          ? buildStandingPRUpdateArgs(input)
-          : mode === 'standing-pr-publish'
-            ? buildStandingPRPublishArgs(input)
-            : buildPreviewArgs(input);
+  const argBuilders = {
+    release: buildReleaseArgs,
+    gate: buildGateArgs,
+    'standing-pr-update': buildStandingPRUpdateArgs,
+    'standing-pr-publish': buildStandingPRPublishArgs,
+    backfill: buildBackfillArgs,
+    preview: buildPreviewArgs,
+  };
+  const args = (argBuilders[mode] ?? buildPreviewArgs)(input);
 
   const projectDir = input.projectDir || '.';
   const actionDir = fileURLToPath(import.meta.url).replace(/[/\\]scripts[/\\]run-action.mjs$/, '');
@@ -552,6 +577,8 @@ async function main() {
     writeGateOutputs(result.stdout ?? '', verbose);
   } else if (result.mode === 'standing-pr-update' || result.mode === 'standing-pr-publish') {
     writeStandingPROutputs(result.stdout ?? '', verbose);
+  } else if (result.mode === 'backfill') {
+    // Backfill streams its own progress and exposes only the core success/mode outputs.
   } else {
     writePreviewOutputs(input, result.stdout ?? '');
   }

--- a/scripts/run-action.mjs
+++ b/scripts/run-action.mjs
@@ -252,7 +252,8 @@ export async function runAction(input, options = {}) {
     backfill: buildBackfillArgs,
     preview: buildPreviewArgs,
   };
-  const args = (argBuilders[mode] ?? buildPreviewArgs)(input);
+  // `mode` is validated against validModes above, and every entry has a key here.
+  const args = argBuilders[mode](input);
 
   const projectDir = input.projectDir || '.';
   const actionDir = fileURLToPath(import.meta.url).replace(/[/\\]scripts[/\\]run-action.mjs$/, '');

--- a/templates/workflows/backfill.yml
+++ b/templates/workflows/backfill.yml
@@ -1,0 +1,44 @@
+name: Backfill Release Notes
+
+# Manually regenerate release notes for already-released versions from git history and update the
+# matching GitHub release bodies. Dry-run by default — review the run logs, then re-run with
+# apply: true. Leave `package` blank to backfill every package in the workspace.
+on:
+  workflow_dispatch:
+    inputs:
+      package:
+        description: Package to backfill (blank = every workspace package)
+        required: false
+      from:
+        description: Earliest version to backfill (inclusive)
+        required: false
+      to:
+        description: Latest version to backfill (inclusive)
+        required: false
+      apply:
+        description: Apply changes (off = dry-run preview)
+        type: boolean
+        default: false
+
+jobs:
+  backfill:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # gh release edit (update-releases)
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # full history — backfill reads every tag
+      - uses: goosewobbler/releasekit@v0
+        with:
+          mode: backfill
+          # `all` and `package` are mutually exclusive; pick by whether a package was given.
+          package: ${{ inputs.package }}
+          all: ${{ inputs.package == '' }}
+          from: ${{ inputs.from }}
+          to: ${{ inputs.to }}
+          update-releases: "true"
+          only-missing: "true"
+          apply: ${{ inputs.apply }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/test/integration/action-runner.spec.ts
+++ b/test/integration/action-runner.spec.ts
@@ -3,6 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 import {
+  buildBackfillArgs,
   buildGateArgs,
   buildGateSummary,
   buildPreviewArgs,
@@ -291,6 +292,81 @@ describe('action runner', () => {
         'electron',
       ]),
     );
+  });
+
+  it('should build backfill args for --all with release updates', () => {
+    const args = buildBackfillArgs({
+      config: 'releasekit.config.json',
+      backfillAll: 'true',
+      backfillUpdateReleases: 'true',
+      backfillOnlyMissing: 'true',
+      backfillApply: 'true',
+    });
+
+    expect(args).toEqual(
+      expect.arrayContaining([
+        'backfill',
+        '--config',
+        'releasekit.config.json',
+        '--all',
+        '--update-releases',
+        '--only-missing',
+        '--apply',
+      ]),
+    );
+    // backfill resolves the project via the runner's cwd, not a CLI flag.
+    expect(args).not.toContain('--project-dir');
+  });
+
+  it('should build single-package backfill args and omit unset flags', () => {
+    const args = buildBackfillArgs({
+      backfillPackage: '@scope/pkg',
+      backfillPath: 'packages/pkg',
+      backfillFrom: '1.1.0',
+    });
+
+    expect(args).toEqual(
+      expect.arrayContaining(['backfill', '--package', '@scope/pkg', '--path', 'packages/pkg', '--from', '1.1.0']),
+    );
+    expect(args).not.toContain('--all');
+    expect(args).not.toContain('--to');
+    expect(args).not.toContain('--update-releases');
+    expect(args).not.toContain('--only-missing');
+    expect(args).not.toContain('--apply');
+  });
+
+  it('should accept backfill mode and map its inputs', () => {
+    const parsed = parseInputs({
+      INPUT_MODE: 'backfill',
+      INPUT_PACKAGE: '@scope/pkg',
+      INPUT_ALL: 'true',
+      INPUT_FROM: '1.0.0',
+      INPUT_UPDATE_RELEASES: 'true',
+      INPUT_APPLY: 'true',
+    });
+
+    expect(parsed.mode).toBe('backfill');
+    expect(parsed.backfillPackage).toBe('@scope/pkg');
+    expect(parsed.backfillAll).toBe('true');
+    expect(parsed.backfillFrom).toBe('1.0.0');
+    expect(parsed.backfillUpdateReleases).toBe('true');
+    expect(parsed.backfillApply).toBe('true');
+  });
+
+  it('should dispatch backfill mode to the backfill subcommand', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'releasekit-action-runner-test-'));
+    tempDirs.push(tempDir);
+    const cliPath = path.join(tempDir, 'fake-cli.mjs');
+    fs.writeFileSync(cliPath, 'console.log(process.argv.slice(2).join(" "))\n', 'utf-8');
+
+    const result = await runAction(
+      { mode: 'backfill', projectDir: '.', backfillAll: 'true', backfillApply: 'true' },
+      { cliPath },
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.args).toEqual(expect.arrayContaining(['backfill', '--all', '--apply']));
+    expect(result.stdout).toContain('backfill --all --apply');
   });
 
   it('should parse gate outputs from JSON stdout', () => {


### PR DESCRIPTION
## Summary

Exposes the `backfill` CLI command (merged in #308) as a **GitHub Action mode**, so consumers can regenerate release notes from CI — e.g. a one-off `workflow_dispatch` — without installing releasekit. First of the remaining #293 follow-ups.

The CLI command was already registered; this is purely the action layer:

- **`action.yml`** — `mode: backfill` plus inputs `package` / `path` / `all` / `from` / `to` / `update-releases` / `only-missing` / `apply`, wired through to `INPUT_*` env.
- **`scripts/run-action.mjs`** — parses the inputs, adds `backfill` to the valid modes, and builds the backfill args (`buildBackfillArgs`). Backfill has no `--project-dir` flag, so the runner's existing cwd handling covers it. Also **replaced the mode→builder nested ternary with a lookup map** while adding the branch.
- **`docs/action.md`** — backfill mode entry, a Backfill-mode inputs table, and a `workflow_dispatch` example.
- **`templates/workflows/backfill.yml`** — copy-pasteable `workflow_dispatch` template. Blank `package` ⇒ `--all` (the two are mutually exclusive, resolved via `all: ${{ inputs.package == '' }}`); dry-run unless `apply: true`.

## Testing

- Unit tests (`test/integration/action-runner.spec.ts`): `buildBackfillArgs` (full `--all` + release-update flags, and single-package with unset flags omitted), `parseInputs` accepts `mode: backfill` and maps its inputs, and `runAction` dispatches `backfill` mode to the `backfill` subcommand. **335 action-runner tests pass.**
- Verified end-to-end through the **production runner**: `INPUT_MODE=backfill INPUT_ALL=true … node scripts/run-action.mjs` reconstructs every workspace package with correct per-tag dates.

## Notes

- `update-releases` needs `contents: write` + `GITHUB_TOKEN` (for `gh release edit`, preinstalled on GitHub runners).
- The existing `templates/workflows/*` are CLI-based; this one is action-based since it showcases the new action surface (the docs example is the inline counterpart).

Refs #293. Remaining follow-ups (separate PRs): LLM range-hash caching, pub-only `--all` discovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR exposes the `backfill` CLI command as a new GitHub Action mode, letting consumers regenerate historical release notes from CI without installing releasekit locally. The implementation is purely the action layer — the underlying CLI command shipped in #308.

- **`action.yml`** adds eight new inputs scoped to backfill mode and wires them as `INPUT_*` env vars; **`scripts/run-action.mjs`** adds `buildBackfillArgs`, maps those inputs in `parseInputs`, replaces the old nested ternary with a lookup map in `runAction`, and adds a no-op output branch (backfill streams its own progress).
- **`templates/workflows/backfill.yml`** is a new `workflow_dispatch` template; it uses `all: ${{ inputs.package == '' }}` to make `package`/`all` mutually exclusive, which correctly produces the `"true"`/`"false"` strings that `normalizeBoolean` expects.
- Four integration tests cover the two `buildBackfillArgs` paths, `parseInputs` accepting the new mode, and end-to-end dispatch through a fake CLI.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — purely additive action layer with no changes to existing modes, backed by solid integration tests.

All five files contain clean, additive changes. The new inputs are correctly scoped so they cannot interfere with existing modes. The lookup-map refactor closes the previous dead-code concern. Tests cover both happy paths for buildBackfillArgs plus dispatch integration.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| action.yml | Adds 8 new backfill-specific inputs and wires them through as INPUT_* env vars; mode description updated to include backfill. |
| scripts/run-action.mjs | Adds buildBackfillArgs, maps backfill inputs in parseInputs, replaces nested ternary with a lookup map in runAction, and adds a no-op output branch for backfill mode. |
| templates/workflows/backfill.yml | New workflow_dispatch template; uses all: ${{ inputs.package == '' }} to make package/all mutually exclusive correctly. |
| test/integration/action-runner.spec.ts | Adds four well-scoped tests covering both buildBackfillArgs paths, parseInputs accepting backfill mode, and end-to-end dispatch via a fake CLI. |
| docs/action.md | Adds backfill mode entry, a Backfill mode inputs table, and a workflow_dispatch example; accurate and consistent with the implementation. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant W as workflow_dispatch
    participant A as action.yml
    participant R as run-action.mjs
    participant C as CLI (backfill)

    W->>A: inputs (package, all, from, to, update-releases, only-missing, apply)
    A->>R: INPUT_PACKAGE, INPUT_ALL, INPUT_FROM, INPUT_TO, INPUT_UPDATE_RELEASES, INPUT_ONLY_MISSING, INPUT_APPLY
    R->>R: "parseInputs() → backfill* fields"
    R->>R: argBuilders[backfill](input) → buildBackfillArgs()
    R->>C: "node cli.js backfill [--all|--package] [--from] [--to] [--update-releases] [--only-missing] [--apply]"
    C-->>R: streamed stdout/stderr + exit code
    R->>A: "outputs: mode=backfill, success=true/false"
```
</details>

<sub>Reviews (2): Last reviewed commit: ["refactor(action): drop the unreachable a..."](https://github.com/goosewobbler/releasekit/commit/db9bcc08ac48c90b6a7ae1e7db2bbe3b2d50a1fc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37619794)</sub>

<!-- /greptile_comment -->