### PR TITLE
feat(release): add cost estimation and --no-llm flag

### DIFF
--- a/packages/release/src/backfill/github-release.ts
+++ b/packages/release/src/backfill/github-release.ts
@@ -7,19 +7,28 @@ import { execFileSync } from 'node:child_process';
  */
 export const NOTES_MARKER = '<!-- releasekit-notes -->';
 
-export type UpdateDecision = { action: 'update' } | { action: 'skip'; reason: 'no-release' | 'already-backfilled' };
+export type UpdateDecision =
+  | { action: 'update' }
+  | { action: 'skip'; reason: 'no-release' | 'already-backfilled' | 'hand-edited' };
 
 /**
  * Decide whether to (re)write a release body during backfill.
  *
  * - No release exists for the tag (`existingBody === null`) → skip; backfill edits, it doesn't create.
  * - `--only-missing` and the body already carries our marker → skip; we've backfilled it before.
- * - Otherwise update. An unmarked body (empty, GitHub auto-generated, or pre-releasekit hand-written)
- *   is treated as a gap to fill; the default (non-`--only-missing`) run also refreshes marked bodies.
+ * - Default mode + non-empty body without marker + not `--force` → skip; suspected hand-edit.
+ * - Otherwise update. An empty body or one carrying our marker is safe to overwrite.
  */
