### PR TITLE
feat(release): handle draft releases and skipPackages config

### DIFF
--- a/packages/release/src/backfill/github-release.ts
+++ b/packages/release/src/backfill/github-release.ts
@@ -7,19 +7,28 @@ import { execFileSync } from 'node:child_process';
  */
 export const NOTES_MARKER = '<!-- releasekit-notes -->';
 
-export type UpdateDecision = { action: 'update' } | { action: 'skip'; reason: 'no-release' | 'already-backfilled' };
+export type UpdateDecision =
+  | { action: 'update' }
+  | { action: 'skip'; reason: 'no-release' | 'already-backfilled' | 'hand-edited' };
 
 /**
  * Decide whether to (re)write a release body during backfill.
  *
  * - No release exists for the tag (`existingBody === null`) → skip; backfill edits, it doesn't create.
  * - `--only-missing` and the body already carries our marker → skip; we've backfilled it before.
- * - Otherwise update. An unmarked body (empty, GitHub auto-generated, or pre-releasekit hand-written)
- *   is treated as a gap to fill; the default (non-`--only-missing`) run also refreshes marked bodies.
+ * - Default mode + non-empty body without marker + not `--force` → skip; suspected hand-edit.
+ * - Otherwise update. An empty body or one carrying our marker is safe to overwrite.
  */
