### PR TITLE
feat(notes): opt-in on-disk cache for LLM responses

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -298,6 +298,7 @@ LLM configuration for release notes.
 | `examples` | integer | `3` | Number of few-shot examples to include in LLM prompts (0–5). |
 | `context` | object | — | Additional context sources for the LLM. |
 | `categoryOrder` | `string[]` | — | Explicit ordering of categories in the output. Categories not listed retain their configured order after the listed ones. |
+| `cache` | boolean | `false` | Cache LLM responses on disk (under the OS temp dir), keyed by a hash of the provider, model, prompt, and request options. A re-run or backfill with the same inputs reuses the cached generation instead of re-calling the provider. Off by default. |
 
 #### `notes.releaseNotes.llm.options`
 

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -413,6 +413,12 @@ export const LLMConfigSchema = z.object({
     .describe(
       'Explicit ordering of categories in the output. Categories not listed retain their configured order after the listed ones.',
     ),
+  cache: z
+    .boolean()
+    .default(false)
+    .describe(
+      'Cache LLM responses on disk (under the OS temp dir), keyed by a hash of the provider, model, prompt, and request options. A re-run or backfill with the same inputs reuses the cached generation instead of re-calling the provider. Off by default.',
+    ),
 });
 
 export const ReleaseNotesConfigSchema = z