-export function decideReleaseUpdate(existingBody: string | null, onlyMissing: boolean): UpdateDecision {
+export function decideReleaseUpdate(
+  existingBody: string | null,
+  onlyMissing: boolean,
+  force: boolean = false,
+): UpdateDecision {
   if (existingBody === null) return { action: 'skip', reason: 'no-release' };
   if (onlyMissing && existingBody.includes(NOTES_MARKER)) return { action: 'skip', reason: 'already-backfilled' };
+  if (!force && !onlyMissing && existingBody.trim() && !existingBody.includes(NOTES_MARKER)) {
+    return { action: 'skip', reason: 'hand-edited' };
+  }
   return { action: 'update' };
 }
 

--- a/packages/release/src/commands/backfill-command.ts
+++ b/packages/release/src/commands/backfill-command.ts
@@ -55,6 +55,7 @@ export function createBackfillCommand(): Command {
     .option('--to <version>', 'Latest version to backfill (inclusive)')
     .option('--update-releases', 'Update matching GitHub release bodies via `gh release edit`', false)
     .option('--only-missing', 'With --update-releases, skip releases already carrying releasekit notes', false)
+    .option('--force', 'Overwrite hand-edited release bodies (use with --update-releases)', false)
     .option('--apply', 'Apply changes (default: dry-run preview)', false)
     .option('-c, --config <path>', 'Config file path')
     .action(async (options) => {
@@ -103,9 +104,14 @@ export function createBackfillCommand(): Command {
         error('--only-missing only applies with --update-releases.');
         process.exit(EXIT_CODES.GENERAL_ERROR);
       }
+      if (options.force && !updateReleases) {
+        error('--force only applies with --update-releases.');
+        process.exit(EXIT_CODES.GENERAL_ERROR);
+      }
 
       const versionConfig = loadVersionConfig({ cwd, configPath: options.config });
       const dryRun = !options.apply;
+      const force = options.force === true;
 
       const targets = await resolveTargets(options, cwd, versionConfig);
 
@@ -182,6 +188,7 @@ export function createBackfillCommand(): Command {
           let updated = 0;
           let skippedNoRelease = 0;
           let skippedExisting = 0;
+          let skippedHandEdited = 0;
           for (let i = 0; i < reconstructed.length; i++) {
             const tag = reconstructed[i]?.tag;
             const body = renderedBodies[i];
@@ -190,14 +197,18 @@ export function createBackfillCommand(): Command {
               warn(`  ${tag}: no notes rendered, skipping release update`);
               continue;
             }
-            const decision = decideReleaseUpdate(getReleaseBody(tag), onlyMissing);
+            const existingBody = getReleaseBody(tag);
+            const decision = decideReleaseUpdate(existingBody, onlyMissing, force);
             if (decision.action === 'skip') {
               if (decision.reason === 'no-release') {
                 warn(`  ${tag}: no GitHub release found, skipping`);
                 skippedNoRelease++;
-              } else {
+              } else if (decision.reason === 'already-backfilled') {
                 info(`  ${tag}: already has releasekit notes, skipping`);
                 skippedExisting++;
+              } else if (decision.reason === 'hand-edited') {
+                info(`  ${tag}: hand-edited release body (use --force to overwrite), skipping`);
+                skippedHandEdited++;
               }
               continue;
             }
@@ -211,7 +222,8 @@ export function createBackfillCommand(): Command {
           }
           const skips = [
             skippedNoRelease > 0 ? `${skippedNoRelease} without a release` : null,
-            skippedExisting > 0 ? `${skippedExisting} already done` : null,
+            skippedExisting > 0 ? `${skippedExisting} already backfilled` : null,
+            skippedHandEdited > 0 ? `${skippedHandEdited} hand-edited` : null,
           ].filter(Boolean);
           const suffix = skips.length > 0 ? ` (skipped ${skips.join(', ')})` : '';
           if (dryRun) {

--- a/packages/release/src/commands/backfill-command.ts
+++ b/packages/release/src/commands/backfill-command.ts
@@ -56,6 +56,7 @@ export function createBackfillCommand(): Command {
     .option('--update-releases', 'Update matching GitHub release bodies via `gh release edit`', false)
     .option('--only-missing', 'With --update-releases, skip releases already carrying releasekit notes', false)
     .option('--force', 'Overwrite hand-edited release bodies (use with --update-releases)', false)
+    .option('--no-llm', 'Disable LLM (use deterministic, zero-cost backfill)', false)
     .option('--apply', 'Apply changes (default: dry-run preview)', false)
     .option('-c, --config <path>', 'Config file path')
     .action(async (options) => {
@@ -112,9 +113,17 @@ export function createBackfillCommand(): Command {
       const versionConfig = loadVersionConfig({ cwd, configPath: options.config });
       const dryRun = !options.apply;
       const force = options.force === true;
+      const noLlm = options.noLlm === true;
 
       const targets = await resolveTargets(options, cwd, versionConfig);
 
+      let totalReleaseCount = 0;
+      const releasesByTarget: Array<{
+        target: BackfillTarget;
+        reconstructed: Awaited<ReturnType<typeof reconstructChangelogs>>;
+      }> = [];
+
+      // Scan all targets to count total releases and estimate cost upfront
       for (const target of targets) {
         const reconstructed = await reconstructChangelogs({
           packageName: target.packageName,
@@ -127,11 +136,30 @@ export function createBackfillCommand(): Command {
           to: options.to,
         });
 
-        if (reconstructed.length === 0) {
-          info(`No matching tags found for ${target.packageName}.`);
-          continue;
+        if (reconstructed.length > 0) {
+          totalReleaseCount += reconstructed.length;
+          releasesByTarget.push({ target, reconstructed });
         }
+      }
 
+      // Estimate and warn about LLM cost if not in --no-llm mode and LLM is enabled
+      const llmEnabled = !noLlm && notesConfig.releaseNotes?.llm;
+      if (llmEnabled && totalReleaseCount > 0 && !dryRun) {
+        const llmConfig = notesConfig.releaseNotes?.llm;
+        const enabledTasks = countEnabledLlmTasks(llmConfig?.tasks);
+        warn(
+          `Estimated cost: ~${totalReleaseCount} release(s) × ${enabledTasks} LLM task(s). ` +
+            `Use --no-llm to disable LLM (deterministic, zero-cost run).`,
+        );
+      }
+
+      // Handle case where no releases were found across all targets
+      if (releasesByTarget.length === 0) {
+        info(`No matching tags found across ${targets.length} target(s).`);
+        return;
+      }
+
+      for (const { target, reconstructed } of releasesByTarget) {
         const changelogs = reconstructed.map((r) => r.changelog);
         const versionOutput: VersionOutput = { dryRun, updates: [], changelogs, tags: [] };
         const input = versionOutputToChangelogInput(versionOutput);
@@ -145,6 +173,11 @@ export function createBackfillCommand(): Command {
           if (date && pkg) pkg.date = date;
         }
 
+        // Override LLM config if --no-llm is set
+        const adjustedNotesConfig = noLlm
+          ? { ...notesConfig, releaseNotes: { ...notesConfig.releaseNotes, llm: undefined } }
+          : notesConfig;
+
         // Render one version per pipeline call (single context each). The pipeline's nesting decision
         // (`detectMonorepo(cwd).isMonorepo || contexts.length > 1`) then matches the live release
         // pipeline, which also renders one package per run. Passing all versions at once would make
@@ -157,7 +190,7 @@ export function createBackfillCommand(): Command {
         for (const pkg of input.packages) {
           const result = await runPipeline(
             { ...input, packages: [pkg] },
-            { ...notesConfig, changelog: false },
+            { ...adjustedNotesConfig, changelog: false },
             dryRun,
             {
               skipChangelogs: true,
@@ -234,6 +267,17 @@ export function createBackfillCommand(): Command {
         }
       }
     });
+}
+
+/** Count the number of enabled LLM tasks (summarize, enhance, categorize, releaseNotes). */
+function countEnabledLlmTasks(tasks?: {
+  summarize?: boolean;
+  enhance?: boolean;
+  categorize?: boolean;
+  releaseNotes?: boolean;
+}): number {
+  if (!tasks) return 4; // All tasks enabled by default
+  return Object.values(tasks).filter(Boolean).length || 4;
 }
 
 /**

--- a/packages/release/src/commands/backfill-command.ts
+++ b/packages/release/src/commands/backfill-command.ts
@@ -139,6 +139,8 @@ export function createBackfillCommand(): Command {
         if (reconstructed.length > 0) {
           totalReleaseCount += reconstructed.length;
           releasesByTarget.push({ target, reconstructed });
+        } else if (targets.length > 1) {
+          info(`${target.packageName}: no matching tags found, skipping`);
         }
       }
 

--- a/packages/release/src/commands/backfill-command.ts
+++ b/packages/release/src/commands/backfill-command.ts
@@ -144,7 +144,7 @@ export function createBackfillCommand(): Command {
 
       // Estimate and warn about LLM cost if not in --no-llm mode and LLM is enabled
       const llmEnabled = !noLlm && notesConfig.releaseNotes?.llm;
-      if (llmEnabled && totalReleaseCount > 0 && !dryRun) {
+      if (llmEnabled && totalReleaseCount > 0) {
         const llmConfig = notesConfig.releaseNotes?.llm;
         const enabledTasks = countEnabledLlmTasks(llmConfig?.tasks);
         warn(

--- a/packages/release/src/commands/backfill-command.ts
+++ b/packages/release/src/commands/backfill-command.ts
@@ -56,7 +56,7 @@ export function createBackfillCommand(): Command {
     .option('--update-releases', 'Update matching GitHub release bodies via `gh release edit`', false)
     .option('--only-missing', 'With --update-releases, skip releases already carrying releasekit notes', false)
     .option('--force', 'Overwrite hand-edited release bodies (use with --update-releases)', false)
-    .option('--no-llm', 'Disable LLM (use deterministic, zero-cost backfill)', false)
+    .option('--no-llm', 'Disable LLM (use deterministic, zero-cost backfill)')
     .option('--apply', 'Apply changes (default: dry-run preview)', false)
     .option('-c, --config <path>', 'Config file path')
     .action(async (options) => {
@@ -113,7 +113,7 @@ export function createBackfillCommand(): Command {
       const versionConfig = loadVersionConfig({ cwd, configPath: options.config });
       const dryRun = !options.apply;
       const force = options.force === true;
-      const noLlm = options.noLlm === true;
+      const noLlm = options.llm === false;
 
       const targets = await resolveTargets(options, cwd, versionConfig);
 
@@ -277,7 +277,8 @@ function countEnabledLlmTasks(tasks?: {
   releaseNotes?: boolean;
 }): number {
   if (!tasks) return 4; // All tasks enabled by default
-  return Object.values(tasks).filter(Boolean).length || 4;
+  const allTaskKeys = ['summarize', 'enhance', 'categorize', 'releaseNotes'] as const;
+  return allTaskKeys.filter((k) => tasks[k] !== false).length;
 }
 
 /**

--- a/packages/release/test/unit/backfill/github-release.spec.ts
+++ b/packages/release/test/unit/backfill/github-release.spec.ts
@@ -19,7 +19,8 @@ describe('decideReleaseUpdate', () => {
     // Empty bodies are always treated as gaps.
     expect(decideReleaseUpdate('', false)).toEqual({ action: 'update' });
     expect(decideReleaseUpdate('', true)).toEqual({ action: 'update' });
-    // Under --only-missing, non-empty unmarked bodies are still updated (they haven't been backfilled yet).
+    // Under --only-missing, non-empty unmarked bodies are updated (they haven't been backfilled yet).
+    // In default mode, the same body would be skipped as hand-edited (see separate test).
     expect(decideReleaseUpdate('## What changed\n- auto stuff', true)).toEqual({ action: 'update' });
   });
 

--- a/packages/release/test/unit/backfill/github-release.spec.ts
+++ b/packages/release/test/unit/backfill/github-release.spec.ts
@@ -28,6 +28,29 @@ describe('decideReleaseUpdate', () => {
     // Default (force-refresh) run rewrites even bodies we authored before.
     expect(decideReleaseUpdate(marked, false)).toEqual({ action: 'update' });
   });
+
+  it('should skip hand-edited (non-empty, unmarked) bodies in default mode', () => {
+    const handEdited = 'My custom notes about this release';
+    expect(decideReleaseUpdate(handEdited, false, false)).toEqual({
+      action: 'skip',
+      reason: 'hand-edited',
+    });
+  });
+
+  it('should not skip hand-edited bodies when --force is passed', () => {
+    const handEdited = 'My custom notes about this release';
+    expect(decideReleaseUpdate(handEdited, false, true)).toEqual({ action: 'update' });
+  });
+
+  it('should not skip hand-edited bodies under --only-missing even without --force', () => {
+    const handEdited = 'My custom notes about this release';
+    expect(decideReleaseUpdate(handEdited, true, false)).toEqual({ action: 'update' });
+  });
+
+  it('should treat whitespace-only bodies as empty', () => {
+    expect(decideReleaseUpdate('   ', false, false)).toEqual({ action: 'update' });
+    expect(decideReleaseUpdate('\n\n', false, false)).toEqual({ action: 'update' });
+  });
 });
 
 describe('withMarker', () => {

--- a/packages/release/test/unit/backfill/github-release.spec.ts
+++ b/packages/release/test/unit/backfill/github-release.spec.ts
@@ -15,10 +15,11 @@ describe('decideReleaseUpdate', () => {
     expect(decideReleaseUpdate(null, true)).toEqual({ action: 'skip', reason: 'no-release' });
   });
 
-  it('should update an unmarked body regardless of --only-missing', () => {
-    // Empty, GitHub auto-generated, and pre-releasekit hand-written bodies all count as gaps.
+  it('should update empty or already-marked bodies in default mode, and non-empty bodies under --only-missing', () => {
+    // Empty bodies are always treated as gaps.
     expect(decideReleaseUpdate('', false)).toEqual({ action: 'update' });
     expect(decideReleaseUpdate('', true)).toEqual({ action: 'update' });
+    // Under --only-missing, non-empty unmarked bodies are still updated (they haven't been backfilled yet).
     expect(decideReleaseUpdate('## What changed\n- auto stuff', true)).toEqual({ action: 'update' });
   });
 


### PR DESCRIPTION
## Summary

Add upfront cost estimation for LLM-backed backfill runs to prevent surprise charges on large operations. Also add `--no-llm` flag to disable LLM for deterministic, zero-cost backfill runs.

## Changes

- Scan all targeted releases upfront to estimate cost
- Warn about ~N release(s) × M LLM task(s) before running
- `--no-llm` flag disables LLM regardless of config
- Helper function to count enabled LLM tasks

## Test plan

- [x] All unit tests pass
- [x] Cost estimate shown when LLM enabled
- [x] --no-llm disables LLM in config override
- [x] No cost estimate in --no-llm mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds upfront LLM cost estimation and a `--no-llm` flag to the `backfill` command by refactoring the single-pass loop into a two-pass scan (collect all releases, then warn, then process).

- **Two-pass scanning**: all targets are enumerated first to compute `totalReleaseCount`, then a cost warning is emitted (`~N release(s) × M LLM task(s)`) when LLM is enabled.
- **`--no-llm` flag**: uses Commander.js negatable boolean pattern (no explicit default) so `options.llm === false` correctly detects the flag; `adjustedNotesConfig` nulls out `llm` for the pipeline calls.
- **`countEnabledLlmTasks`**: counts only keys not explicitly set to `false`, correctly defaulting to 4 when the `tasks` object is absent or empty.
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge — the two-pass refactor is well-contained and the Commander.js negatable-boolean pattern is used correctly.

The Commander.js --no-llm negatable option (no third argument) correctly sets options.llm to false when the flag is passed, and countEnabledLlmTasks uses !== false to distinguish explicitly-disabled tasks from unset ones. No functional regressions were found.

No files require special attention; the logic in backfill-command.ts is correct as written.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/release/src/commands/backfill-command.ts | Adds two-pass scanning for cost estimation and --no-llm flag; Commander.js negatable option and countEnabledLlmTasks logic both look correct, with a minor efficiency issue of adjustedNotesConfig being reconstructed per-target despite being constant. |
| packages/release/test/unit/backfill/github-release.spec.ts | Comment-only update clarifying default-mode hand-edit skip behavior; no logic changes, comment accurately reflects current semantics. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[backfill command invoked] --> B[Validate options & load config]
    B --> C[resolveTargets]
    C --> D{Pass 1: scan all targets}
    D --> |for each target| E[reconstructChangelogs]
    E --> F{releases found?}
    F -- yes --> G[push to releasesByTarget]
    F -- no --> H{multiple targets?}
    H -- yes --> I[log: skipping]
    H -- no --> J[silent]
    G --> D
    I --> D
    J --> D
    D --> K{llmEnabled AND totalReleaseCount > 0?}
    K -- yes --> L[warn cost estimate]
    K -- no --> M{releasesByTarget empty?}
    L --> M
    M -- yes --> N[return]
    M -- no --> O{Pass 2: process each target}
    O --> P[build input]
    P --> Q{--no-llm?}
    Q -- yes --> R[llm: undefined]
    Q -- no --> S[original config]
    R --> T[runPipeline]
    S --> T
    T --> U{--update-releases?}
    U -- yes --> V[editReleaseBody]
    U -- no --> W[write files]
    V --> O
    W --> O
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[backfill command invoked] --> B[Validate options & load config]
    B --> C[resolveTargets]
    C --> D{Pass 1: scan all targets}
    D --> |for each target| E[reconstructChangelogs]
    E --> F{releases found?}
    F -- yes --> G[push to releasesByTarget]
    F -- no --> H{multiple targets?}
    H -- yes --> I[log: skipping]
    H -- no --> J[silent]
    G --> D
    I --> D
    J --> D
    D --> K{llmEnabled AND totalReleaseCount > 0?}
    K -- yes --> L[warn cost estimate]
    K -- no --> M{releasesByTarget empty?}
    L --> M
    M -- yes --> N[return]
    M -- no --> O{Pass 2: process each target}
    O --> P[build input]
    P --> Q{--no-llm?}
    Q -- yes --> R[llm: undefined]
    Q -- no --> S[original config]
    R --> T[runPipeline]
    S --> T
    T --> U{--update-releases?}
    U -- yes --> V[editReleaseBody]
    U -- no --> W[write files]
    V --> O
    W --> O
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/release/test/unit/backfill/github-release.spec.ts`, line 18-23 ([link](https://github.com/goosewobbler/releasekit/blob/cf7213e3557f9d62cf01437dec5f2a6b59f3aca9/packages/release/test/unit/backfill/github-release.spec.ts#L18-L23)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Stale test comment contradicts the new behavior added in this PR**

   The inline comment "pre-releasekit hand-written bodies all count as gaps" was accurate before this change, but is now misleading. In default mode (`onlyMissing=false, force=false`) a non-empty, unmarked body is now skipped as a suspected hand-edit. The test still passes because the non-empty assertion only exercises `onlyMissing=true`, but the comment describes a contract that no longer holds in default mode.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Frelease%2Ftest%2Funit%2Fbackfill%2Fgithub-release.spec.ts%0ALine%3A%2018-23%0A%0AComment%3A%0A**Stale%20test%20comment%20contradicts%20the%20new%20behavior%20added%20in%20this%20PR**%0A%0AThe%20inline%20comment%20%22pre-releasekit%20hand-written%20bodies%20all%20count%20as%20gaps%22%20was%20accurate%20before%20this%20change%2C%20but%20is%20now%20misleading.%20In%20default%20mode%20%28%60onlyMissing%3Dfalse%2C%20force%3Dfalse%60%29%20a%20non-empty%2C%20unmarked%20body%20is%20now%20skipped%20as%20a%20suspected%20hand-edit.%20The%20test%20still%20passes%20because%20the%20non-empty%20assertion%20only%20exercises%20%60onlyMissing%3Dtrue%60%2C%20but%20the%20comment%20describes%20a%20contract%20that%20no%20longer%20holds%20in%20default%20mode.%0A%0A%60%60%60suggestion%0A%20%20it%28'should%20update%20empty%20or%20already-marked%20bodies%20in%20default%20mode%2C%20and%20non-empty%20bodies%20under%20--only-missing'%2C%20%28%29%20%3D%3E%20%7B%0A%20%20%20%20%2F%2F%20Empty%20bodies%20are%20always%20treated%20as%20gaps.%0A%20%20%20%20expect%28decideReleaseUpdate%28''%2C%20false%29%29.toEqual%28%7B%20action%3A%20'update'%20%7D%29%3B%0A%20%20%20%20expect%28decideReleaseUpdate%28''%2C%20true%29%29.toEqual%28%7B%20action%3A%20'update'%20%7D%29%3B%0A%20%20%20%20%2F%2F%20Under%20--only-missing%2C%20non-empty%20unmarked%20bodies%20are%20still%20updated%20%28they%20haven't%20been%20backfilled%20yet%29.%0A%20%20%20%20expect%28decideReleaseUpdate%28'%23%23%20What%20changed%5Cn-%20auto%20stuff'%2C%20true%29%29.toEqual%28%7B%20action%3A%20'update'%20%7D%29%3B%0A%20%20%7D%29%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=goosewobbler%2Freleasekit&pr=316&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Frelease%2Ftest%2Funit%2Fbackfill%2Fgithub-release.spec.ts%0ALine%3A%2018-23%0A%0AComment%3A%0A**Stale%20test%20comment%20contradicts%20the%20new%20behavior%20added%20in%20this%20PR**%0A%0AThe%20inline%20comment%20%22pre-releasekit%20hand-written%20bodies%20all%20count%20as%20gaps%22%20was%20accurate%20before%20this%20change%2C%20but%20is%20now%20misleading.%20In%20default%20mode%20%28%60onlyMissing%3Dfalse%2C%20force%3Dfalse%60%29%20a%20non-empty%2C%20unmarked%20body%20is%20now%20skipped%20as%20a%20suspected%20hand-edit.%20The%20test%20still%20passes%20because%20the%20non-empty%20assertion%20only%20exercises%20%60onlyMissing%3Dtrue%60%2C%20but%20the%20comment%20describes%20a%20contract%20that%20no%20longer%20holds%20in%20default%20mode.%0A%0A%60%60%60suggestion%0A%20%20it%28'should%20update%20empty%20or%20already-marked%20bodies%20in%20default%20mode%2C%20and%20non-empty%20bodies%20under%20--only-missing'%2C%20%28%29%20%3D%3E%20%7B%0A%20%20%20%20%2F%2F%20Empty%20bodies%20are%20always%20treated%20as%20gaps.%0A%20%20%20%20expect%28decideReleaseUpdate%28''%2C%20false%29%29.toEqual%28%7B%20action%3A%20'update'%20%7D%29%3B%0A%20%20%20%20expect%28decideReleaseUpdate%28''%2C%20true%29%29.toEqual%28%7B%20action%3A%20'update'%20%7D%29%3B%0A%20%20%20%20%2F%2F%20Under%20--only-missing%2C%20non-empty%20unmarked%20bodies%20are%20still%20updated%20%28they%20haven't%20been%20backfilled%20yet%29.%0A%20%20%20%20expect%28decideReleaseUpdate%28'%23%23%20What%20changed%5Cn-%20auto%20stuff'%2C%20true%29%29.toEqual%28%7B%20action%3A%20'update'%20%7D%29%3B%0A%20%20%7D%29%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=316&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (5): Last reviewed commit: ["fix(release): restore per-target no-matc..."](https://github.com/goosewobbler/releasekit/commit/83a804ef10e390b189ce6b69904eafc2d76d973b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37749108)</sub>

<!-- /greptile_comment -->