-export function decideReleaseUpdate(existingBody: string | null, onlyMissing: boolean): UpdateDecision {
+export function decideReleaseUpdate(
+  existingBody: string | null,
+  onlyMissing: boolean,
+  force: boolean = false,
+): UpdateDecision {
   if (existingBody === null) return { action: 'skip', reason: 'no-release' };
   if (onlyMissing && existingBody.includes(NOTES_MARKER)) return { action: 'skip', reason: 'already-backfilled' };
+  if (!force && !onlyMissing && existingBody.trim() && !existingBody.includes(NOTES_MARKER)) {
+    return { action: 'skip', reason: 'hand-edited' };
+  }
   return { action: 'update' };
 }
 

--- a/packages/release/src/backfill/github-release.ts
+++ b/packages/release/src/backfill/github-release.ts
@@ -63,3 +63,18 @@ export function getReleaseBody(tag: string): string | null {
 export function editReleaseBody(tag: string, body: string): void {
   execFileSync('gh', ['release', 'edit', tag, '--notes', body], { encoding: 'utf8' });
 }
+
+/** Check if a GitHub release is a draft. Returns false if no release exists. */
+export function isReleaseDraft(tag: string): boolean {
+  try {
+    const isDraft = execFileSync('gh', ['release', 'view', tag, '--json', 'isDraft', '--jq', '.isDraft'], {
+      encoding: 'utf8',
+    }).trim();
+    return isDraft === 'true';
+  } catch (err) {
+    const e = err as { code?: string; stderr?: string | Buffer; message?: string };
+    const stderr = (typeof e.stderr === 'string' ? e.stderr : e.stderr?.toString()) || '';
+    if (/release not found/i.test(stderr)) return false;
+    throw err;
+  }
+}

--- a/packages/release/src/backfill/github-release.ts
+++ b/packages/release/src/backfill/github-release.ts
@@ -64,6 +64,26 @@ export function editReleaseBody(tag: string, body: string): void {
   execFileSync('gh', ['release', 'edit', tag, '--notes', body], { encoding: 'utf8' });
 }
 
+/**
+ * Fetch release metadata (isDraft and body) in a single gh call. Returns null when no release exists.
+ * Throws on auth/CLI/network failures.
+ */
+export function getReleaseInfo(tag: string): { isDraft: boolean; body: string | null } | null {
+  try {
+    const json = execFileSync('gh', ['release', 'view', tag, '--json', 'isDraft,body'], { encoding: 'utf8' });
+    const parsed = JSON.parse(json) as { isDraft: boolean; body: string | null };
+    return parsed;
+  } catch (err) {
+    const e = err as { code?: string; stderr?: string | Buffer; message?: string };
+    if (e.code === 'ENOENT') {
+      throw new Error('GitHub CLI (`gh`) not found — install it and run `gh auth login` to update release bodies.');
+    }
+    const stderr = (typeof e.stderr === 'string' ? e.stderr : e.stderr?.toString()) || e.message || '';
+    if (/release not found/i.test(stderr)) return null;
+    throw new Error(`\`gh release view ${tag}\` failed: ${stderr.trim() || 'unknown error'}`);
+  }
+}
+
 /** Check if a GitHub release is a draft. Returns false if no release exists. */
 export function isReleaseDraft(tag: string): boolean {
   try {
@@ -73,6 +93,9 @@ export function isReleaseDraft(tag: string): boolean {
     return isDraft === 'true';
   } catch (err) {
     const e = err as { code?: string; stderr?: string | Buffer; message?: string };
+    if (e.code === 'ENOENT') {
+      throw new Error('GitHub CLI (`gh`) not found — install it and run `gh auth login` to update release bodies.');
+    }
     const stderr = (typeof e.stderr === 'string' ? e.stderr : e.stderr?.toString()) || '';
     if (/release not found/i.test(stderr)) return false;
     throw err;

--- a/packages/release/src/backfill/github-release.ts
+++ b/packages/release/src/backfill/github-release.ts
@@ -83,21 +83,3 @@ export function getReleaseInfo(tag: string): { isDraft: boolean; body: string | 
     throw new Error(`\`gh release view ${tag}\` failed: ${stderr.trim() || 'unknown error'}`);
   }
 }
-
-/** Check if a GitHub release is a draft. Returns false if no release exists. */
-export function isReleaseDraft(tag: string): boolean {
-  try {
-    const isDraft = execFileSync('gh', ['release', 'view', tag, '--json', 'isDraft', '--jq', '.isDraft'], {
-      encoding: 'utf8',
-    }).trim();
-    return isDraft === 'true';
-  } catch (err) {
-    const e = err as { code?: string; stderr?: string | Buffer; message?: string };
-    if (e.code === 'ENOENT') {
-      throw new Error('GitHub CLI (`gh`) not found — install it and run `gh auth login` to update release bodies.');
-    }
-    const stderr = (typeof e.stderr === 'string' ? e.stderr : e.stderr?.toString()) || '';
-    if (/release not found/i.test(stderr)) return false;
-    throw err;
-  }
-}

--- a/packages/release/src/commands/backfill-command.ts
+++ b/packages/release/src/commands/backfill-command.ts
@@ -55,6 +55,7 @@ export function createBackfillCommand(): Command {
     .option('--to <version>', 'Latest version to backfill (inclusive)')
     .option('--update-releases', 'Update matching GitHub release bodies via `gh release edit`', false)
     .option('--only-missing', 'With --update-releases, skip releases already carrying releasekit notes', false)
+    .option('--force', 'Overwrite hand-edited release bodies (use with --update-releases)', false)
     .option('--apply', 'Apply changes (default: dry-run preview)', false)
     .option('-c, --config <path>', 'Config file path')
     .action(async (options) => {
@@ -103,9 +104,14 @@ export function createBackfillCommand(): Command {
         error('--only-missing only applies with --update-releases.');
         process.exit(EXIT_CODES.GENERAL_ERROR);
       }
+      if (options.force && !updateReleases) {
+        error('--force only applies with --update-releases.');
+        process.exit(EXIT_CODES.GENERAL_ERROR);
+      }
 
       const versionConfig = loadVersionConfig({ cwd, configPath: options.config });
       const dryRun = !options.apply;
+      const force = options.force === true;
 
       const targets = await resolveTargets(options, cwd, versionConfig);
 
@@ -182,6 +188,7 @@ export function createBackfillCommand(): Command {
           let updated = 0;
           let skippedNoRelease = 0;
           let skippedExisting = 0;
+          let skippedHandEdited = 0;
           for (let i = 0; i < reconstructed.length; i++) {
             const tag = reconstructed[i]?.tag;
             const body = renderedBodies[i];
@@ -190,14 +197,18 @@ export function createBackfillCommand(): Command {
               warn(`  ${tag}: no notes rendered, skipping release update`);
               continue;
             }
-            const decision = decideReleaseUpdate(getReleaseBody(tag), onlyMissing);
+            const existingBody = getReleaseBody(tag);
+            const decision = decideReleaseUpdate(existingBody, onlyMissing, force);
             if (decision.action === 'skip') {
               if (decision.reason === 'no-release') {
                 warn(`  ${tag}: no GitHub release found, skipping`);
                 skippedNoRelease++;
-              } else {
+              } else if (decision.reason === 'already-backfilled') {
                 info(`  ${tag}: already has releasekit notes, skipping`);
                 skippedExisting++;
+              } else if (decision.reason === 'hand-edited') {
+                info(`  ${tag}: hand-edited release body (use --force to overwrite), skipping`);
+                skippedHandEdited++;
               }
               continue;
             }
@@ -211,7 +222,8 @@ export function createBackfillCommand(): Command {
           }
           const skips = [
             skippedNoRelease > 0 ? `${skippedNoRelease} without a release` : null,
-            skippedExisting > 0 ? `${skippedExisting} already done` : null,
+            skippedExisting > 0 ? `${skippedExisting} already backfilled` : null,
+            skippedHandEdited > 0 ? `${skippedHandEdited} hand-edited` : null,
           ].filter(Boolean);
           const suffix = skips.length > 0 ? ` (skipped ${skips.join(', ')})` : '';
           if (dryRun) {

--- a/packages/release/src/commands/backfill-command.ts
+++ b/packages/release/src/commands/backfill-command.ts
@@ -5,13 +5,7 @@ import { EXIT_CODES, error, info, success, warn } from '@releasekit/core';
 import type { Config as VersionConfig } from '@releasekit/version';
 import { Command } from 'commander';
 import semver from 'semver';
-import {
-  decideReleaseUpdate,
-  editReleaseBody,
-  getReleaseBody,
-  isReleaseDraft,
-  withMarker,
-} from '../backfill/github-release.js';
+import { decideReleaseUpdate, editReleaseBody, getReleaseInfo, withMarker } from '../backfill/github-release.js';
 import { reconstructChangelogs } from '../backfill/reconstruct.js';
 import { normalizeRepoUrl } from '../backfill/repo-url.js';
 
@@ -62,7 +56,7 @@ export function createBackfillCommand(): Command {
     .option('--update-releases', 'Update matching GitHub release bodies via `gh release edit`', false)
     .option('--only-missing', 'With --update-releases, skip releases already carrying releasekit notes', false)
     .option('--force', 'Overwrite hand-edited release bodies (use with --update-releases)', false)
-    .option('--no-llm', 'Disable LLM (use deterministic, zero-cost backfill)', false)
+    .option('--no-llm', 'Disable LLM (use deterministic, zero-cost backfill)')
     .option('--apply', 'Apply changes (default: dry-run preview)', false)
     .option('-c, --config <path>', 'Config file path')
     .action(async (options) => {
@@ -121,7 +115,7 @@ export function createBackfillCommand(): Command {
       const versionConfig = loadVersionConfig({ cwd, configPath: options.config });
       const dryRun = !options.apply;
       const force = options.force === true;
-      const noLlm = options.noLlm === true;
+      const noLlm = options.llm === false;
 
       const targets = await resolveTargets(options, cwd, versionConfig);
 
@@ -239,48 +233,48 @@ export function createBackfillCommand(): Command {
           if (isSkipped) {
             warn(`  Skipping all releases for ${target.packageName} (in githubRelease.skipPackages)`);
             skippedInSkipPackages = reconstructed.length;
-            continue;
-          }
+          } else {
+            for (let i = 0; i < reconstructed.length; i++) {
+              const tag = reconstructed[i]?.tag;
+              const body = renderedBodies[i];
+              if (!tag) continue;
+              if (!body) {
+                warn(`  ${tag}: no notes rendered, skipping release update`);
+                continue;
+              }
 
-          for (let i = 0; i < reconstructed.length; i++) {
-            const tag = reconstructed[i]?.tag;
-            const body = renderedBodies[i];
-            if (!tag) continue;
-            if (!body) {
-              warn(`  ${tag}: no notes rendered, skipping release update`);
-              continue;
-            }
-
-            // Check if release is a draft
-            const isDraft = isReleaseDraft(tag);
-            if (isDraft) {
-              info(`  ${tag}: release is a draft, skipping`);
-              skippedDraft++;
-              continue;
-            }
-
-            const existingBody = getReleaseBody(tag);
-            const decision = decideReleaseUpdate(existingBody, onlyMissing, force);
-            if (decision.action === 'skip') {
-              if (decision.reason === 'no-release') {
+              const releaseInfo = getReleaseInfo(tag);
+              if (releaseInfo === null) {
                 warn(`  ${tag}: no GitHub release found, skipping`);
                 skippedNoRelease++;
-              } else if (decision.reason === 'already-backfilled') {
-                info(`  ${tag}: already has releasekit notes, skipping`);
-                skippedExisting++;
-              } else if (decision.reason === 'hand-edited') {
-                info(`  ${tag}: hand-edited release body (use --force to overwrite), skipping`);
-                skippedHandEdited++;
+                continue;
               }
-              continue;
+
+              if (releaseInfo.isDraft) {
+                info(`  ${tag}: release is a draft, skipping`);
+                skippedDraft++;
+                continue;
+              }
+
+              const decision = decideReleaseUpdate(releaseInfo.body, onlyMissing, force);
+              if (decision.action === 'skip') {
+                if (decision.reason === 'already-backfilled') {
+                  info(`  ${tag}: already has releasekit notes, skipping`);
+                  skippedExisting++;
+                } else if (decision.reason === 'hand-edited') {
+                  info(`  ${tag}: hand-edited release body (use --force to overwrite), skipping`);
+                  skippedHandEdited++;
+                }
+                continue;
+              }
+              if (dryRun) {
+                info(`  ${tag}: would update release body`);
+              } else {
+                editReleaseBody(tag, withMarker(body));
+                info(`  ${tag}: updated release body`);
+              }
+              updated++;
             }
-            if (dryRun) {
-              info(`  ${tag}: would update release body`);
-            } else {
-              editReleaseBody(tag, withMarker(body));
-              info(`  ${tag}: updated release body`);
-            }
-            updated++;
           }
 
           const skips = [
@@ -309,7 +303,8 @@ function countEnabledLlmTasks(tasks?: {
   releaseNotes?: boolean;
 }): number {
   if (!tasks) return 4; // All tasks enabled by default
-  return Object.values(tasks).filter(Boolean).length || 4;
+  const allTaskKeys = ['summarize', 'enhance', 'categorize', 'releaseNotes'] as const;
+  return allTaskKeys.filter((k) => tasks[k] !== false).length;
 }
 
 /**

--- a/packages/release/src/commands/backfill-command.ts
+++ b/packages/release/src/commands/backfill-command.ts
@@ -56,6 +56,7 @@ export function createBackfillCommand(): Command {
     .option('--update-releases', 'Update matching GitHub release bodies via `gh release edit`', false)
     .option('--only-missing', 'With --update-releases, skip releases already carrying releasekit notes', false)
     .option('--force', 'Overwrite hand-edited release bodies (use with --update-releases)', false)
+    .option('--no-llm', 'Disable LLM (use deterministic, zero-cost backfill)', false)
     .option('--apply', 'Apply changes (default: dry-run preview)', false)
     .option('-c, --config <path>', 'Config file path')
     .action(async (options) => {
@@ -112,9 +113,17 @@ export function createBackfillCommand(): Command {
       const versionConfig = loadVersionConfig({ cwd, configPath: options.config });
       const dryRun = !options.apply;
       const force = options.force === true;
+      const noLlm = options.noLlm === true;
 
       const targets = await resolveTargets(options, cwd, versionConfig);
 
+      let totalReleaseCount = 0;
+      const releasesByTarget: Array<{
+        target: BackfillTarget;
+        reconstructed: Awaited<ReturnType<typeof reconstructChangelogs>>;
+      }> = [];
+
+      // Scan all targets to count total releases and estimate cost upfront
       for (const target of targets) {
         const reconstructed = await reconstructChangelogs({
           packageName: target.packageName,
@@ -127,11 +136,30 @@ export function createBackfillCommand(): Command {
           to: options.to,
         });
 
-        if (reconstructed.length === 0) {
-          info(`No matching tags found for ${target.packageName}.`);
-          continue;
+        if (reconstructed.length > 0) {
+          totalReleaseCount += reconstructed.length;
+          releasesByTarget.push({ target, reconstructed });
         }
+      }
 
+      // Estimate and warn about LLM cost if not in --no-llm mode and LLM is enabled
+      const llmEnabled = !noLlm && notesConfig.releaseNotes?.llm;
+      if (llmEnabled && totalReleaseCount > 0 && !dryRun) {
+        const llmConfig = notesConfig.releaseNotes?.llm;
+        const enabledTasks = countEnabledLlmTasks(llmConfig?.tasks);
+        warn(
+          `Estimated cost: ~${totalReleaseCount} release(s) × ${enabledTasks} LLM task(s). ` +
+            `Use --no-llm to disable LLM (deterministic, zero-cost run).`,
+        );
+      }
+
+      // Handle case where no releases were found across all targets
+      if (releasesByTarget.length === 0) {
+        info(`No matching tags found across ${targets.length} target(s).`);
+        return;
+      }
+
+      for (const { target, reconstructed } of releasesByTarget) {
         const changelogs = reconstructed.map((r) => r.changelog);
         const versionOutput: VersionOutput = { dryRun, updates: [], changelogs, tags: [] };
         const input = versionOutputToChangelogInput(versionOutput);
@@ -145,6 +173,11 @@ export function createBackfillCommand(): Command {
           if (date && pkg) pkg.date = date;
         }
 
+        // Override LLM config if --no-llm is set
+        const adjustedNotesConfig = noLlm
+          ? { ...notesConfig, releaseNotes: { ...notesConfig.releaseNotes, llm: undefined } }
+          : notesConfig;
+
         // Render one version per pipeline call (single context each). The pipeline's nesting decision
         // (`detectMonorepo(cwd).isMonorepo || contexts.length > 1`) then matches the live release
         // pipeline, which also renders one package per run. Passing all versions at once would make
@@ -157,7 +190,7 @@ export function createBackfillCommand(): Command {
         for (const pkg of input.packages) {
           const result = await runPipeline(
             { ...input, packages: [pkg] },
-            { ...notesConfig, changelog: false },
+            { ...adjustedNotesConfig, changelog: false },
             dryRun,
             {
               skipChangelogs: true,
@@ -234,6 +267,17 @@ export function createBackfillCommand(): Command {
         }
       }
     });
+}
+
+/** Count the number of enabled LLM tasks (summarize, enhance, categorize, releaseNotes). */
+function countEnabledLlmTasks(tasks?: {
+  summarize?: boolean;
+  enhance?: boolean;
+  categorize?: boolean;
+  releaseNotes?: boolean;
+}): number {
+  if (!tasks) return 4; // All tasks enabled by default
+  return Object.values(tasks).filter(Boolean).length || 4;
 }
 
 /**

--- a/packages/release/src/commands/backfill-command.ts
+++ b/packages/release/src/commands/backfill-command.ts
@@ -164,6 +164,21 @@ export function createBackfillCommand(): Command {
       }
 
       for (const { target, reconstructed } of releasesByTarget) {
+        // Check skipPackages before rendering to avoid unnecessary LLM calls for excluded packages.
+        const skipPackages = publishConfig.githubRelease?.skipPackages ?? [];
+        const isSkipped = updateReleases && skipPackages.includes(target.packageName);
+        if (isSkipped && !dir) {
+          warn(`  Skipping all releases for ${target.packageName} (in githubRelease.skipPackages)`);
+          const skippedInSkipPackages = reconstructed.length;
+          const suffix = ` (skipped ${skippedInSkipPackages} in skipPackages)`;
+          if (dryRun) {
+            info(`[dry-run] Would update 0 GitHub release body(ies)${suffix}. Re-run with --apply.`);
+          } else {
+            success(`Updated 0 GitHub release body(ies)${suffix}.`);
+          }
+          continue;
+        }
+
         const changelogs = reconstructed.map((r) => r.changelog);
         const versionOutput: VersionOutput = { dryRun, updates: [], changelogs, tags: [] };
         const input = versionOutputToChangelogInput(versionOutput);
@@ -228,9 +243,6 @@ export function createBackfillCommand(): Command {
           let skippedHandEdited = 0;
           let skippedDraft = 0;
           let skippedInSkipPackages = 0;
-
-          const skipPackages = publishConfig.githubRelease?.skipPackages ?? [];
-          const isSkipped = skipPackages.includes(target.packageName);
 
           if (isSkipped) {
             warn(`  Skipping all releases for ${target.packageName} (in githubRelease.skipPackages)`);

--- a/packages/release/src/commands/backfill-command.ts
+++ b/packages/release/src/commands/backfill-command.ts
@@ -256,7 +256,7 @@ export function createBackfillCommand(): Command {
                 continue;
               }
 
-              const decision = decideReleaseUpdate(releaseInfo.body, onlyMissing, force);
+              const decision = decideReleaseUpdate(releaseInfo.body ?? '', onlyMissing, force);
               if (decision.action === 'skip') {
                 if (decision.reason === 'already-backfilled') {
                   info(`  ${tag}: already has releasekit notes, skipping`);

--- a/packages/release/src/commands/backfill-command.ts
+++ b/packages/release/src/commands/backfill-command.ts
@@ -5,7 +5,13 @@ import { EXIT_CODES, error, info, success, warn } from '@releasekit/core';
 import type { Config as VersionConfig } from '@releasekit/version';
 import { Command } from 'commander';
 import semver from 'semver';
-import { decideReleaseUpdate, editReleaseBody, getReleaseBody, withMarker } from '../backfill/github-release.js';
+import {
+  decideReleaseUpdate,
+  editReleaseBody,
+  getReleaseBody,
+  isReleaseDraft,
+  withMarker,
+} from '../backfill/github-release.js';
 import { reconstructChangelogs } from '../backfill/reconstruct.js';
 import { normalizeRepoUrl } from '../backfill/repo-url.js';
 
@@ -83,11 +89,13 @@ export function createBackfillCommand(): Command {
         runPipeline,
         loadConfig: loadNotesConfig,
       } = await import('@releasekit/notes');
+      const { loadConfig: loadPublishConfig } = await import('@releasekit/publish');
 
       const cwd = process.cwd();
       const updateReleases: boolean = options.updateReleases === true;
       const onlyMissing: boolean = options.onlyMissing === true;
       const notesConfig = loadNotesConfig(cwd, options.config);
+      const publishConfig = loadPublishConfig(cwd, options.config);
       const releaseNotesEnabled = notesConfig.releaseNotes !== false && notesConfig.releaseNotes !== undefined;
       const dir = releaseNotesEnabled ? notesConfig.releaseNotes?.file?.dir : undefined;
       if (!dir && !updateReleases) {
@@ -222,6 +230,18 @@ export function createBackfillCommand(): Command {
           let skippedNoRelease = 0;
           let skippedExisting = 0;
           let skippedHandEdited = 0;
+          let skippedDraft = 0;
+          let skippedInSkipPackages = 0;
+
+          const skipPackages = publishConfig.githubRelease?.skipPackages ?? [];
+          const isSkipped = skipPackages.includes(target.packageName);
+
+          if (isSkipped) {
+            warn(`  Skipping all releases for ${target.packageName} (in githubRelease.skipPackages)`);
+            skippedInSkipPackages = reconstructed.length;
+            continue;
+          }
+
           for (let i = 0; i < reconstructed.length; i++) {
             const tag = reconstructed[i]?.tag;
             const body = renderedBodies[i];
@@ -230,6 +250,15 @@ export function createBackfillCommand(): Command {
               warn(`  ${tag}: no notes rendered, skipping release update`);
               continue;
             }
+
+            // Check if release is a draft
+            const isDraft = isReleaseDraft(tag);
+            if (isDraft) {
+              info(`  ${tag}: release is a draft, skipping`);
+              skippedDraft++;
+              continue;
+            }
+
             const existingBody = getReleaseBody(tag);
             const decision = decideReleaseUpdate(existingBody, onlyMissing, force);
             if (decision.action === 'skip') {
@@ -253,10 +282,13 @@ export function createBackfillCommand(): Command {
             }
             updated++;
           }
+
           const skips = [
             skippedNoRelease > 0 ? `${skippedNoRelease} without a release` : null,
             skippedExisting > 0 ? `${skippedExisting} already backfilled` : null,
             skippedHandEdited > 0 ? `${skippedHandEdited} hand-edited` : null,
+            skippedDraft > 0 ? `${skippedDraft} draft` : null,
+            skippedInSkipPackages > 0 ? `${skippedInSkipPackages} in skipPackages` : null,
           ].filter(Boolean);
           const suffix = skips.length > 0 ? ` (skipped ${skips.join(', ')})` : '';
           if (dryRun) {

--- a/packages/release/test/unit/backfill/github-release.spec.ts
+++ b/packages/release/test/unit/backfill/github-release.spec.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   decideReleaseUpdate,
   getReleaseBody,
-  isReleaseDraft,
+  getReleaseInfo,
   NOTES_MARKER,
   withMarker,
 } from '../../../src/backfill/github-release.js';
@@ -98,32 +98,39 @@ describe('getReleaseBody', () => {
   });
 });
 
-describe('isReleaseDraft', () => {
+describe('getReleaseInfo', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('should return true for draft releases', () => {
-    vi.mocked(execFileSync).mockReturnValue('true');
-    expect(isReleaseDraft('v1.0.0')).toBe(true);
+  it('should return isDraft and body on success', () => {
+    vi.mocked(execFileSync).mockReturnValue(JSON.stringify({ isDraft: false, body: '## Notes\n- a thing\n' }));
+    expect(getReleaseInfo('v1.0.0')).toEqual({ isDraft: false, body: '## Notes\n- a thing\n' });
   });
 
-  it('should return false for published releases', () => {
-    vi.mocked(execFileSync).mockReturnValue('false');
-    expect(isReleaseDraft('v1.0.0')).toBe(false);
+  it('should return isDraft true for draft releases', () => {
+    vi.mocked(execFileSync).mockReturnValue(JSON.stringify({ isDraft: true, body: null }));
+    expect(getReleaseInfo('v1.0.0')).toEqual({ isDraft: true, body: null });
   });
 
-  it('should return false when no release exists for the tag', () => {
+  it('should return null for a genuinely missing release', () => {
     vi.mocked(execFileSync).mockImplementation(() => {
       throw execError('release not found\n');
     });
-    expect(isReleaseDraft('v9.9.9')).toBe(false);
+    expect(getReleaseInfo('v9.9.9')).toBeNull();
   });
 
-  it('should throw for non-not-found errors', () => {
+  it('should throw a clear error when gh is not installed', () => {
+    vi.mocked(execFileSync).mockImplementation(() => {
+      throw execError('', 'ENOENT');
+    });
+    expect(() => getReleaseInfo('v1.0.0')).toThrow(/GitHub CLI .* not found/);
+  });
+
+  it('should surface auth/network failures instead of reporting "no release"', () => {
     vi.mocked(execFileSync).mockImplementation(() => {
       throw execError('gh: Bad credentials (HTTP 401)\n');
     });
-    expect(() => isReleaseDraft('v1.0.0')).toThrow();
+    expect(() => getReleaseInfo('v1.0.0')).toThrow(/Bad credentials/);
   });
 });

--- a/packages/release/test/unit/backfill/github-release.spec.ts
+++ b/packages/release/test/unit/backfill/github-release.spec.ts
@@ -28,6 +28,29 @@ describe('decideReleaseUpdate', () => {
     // Default (force-refresh) run rewrites even bodies we authored before.
     expect(decideReleaseUpdate(marked, false)).toEqual({ action: 'update' });
   });
+
+  it('should skip hand-edited (non-empty, unmarked) bodies in default mode', () => {
+    const handEdited = 'My custom notes about this release';
+    expect(decideReleaseUpdate(handEdited, false, false)).toEqual({
+      action: 'skip',
+      reason: 'hand-edited',
+    });
+  });
+
+  it('should not skip hand-edited bodies when --force is passed', () => {
+    const handEdited = 'My custom notes about this release';
+    expect(decideReleaseUpdate(handEdited, false, true)).toEqual({ action: 'update' });
+  });
+
+  it('should not skip hand-edited bodies under --only-missing even without --force', () => {
+    const handEdited = 'My custom notes about this release';
+    expect(decideReleaseUpdate(handEdited, true, false)).toEqual({ action: 'update' });
+  });
+
+  it('should treat whitespace-only bodies as empty', () => {
+    expect(decideReleaseUpdate('   ', false, false)).toEqual({ action: 'update' });
+    expect(decideReleaseUpdate('\n\n', false, false)).toEqual({ action: 'update' });
+  });
 });
 
 describe('withMarker', () => {

--- a/packages/release/test/unit/backfill/github-release.spec.ts
+++ b/packages/release/test/unit/backfill/github-release.spec.ts
@@ -1,6 +1,12 @@
 import { execFileSync } from 'node:child_process';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { decideReleaseUpdate, getReleaseBody, NOTES_MARKER, withMarker } from '../../../src/backfill/github-release.js';
+import {
+  decideReleaseUpdate,
+  getReleaseBody,
+  isReleaseDraft,
+  NOTES_MARKER,
+  withMarker,
+} from '../../../src/backfill/github-release.js';
 
 vi.mock('node:child_process', () => ({ execFileSync: vi.fn() }));
 
@@ -88,5 +94,35 @@ describe('getReleaseBody', () => {
       throw execError('gh: Bad credentials (HTTP 401)\n');
     });
     expect(() => getReleaseBody('v1.0.0')).toThrow(/Bad credentials/);
+  });
+});
+
+describe('isReleaseDraft', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should return true for draft releases', () => {
+    vi.mocked(execFileSync).mockReturnValue('true');
+    expect(isReleaseDraft('v1.0.0')).toBe(true);
+  });
+
+  it('should return false for published releases', () => {
+    vi.mocked(execFileSync).mockReturnValue('false');
+    expect(isReleaseDraft('v1.0.0')).toBe(false);
+  });
+
+  it('should return false when no release exists for the tag', () => {
+    vi.mocked(execFileSync).mockImplementation(() => {
+      throw execError('release not found\n');
+    });
+    expect(isReleaseDraft('v9.9.9')).toBe(false);
+  });
+
+  it('should throw for non-not-found errors', () => {
+    vi.mocked(execFileSync).mockImplementation(() => {
+      throw execError('gh: Bad credentials (HTTP 401)\n');
+    });
+    expect(() => isReleaseDraft('v1.0.0')).toThrow();
   });
 });

--- a/packages/release/test/unit/backfill/github-release.spec.ts
+++ b/packages/release/test/unit/backfill/github-release.spec.ts
@@ -21,10 +21,11 @@ describe('decideReleaseUpdate', () => {
     expect(decideReleaseUpdate(null, true)).toEqual({ action: 'skip', reason: 'no-release' });
   });
 
-  it('should update an unmarked body regardless of --only-missing', () => {
-    // Empty, GitHub auto-generated, and pre-releasekit hand-written bodies all count as gaps.
+  it('should update empty or already-marked bodies in default mode, and non-empty bodies under --only-missing', () => {
+    // Empty bodies are always treated as gaps.
     expect(decideReleaseUpdate('', false)).toEqual({ action: 'update' });
     expect(decideReleaseUpdate('', true)).toEqual({ action: 'update' });
+    // Under --only-missing, non-empty unmarked bodies are still updated (they haven't been backfilled yet).
     expect(decideReleaseUpdate('## What changed\n- auto stuff', true)).toEqual({ action: 'update' });
   });
 


### PR DESCRIPTION
## Summary

Skip draft releases during backfill `--update-releases` to prevent unwanted edits to unreleased versions. Also respect `githubRelease.skipPackages` config when updating releases for config-driven exclusion.

## Changes

- `isReleaseDraft()` helper to check draft status via gh CLI
- Skip draft releases with clear feedback
- Load publish config and check skipPackages
- Skip all releases for packages in skipPackages config
- Comprehensive skip reason reporting

## Test plan

- [x] All unit tests pass (new tests for isReleaseDraft)
- [x] Draft releases are skipped
- [x] skipPackages config is respected
- [x] Skip reasons are clearly reported

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR addresses two gaps in the `--update-releases` backfill path: draft GitHub releases are now detected and skipped (instead of overwritten), and packages listed in `githubRelease.skipPackages` are excluded from release updates. A new `getReleaseInfo` helper consolidates what were previously two separate `gh release view` subprocess calls into one, also resolving the `ENOENT`/missing-release error-handling gap that existed in the old `isReleaseDraft` approach.

- **`getReleaseInfo`** fetches `isDraft` and `body` in a single `gh` call with the same robust error handling (`ENOENT`, `release not found`, auth failures) as `getReleaseBody`.
- **Early-exit path** (`isSkipped && !dir`): skips LLM rendering entirely for packages in `skipPackages` when no file output is configured, printing a clear summary before `continue`.
- **Inner skip path** (`isSkipped && dir`): when file output is also configured, notes are still rendered to disk but GitHub release edits are skipped; `skippedInSkipPackages` counter is correctly surfaced in the summary.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are well-scoped to the backfill update-releases path, prior review findings are addressed, and new behaviour is covered by unit tests.

The consolidated `getReleaseInfo` replaces two separate subprocess calls with one, fixing a previous ENOENT-handling gap. The `skipPackages` early-exit correctly avoids LLM cost before rendering. The `body ?? ''` fix means a null GitHub release body is now treated as an empty (safe-to-overwrite) body rather than silently skipped. Counter wiring for `skippedInSkipPackages` is correct in both the early-exit and inner-skip paths. No new logic gaps introduced.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/release/src/backfill/github-release.ts | Adds `getReleaseInfo` that fetches both `isDraft` and `body` in one `gh release view --json isDraft,body` call, with full ENOENT/not-found/auth error handling mirroring the existing `getReleaseBody`; old function is preserved for backward compatibility. |
| packages/release/src/commands/backfill-command.ts | Replaces the two-call `getReleaseBody` path with the consolidated `getReleaseInfo`; adds draft-release skip logic; adds `skipPackages`-aware early-exit (before LLM rendering) and an inner skip branch (when `dir` is also set); counters and summary messages are wired correctly in both paths. |
| packages/release/test/unit/backfill/github-release.spec.ts | Adds a `getReleaseInfo` describe block with five cases covering success, draft, missing release, missing CLI, and auth failure — mirrors the existing `getReleaseBody` test coverage. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[for each releasesByTarget] --> B{isSkipped AND not dir?}
    B -- yes --> C[warn: skipping package\nprint 0-updated summary\ncontinue]
    B -- no --> D[render notes via LLM pipeline\nwrite files if dir set]
    D --> E{updateReleases?}
    E -- no --> F[next target]
    E -- yes --> G{isSkipped?}
    G -- yes --> H[warn: skipping package\nskippedInSkipPackages = reconstructed.length]
    G -- no --> I[for each tag]
    I --> J{getReleaseInfo returns null?}
    J -- yes --> K[skippedNoRelease++\ncontinue]
    J -- no --> L{isDraft?}
    L -- yes --> M[skippedDraft++\ncontinue]
    L -- no --> N[decideReleaseUpdate\nbody ?? empty string]
    N --> O{action = skip?}
    O -- already-backfilled --> P[skippedExisting++\ncontinue]
    O -- hand-edited --> Q[skippedHandEdited++\ncontinue]
    O -- no --> R{dryRun?}
    R -- yes --> S[log: would update]
    R -- no --> T[editReleaseBody\nlog: updated]
    S --> U[updated++]
    T --> U
    H --> V[build skips suffix\nprint summary]
    U --> V
    K --> I
    M --> I
    P --> I
    Q --> I
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[for each releasesByTarget] --> B{isSkipped AND not dir?}
    B -- yes --> C[warn: skipping package\nprint 0-updated summary\ncontinue]
    B -- no --> D[render notes via LLM pipeline\nwrite files if dir set]
    D --> E{updateReleases?}
    E -- no --> F[next target]
    E -- yes --> G{isSkipped?}
    G -- yes --> H[warn: skipping package\nskippedInSkipPackages = reconstructed.length]
    G -- no --> I[for each tag]
    I --> J{getReleaseInfo returns null?}
    J -- yes --> K[skippedNoRelease++\ncontinue]
    J -- no --> L{isDraft?}
    L -- yes --> M[skippedDraft++\ncontinue]
    L -- no --> N[decideReleaseUpdate\nbody ?? empty string]
    N --> O{action = skip?}
    O -- already-backfilled --> P[skippedExisting++\ncontinue]
    O -- hand-edited --> Q[skippedHandEdited++\ncontinue]
    O -- no --> R{dryRun?}
    R -- yes --> S[log: would update]
    R -- no --> T[editReleaseBody\nlog: updated]
    S --> U[updated++]
    T --> U
    H --> V[build skips suffix\nprint summary]
    U --> V
    K --> I
    M --> I
    P --> I
    Q --> I
```

</a>
</details>

<sub>Reviews (6): Last reviewed commit: ["fix(release): skip runPipeline for skipP..."](https://github.com/goosewobbler/releasekit/commit/741ac3ab1166b5a87358ca25c65ff44357bde25c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37749126)</sub>

<!-- /greptile_comment -->