### PR TITLE
feat(release): add --force flag for hand-edited release body protection

### DIFF
--- a/packages/release/src/backfill/github-release.ts
+++ b/packages/release/src/backfill/github-release.ts
@@ -7,19 +7,28 @@ import { execFileSync } from 'node:child_process';
  */
 export const NOTES_MARKER = '<!-- releasekit-notes -->';
 
-export type UpdateDecision = { action: 'update' } | { action: 'skip'; reason: 'no-release' | 'already-backfilled' };
+export type UpdateDecision =
+  | { action: 'update' }
+  | { action: 'skip'; reason: 'no-release' | 'already-backfilled' | 'hand-edited' };
 
 /**
  * Decide whether to (re)write a release body during backfill.
  *
  * - No release exists for the tag (`existingBody === null`) → skip; backfill edits, it doesn't create.
  * - `--only-missing` and the body already carries our marker → skip; we've backfilled it before.
- * - Otherwise update. An unmarked body (empty, GitHub auto-generated, or pre-releasekit hand-written)
- *   is treated as a gap to fill; the default (non-`--only-missing`) run also refreshes marked bodies.
+ * - Default mode + non-empty body without marker + not `--force` → skip; suspected hand-edit.
+ * - Otherwise update. An empty body or one carrying our marker is safe to overwrite.
  */
