### PR TITLE
feat: first-release intro + editable release notes (#200)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -394,6 +394,7 @@ PR label names used for release control. Override to match your repository's lab
 | `skip` | string | `"release:skip"` | Label to suppress a release on this PR |
 | `immediate` | string | `"release:immediate"` | Label to bypass the standing PR for one merge — triggers a direct release. Standing-pr mode only. |
 | `retry` | string | `"release:retry"` | Label to retry a failed publish by re-applying it to a merged standing PR. Standing-pr mode only. |
+| `previewNotes` | string | `"release:preview-notes"` | Label on the standing PR that generates LLM release notes on demand into an editable region in the PR body, for review and editing before merge. Standing-pr mode only. |
 | `major` | string | `"bump:major"` | Label to force a major bump |
 | `minor` | string | `"bump:minor"` | Label to force a minor bump |
 | `patch` | string | `"bump:patch"` | Label to force a patch bump |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -274,6 +274,7 @@ Set to `false` to disable.
 |-----|------|---------|-------------|
 | `file` | object | — | Optional in-repo file output. Omit to keep release notes only on the GitHub release body (the default). When set, writes one immutable Markdown file per version under `dir` — release-notes/<package>/<version>.md in a monorepo, release-notes/<version>.md in a single-package repo — giving a browsable, provider-independent per-release history. |
 | `links` | object | — | Extra links to append to the release notes. |
+| `firstRelease` | boolean \| object | — | First-release placeholder intro, shown when a package has no prior version (previousVersion is null). Default-on with a factual line; set to false to disable. |
 
 **`notes.releaseNotes.templates`** — Template for rendering release notes (e.g. to add docs-site frontmatter). Takes precedence over LLM prose and the default formatted section.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -274,7 +274,7 @@ Set to `false` to disable.
 |-----|------|---------|-------------|
 | `file` | object | — | Optional in-repo file output. Omit to keep release notes only on the GitHub release body (the default). When set, writes one immutable Markdown file per version under `dir` — release-notes/<package>/<version>.md in a monorepo, release-notes/<version>.md in a single-package repo — giving a browsable, provider-independent per-release history. |
 | `links` | object | — | Extra links to append to the release notes. |
-| `firstRelease` | boolean \| object | — | First-release placeholder intro, shown when a package has no prior version (previousVersion is null). Default-on with a factual line; set to false to disable. |
+| `firstRelease` | `false` \| object | — | First-release placeholder intro, shown when a package has no prior version (previousVersion is null). Default-on with a factual line; set to false to disable. |
 
 **`notes.releaseNotes.templates`** — Template for rendering release notes (e.g. to add docs-site frontmatter). Takes precedence over LLM prose and the default formatted section.
 

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -453,12 +453,10 @@ export const ReleaseNotesConfigSchema = z
       .union([
         z.literal(false).describe('Set to false to disable the first-release placeholder intro.'),
         z.object({
-          text: z
-            .string()
-            .optional()
-            .describe(
-              "Placeholder intro line for a package's first release. Supports ${packageName} and ${version}. Defaults to a factual line so it reads cleanly even when published unedited.",
-            ),
+          text: z.string().optional().describe(
+            // biome-ignore lint/suspicious/noTemplateCurlyInString: documenting placeholder syntax to the user
+            "Placeholder intro line for a package's first release. Supports ${packageName} and ${version}. Defaults to a factual line so it reads cleanly even when published unedited.",
+          ),
         }),
       ])
       .optional()
@@ -500,6 +498,12 @@ export const CILabelsConfigSchema = z.object({
     .string()
     .default('release:retry')
     .describe('Label to retry a failed publish by re-applying it to a merged standing PR. Standing-pr mode only.'),
+  previewNotes: z
+    .string()
+    .default('release:preview-notes')
+    .describe(
+      'Label on the standing PR that generates LLM release notes on demand into an editable region in the PR body, for review and editing before merge. Standing-pr mode only.',
+    ),
   major: z.string().default('bump:major').describe('Label to force a major bump'),
   minor: z.string().default('bump:minor').describe('Label to force a minor bump'),
   patch: z.string().default('bump:patch').describe('Label to force a patch bump'),
@@ -577,6 +581,7 @@ export const CIConfigSchema = z.object({
     skip: 'release:skip',
     immediate: 'release:immediate',
     retry: 'release:retry',
+    previewNotes: 'release:preview-notes',
     major: 'bump:major',
     minor: 'bump:minor',
     patch: 'bump:patch',

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -449,6 +449,22 @@ export const ReleaseNotesConfigSchema = z
       })
       .optional()
       .describe('Extra links to append to the release notes.'),
+    firstRelease: z
+      .union([
+        z.literal(false).describe('Set to false to disable the first-release placeholder intro.'),
+        z.object({
+          text: z
+            .string()
+            .optional()
+            .describe(
+              "Placeholder intro line for a package's first release. Supports ${packageName} and ${version}. Defaults to a factual line so it reads cleanly even when published unedited.",
+            ),
+        }),
+      ])
+      .optional()
+      .describe(
+        'First-release placeholder intro, shown when a package has no prior version (previousVersion is null). Default-on with a factual line; set to false to disable.',
+      ),
   })
   .describe('Release notes configuration');
 

--- a/packages/config/test/unit/schema.spec.ts
+++ b/packages/config/test/unit/schema.spec.ts
@@ -505,6 +505,7 @@ describe('CIConfigSchema', () => {
       skip: 'release:skip',
       immediate: 'release:immediate',
       retry: 'release:retry',
+      previewNotes: 'release:preview-notes',
       major: 'bump:major',
       minor: 'bump:minor',
       patch: 'bump:patch',

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -16,6 +16,12 @@ export {
   warn,
 } from './logger.js';
 export {
+  extractNotesRegion,
+  NOTES_MARKER,
+  NOTES_MARKER_END,
+  wrapNotesRegion,
+} from './notesRegion.js';
+export {
   matchesPackageTarget,
   shouldMatchPackageTargets,
   shouldProcessPackage,

--- a/packages/core/src/notesRegion.ts
+++ b/packages/core/src/notesRegion.ts
@@ -1,0 +1,46 @@
+/**
+ * Markers delimiting a human-editable release-notes region inside a round-trippable surface
+ * (a GitHub release body, or a standing-PR body). The tool seeds the region, a human may edit it,
+ * and the tool extracts it back out — by marker slicing, never by parsing the surrounding prose.
+ *
+ * `NOTES_MARKER` is the region opener and is byte-identical to the original backfill provenance tag,
+ * so `decideReleaseUpdate`'s `includes(NOTES_MARKER)` ownership check keeps working unchanged: a body
+ * carrying the opener is recognised as releasekit-authored. The `-end` closer does not contain the
+ * opener as a substring, so it never false-matches that check on its own.
+ *
+ * Multiple packages share one surface (a multi-package standing PR) by keying the markers:
+ * `<!-- releasekit-notes:<key> -->` … `<!-- releasekit-notes-end:<key> -->`.
+ */
+export const NOTES_MARKER = '<!-- releasekit-notes -->';
+export const NOTES_MARKER_END = '<!-- releasekit-notes-end -->';
+
+function openMarker(pkgKey?: string): string {
+  return pkgKey ? `<!-- releasekit-notes:${pkgKey} -->` : NOTES_MARKER;
+}
+
+function closeMarker(pkgKey?: string): string {
+  return pkgKey ? `<!-- releasekit-notes-end:${pkgKey} -->` : NOTES_MARKER_END;
+}
+
+/** Wrap rendered notes in the editable-region markers so they can be recognised and extracted later. */
+export function wrapNotesRegion(content: string, pkgKey?: string): string {
+  return `${openMarker(pkgKey)}\n\n${content.trim()}\n\n${closeMarker(pkgKey)}`;
+}
+
+/**
+ * Extract the editable-region content from a body, or `undefined` when the opener is absent.
+ *
+ * Pure marker slicing — it never interprets the prose. An opener with no closer (a legacy body
+ * backfilled when only the opener was prepended) falls back to "everything after the opener", so
+ * older release bodies still round-trip.
+ */
+export function extractNotesRegion(body: string, pkgKey?: string): string | undefined {
+  const open = openMarker(pkgKey);
+  const start = body.indexOf(open);
+  if (start === -1) return undefined;
+
+  const afterOpen = start + open.length;
+  const end = body.indexOf(closeMarker(pkgKey), afterOpen);
+  const region = end === -1 ? body.slice(afterOpen) : body.slice(afterOpen, end);
+  return region.trim();
+}

--- a/packages/core/test/unit/notesRegion.spec.ts
+++ b/packages/core/test/unit/notesRegion.spec.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { extractNotesRegion, NOTES_MARKER, NOTES_MARKER_END, wrapNotesRegion } from '../../src/notesRegion.js';
+
+describe('notesRegion', () => {
+  describe('wrapNotesRegion', () => {
+    it('should wrap content in the opener and closer markers', () => {
+      const wrapped = wrapNotesRegion('hello world');
+      expect(wrapped).toBe(`${NOTES_MARKER}\n\nhello world\n\n${NOTES_MARKER_END}`);
+    });
+
+    it('should trim the content before wrapping', () => {
+      expect(wrapNotesRegion('  padded  ')).toBe(`${NOTES_MARKER}\n\npadded\n\n${NOTES_MARKER_END}`);
+    });
+
+    it('should use per-package keyed markers when a key is given', () => {
+      const wrapped = wrapNotesRegion('notes', '@scope/pkg');
+      expect(wrapped).toBe('<!-- releasekit-notes:@scope/pkg -->\n\nnotes\n\n<!-- releasekit-notes-end:@scope/pkg -->');
+    });
+  });
+
+  describe('extractNotesRegion', () => {
+    it('should round-trip wrapped content', () => {
+      expect(extractNotesRegion(wrapNotesRegion('the notes'))).toBe('the notes');
+    });
+
+    it('should round-trip per-package keyed content', () => {
+      const body = `intro\n${wrapNotesRegion('pkg notes', '@scope/pkg')}\noutro`;
+      expect(extractNotesRegion(body, '@scope/pkg')).toBe('pkg notes');
+    });
+
+    it('should return undefined when the opener is absent', () => {
+      expect(extractNotesRegion('no markers here')).toBeUndefined();
+    });
+
+    it('should extract only the region, ignoring surrounding prose', () => {
+      const body = `before\n${wrapNotesRegion('region body')}\nafter`;
+      expect(extractNotesRegion(body)).toBe('region body');
+    });
+
+    it('should fall back to everything after a lone opener (legacy backfilled body)', () => {
+      // Bodies backfilled before the closer existed carry only the opener (the old withMarker form).
+      const legacy = `${NOTES_MARKER}\n\nlegacy notes\n`;
+      expect(extractNotesRegion(legacy)).toBe('legacy notes');
+    });
+
+    it('should not confuse the bare opener with a keyed opener', () => {
+      const keyed = wrapNotesRegion('keyed', 'pkg');
+      expect(extractNotesRegion(keyed)).toBeUndefined();
+    });
+
+    it('should not match the closer as if it were the opener', () => {
+      // The closer alone must not register as a region (back-compat with decideReleaseUpdate).
+      expect(extractNotesRegion(NOTES_MARKER_END)).toBeUndefined();
+    });
+  });
+});

--- a/packages/notes/src/core/pipeline.ts
+++ b/packages/notes/src/core/pipeline.ts
@@ -152,6 +152,7 @@ export function createTemplateContext(pkg: PackageChangelog): TemplateContext {
     repoUrl: pkg.repoUrl,
     entries: pkg.entries,
     compareUrl,
+    isFirstRelease: pkg.previousVersion === null,
   };
 }
 
@@ -444,6 +445,7 @@ export async function runPipeline(
     includePackageName: contexts.length > 1 || contexts.some((c) => c.packageName.includes('/')),
     categoryOrder: llmConfig?.categoryOrder,
     links: releaseNotesConfig?.links,
+    firstRelease: releaseNotesConfig?.firstRelease,
   };
 
   if (!pipelineOptions?.skipChangelogs && changelogConfig !== false && changelogConfig.mode) {
@@ -512,7 +514,9 @@ export async function runPipeline(
   const packageNotes: Record<string, string> = {};
   const releaseNotesResult: Record<string, string> = {};
   for (const ctx of contexts) {
-    packageNotes[ctx.packageName] = formatVersion(ctx);
+    // packageNotes is already keyed by package, so it keeps the bare header (no includePackageName);
+    // only the first-release intro is threaded in.
+    packageNotes[ctx.packageName] = formatVersion(ctx, { firstRelease: releaseNotesConfig?.firstRelease });
     if (pipelineOptions?.skipReleaseNotes) {
       // Caller asked to skip release notes — don't populate the per-package map either,
       // otherwise the callsite will treat it as "available" content and propagate it.
@@ -542,7 +546,7 @@ export async function runPipeline(
         info(
           `No LLM release notes or template output for ${ctx.packageName}, using formatted changelog as release notes preview`,
         );
-        releaseNotesResult[ctx.packageName] = formatVersion(ctx);
+        releaseNotesResult[ctx.packageName] = formatVersion(ctx, { firstRelease: releaseNotesConfig?.firstRelease });
       }
     }
   }

--- a/packages/notes/src/core/types.ts
+++ b/packages/notes/src/core/types.ts
@@ -65,6 +65,9 @@ export interface TemplateContext {
   entries: ChangelogEntry[];
   compareUrl?: string;
   enhanced?: EnhancedData;
+  /** True when `previousVersion === null` — the package has no prior release. Templates can branch
+   *  on it to add a first-release intro; the default renderer seeds a placeholder line. */
+  isFirstRelease?: boolean;
 }
 
 export interface DocumentContext {
@@ -198,10 +201,17 @@ export interface ReleaseNotesFileConfig {
   dir?: string;
 }
 
+export interface FirstReleaseConfig {
+  /** Placeholder intro line for a package's first release. Supports ${packageName} and ${version}. */
+  text?: string;
+}
+
 export interface ReleaseNotesConfig {
   /** In-repo per-version file output. Omit to keep notes only on the GitHub release body. */
   file?: ReleaseNotesFileConfig;
   templates?: TemplateConfig;
   llm?: LLMConfig;
   links?: LinksConfig;
+  /** First-release placeholder intro. Default-on with a factual line; set to false to disable. */
+  firstRelease?: false | FirstReleaseConfig;
 }

--- a/packages/notes/src/output/markdown.ts
+++ b/packages/notes/src/output/markdown.ts
@@ -1,7 +1,26 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { info, success } from '@releasekit/core';
-import type { ChangelogEntry, Config, EnhancedCategory, LinksConfig, TemplateContext } from '../core/types.js';
+import type {
+  ChangelogEntry,
+  Config,
+  EnhancedCategory,
+  FirstReleaseConfig,
+  LinksConfig,
+  TemplateContext,
+} from '../core/types.js';
+
+const DEFAULT_FIRST_RELEASE_TEXT = '_First release of ${packageName}._';
+
+/**
+ * The placeholder intro line for a first release, or `undefined` when not a first release or disabled.
+ * The default text is a true statement so it reads fine even when published unedited (automated modes).
+ */
+export function firstReleaseLine(context: TemplateContext, config?: FirstReleaseConfig | false): string | undefined {
+  if (!context.isFirstRelease || config === false) return undefined;
+  const template = config?.text ?? DEFAULT_FIRST_RELEASE_TEXT;
+  return template.replaceAll('${packageName}', context.packageName).replaceAll('${version}', context.version);
+}
 
 const TYPE_ORDER: ChangelogEntry['type'][] = ['added', 'changed', 'deprecated', 'removed', 'fixed', 'security'];
 
@@ -221,6 +240,8 @@ export interface FormatVersionOptions {
   categoryOrder?: string[];
   /** Migration/doc links to render at the end of the release notes section. */
   links?: LinksConfig;
+  /** First-release placeholder intro config, or `false` to suppress it. */
+  firstRelease?: FirstReleaseConfig | false;
 }
 
 export function formatVersion(context: TemplateContext, options?: FormatVersionOptions): string {
@@ -232,6 +253,12 @@ export function formatVersion(context: TemplateContext, options?: FormatVersionO
 
   lines.push(`${versionHeader} - ${context.date}`);
   lines.push('');
+
+  const introLine = firstReleaseLine(context, options?.firstRelease);
+  if (introLine) {
+    lines.push(introLine);
+    lines.push('');
+  }
 
   if (context.compareUrl) {
     lines.push(`[Full Changelog](${context.compareUrl})`);

--- a/packages/notes/test/integration/pipeline.spec.ts
+++ b/packages/notes/test/integration/pipeline.spec.ts
@@ -319,8 +319,10 @@ describe('Monorepo: aggregation and splitting', () => {
   });
 
   it('should include package name in formatVersion only when requested', () => {
-    const withName = formatVersion(pkgA, { includePackageName: true });
-    const withoutName = formatVersion(pkgA);
+    // firstRelease disabled to isolate the includePackageName behaviour from the first-release intro,
+    // whose line legitimately names the package.
+    const withName = formatVersion(pkgA, { includePackageName: true, firstRelease: false });
+    const withoutName = formatVersion(pkgA, { firstRelease: false });
 
     expect(withName).toContain('## @acme/core@1.0.0');
     expect(withoutName).toContain('## 1.0.0');

--- a/packages/notes/test/unit/output/markdown.spec.ts
+++ b/packages/notes/test/unit/output/markdown.spec.ts
@@ -586,3 +586,57 @@ describe('formatVersion: non-LLM path', () => {
     expect(result).toContain('### Fixed');
   });
 });
+
+// ---------------------------------------------------------------------------
+// formatVersion — first-release intro
+// ---------------------------------------------------------------------------
+
+describe('formatVersion: first-release intro', () => {
+  const firstReleaseCtx = (overrides = {}) =>
+    makeContext({ previousVersion: null, isFirstRelease: true, ...overrides });
+
+  it('should emit the default factual intro line after the header on a first release', async () => {
+    const { formatVersion } = await import('../../../src/output/markdown.js');
+
+    const result = formatVersion(firstReleaseCtx());
+
+    expect(result).toContain('_First release of test-pkg._');
+    // Intro sits between the header and the sections.
+    expect(result.indexOf('## 1.0.0')).toBeLessThan(result.indexOf('_First release of test-pkg._'));
+    expect(result.indexOf('_First release of test-pkg._')).toBeLessThan(result.indexOf('### Added'));
+  });
+
+  it('should not emit an intro for a non-first release', async () => {
+    const { formatVersion } = await import('../../../src/output/markdown.js');
+
+    const result = formatVersion(makeContext({ isFirstRelease: false }));
+
+    expect(result).not.toContain('First release of');
+  });
+
+  it('should suppress the intro when firstRelease is false', async () => {
+    const { formatVersion } = await import('../../../src/output/markdown.js');
+
+    const result = formatVersion(firstReleaseCtx(), { firstRelease: false });
+
+    expect(result).not.toContain('First release of');
+  });
+
+  it('should substitute ${packageName} and ${version} in a custom intro template', async () => {
+    const { formatVersion } = await import('../../../src/output/markdown.js');
+
+    const result = formatVersion(firstReleaseCtx(), {
+      firstRelease: { text: 'Introducing ${packageName} ${version}!' },
+    });
+
+    expect(result).toContain('Introducing test-pkg 1.0.0!');
+  });
+
+  it('should never wrap the intro in region markers (changelog/file surface)', async () => {
+    const { formatVersion } = await import('../../../src/output/markdown.js');
+
+    const result = formatVersion(firstReleaseCtx());
+
+    expect(result).not.toContain('<!-- releasekit-notes');
+  });
+});

--- a/packages/notes/test/unit/templates.spec.ts
+++ b/packages/notes/test/unit/templates.spec.ts
@@ -11,6 +11,7 @@ const sampleContext: TemplateContext = {
   packageName: 'test-pkg',
   version: '1.0.0',
   previousVersion: null,
+  isFirstRelease: true,
   date: '2026-02-21',
   repoUrl: 'https://github.com/test/test-pkg',
   entries: [
@@ -37,6 +38,12 @@ describe('Liquid Engine', () => {
     const result = renderLiquid(template, sampleContext);
     expect(result).toBe('No previous');
   });
+
+  it('should branch on isFirstRelease', () => {
+    const template = '{% if isFirstRelease %}First!{% else %}Update{% endif %}';
+    expect(renderLiquid(template, sampleContext)).toBe('First!');
+    expect(renderLiquid(template, { ...sampleContext, isFirstRelease: false })).toBe('Update');
+  });
 });
 
 describe('Handlebars Engine', () => {
@@ -50,6 +57,12 @@ describe('Handlebars Engine', () => {
     const template = '{{#each entries}}- {{description}}{{/each}}';
     const result = renderHandlebars(template, sampleContext);
     expect(result).toBe('- New feature- Bug fix');
+  });
+
+  it('should branch on isFirstRelease', () => {
+    const template = '{{#if isFirstRelease}}First!{{else}}Update{{/if}}';
+    expect(renderHandlebars(template, sampleContext)).toBe('First!');
+    expect(renderHandlebars(template, { ...sampleContext, isFirstRelease: false })).toBe('Update');
   });
 
   it('should uppercase the first letter of a string with the capitalize helper', () => {

--- a/packages/publish/src/stages/github-release.ts
+++ b/packages/publish/src/stages/github-release.ts
@@ -50,7 +50,7 @@ function resolveNotes(
   if (bodySource === 'changelog') {
     const packageBody = formatChangelogForTag(tag, changelogs);
     if (packageBody) {
-      return { body: wrapNotesRegion(packageBody), useGithubNotes: false };
+      return { body: packageBody, useGithubNotes: false };
     }
     warn('No changelog found for tag, falling back to GitHub auto-notes');
     return { useGithubNotes: true };

--- a/packages/publish/src/stages/github-release.ts
+++ b/packages/publish/src/stages/github-release.ts
@@ -1,5 +1,5 @@
 import type { VersionPackageChangelog } from '@releasekit/core';
-import { debug, info, sanitizePackageName, success, warn, wrapNotesRegion } from '@releasekit/core';
+import { debug, info, sanitizePackageName, success, warn } from '@releasekit/core';
 import type { GitHubReleaseResult, PipelineContext } from '../types.js';
 import { execCommand, execCommandSafe } from '../utils/exec.js';
 import { isPrerelease } from '../utils/semver.js';
@@ -41,7 +41,7 @@ function resolveNotes(
     }
     if (pipelineNotes) {
       const body = findNotesForTag(tag, pipelineNotes);
-      if (body) return { body: wrapNotesRegion(body), useGithubNotes: false };
+      if (body) return { body, useGithubNotes: false };
     }
     warn('No release notes found in pipeline output, falling back to GitHub auto-notes');
     return { useGithubNotes: true };
@@ -59,7 +59,7 @@ function resolveNotes(
   // 'auto' mode — try release notes, fall back to GitHub auto-generated notes
   if (releaseNotesEnabled && pipelineNotes) {
     const body = findNotesForTag(tag, pipelineNotes);
-    if (body) return { body: wrapNotesRegion(body), useGithubNotes: false };
+    if (body) return { body, useGithubNotes: false };
     warn(`Release notes configured but no content found for tag ${tag}, falling back to GitHub auto-generated notes`);
   }
 

--- a/packages/publish/src/stages/github-release.ts
+++ b/packages/publish/src/stages/github-release.ts
@@ -50,7 +50,7 @@ function resolveNotes(
   if (bodySource === 'changelog') {
     const packageBody = formatChangelogForTag(tag, changelogs);
     if (packageBody) {
-      return { body: packageBody, useGithubNotes: false };
+      return { body: wrapNotesRegion(packageBody), useGithubNotes: false };
     }
     warn('No changelog found for tag, falling back to GitHub auto-notes');
     return { useGithubNotes: true };

--- a/packages/publish/src/stages/github-release.ts
+++ b/packages/publish/src/stages/github-release.ts
@@ -1,5 +1,5 @@
 import type { VersionPackageChangelog } from '@releasekit/core';
-import { debug, info, sanitizePackageName, success, warn } from '@releasekit/core';
+import { debug, info, sanitizePackageName, success, warn, wrapNotesRegion } from '@releasekit/core';
 import type { GitHubReleaseResult, PipelineContext } from '../types.js';
 import { execCommand, execCommandSafe } from '../utils/exec.js';
 import { isPrerelease } from '../utils/semver.js';
@@ -41,7 +41,7 @@ function resolveNotes(
     }
     if (pipelineNotes) {
       const body = findNotesForTag(tag, pipelineNotes);
-      if (body) return { body, useGithubNotes: false };
+      if (body) return { body: wrapNotesRegion(body), useGithubNotes: false };
     }
     warn('No release notes found in pipeline output, falling back to GitHub auto-notes');
     return { useGithubNotes: true };
@@ -59,7 +59,7 @@ function resolveNotes(
   // 'auto' mode — try release notes, fall back to GitHub auto-generated notes
   if (releaseNotesEnabled && pipelineNotes) {
     const body = findNotesForTag(tag, pipelineNotes);
-    if (body) return { body, useGithubNotes: false };
+    if (body) return { body: wrapNotesRegion(body), useGithubNotes: false };
     warn(`Release notes configured but no content found for tag ${tag}, falling back to GitHub auto-generated notes`);
   }
 

--- a/packages/publish/test/unit/stages/github-release.spec.ts
+++ b/packages/publish/test/unit/stages/github-release.spec.ts
@@ -1,5 +1,4 @@
 import * as fs from 'node:fs';
-import { wrapNotesRegion } from '@releasekit/core';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { getDefaultConfig } from '../../../src/config.js';
 import { runGithubReleaseStage } from '../../../src/stages/github-release.js';
@@ -129,7 +128,7 @@ describe('github-release stage', () => {
 
     const args = vi.mocked(execCommand).mock.calls[0]?.[1] as string[];
     expect(args).toContain('--notes');
-    expect(args).toContain(wrapNotesRegion('## 1.0.0\n\n- Enhanced notes from pipeline'));
+    expect(args).toContain('## 1.0.0\n\n- Enhanced notes from pipeline');
     expect(args).not.toContain('--generate-notes');
   });
 
@@ -332,7 +331,7 @@ describe('github-release stage', () => {
 
     const args = vi.mocked(execCommand).mock.calls[0]?.[1] as string[];
     expect(args).toContain('--notes');
-    expect(args[args.indexOf('--notes') + 1]).toBe(wrapNotesRegion('LLM-enhanced release notes'));
+    expect(args[args.indexOf('--notes') + 1]).toBe('LLM-enhanced release notes');
     expect(args).not.toContain('--generate-notes');
     // Title should be resolved via the releaseNotes keys even though changelogs is empty
     expect(args[args.indexOf('--title') + 1]).toBe('@releasekit/version: v0.4.1');
@@ -361,7 +360,7 @@ describe('github-release stage', () => {
 
     const args = vi.mocked(execCommand).mock.calls[0]?.[1] as string[];
     expect(args).toContain('--notes');
-    expect(args[args.indexOf('--notes') + 1]).toBe(wrapNotesRegion('LLM-enhanced release notes'));
+    expect(args[args.indexOf('--notes') + 1]).toBe('LLM-enhanced release notes');
     expect(args).not.toContain('--generate-notes');
     // Title resolves via the original (unsanitized) scoped name
     expect(args[args.indexOf('--title') + 1]).toBe('@wdio/tauri-plugin: v1.1.0');

--- a/packages/publish/test/unit/stages/github-release.spec.ts
+++ b/packages/publish/test/unit/stages/github-release.spec.ts
@@ -1,4 +1,5 @@
 import * as fs from 'node:fs';
+import { wrapNotesRegion } from '@releasekit/core';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { getDefaultConfig } from '../../../src/config.js';
 import { runGithubReleaseStage } from '../../../src/stages/github-release.js';
@@ -128,7 +129,7 @@ describe('github-release stage', () => {
 
     const args = vi.mocked(execCommand).mock.calls[0]?.[1] as string[];
     expect(args).toContain('--notes');
-    expect(args).toContain('## 1.0.0\n\n- Enhanced notes from pipeline');
+    expect(args).toContain(wrapNotesRegion('## 1.0.0\n\n- Enhanced notes from pipeline'));
     expect(args).not.toContain('--generate-notes');
   });
 
@@ -331,7 +332,7 @@ describe('github-release stage', () => {
 
     const args = vi.mocked(execCommand).mock.calls[0]?.[1] as string[];
     expect(args).toContain('--notes');
-    expect(args[args.indexOf('--notes') + 1]).toBe('LLM-enhanced release notes');
+    expect(args[args.indexOf('--notes') + 1]).toBe(wrapNotesRegion('LLM-enhanced release notes'));
     expect(args).not.toContain('--generate-notes');
     // Title should be resolved via the releaseNotes keys even though changelogs is empty
     expect(args[args.indexOf('--title') + 1]).toBe('@releasekit/version: v0.4.1');
@@ -360,7 +361,7 @@ describe('github-release stage', () => {
 
     const args = vi.mocked(execCommand).mock.calls[0]?.[1] as string[];
     expect(args).toContain('--notes');
-    expect(args[args.indexOf('--notes') + 1]).toBe('LLM-enhanced release notes');
+    expect(args[args.indexOf('--notes') + 1]).toBe(wrapNotesRegion('LLM-enhanced release notes'));
     expect(args).not.toContain('--generate-notes');
     // Title resolves via the original (unsanitized) scoped name
     expect(args[args.indexOf('--title') + 1]).toBe('@wdio/tauri-plugin: v1.1.0');

--- a/packages/publish/test/unit/stages/github-release.spec.ts
+++ b/packages/publish/test/unit/stages/github-release.spec.ts
@@ -367,48 +367,6 @@ describe('github-release stage', () => {
     expect(args[args.indexOf('--title') + 1]).toBe('@wdio/tauri-plugin: v1.1.0');
   });
 
-  it('should wrap changelog body with notesRegion markers when body is changelog', async () => {
-    const { execCommand } = await import('../../../src/utils/exec.js');
-    const config = getDefaultConfig();
-    config.githubRelease.body = 'changelog';
-
-    const ctx = createContext({
-      config,
-      input: {
-        dryRun: false,
-        updates: [],
-        changelogs: [
-          {
-            packageName: 'pkg-a',
-            version: '1.0.0',
-            previousVersion: '0.9.0',
-            revisionRange: 'v0.9.0..HEAD',
-            repoUrl: null,
-            entries: [{ type: 'fix', description: 'fix a bug' }],
-          },
-        ],
-        tags: ['pkg-a@v1.0.0'],
-      },
-      output: {
-        dryRun: false,
-        git: { committed: true, tags: ['pkg-a@v1.0.0'], pushed: true },
-        npm: [],
-        cargo: [],
-        verification: [],
-        githubReleases: [],
-      },
-    });
-
-    await runGithubReleaseStage(ctx);
-
-    const args = vi.mocked(execCommand).mock.calls[0]?.[1] as string[];
-    expect(args).toContain('--notes');
-    const notesValue = args[args.indexOf('--notes') + 1] as string;
-    expect(notesValue).toContain('<!-- releasekit-notes -->');
-    expect(notesValue).toContain('fix a bug');
-    expect(args).not.toContain('--generate-notes');
-  });
-
   it('should always use --generate-notes when body is generated', async () => {
     const { execCommand } = await import('../../../src/utils/exec.js');
     const config = getDefaultConfig();

--- a/packages/publish/test/unit/stages/github-release.spec.ts
+++ b/packages/publish/test/unit/stages/github-release.spec.ts
@@ -367,6 +367,48 @@ describe('github-release stage', () => {
     expect(args[args.indexOf('--title') + 1]).toBe('@wdio/tauri-plugin: v1.1.0');
   });
 
+  it('should wrap changelog body with notesRegion markers when body is changelog', async () => {
+    const { execCommand } = await import('../../../src/utils/exec.js');
+    const config = getDefaultConfig();
+    config.githubRelease.body = 'changelog';
+
+    const ctx = createContext({
+      config,
+      input: {
+        dryRun: false,
+        updates: [],
+        changelogs: [
+          {
+            packageName: 'pkg-a',
+            version: '1.0.0',
+            previousVersion: '0.9.0',
+            revisionRange: 'v0.9.0..HEAD',
+            repoUrl: null,
+            entries: [{ type: 'fix', description: 'fix a bug' }],
+          },
+        ],
+        tags: ['pkg-a@v1.0.0'],
+      },
+      output: {
+        dryRun: false,
+        git: { committed: true, tags: ['pkg-a@v1.0.0'], pushed: true },
+        npm: [],
+        cargo: [],
+        verification: [],
+        githubReleases: [],
+      },
+    });
+
+    await runGithubReleaseStage(ctx);
+
+    const args = vi.mocked(execCommand).mock.calls[0]?.[1] as string[];
+    expect(args).toContain('--notes');
+    const notesValue = args[args.indexOf('--notes') + 1] as string;
+    expect(notesValue).toContain('<!-- releasekit-notes -->');
+    expect(notesValue).toContain('fix a bug');
+    expect(args).not.toContain('--generate-notes');
+  });
+
   it('should always use --generate-notes when body is generated', async () => {
     const { execCommand } = await import('../../../src/utils/exec.js');
     const config = getDefaultConfig();

--- a/packages/release/docs/ci-setup.md
+++ b/packages/release/docs/ci-setup.md
@@ -544,6 +544,21 @@ If a standing-PR publish fails partway through (some packages on the registry, n
 
 Applying the label to a non-standing or unmerged PR simply doesn't match the job's guard — nothing runs. A successful retry resolves the partial-publish failure report and clears the supersede warning from the next standing PR. Full recovery walkthrough: [Recovering from a failed publish](../../../docs/troubleshooting.md#recovering-from-a-failed-publish). (For reference, releasekit's own repo implements the same flow as a standalone [`release-retry.yml`](../../../.github/workflows/release-retry.yml) that dispatches its release workflow — useful if your publish runs in a separate dispatchable workflow.)
 
+#### Previewing and editing release notes
+
+By default the standing PR generates only changelogs — LLM release notes are produced at **publish** time, so the workflow never depends on LLM availability on every push. To review and **edit** the release notes *before* merging, label the standing PR **`release:preview-notes`** (configurable via `ci.labels.previewNotes`).
+
+1. Add the label to the standing PR (`gh pr edit <n> --add-label release:preview-notes`).
+2. On the next `standing-pr update` — the next push to `main`, the hourly `schedule`, or a manual re-run of the workflow — releasekit generates LLM release notes into an editable **`## Release Notes`** region in the PR body, with one block per package delimited by `<!-- releasekit-notes:<package> -->` markers.
+3. Edit the prose between the markers directly in the PR description. **Keep the marker comments** — they delimit the region that's read back.
+4. Merge as usual. The edited notes become the GitHub release body, winning per package over freshly generated notes.
+
+Your edits are **preserved across update runs**: notes are generated once when the label is first applied, then carried over (not regenerated) on later pushes — so a push to `main` while you're mid-edit won't clobber your text. A package added to the queue *after* you started gets fresh notes; existing blocks keep your edits. Requires `notes.releaseNotes.llm` configured and the provider secret available to the `update-release-pr` job (same as publish-time generation).
+
+This is a standing-pr-only feature — it needs a durable pre-publish artifact (the PR body) to edit. In `direct`/`manual` mode, edit the GitHub Release after it's published instead. (A manual-mode draft-then-dispatch flow is tracked in [#319](https://github.com/goosewobbler/releasekit/issues/319).)
+
+> **Edit race:** a standing-PR update reads the live PR body, merges your edits, and rewrites it. An edit saved in the narrow window between that read and rewrite can be overwritten. Updates are infrequent (push/schedule-driven), so in practice this is rare — re-apply the edit if it happens.
+
 ### Troubleshooting
 
 | Symptom | Cause / fix |
@@ -555,6 +570,8 @@ Applying the label to a non-standing or unmerged PR simply doesn't match the job
 | Standing PR keeps closing immediately | `minPackages` is set higher than the current change count. Either lower the threshold or wait for more package changes to accumulate. |
 | Standing PR ignores my `bump:*` label on a feeder PR | By design — feeder labels are advisory in standing-pr mode. Add the label to the standing PR itself, or use `release:immediate` to bypass the queue. |
 | Standing PR shows `pending` status `Conflicting bump labels…` | Two conflicting labels on the standing PR (e.g. `bump:patch` + `bump:major`). Remove one and re-run `standing-pr update`. |
+| Added `release:preview-notes` but no notes appear | The region is written on the next `standing-pr update` (push to `main`, the hourly `schedule`, or a manual re-run) — not the instant the label is applied. Also confirm `notes.releaseNotes.llm` is set and the provider secret reaches the `update-release-pr` job. |
+| Edited release notes didn't ship | Confirm you edited *inside* the `<!-- releasekit-notes:<package> -->` markers and left them intact — content outside the markers isn't read back. |
 | Force-push to `release/next` fails | Branch is protected. Remove protection on the release branch, or grant the bot bypass. |
 | `minAge` never advances | The hourly `schedule` trigger isn't running. Confirm the workflow has a `schedule:` block and that the repo isn't paused (GitHub disables `schedule` on inactive repos after 60 days). |
 

--- a/packages/release/src/backfill/github-release.ts
+++ b/packages/release/src/backfill/github-release.ts
@@ -1,11 +1,13 @@
 import { execFileSync } from 'node:child_process';
+import { NOTES_MARKER } from '@releasekit/core';
 
 /**
  * Marker that identifies a GitHub release body releasekit authored. Embedded at the top of every
  * backfilled body so re-runs can recognise their own work (see `decideReleaseUpdate`) — the same
- * idempotent-marker convention the preview/manifest/publish-failure comments use.
+ * idempotent-marker convention the preview/manifest/publish-failure comments use. Re-exported from
+ * `@releasekit/core`, which owns the editable-region marker family shared with the notes pipeline.
  */
-export const NOTES_MARKER = '<!-- releasekit-notes -->';
+export { NOTES_MARKER };
 
 export type UpdateDecision =
   | { action: 'update' }

--- a/packages/release/src/label-definitions.ts
+++ b/packages/release/src/label-definitions.ts
@@ -52,6 +52,11 @@ export function deriveLabelDefinitions(ciConfig: CIConfig | undefined): LabelDef
       color: COLOR_RELEASE,
       description: 'ReleaseKit: retry a failed publish on this merged standing PR',
     },
+    {
+      name: labels.previewNotes,
+      color: COLOR_RELEASE,
+      description: 'ReleaseKit: generate editable release notes in the standing PR body',
+    },
   ];
 
   for (const scopeLabel of Object.keys(scopeLabels)) {

--- a/packages/release/src/label-utils.ts
+++ b/packages/release/src/label-utils.ts
@@ -4,6 +4,7 @@ export interface LabelConfig {
   skip: string;
   immediate: string;
   retry: string;
+  previewNotes: string;
   major: string;
   minor: string;
   patch: string;
@@ -15,6 +16,7 @@ export const DEFAULT_LABELS: LabelConfig = {
   skip: 'release:skip',
   immediate: 'release:immediate',
   retry: 'release:retry',
+  previewNotes: 'release:preview-notes',
   major: 'bump:major',
   minor: 'bump:minor',
   patch: 'bump:patch',

--- a/packages/release/src/standing-pr/notes-region.ts
+++ b/packages/release/src/standing-pr/notes-region.ts
@@ -1,0 +1,46 @@
+import { extractNotesRegion, wrapNotesRegion } from '@releasekit/core';
+
+/**
+ * The editable release-notes region of a standing-PR body. The bot seeds one keyed sub-region per
+ * package; a human edits the prose between the markers; the bot extracts it back by marker slicing
+ * (never by parsing the prose) so edits survive the body being regenerated and force-pushed.
+ *
+ * Per-package keying lets a multi-package standing PR carry several independently-editable blocks,
+ * and lets `publishFromManifest` pull each package's notes out by name at merge time.
+ */
+const REGION_HEADING = '## Release Notes';
+const REGION_HINT =
+  '> Edit the release notes for each package below before merging. Keep the `<!-- releasekit-notes... -->` marker comments — they delimit the editable region.';
+
+/** Render the editable region for the given per-package notes, with keyed markers per package. */
+export function renderNotesRegion(notesByPackage: Record<string, string>): string {
+  const packages = Object.keys(notesByPackage).sort();
+  if (packages.length === 0) return '';
+
+  const lines: string[] = [REGION_HEADING, '', REGION_HINT, ''];
+  for (const pkg of packages) {
+    lines.push(`### \`${pkg}\``, '', wrapNotesRegion(notesByPackage[pkg] ?? '', pkg), '');
+  }
+  return lines.join('\n').trimEnd();
+}
+
+/** Extract each package's edited notes from a PR body, keyed by package name. Missing → omitted. */
+export function extractNotesRegions(body: string, packageNames: string[]): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const pkg of packageNames) {
+    const region = extractNotesRegion(body, pkg);
+    if (region !== undefined && region.length > 0) result[pkg] = region;
+  }
+  return result;
+}
+
+/**
+ * Merge freshly generated notes with edited notes pulled from the live PR body. Edited content wins
+ * per package; packages new since the last edit (absent from `edited`) fall back to the fresh notes.
+ */
+export function mergeNotesRegions(
+  fresh: Record<string, string>,
+  edited: Record<string, string>,
+): Record<string, string> {
+  return { ...fresh, ...edited };
+}

--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -16,6 +16,7 @@ import { DEFAULT_LABELS } from '../label-utils.js';
 import { runNotesStep, runPublishStep, runVersionStep } from '../steps.js';
 import type { ReleaseOptions, ReleaseOutput } from '../types.js';
 import { publishableUpdates, syncVersionDisplay } from '../version-display.js';
+import { extractNotesRegions, mergeNotesRegions, renderNotesRegion } from './notes-region.js';
 import { postStandingPRStatusSafe } from './status.js';
 
 const MANIFEST_MARKER = '<!-- releasekit-manifest -->';
@@ -327,7 +328,7 @@ function deleteReleaseBranch(releaseBranch: string, cwd: string): void {
   }
 }
 
-function renderPrBody(versionOutput: VersionOutput, supersedeWarning?: string[]): string {
+function renderPrBody(versionOutput: VersionOutput, supersedeWarning?: string[], notesRegion?: string): string {
   const lines: string[] = ['## Release', ''];
 
   // While a prior release remains partially published, lead with the supersede warning so the
@@ -360,6 +361,9 @@ function renderPrBody(versionOutput: VersionOutput, supersedeWarning?: string[])
 
   const changelog = renderChangelogSection(versionOutput);
   if (changelog) lines.push('', changelog, '');
+  // The editable release-notes region (opt-in via the preview-notes label) sits below the changelog
+  // and above the merge instructions, so a reviewer reads/edits it in the natural place.
+  if (notesRegion) lines.push('', notesRegion, '');
   lines.push('---', '> Merge this PR to publish. The release will be triggered automatically.');
   lines.push('', ATTRIBUTION_FOOTER);
   return lines.join('\n');
@@ -651,6 +655,11 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
     }
   }
 
+  // Preview-notes opt-in (#200): when the standing PR carries the preview-notes label, generate LLM
+  // release notes on demand into an editable region in the PR body. Default path stays LLM-free.
+  const previewNotesLabel = (ciConfig?.labels ?? DEFAULT_LABELS).previewNotes;
+  const previewNotesEnabled = (existingStandingPr?.labels ?? []).includes(previewNotesLabel);
+
   const overrides = resolveStandingPrLabelOverrides(existingStandingPr?.labels ?? [], ciConfig);
   if (overrides.bump) info(`Standing PR label override: bump=${overrides.bump}`);
   if (overrides.target) info(`Standing PR label override: target=${overrides.target}`);
@@ -741,11 +750,33 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
   const writeOptions = buildBaseReleaseOptions(options, false, buildExtras);
   const versionOutput = await runVersionStep(writeOptions);
 
-  // Generate per-package CHANGELOG.md only — release-notes generation (LLM + RELEASE_NOTES.md)
-  // is deferred to publish time. This decouples standing-PR updates from LLM availability and
-  // avoids paying for an LLM call on every push to main when only the final publish needs it.
+  // With the preview-notes label, pull any release notes a human has already edited into the live PR
+  // body so they survive this regenerate-and-force-push. Marker slicing only — never parse the prose.
+  const previewPackages = publishableUpdates(versionOutput).map((u) => u.packageName);
+  let editedNotes: Record<string, string> = {};
+  if (previewNotesEnabled && existingStandingPr && githubContext?.token) {
+    try {
+      const previewOctokit = createOctokit(githubContext.token);
+      const { data: livePr } = await previewOctokit.rest.pulls.get({
+        owner: githubContext.owner,
+        repo: githubContext.repo,
+        pull_number: existingStandingPr.number,
+      });
+      editedNotes = extractNotesRegions(livePr.body ?? '', previewPackages);
+    } catch (err) {
+      warn(
+        `Could not read current PR body to preserve note edits: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  // Generate per-package CHANGELOG.md always; LLM release notes only when previewing. To keep LLM
+  // load low (#200), skip generation when every releasing package already has an edited region —
+  // notes are seeded once when the label is first applied, then preserved on later pushes.
   info('Generating changelog...');
-  const notesOptions = { ...writeOptions, skipNotes: false, skipReleaseNotes: true };
+  const allPackagesHaveRegions = previewPackages.length > 0 && previewPackages.every((p) => p in editedNotes);
+  const generateReleaseNotes = previewNotesEnabled && !allPackagesHaveRegions;
+  const notesOptions = { ...writeOptions, skipNotes: false, skipReleaseNotes: !generateReleaseNotes };
   const notesResult = await runNotesStep(versionOutput, notesOptions);
 
   // Commit and force-push the release branch
@@ -809,7 +840,17 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
     warn(`Could not check for unresolved publish failures: ${err instanceof Error ? err.message : String(err)}`);
   }
 
-  const body = renderPrBody(versionOutput, supersedeWarning);
+  // Edited notes win per package; packages new since the last edit fall back to freshly generated.
+  // The read-modify-write here has a small window: a human edit landing between the pulls.get above
+  // and the pulls.update below can be overwritten. Standing-PR updates are infrequent (push-driven),
+  // so we accept it rather than add optimistic-concurrency machinery.
+  let notesRegion: string | undefined;
+  if (previewNotesEnabled) {
+    const merged = mergeNotesRegions(notesResult.releaseNotes ?? {}, editedNotes);
+    if (Object.keys(merged).length > 0) notesRegion = renderNotesRegion(merged);
+  }
+
+  const body = renderPrBody(versionOutput, supersedeWarning, notesRegion);
 
   let prNumber: number;
   let prUrl: string;
@@ -1017,6 +1058,21 @@ export async function publishFromManifest(prNumber: number, options: StandingPRO
     projectDir: cwd,
   };
 
+  // Pull any human-edited release notes from the live (now-merged, still-readable) PR body (#200).
+  // Marker slicing only — the manifest never stores prose, so "manifest = machine state only" holds.
+  let editedNotes: Record<string, string> = {};
+  try {
+    const { data: livePr } = await octokit.rest.pulls.get({ owner, repo, pull_number: prNumber });
+    editedNotes = extractNotesRegions(
+      livePr.body ?? '',
+      publishableUpdates(manifest.versionOutput).map((u) => u.packageName),
+    );
+  } catch (err) {
+    warn(
+      `Could not read PR #${prNumber} body for edited release notes: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
   let releaseNotes: Record<string, string> = {};
   let notesFiles: string[] = [...manifest.notesFiles];
   try {
@@ -1039,6 +1095,13 @@ export async function publishFromManifest(prNumber: number, options: StandingPRO
   } catch (err) {
     warn(`Release notes generation failed: ${err instanceof Error ? err.message : String(err)}`);
     warn('Publish will proceed with empty release notes; GitHub release will use auto-generated notes.');
+  }
+
+  // Human-edited notes win per package for the GitHub release body. Applied after regeneration so
+  // edits override fresh prose, and so a regeneration failure still yields the edited content.
+  if (Object.keys(editedNotes).length > 0) {
+    releaseNotes = { ...releaseNotes, ...editedNotes };
+    info(`Using human-edited release notes for ${Object.keys(editedNotes).length} package(s) from the PR body.`);
   }
 
   // Create the release tags at HEAD before invoking the publish pipeline. The pipeline's

--- a/packages/release/test/unit/labels-command.spec.ts
+++ b/packages/release/test/unit/labels-command.spec.ts
@@ -112,6 +112,7 @@ describe('runLabelsSync', () => {
       'release:skip',
       'release:immediate',
       'release:retry',
+      'release:preview-notes',
       'release',
     ]);
     vi.mocked(createOctokit).mockReturnValue(octokit as never);

--- a/packages/release/test/unit/standing-pr.spec.ts
+++ b/packages/release/test/unit/standing-pr.spec.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderFailureReport, renderResolvedReport } from '../../src/failure-report/failure-report.js';
+import { renderNotesRegion } from '../../src/standing-pr/notes-region.js';
 import type { StandingPRManifest } from '../../src/standing-pr/standing-pr.js';
 import {
   createReleaseTags,
@@ -302,6 +303,7 @@ describe('runStandingPRUpdate', () => {
         prerelease: 'channel:prerelease',
         skip: 'release:skip',
         immediate: 'release:immediate',
+        previewNotes: 'release:preview-notes',
         major: 'bump:major',
         minor: 'bump:minor',
         patch: 'bump:patch',
@@ -1107,6 +1109,82 @@ describe('runStandingPRUpdate', () => {
       expect(runVersionStepMock.mock.calls[0]?.[0]).toMatchObject({ sync: true });
     });
   });
+
+  describe('preview-notes editable region (#200)', () => {
+    async function setupPreviewPR(opts: { labels: string[]; liveBody?: string; freshNotes?: Record<string, string> }) {
+      const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
+      const versionOutput = createMockVersionOutput([{ packageName: '@scope/core', newVersion: '1.2.3' }]);
+      vi.mocked(runVersionStep)
+        .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>)
+        .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>);
+      vi.mocked(runNotesStep).mockResolvedValue({
+        packageNotes: {},
+        releaseNotes: opts.freshNotes ?? {},
+        files: [],
+      });
+
+      const { createOctokit } = await import('../../src/github.js');
+      const { mocks, octokit } = createMockOctokit();
+      mocks.pullsList.mockResolvedValue({
+        data: [
+          {
+            number: 99,
+            html_url: 'https://github.com/owner/repo/pull/99',
+            labels: opts.labels.map((name) => ({ name })),
+          },
+        ],
+      });
+      mocks.pullsGet.mockResolvedValue({ data: { body: opts.liveBody ?? '' } });
+      vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+
+      return { mocks, runNotesStepMock: vi.mocked(runNotesStep) };
+    }
+
+    it('should seed generated notes into the editable region when the preview label is present', async () => {
+      const { mocks, runNotesStepMock } = await setupPreviewPR({
+        labels: ['release', 'release:preview-notes'],
+        liveBody: '',
+        freshNotes: { '@scope/core': 'Generated notes for core' },
+      });
+
+      await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
+
+      // LLM release notes were requested (skipReleaseNotes false) on the seeding run.
+      expect(runNotesStepMock.mock.calls.at(-1)?.[1]).toMatchObject({ skipReleaseNotes: false });
+      const body = mocks.pullsUpdate.mock.calls.at(-1)?.[0]?.body as string;
+      expect(body).toContain('## Release Notes');
+      expect(body).toContain('<!-- releasekit-notes:@scope/core -->');
+      expect(body).toContain('Generated notes for core');
+    });
+
+    it('should preserve a human-edited region across an update without regenerating', async () => {
+      const editedBody = renderNotesRegion({ '@scope/core': 'HUMAN EDITED notes' });
+      const { mocks, runNotesStepMock } = await setupPreviewPR({
+        labels: ['release', 'release:preview-notes'],
+        liveBody: editedBody,
+        // Even if the mock returned fresh notes, the edit must win — but generation should be skipped.
+        freshNotes: { '@scope/core': 'REGENERATED notes' },
+      });
+
+      await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
+
+      // Every releasing package already has a region → LLM generation is skipped.
+      expect(runNotesStepMock.mock.calls.at(-1)?.[1]).toMatchObject({ skipReleaseNotes: true });
+      const body = mocks.pullsUpdate.mock.calls.at(-1)?.[0]?.body as string;
+      expect(body).toContain('HUMAN EDITED notes');
+      expect(body).not.toContain('REGENERATED notes');
+    });
+
+    it('should not add a notes region when the preview label is absent', async () => {
+      const { mocks } = await setupPreviewPR({ labels: ['release'], freshNotes: {} });
+
+      await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
+
+      const body = mocks.pullsUpdate.mock.calls.at(-1)?.[0]?.body as string;
+      expect(body).not.toContain('## Release Notes');
+      expect(body).not.toContain('<!-- releasekit-notes');
+    });
+  });
 });
 
 describe('findLatestMergedStandingPR', () => {
@@ -1553,6 +1631,38 @@ describe('publishFromManifest', () => {
     await expect(
       publishFromManifest(42, { projectDir: '/test', verbose: false, quiet: false, json: false }),
     ).rejects.toThrow(/manifest not found/);
+  });
+
+  it('should use human-edited notes from the PR body at merge, overriding regenerated notes (#200)', async () => {
+    const { runNotesStep, runPublishStep } = await import('../../src/steps.js');
+    vi.mocked(runNotesStep).mockResolvedValue({
+      packageNotes: {},
+      releaseNotes: { '@scope/core': 'REGENERATED at merge' },
+      files: [],
+    });
+    vi.mocked(runPublishStep).mockResolvedValue({
+      npm: [],
+      cargo: [],
+      githubReleases: [],
+      git: { committed: true, tags: [], pushed: true },
+    } as unknown as Awaited<ReturnType<typeof runPublishStep>>);
+
+    const { createOctokit } = await import('../../src/github.js');
+    const { mocks, octokit } = createMockOctokit();
+    // Manifest comment present so publish proceeds.
+    mocks.paginate.iterator.mockReturnValue({
+      async *[Symbol.asyncIterator]() {
+        yield { data: [{ id: 77, body: serializeManifest(baseManifest) }] };
+      },
+    });
+    // The merged PR body carries a human-edited region for @scope/core.
+    mocks.pullsGet.mockResolvedValue({ data: { body: renderNotesRegion({ '@scope/core': 'EDITED AT MERGE' }) } });
+    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+
+    await publishFromManifest(99, { projectDir: '/test', verbose: false, quiet: false, json: false });
+
+    // The edited notes (not the regenerated ones) reach the publish step's release-body map.
+    expect(vi.mocked(runPublishStep).mock.calls[0]?.[2]).toMatchObject({ '@scope/core': 'EDITED AT MERGE' });
   });
 });
 

--- a/packages/release/test/unit/standing-pr/notes-region.spec.ts
+++ b/packages/release/test/unit/standing-pr/notes-region.spec.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { extractNotesRegions, mergeNotesRegions, renderNotesRegion } from '../../../src/standing-pr/notes-region.js';
+
+describe('notes-region', () => {
+  describe('renderNotesRegion', () => {
+    it('should render a keyed editable region per package', () => {
+      const rendered = renderNotesRegion({ '@scope/a': 'Notes A', '@scope/b': 'Notes B' });
+
+      expect(rendered).toContain('## Release Notes');
+      expect(rendered).toContain('<!-- releasekit-notes:@scope/a -->');
+      expect(rendered).toContain('<!-- releasekit-notes-end:@scope/a -->');
+      expect(rendered).toContain('Notes A');
+      expect(rendered).toContain('<!-- releasekit-notes:@scope/b -->');
+      expect(rendered).toContain('Notes B');
+    });
+
+    it('should return an empty string when there are no packages', () => {
+      expect(renderNotesRegion({})).toBe('');
+    });
+
+    it('should round-trip through extractNotesRegions', () => {
+      const notes = { '@scope/a': 'Notes A', pkg: 'Plain notes' };
+      const rendered = renderNotesRegion(notes);
+
+      expect(extractNotesRegions(rendered, ['@scope/a', 'pkg'])).toEqual(notes);
+    });
+  });
+
+  describe('extractNotesRegions', () => {
+    it('should extract only the requested packages and omit missing ones', () => {
+      const body = `prose\n${renderNotesRegion({ '@scope/a': 'Notes A' })}\nmore prose`;
+
+      expect(extractNotesRegions(body, ['@scope/a', '@scope/missing'])).toEqual({ '@scope/a': 'Notes A' });
+    });
+
+    it('should return an empty object when the body has no region', () => {
+      expect(extractNotesRegions('just a normal PR body', ['pkg'])).toEqual({});
+    });
+
+    it('should preserve human edits inside the markers', () => {
+      const seeded = renderNotesRegion({ pkg: 'original' });
+      const edited = seeded.replace('original', 'human edited this');
+
+      expect(extractNotesRegions(edited, ['pkg'])).toEqual({ pkg: 'human edited this' });
+    });
+  });
+
+  describe('mergeNotesRegions', () => {
+    it('should let edited notes win per package', () => {
+      const fresh = { a: 'fresh A', b: 'fresh B' };
+      const edited = { a: 'edited A' };
+
+      expect(mergeNotesRegions(fresh, edited)).toEqual({ a: 'edited A', b: 'fresh B' });
+    });
+
+    it('should fall back to fresh notes for packages with no edit', () => {
+      expect(mergeNotesRegions({ a: 'fresh A' }, {})).toEqual({ a: 'fresh A' });
+    });
+
+    it('should include edited-only packages even when fresh is empty', () => {
+      expect(mergeNotesRegions({}, { a: 'edited A' })).toEqual({ a: 'edited A' });
+    });
+  });
+});

--- a/releasekit.schema.json
+++ b/releasekit.schema.json
@@ -1121,6 +1121,11 @@
               "default": "release:retry",
               "description": "Label to retry a failed publish by re-applying it to a merged standing PR. Standing-pr mode only."
             },
+            "previewNotes": {
+              "type": "string",
+              "default": "release:preview-notes",
+              "description": "Label on the standing PR that generates LLM release notes on demand into an editable region in the PR body, for review and editing before merge. Standing-pr mode only."
+            },
             "major": {
               "type": "string",
               "default": "bump:major",

--- a/releasekit.schema.json
+++ b/releasekit.schema.json
@@ -1004,6 +1004,28 @@
                     }
                   },
                   "description": "Extra links to append to the release notes."
+                },
+                "firstRelease": {
+                  "oneOf": [
+                    {
+                      "type": "boolean",
+                      "enum": [
+                        false
+                      ],
+                      "description": "Set to false to disable the first-release placeholder intro."
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "text": {
+                          "type": "string",
+                          "description": "Placeholder intro line for a package's first release. Supports ${packageName} and ${version}. Defaults to a factual line so it reads cleanly even when published unedited."
+                        }
+                      }
+                    }
+                  ],
+                  "description": "First-release placeholder intro, shown when a package has no prior version (previousVersion is null). Default-on with a factual line; set to false to disable."
                 }
               },
               "description": "Release notes configuration"

--- a/scripts/generate-config-docs.ts
+++ b/scripts/generate-config-docs.ts
@@ -63,6 +63,7 @@ function fmtType(prop: SchemaProperty): string {
   if (prop.oneOf) {
     return prop.oneOf
       .map((s) => {
+        if (s.type === 'boolean' && s.enum) return (s.enum as unknown[]).map((v) => `\`${v}\``).join(' | ');
         if (s.type === 'boolean') return 'boolean';
         if (s.type === 'string' && s.enum) return s.enum.map((v) => `\`"${v}"\``).join(' | ');
         return s.type ?? 'any';

--- a/test/integration/single.spec.ts
+++ b/test/integration/single.spec.ts
@@ -143,4 +143,47 @@ describe('Integration: single package', () => {
       expect(markdown).toContain('Add streaming support');
     });
   });
+
+  describe('First release -> intro line, no compare link', () => {
+    it('should derive isFirstRelease from a null previousVersion and render the intro', () => {
+      const versionOutput = {
+        dryRun: true,
+        updates: [
+          {
+            packageName: 'test-single-package',
+            previousVersion: null,
+            newVersion: '0.1.0',
+            filePath: 'package.json',
+          },
+        ],
+        changelogs: [
+          {
+            packageName: 'test-single-package',
+            version: '0.1.0',
+            previousVersion: null,
+            revisionRange: 'HEAD',
+            repoUrl: null,
+            entries: [{ type: 'added', description: 'Initial public API' }],
+          },
+        ],
+        tags: ['v0.1.0'],
+        commitMessage: 'chore: release test-single-package v0.1.0',
+      };
+
+      const input = parseVersionOutput(JSON.stringify(versionOutput));
+      const contexts = input.packages.map(createTemplateContext);
+      // The version→notes contract: a null previousVersion is the first-release signal.
+      expect(contexts[0]?.isFirstRelease).toBe(true);
+
+      const markdown = renderMarkdown(contexts);
+
+      // Unbracketed header (no prior version to link), the factual intro line, and the entries.
+      expect(markdown).toContain('## 0.1.0');
+      expect(markdown).not.toContain('## [0.1.0]');
+      expect(markdown).toContain('_First release of test-single-package._');
+      expect(markdown).toContain('Initial public API');
+      // Markers live only on the GitHub release body surface, never in the changelog document.
+      expect(markdown).not.toContain('<!-- releasekit-notes');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Closes #200. Two composed features around a shared **editable release-notes region** primitive. (Originally split into #320 + #321; #321 has been merged into this branch, so this PR now carries both.)

### 1. First-release intro (cross-mode)
A package's first release (`previousVersion === null`) no longer reads identically to a patch release.
- `isFirstRelease` context flag, derived once in `createTemplateContext`; templates can branch `{% if isFirstRelease %}`.
- Default-on, factual intro line (`_First release of <pkg>._`) in `formatVersion` — reads fine even when published unedited.
- `releaseNotes.firstRelease` config (`false` to disable, or `{ text }` with `${packageName}`/`${version}`).

### 2. General editable region + standing-PR preview/edit (#200)
- Shared `wrapNotesRegion`/`extractNotesRegion` in `@releasekit/core`, reusing the existing `<!-- releasekit-notes -->` tag as the opener (byte-identical → backfill's ownership check stays back-compatible) + new `-end` closer + per-package keying.
- `release:preview-notes` label generates LLM release notes on demand into an editable per-package region in the **standing-PR body**; edits are preserved across force-pushed update runs (seed once, then preserve — keeps LLM load low); at merge `publishFromManifest` extracts the edits from the live PR body and lets them win per package (**Option A** — manifest untouched, "machine state only" preserved).

## Scope notes
- Editing pre-publish is standing-PR-only (the one mode with a durable pre-publish artifact). Manual-mode draft-then-dispatch is tracked separately in #319.
- The editable region lives in the **standing-PR body**, not the published GitHub release body — published bodies are left as plain prose. (Marking published bodies for backfill provenance is a separate, deliberate decision, not bundled here.)

## Docs
`packages/release/docs/ci-setup.md` — "Previewing and editing release notes" section + troubleshooting rows. Config reference (`releaseNotes.firstRelease`, `ci.labels.previewNotes`) regenerated in `docs/configuration.md`.

## Verification
- `pnpm turbo run lint typecheck test` → 24/24 tasks pass
- `pnpm schema:check` → in sync
- `pnpm test:harness` → preview CI sim exits 0
- Tests: core region round-trip (legacy fallback + keyed markers); `formatVersion` intro (default/disable/custom/no-markers); template `isFirstRelease` branching; standing-PR seed / preserve-without-regenerate / no-label; `publishFromManifest` edited-notes-win-at-merge; first-release integration test through the real notes pipeline.

## Notes
- **Edit race (documented):** a human edit landing between a standing-PR update's body read and rewrite can be overwritten. Updates are push/schedule-driven and infrequent, so no optimistic-concurrency machinery.

Closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds two standing-PR features around a shared editable release-notes region primitive: a **first-release intro line** (`isFirstRelease` context flag + `firstRelease` config, default-on with a factual placeholder) and an **opt-in editable notes region** for standing PRs (seed LLM notes once on label, preserve edits across force-pushed updates, edited notes win at merge via `publishFromManifest`).

- `@releasekit/core` gains `wrapNotesRegion`/`extractNotesRegion` with keyed per-package markers; bare `<!-- releasekit-notes -->` is backward-compatible with `decideReleaseUpdate`'s ownership check.
- `runStandingPRUpdate` skips LLM generation when all packages already have an edited region, keeping the default path LLM-free and incurring an API call only for the initial seed.
- `publishFromManifest` reads the live (merged) PR body and applies edited notes over freshly generated ones, preserving human prose all the way to the GitHub release body.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changed paths are additive and opt-in, with no changes to the default standing-PR or publish flows.

The first-release intro is default-on but purely additive (a static italic line before existing changelog entries, suppressible via config). The editable-region feature only activates when the release:preview-notes label is present; the default path is unchanged. The read-modify-write race condition is real but deliberately accepted and documented. Marker design is correct: bare and keyed openers share no substring, legacy bodies round-trip via the fallback slice, and decideReleaseUpdate's ownership check is unaffected. Test coverage is thorough across all branching paths.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/core/src/notesRegion.ts | New primitive: keyed and bare region markers, wrap/extract helpers. Bare opener is byte-identical to the old backfill marker preserving backward compat; keyed and bare markers don't share substrings so indexOf can't false-match across them. |
| packages/release/src/standing-pr/standing-pr.ts | Main logic changes: preview-notes label detection, seed-once-preserve pattern, merge-time edited-notes win. Race condition is documented and accepted. Skip-generation optimization (allPackagesHaveRegions) is guarded against the vacuously-true empty-array case. |
| packages/release/src/standing-pr/notes-region.ts | New helpers: renderNotesRegion (sorted packages, keyed markers), extractNotesRegions (filters out empty regions), mergeNotesRegions ({...fresh, ...edited} — edited wins). Clean and well-tested. |
| packages/notes/src/output/markdown.ts | Adds firstReleaseLine helper and threads firstRelease config through formatVersion. Default text is a true statement that reads fine unpublished; ${packageName}/${version} substitution is safe (internal data, not user input). |
| packages/notes/src/core/pipeline.ts | isFirstRelease derived once in createTemplateContext via strict null check; firstRelease config threaded into both formatVersion call sites inside runPipeline. |
| packages/config/src/schema.ts | Adds firstRelease (false | {text?}) to ReleaseNotesConfigSchema and previewNotes string to CILabelsConfigSchema with correct defaults. Schema and docs are in sync. |
| packages/release/src/backfill/github-release.ts | NOTES_MARKER moved to @releasekit/core and re-exported here — pure refactor, no behavior change. |
| packages/release/test/unit/standing-pr.spec.ts | New describe blocks cover: seed on first label application, preserve-without-regenerate, no-region when label absent, and edited-notes-win at publishFromManifest merge. Good coverage of all branching paths. |
| scripts/generate-config-docs.ts | Minor fix: handles boolean enums in oneOf rendering (for the false literal in firstRelease config); previously would fall through to the generic 'boolean' branch and drop the value. |

</details>

</details>

<sub>Reviews (5): Last reviewed commit: ["docs(config): render boolean-literal uni..."](https://github.com/goosewobbler/releasekit/commit/6f6a770c81f6f5f162a051c424210b8f086fc543) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37848192)</sub>

<!-- /greptile_comment -->