--- a/packages/notes/src/core/pipeline.ts
+++ b/packages/notes/src/core/pipeline.ts
@@ -203,7 +203,9 @@ async function processWithLLM(
 
     const rawProvider = createProvider(llmConfig);
     // Opt-in on-disk cache (innermost, so a hit skips both the provider call and the retry wrapper).
-    const baseProvider = llmConfig.cache ? withContentHashCache(rawProvider, llmConfig.model) : rawProvider;
+    const baseProvider = llmConfig.cache
+      ? withContentHashCache(rawProvider, { model: llmConfig.model, baseURL: llmConfig.baseURL })
+      : rawProvider;
     const retryOpts = llmConfig.retry ?? LLM_DEFAULTS.retry;
     const configOptions = llmConfig.options;
     const provider: LLMProvider = {

--- a/packages/notes/src/core/pipeline.ts
+++ b/packages/notes/src/core/pipeline.ts
@@ -2,6 +2,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { debug, info, success, warn } from '@releasekit/core';
 import { parseVersionOutput } from '../input/version-output.js';
+import { withContentHashCache } from '../llm/cache.js';
 import { fetchPullRequestContext, parseIssueNumbers, resolveGitHubToken } from '../llm/context/prFetcher.js';
 import { LLM_DEFAULTS } from '../llm/defaults.js';
 import { fetchExamples } from '../llm/examples/fetcher.js';
@@ -201,13 +202,15 @@ async function processWithLLM(
     }
 
     const rawProvider = createProvider(llmConfig);
+    // Opt-in on-disk cache (innermost, so a hit skips both the provider call and the retry wrapper).
+    const baseProvider = llmConfig.cache ? withContentHashCache(rawProvider, llmConfig.model) : rawProvider;
     const retryOpts = llmConfig.retry ?? LLM_DEFAULTS.retry;
     const configOptions = llmConfig.options;
     const provider: LLMProvider = {
-      name: rawProvider.name,
-      capabilities: rawProvider.capabilities,
+      name: baseProvider.name,
+      capabilities: baseProvider.capabilities,
       complete: (messages, opts) =>
-        withRetry(() => rawProvider.complete(messages, { ...configOptions, ...opts }), retryOpts),
+        withRetry(() => baseProvider.complete(messages, { ...configOptions, ...opts }), retryOpts),
     };
 
     const activeTasks = Object.entries(tasks)

--- a/packages/notes/src/core/types.ts
+++ b/packages/notes/src/core/types.ts
@@ -170,6 +170,7 @@ export interface LLMConfig {
   };
   examples?: number;
   categoryOrder?: string[];
+  cache?: boolean;
   categories?: Array<{ name: string; description: string; scopes?: string[] }>;
   style?: string;
   scopes?: ScopeConfig;

--- a/packages/notes/src/llm/cache.ts
+++ b/packages/notes/src/llm/cache.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto';
-import * as fs from 'node:fs';
+import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import type { CompleteOptions } from '../core/types.js';
@@ -60,15 +60,15 @@ export function withContentHashCache(
       const file = path.join(dir, `${key}.json`);
 
       try {
-        return JSON.parse(fs.readFileSync(file, 'utf-8')) as CompleteResult;
+        return JSON.parse(await fs.readFile(file, 'utf-8')) as CompleteResult;
       } catch {
         // Cache miss or unreadable entry — fall through to a live call.
       }
 
       const result = await provider.complete(messages, options);
       try {
-        fs.mkdirSync(dir, { recursive: true });
-        fs.writeFileSync(file, JSON.stringify(result));
+        await fs.mkdir(dir, { recursive: true });
+        await fs.writeFile(file, JSON.stringify(result));
       } catch {
         // Caching is best-effort; a write failure must not fail the run.
       }

--- a/packages/notes/src/llm/cache.ts
+++ b/packages/notes/src/llm/cache.ts
@@ -1,0 +1,69 @@
+import { createHash } from 'node:crypto';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { CompleteOptions } from '../core/types.js';
+import type { CompleteResult, LLMMessage, LLMProvider } from './provider.js';
+
+/** On-disk cache location, under the OS temp dir — same convention as the few-shot examples fetcher. */
+function defaultCacheDir(): string {
+  return path.join(os.tmpdir(), 'releasekit', 'llm-cache');
+}
+
+/** Deterministic JSON: recursively sort object keys so equivalent inputs hash to the same key. */
+function stableStringify(value: unknown): string {
+  return JSON.stringify(value, (_key, val) =>
+    val && typeof val === 'object' && !Array.isArray(val)
+      ? Object.fromEntries(Object.entries(val as Record<string, unknown>).sort(([a], [b]) => (a < b ? -1 : 1)))
+      : val,
+  );
+}
+
+/**
+ * Wrap a provider so identical completions are served from an on-disk cache. The key covers
+ * everything that determines the output — provider, model, the full message array, temperature and
+ * maxTokens, and any structured-output schema/tool — so a changed input misses cleanly. Lets a
+ * dry-run → `--apply` backfill (or a retried run) reuse prior generations instead of paying the LLM
+ * again. Best-effort: any read/parse/write failure falls back to a live call.
+ */
+export function withContentHashCache(
+  provider: LLMProvider,
+  model: string,
+  dir: string = defaultCacheDir(),
+): LLMProvider {
+  return {
+    name: provider.name,
+    capabilities: provider.capabilities,
+    async complete(messages: LLMMessage[], options?: CompleteOptions): Promise<CompleteResult> {
+      const key = createHash('sha256')
+        .update(
+          stableStringify({
+            provider: provider.name,
+            model,
+            messages,
+            temperature: options?.temperature,
+            maxTokens: options?.maxTokens,
+            schema: options?.schema,
+            toolName: options?.toolName,
+          }),
+        )
+        .digest('hex');
+      const file = path.join(dir, `${key}.json`);
+
+      try {
+        return JSON.parse(fs.readFileSync(file, 'utf-8')) as CompleteResult;
+      } catch {
+        // Cache miss or unreadable entry — fall through to a live call.
+      }
+
+      const result = await provider.complete(messages, options);
+      try {
+        fs.mkdirSync(dir, { recursive: true });
+        fs.writeFileSync(file, JSON.stringify(result));
+      } catch {
+        // Caching is best-effort; a write failure must not fail the run.
+      }
+      return result;
+    },
+  };
+}

--- a/packages/notes/src/llm/cache.ts
+++ b/packages/notes/src/llm/cache.ts
@@ -19,16 +19,24 @@ function stableStringify(value: unknown): string {
   );
 }
 
+/** Identity of the model endpoint — distinct values must never share cached responses. */
+export interface CacheIdentity {
+  model: string;
+  /** Custom endpoint (openai-compatible / ollama). Two servers with the same model name and prompt
+   *  would otherwise collide and serve each other's responses, so it's part of the key. */
+  baseURL?: string;
+}
+
 /**
  * Wrap a provider so identical completions are served from an on-disk cache. The key covers
- * everything that determines the output — provider, model, the full message array, temperature and
- * maxTokens, and any structured-output schema/tool — so a changed input misses cleanly. Lets a
- * dry-run → `--apply` backfill (or a retried run) reuse prior generations instead of paying the LLM
- * again. Best-effort: any read/parse/write failure falls back to a live call.
+ * everything that determines the output — provider, model, baseURL, the full message array,
+ * temperature and maxTokens, and any structured-output schema/tool — so a changed input misses
+ * cleanly. Lets a dry-run → `--apply` backfill (or a retried run) reuse prior generations instead of
+ * paying the LLM again. Best-effort: any read/parse/write failure falls back to a live call.
  */
 export function withContentHashCache(
   provider: LLMProvider,
-  model: string,
+  identity: CacheIdentity,
   dir: string = defaultCacheDir(),
 ): LLMProvider {
   return {
@@ -39,7 +47,8 @@ export function withContentHashCache(
         .update(
           stableStringify({
             provider: provider.name,
-            model,
+            model: identity.model,
+            baseURL: identity.baseURL,
             messages,
             temperature: options?.temperature,
             maxTokens: options?.maxTokens,

--- a/packages/notes/test/unit/llm/cache.spec.ts
+++ b/packages/notes/test/unit/llm/cache.spec.ts
@@ -1,0 +1,103 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { withContentHashCache } from '../../../src/llm/cache.js';
+import type { CompleteResult, LLMMessage, LLMProvider } from '../../../src/llm/provider.js';
+
+function mockProvider(responder: (messages: LLMMessage[]) => string): LLMProvider & { calls: number } {
+  let calls = 0;
+  return {
+    name: 'mock',
+    capabilities: { systemRole: true, structuredOutputs: false, toolUse: false },
+    get calls() {
+      return calls;
+    },
+    async complete(messages: LLMMessage[]): Promise<CompleteResult> {
+      calls += 1;
+      return { content: responder(messages) };
+    },
+  };
+}
+
+describe('withContentHashCache', () => {
+  const dirs: string[] = [];
+  const freshDir = () => {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'rk-llm-cache-'));
+    dirs.push(d);
+    return d;
+  };
+
+  afterEach(() => {
+    for (const d of dirs) fs.rmSync(d, { recursive: true, force: true });
+    dirs.length = 0;
+  });
+
+  const msgs: LLMMessage[] = [{ role: 'user', content: 'hi' }];
+
+  it('should call the provider once and serve identical requests from cache', async () => {
+    const dir = freshDir();
+    const provider = mockProvider(() => 'response-A');
+    const cached = withContentHashCache(provider, 'model-x', dir);
+
+    const first = await cached.complete(msgs);
+    const second = await cached.complete(msgs);
+
+    expect(first).toEqual({ content: 'response-A' });
+    expect(second).toEqual({ content: 'response-A' });
+    expect(provider.calls).toBe(1);
+  });
+
+  it('should miss when the messages change', async () => {
+    const dir = freshDir();
+    const provider = mockProvider((m) => `echo:${m[0]?.content}`);
+    const cached = withContentHashCache(provider, 'model-x', dir);
+
+    await cached.complete([{ role: 'user', content: 'one' }]);
+    await cached.complete([{ role: 'user', content: 'two' }]);
+
+    expect(provider.calls).toBe(2);
+  });
+
+  it('should miss when the model, temperature, or schema changes', async () => {
+    const dir = freshDir();
+    const provider = mockProvider(() => 'r');
+
+    await withContentHashCache(provider, 'model-x', dir).complete(msgs);
+    await withContentHashCache(provider, 'model-y', dir).complete(msgs); // different model
+    await withContentHashCache(provider, 'model-x', dir).complete(msgs, { temperature: 0.1 }); // different temp
+    await withContentHashCache(provider, 'model-x', dir).complete(msgs, { schema: { type: 'object' } }); // different schema
+
+    expect(provider.calls).toBe(4);
+  });
+
+  it('should hash message order, not just contents', async () => {
+    const dir = freshDir();
+    const provider = mockProvider(() => 'r');
+    const cached = withContentHashCache(provider, 'model-x', dir);
+
+    await cached.complete([
+      { role: 'system', content: 'a' },
+      { role: 'user', content: 'b' },
+    ]);
+    await cached.complete([
+      { role: 'user', content: 'b' },
+      { role: 'system', content: 'a' },
+    ]);
+
+    expect(provider.calls).toBe(2);
+  });
+
+  it('should fall back to a live call when the cache location is unwritable', async () => {
+    const dir = freshDir();
+    // Point the cache at a regular file so mkdir/read/write all fail; the completion still succeeds.
+    const asFile = path.join(dir, 'not-a-dir');
+    fs.writeFileSync(asFile, 'x');
+    const provider = mockProvider(() => 'r');
+
+    const result = await withContentHashCache(provider, 'model-x', asFile).complete(msgs);
+
+    expect(result).toEqual({ content: 'r' });
+    expect(provider.calls).toBe(1);
+  });
+});

--- a/packages/notes/test/unit/llm/cache.spec.ts
+++ b/packages/notes/test/unit/llm/cache.spec.ts
@@ -38,7 +38,7 @@ describe('withContentHashCache', () => {
   it('should call the provider once and serve identical requests from cache', async () => {
     const dir = freshDir();
     const provider = mockProvider(() => 'response-A');
-    const cached = withContentHashCache(provider, 'model-x', dir);
+    const cached = withContentHashCache(provider, { model: 'model-x' }, dir);
 
     const first = await cached.complete(msgs);
     const second = await cached.complete(msgs);
@@ -51,7 +51,7 @@ describe('withContentHashCache', () => {
   it('should miss when the messages change', async () => {
     const dir = freshDir();
     const provider = mockProvider((m) => `echo:${m[0]?.content}`);
-    const cached = withContentHashCache(provider, 'model-x', dir);
+    const cached = withContentHashCache(provider, { model: 'model-x' }, dir);
 
     await cached.complete([{ role: 'user', content: 'one' }]);
     await cached.complete([{ role: 'user', content: 'two' }]);
@@ -59,22 +59,25 @@ describe('withContentHashCache', () => {
     expect(provider.calls).toBe(2);
   });
 
-  it('should miss when the model, temperature, or schema changes', async () => {
+  it('should miss when the model, baseURL, temperature, or schema changes', async () => {
     const dir = freshDir();
     const provider = mockProvider(() => 'r');
 
-    await withContentHashCache(provider, 'model-x', dir).complete(msgs);
-    await withContentHashCache(provider, 'model-y', dir).complete(msgs); // different model
-    await withContentHashCache(provider, 'model-x', dir).complete(msgs, { temperature: 0.1 }); // different temp
-    await withContentHashCache(provider, 'model-x', dir).complete(msgs, { schema: { type: 'object' } }); // different schema
+    await withContentHashCache(provider, { model: 'model-x' }, dir).complete(msgs);
+    await withContentHashCache(provider, { model: 'model-y' }, dir).complete(msgs); // different model
+    // Same provider name + model + prompt but a different endpoint must not collide (e.g. Groq vs Together).
+    await withContentHashCache(provider, { model: 'model-x', baseURL: 'https://a.example' }, dir).complete(msgs);
+    await withContentHashCache(provider, { model: 'model-x', baseURL: 'https://b.example' }, dir).complete(msgs);
+    await withContentHashCache(provider, { model: 'model-x' }, dir).complete(msgs, { temperature: 0.1 }); // different temp
+    await withContentHashCache(provider, { model: 'model-x' }, dir).complete(msgs, { schema: { type: 'object' } }); // different schema
 
-    expect(provider.calls).toBe(4);
+    expect(provider.calls).toBe(6);
   });
 
   it('should hash message order, not just contents', async () => {
     const dir = freshDir();
     const provider = mockProvider(() => 'r');
-    const cached = withContentHashCache(provider, 'model-x', dir);
+    const cached = withContentHashCache(provider, { model: 'model-x' }, dir);
 
     await cached.complete([
       { role: 'system', content: 'a' },
@@ -95,7 +98,7 @@ describe('withContentHashCache', () => {
     fs.writeFileSync(asFile, 'x');
     const provider = mockProvider(() => 'r');
 
-    const result = await withContentHashCache(provider, 'model-x', asFile).complete(msgs);
+    const result = await withContentHashCache(provider, { model: 'model-x' }, asFile).complete(msgs);
 
     expect(result).toEqual({ content: 'r' });
     expect(provider.calls).toBe(1);

--- a/releasekit.schema.json
+++ b/releasekit.schema.json
@@ -954,6 +954,11 @@
                         "type": "string"
                       },
                       "description": "Explicit ordering of categories in the output. Categories not listed retain their configured order after the listed ones."
+                    },
+                    "cache": {
+                      "type": "boolean",
+                      "default": false,
+                      "description": "Cache LLM responses on disk (under the OS temp dir), keyed by a hash of the provider, model, prompt, and request options. A re-run or backfill with the same inputs reuses the cached generation instead of re-calling the provider. Off by default."
                     }
                   },
                   "required": [


### PR DESCRIPTION
## Summary

Adds an opt-in on-disk **LLM response cache** so a re-run — or a dry-run → `--apply` backfill — reuses prior generations instead of re-calling (and re-paying for) the provider. The last of the `#293` backfill follow-ups, but it's a general notes feature.

- New config field **`notes.releaseNotes.llm.cache`** (default `false`).
- **`withContentHashCache(provider, model)`** wraps the single chokepoint — `LLMProvider.complete()` — so it covers every task (enhance, categorize, summarize, releaseNotes) without touching the task functions, and faithfully **replays corrective-retry sequences** from cache.
- Applied in `pipeline.ts` *innermost* (a hit skips both the provider call and the retry wrapper):
  ```js
  const baseProvider = llmConfig.cache ? withContentHashCache(rawProvider, llmConfig.model) : rawProvider;
  ```
- **Cache key** = SHA-256 of `{ provider, model, messages, temperature, maxTokens, schema, toolName }` (deterministic key-sorted JSON) — everything that determines the output, so a changed input misses cleanly.
- **Storage:** `os.tmpdir()/releasekit/llm-cache/<hash>.json` — same convention as the few-shot examples fetcher. **Best-effort:** any read/parse/write failure falls back to a live call.

## Testing

- Unit tests (`cache.spec.ts`): provider called **once** then served from cache; misses on changed messages / model / temperature / schema; **message-order sensitivity**; and the unwritable-dir fallback (completion still succeeds). Uses isolated temp dirs.
- Regenerated `releasekit.schema.json` + `docs/configuration.md` (`schema:gen` / `docs:config`); `schema:check` passes.
- **notes 350 + config 205 tests pass**, typecheck + lint clean.

## Notes

- Off by default — enabling it makes notes generation reproducible for identical inputs (the same cached generation is reused). Clear `…/releasekit/llm-cache` to purge.
- I left the backfill follow-up list in `docs/cli.md` untouched to avoid conflicting with #311 (which also edits that line); the feature is documented via the generated config reference.

Refs #293 — this completes the enumerated follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds an opt-in on-disk LLM response cache (`notes.releaseNotes.llm.cache`, default `false`) so repeated runs with identical inputs reuse prior generations instead of re-calling the provider. The two issues flagged in the previous review round — missing `baseURL` in the cache key and synchronous disk I/O — are both addressed in this revision.

- **`cache.ts`**: `withContentHashCache` wraps `LLMProvider.complete()` at the innermost layer. Cache key is a SHA-256 of stable-serialised `{ provider, model, baseURL, messages, temperature, maxTokens, schema, toolName }`. All disk I/O uses `fs.promises`.
- **`pipeline.ts`**: Cache is applied between `rawProvider` and `withRetry`. `baseURL` is threaded through from `llmConfig` into the `CacheIdentity`.
- **`cache.spec.ts`**: Covers hit/miss on messages, model, baseURL, temperature, schema, message order, and unwritable-dir fallback.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the cache is opt-in, off by default, and all disk I/O is best-effort so a failure never breaks a run.

The implementation touches only the innermost provider layer, leaves retry and task logic untouched, and has no impact unless cache: true is set. Both issues from the prior review round are resolved. All CompleteOptions fields that affect LLM output are in the cache key; the omitted timeout field correctly has no bearing on response content. Unit tests cover every key dimension and unwritable-directory fallback.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/notes/src/llm/cache.ts | New file implementing the LLM response cache. Uses fs.promises for all I/O, includes baseURL in the cache identity, and correctly uses stableStringify for deterministic hashing. Best-effort error handling is in place. |
| packages/notes/src/core/pipeline.ts | Cache is inserted between rawProvider and withRetry; a cache hit bypasses both the live call and retry overhead. baseURL is correctly forwarded into CacheIdentity. |
| packages/notes/test/unit/llm/cache.spec.ts | Comprehensive unit tests covering hit, miss on all key dimensions (model, baseURL, temperature, schema, message order), and fallback on an unwritable cache directory. |
| packages/config/src/schema.ts | Adds the cache boolean field to LLMConfigSchema with default false; consistent with types.ts and generated JSON schema. |
| packages/notes/src/core/types.ts | Adds optional cache?: boolean to LLMConfig interface, consistent with schema and pipeline usage. |
| docs/configuration.md | Documents the new cache field with its default, storage location, and key composition. |
| releasekit.schema.json | Generated JSON schema updated with cache boolean field and description, consistent with schema.ts. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Task as LLM Task
    participant Retry as withRetry wrapper
    participant Cache as withContentHashCache
    participant Provider as rawProvider
    participant Disk as OS temp dir llm-cache

    Task->>Retry: complete(messages, opts)
    Retry->>Cache: complete(messages, mergedOpts)
    Cache->>Cache: SHA-256(provider+model+baseURL+messages+opts)
    Cache->>Disk: readFile(hash.json)
    alt Cache HIT
        Disk-->>Cache: cached CompleteResult
        Cache-->>Retry: return result
        Retry-->>Task: return result
    else Cache MISS
        Disk-->>Cache: ENOENT or parse error
        Cache->>Provider: complete(messages, mergedOpts)
        Provider-->>Cache: CompleteResult
        Cache->>Disk: mkdir + writeFile(hash.json) best-effort
        Cache-->>Retry: return result
        Retry-->>Task: return result
    end
```
</details>

<sub>Reviews (3): Last reviewed commit: ["refactor(notes): use async fs in the LLM..."](https://github.com/goosewobbler/releasekit/commit/9dc040f546fb149b487e78989d76f65793377c13) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37629273)</sub>

<!-- /greptile_comment -->