-export function decideReleaseUpdate(existingBody: string | null, onlyMissing: boolean): UpdateDecision {
+export function decideReleaseUpdate(
+  existingBody: string | null,
+  onlyMissing: boolean,
+  force: boolean = false,
+): UpdateDecision {
   if (existingBody === null) return { action: 'skip', reason: 'no-release' };
   if (onlyMissing && existingBody.includes(NOTES_MARKER)) return { action: 'skip', reason: 'already-backfilled' };
+  if (!force && !onlyMissing && existingBody.trim() && !existingBody.includes(NOTES_MARKER)) {
+    return { action: 'skip', reason: 'hand-edited' };
+  }
   return { action: 'update' };
 }
 

--- a/packages/release/src/commands/backfill-command.ts
+++ b/packages/release/src/commands/backfill-command.ts
@@ -55,6 +55,7 @@ export function createBackfillCommand(): Command {
     .option('--to <version>', 'Latest version to backfill (inclusive)')
     .option('--update-releases', 'Update matching GitHub release bodies via `gh release edit`', false)
     .option('--only-missing', 'With --update-releases, skip releases already carrying releasekit notes', false)
+    .option('--force', 'Overwrite hand-edited release bodies (use with --update-releases)', false)
     .option('--apply', 'Apply changes (default: dry-run preview)', false)
     .option('-c, --config <path>', 'Config file path')
     .action(async (options) => {
@@ -103,9 +104,14 @@ export function createBackfillCommand(): Command {
         error('--only-missing only applies with --update-releases.');
         process.exit(EXIT_CODES.GENERAL_ERROR);
       }
+      if (options.force && !updateReleases) {
+        error('--force only applies with --update-releases.');
+        process.exit(EXIT_CODES.GENERAL_ERROR);
+      }
 
       const versionConfig = loadVersionConfig({ cwd, configPath: options.config });
       const dryRun = !options.apply;
+      const force = options.force === true;
 
       const targets = await resolveTargets(options, cwd, versionConfig);
 
@@ -182,6 +188,7 @@ export function createBackfillCommand(): Command {
           let updated = 0;
           let skippedNoRelease = 0;
           let skippedExisting = 0;
+          let skippedHandEdited = 0;
           for (let i = 0; i < reconstructed.length; i++) {
             const tag = reconstructed[i]?.tag;
             const body = renderedBodies[i];
@@ -190,14 +197,18 @@ export function createBackfillCommand(): Command {
               warn(`  ${tag}: no notes rendered, skipping release update`);
               continue;
             }
-            const decision = decideReleaseUpdate(getReleaseBody(tag), onlyMissing);
+            const existingBody = getReleaseBody(tag);
+            const decision = decideReleaseUpdate(existingBody, onlyMissing, force);
             if (decision.action === 'skip') {
               if (decision.reason === 'no-release') {
                 warn(`  ${tag}: no GitHub release found, skipping`);
                 skippedNoRelease++;
-              } else {
+              } else if (decision.reason === 'already-backfilled') {
                 info(`  ${tag}: already has releasekit notes, skipping`);
                 skippedExisting++;
+              } else if (decision.reason === 'hand-edited') {
+                info(`  ${tag}: hand-edited release body (use --force to overwrite), skipping`);
+                skippedHandEdited++;
               }
               continue;
             }
@@ -211,7 +222,8 @@ export function createBackfillCommand(): Command {
           }
           const skips = [
             skippedNoRelease > 0 ? `${skippedNoRelease} without a release` : null,
-            skippedExisting > 0 ? `${skippedExisting} already done` : null,
+            skippedExisting > 0 ? `${skippedExisting} already backfilled` : null,
+            skippedHandEdited > 0 ? `${skippedHandEdited} hand-edited` : null,
           ].filter(Boolean);
           const suffix = skips.length > 0 ? ` (skipped ${skips.join(', ')})` : '';
           if (dryRun) {

--- a/packages/release/test/unit/backfill/github-release.spec.ts
+++ b/packages/release/test/unit/backfill/github-release.spec.ts
@@ -28,6 +28,29 @@ describe('decideReleaseUpdate', () => {
     // Default (force-refresh) run rewrites even bodies we authored before.
     expect(decideReleaseUpdate(marked, false)).toEqual({ action: 'update' });
   });
+
+  it('should skip hand-edited (non-empty, unmarked) bodies in default mode', () => {
+    const handEdited = 'My custom notes about this release';
+    expect(decideReleaseUpdate(handEdited, false, false)).toEqual({
+      action: 'skip',
+      reason: 'hand-edited',
+    });
+  });
+
+  it('should not skip hand-edited bodies when --force is passed', () => {
+    const handEdited = 'My custom notes about this release';
+    expect(decideReleaseUpdate(handEdited, false, true)).toEqual({ action: 'update' });
+  });
+
+  it('should not skip hand-edited bodies under --only-missing even without --force', () => {
+    const handEdited = 'My custom notes about this release';
+    expect(decideReleaseUpdate(handEdited, true, false)).toEqual({ action: 'update' });
+  });
+
+  it('should treat whitespace-only bodies as empty', () => {
+    expect(decideReleaseUpdate('   ', false, false)).toEqual({ action: 'update' });
+    expect(decideReleaseUpdate('\n\n', false, false)).toEqual({ action: 'update' });
+  });
 });
 
 describe('withMarker', () => {

--- a/packages/release/test/unit/backfill/github-release.spec.ts
+++ b/packages/release/test/unit/backfill/github-release.spec.ts
@@ -15,10 +15,11 @@ describe('decideReleaseUpdate', () => {
     expect(decideReleaseUpdate(null, true)).toEqual({ action: 'skip', reason: 'no-release' });
   });
 
-  it('should update an unmarked body regardless of --only-missing', () => {
-    // Empty, GitHub auto-generated, and pre-releasekit hand-written bodies all count as gaps.
+  it('should update empty or already-marked bodies in default mode, and non-empty bodies under --only-missing', () => {
+    // Empty bodies are always treated as gaps.
     expect(decideReleaseUpdate('', false)).toEqual({ action: 'update' });
     expect(decideReleaseUpdate('', true)).toEqual({ action: 'update' });
+    // Under --only-missing, non-empty unmarked bodies are still updated (they haven't been backfilled yet).
     expect(decideReleaseUpdate('## What changed\n- auto stuff', true)).toEqual({ action: 'update' });
   });
 


### PR DESCRIPTION
## Summary

Add `--force` flag to backfill command to prevent accidentally clobbering hand-edited release bodies. By default, non-empty release bodies without the releasekit marker are skipped (suspected hand-edits). Use `--force` to override this protection.

## Changes

- Add `force` parameter to `decideReleaseUpdate()` function
- New skip reason: `hand-edited` for non-empty unmarked bodies
- CLI flag `--force` to override protection
- Clear per-tag feedback when hand-edited bodies are skipped

## Test plan

- [x] All unit tests pass (new tests for hand-edited body detection)
- [x] Backfill with hand-edited body body is skipped by default
- [x] Backfill with --force overwrites hand-edited bodies

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces a `--force` flag for the `backfill` command that protects non-empty, unmarked release bodies (suspected hand-edits) from being accidentally overwritten. Without `--force`, default mode now skips those bodies and emits a clear per-tag message; `--force` opts out of that protection.

- **`decideReleaseUpdate`** gains a `force` parameter (default `false`) and a new `'hand-edited'` skip reason, gated by `!force && !onlyMissing && existingBody.trim() && !existingBody.includes(NOTES_MARKER)`.
- **`backfill-command.ts`** adds the `--force` CLI flag, validates it requires `--update-releases`, threads `force` into the decision call, and tracks a `skippedHandEdited` counter in the final summary line.
- **Tests** cover hand-edited detection, `--force` override, the `--only-missing` bypass, and whitespace-only body edge cases.
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge — the hand-edited guard is a purely additive default-mode protection with no changes to existing behaviour under --only-missing or --force.

The three-branch decision function is straightforward and all new paths are covered by unit tests. CLI validation correctly rejects --force without --update-releases. No data is written or deleted on the new skip path, so the worst case of a logic error is a release body being skipped that shouldn't be, which is recoverable with --force.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/release/src/backfill/github-release.ts | Adds `force` parameter to `decideReleaseUpdate` with a new `hand-edited` skip reason; logic is correct and handles all flag combinations cleanly. |
| packages/release/src/commands/backfill-command.ts | Adds `--force` CLI option with guard validation, wires it through to `decideReleaseUpdate`, and tracks/reports `skippedHandEdited` in the summary line. |
| packages/release/test/unit/backfill/github-release.spec.ts | Four new unit tests cover hand-edited detection, `--force` override, `--only-missing` bypass, and whitespace-only bodies; coverage is thorough. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([existingBody]) --> B{existingBody === null?}
    B -- yes --> C[skip: no-release]
    B -- no --> D{onlyMissing AND\nbody has marker?}
    D -- yes --> E[skip: already-backfilled]
    D -- no --> F{NOT force AND\nNOT onlyMissing AND\nbody.trim non-empty AND\nbody has no marker?}
    F -- yes --> G[skip: hand-edited]
    F -- no --> H[update]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A([existingBody]) --> B{existingBody === null?}
    B -- yes --> C[skip: no-release]
    B -- no --> D{onlyMissing AND\nbody has marker?}
    D -- yes --> E[skip: already-backfilled]
    D -- no --> F{NOT force AND\nNOT onlyMissing AND\nbody.trim non-empty AND\nbody has no marker?}
    F -- yes --> G[skip: hand-edited]
    F -- no --> H[update]
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/release/test/unit/backfill/github-release.spec.ts`, line 18-23 ([link](https://github.com/goosewobbler/releasekit/blob/026f25b1237823ae466ecb10752a2e4b95599503/packages/release/test/unit/backfill/github-release.spec.ts#L18-L23)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The comment "pre-releasekit hand-written bodies all count as gaps" was true before this PR but is now only accurate under `--only-missing`. In default mode, non-empty unmarked bodies are now protected as hand-edited. Updating the comment and test name keeps the test suite self-documenting.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Frelease%2Ftest%2Funit%2Fbackfill%2Fgithub-release.spec.ts%0ALine%3A%2018-23%0A%0AComment%3A%0AThe%20comment%20%22pre-releasekit%20hand-written%20bodies%20all%20count%20as%20gaps%22%20was%20true%20before%20this%20PR%20but%20is%20now%20only%20accurate%20under%20%60--only-missing%60.%20In%20default%20mode%2C%20non-empty%20unmarked%20bodies%20are%20now%20protected%20as%20hand-edited.%20Updating%20the%20comment%20and%20test%20name%20keeps%20the%20test%20suite%20self-documenting.%0A%0A%60%60%60suggestion%0A%20%20it%28'should%20update%20an%20unmarked%20body%20under%20--only-missing'%2C%20%28%29%20%3D%3E%20%7B%0A%20%20%20%20%2F%2F%20Under%20--only-missing%2C%20anything%20without%20the%20marker%20is%20considered%20%22missing%22%20and%20gets%20updated%2C%0A%20%20%20%20%2F%2F%20including%20hand-edited%20bodies.%20The%20hand-edited%20guard%20only%20applies%20in%20default%20%28non-only-missing%29%20mode.%0A%20%20%20%20expect%28decideReleaseUpdate%28''%2C%20false%29%29.toEqual%28%7B%20action%3A%20'update'%20%7D%29%3B%0A%20%20%20%20expect%28decideReleaseUpdate%28''%2C%20true%29%29.toEqual%28%7B%20action%3A%20'update'%20%7D%29%3B%0A%20%20%20%20expect%28decideReleaseUpdate%28'%23%23%20What%20changed%5Cn-%20auto%20stuff'%2C%20true%29%29.toEqual%28%7B%20action%3A%20'update'%20%7D%29%3B%0A%20%20%7D%29%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=goosewobbler%2Freleasekit&pr=315&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Frelease%2Ftest%2Funit%2Fbackfill%2Fgithub-release.spec.ts%0ALine%3A%2018-23%0A%0AComment%3A%0AThe%20comment%20%22pre-releasekit%20hand-written%20bodies%20all%20count%20as%20gaps%22%20was%20true%20before%20this%20PR%20but%20is%20now%20only%20accurate%20under%20%60--only-missing%60.%20In%20default%20mode%2C%20non-empty%20unmarked%20bodies%20are%20now%20protected%20as%20hand-edited.%20Updating%20the%20comment%20and%20test%20name%20keeps%20the%20test%20suite%20self-documenting.%0A%0A%60%60%60suggestion%0A%20%20it%28'should%20update%20an%20unmarked%20body%20under%20--only-missing'%2C%20%28%29%20%3D%3E%20%7B%0A%20%20%20%20%2F%2F%20Under%20--only-missing%2C%20anything%20without%20the%20marker%20is%20considered%20%22missing%22%20and%20gets%20updated%2C%0A%20%20%20%20%2F%2F%20including%20hand-edited%20bodies.%20The%20hand-edited%20guard%20only%20applies%20in%20default%20%28non-only-missing%29%20mode.%0A%20%20%20%20expect%28decideReleaseUpdate%28''%2C%20false%29%29.toEqual%28%7B%20action%3A%20'update'%20%7D%29%3B%0A%20%20%20%20expect%28decideReleaseUpdate%28''%2C%20true%29%29.toEqual%28%7B%20action%3A%20'update'%20%7D%29%3B%0A%20%20%20%20expect%28decideReleaseUpdate%28'%23%23%20What%20changed%5Cn-%20auto%20stuff'%2C%20true%29%29.toEqual%28%7B%20action%3A%20'update'%20%7D%29%3B%0A%20%20%7D%29%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=315&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix(release): update stale test comment ..."](https://github.com/goosewobbler/releasekit/commit/1d5f10f52cb1c852110cc78fe6112c307e5735f0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37749061)</sub>

<!-- /greptile_comment -->