### PR TITLE
feat(release): edit release notes in standing-PR mode (#200)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -394,6 +394,7 @@ PR label names used for release control. Override to match your repository's lab
 | `skip` | string | `"release:skip"` | Label to suppress a release on this PR |
 | `immediate` | string | `"release:immediate"` | Label to bypass the standing PR for one merge — triggers a direct release. Standing-pr mode only. |
 | `retry` | string | `"release:retry"` | Label to retry a failed publish by re-applying it to a merged standing PR. Standing-pr mode only. |
+| `previewNotes` | string | `"release:preview-notes"` | Label on the standing PR that generates LLM release notes on demand into an editable region in the PR body, for review and editing before merge. Standing-pr mode only. |
 | `major` | string | `"bump:major"` | Label to force a major bump |
 | `minor` | string | `"bump:minor"` | Label to force a minor bump |
 | `patch` | string | `"bump:patch"` | Label to force a patch bump |

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -453,12 +453,10 @@ export const ReleaseNotesConfigSchema = z
       .union([
         z.literal(false).describe('Set to false to disable the first-release placeholder intro.'),
         z.object({
-          text: z
-            .string()
-            .optional()
-            .describe(
-              "Placeholder intro line for a package's first release. Supports ${packageName} and ${version}. Defaults to a factual line so it reads cleanly even when published unedited.",
-            ),
+          text: z.string().optional().describe(
+            // biome-ignore lint/suspicious/noTemplateCurlyInString: documenting placeholder syntax to the user
+            "Placeholder intro line for a package's first release. Supports ${packageName} and ${version}. Defaults to a factual line so it reads cleanly even when published unedited.",
+          ),
         }),
       ])
       .optional()
@@ -500,6 +498,12 @@ export const CILabelsConfigSchema = z.object({
     .string()
     .default('release:retry')
     .describe('Label to retry a failed publish by re-applying it to a merged standing PR. Standing-pr mode only.'),
+  previewNotes: z
+    .string()
+    .default('release:preview-notes')
+    .describe(
+      'Label on the standing PR that generates LLM release notes on demand into an editable region in the PR body, for review and editing before merge. Standing-pr mode only.',
+    ),
   major: z.string().default('bump:major').describe('Label to force a major bump'),
   minor: z.string().default('bump:minor').describe('Label to force a minor bump'),
   patch: z.string().default('bump:patch').describe('Label to force a patch bump'),
@@ -577,6 +581,7 @@ export const CIConfigSchema = z.object({
     skip: 'release:skip',
     immediate: 'release:immediate',
     retry: 'release:retry',
+    previewNotes: 'release:preview-notes',
     major: 'bump:major',
     minor: 'bump:minor',
     patch: 'bump:patch',

--- a/packages/config/test/unit/schema.spec.ts
+++ b/packages/config/test/unit/schema.spec.ts
@@ -505,6 +505,7 @@ describe('CIConfigSchema', () => {
       skip: 'release:skip',
       immediate: 'release:immediate',
       retry: 'release:retry',
+      previewNotes: 'release:preview-notes',
       major: 'bump:major',
       minor: 'bump:minor',
       patch: 'bump:patch',

--- a/packages/release/src/label-definitions.ts
+++ b/packages/release/src/label-definitions.ts
@@ -52,6 +52,11 @@ export function deriveLabelDefinitions(ciConfig: CIConfig | undefined): LabelDef
       color: COLOR_RELEASE,
       description: 'ReleaseKit: retry a failed publish on this merged standing PR',
     },
+    {
+      name: labels.previewNotes,
+      color: COLOR_RELEASE,
+      description: 'ReleaseKit: generate editable release notes in the standing PR body',
+    },
   ];
 
   for (const scopeLabel of Object.keys(scopeLabels)) {

--- a/packages/release/src/label-utils.ts
+++ b/packages/release/src/label-utils.ts
@@ -4,6 +4,7 @@ export interface LabelConfig {
   skip: string;
   immediate: string;
   retry: string;
+  previewNotes: string;
   major: string;
   minor: string;
   patch: string;
@@ -15,6 +16,7 @@ export const DEFAULT_LABELS: LabelConfig = {
   skip: 'release:skip',
   immediate: 'release:immediate',
   retry: 'release:retry',
+  previewNotes: 'release:preview-notes',
   major: 'bump:major',
   minor: 'bump:minor',
   patch: 'bump:patch',

--- a/packages/release/src/standing-pr/notes-region.ts
+++ b/packages/release/src/standing-pr/notes-region.ts
@@ -1,0 +1,46 @@
+import { extractNotesRegion, wrapNotesRegion } from '@releasekit/core';
+
+/**
+ * The editable release-notes region of a standing-PR body. The bot seeds one keyed sub-region per
+ * package; a human edits the prose between the markers; the bot extracts it back by marker slicing
+ * (never by parsing the prose) so edits survive the body being regenerated and force-pushed.
+ *
+ * Per-package keying lets a multi-package standing PR carry several independently-editable blocks,
+ * and lets `publishFromManifest` pull each package's notes out by name at merge time.
+ */
+const REGION_HEADING = '## Release Notes';
+const REGION_HINT =
+  '> Edit the release notes for each package below before merging. Keep the `<!-- releasekit-notes... -->` marker comments — they delimit the editable region.';
+
+/** Render the editable region for the given per-package notes, with keyed markers per package. */
+export function renderNotesRegion(notesByPackage: Record<string, string>): string {
+  const packages = Object.keys(notesByPackage).sort();
+  if (packages.length === 0) return '';
+
+  const lines: string[] = [REGION_HEADING, '', REGION_HINT, ''];
+  for (const pkg of packages) {
+    lines.push(`### \`${pkg}\``, '', wrapNotesRegion(notesByPackage[pkg] ?? '', pkg), '');
+  }
+  return lines.join('\n').trimEnd();
+}
+
+/** Extract each package's edited notes from a PR body, keyed by package name. Missing → omitted. */
+export function extractNotesRegions(body: string, packageNames: string[]): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const pkg of packageNames) {
+    const region = extractNotesRegion(body, pkg);
+    if (region !== undefined && region.length > 0) result[pkg] = region;
+  }
+  return result;
+}
+
+/**
+ * Merge freshly generated notes with edited notes pulled from the live PR body. Edited content wins
+ * per package; packages new since the last edit (absent from `edited`) fall back to the fresh notes.
+ */
+export function mergeNotesRegions(
+  fresh: Record<string, string>,
+  edited: Record<string, string>,
+): Record<string, string> {
+  return { ...fresh, ...edited };
+}

--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -16,6 +16,7 @@ import { DEFAULT_LABELS } from '../label-utils.js';
 import { runNotesStep, runPublishStep, runVersionStep } from '../steps.js';
 import type { ReleaseOptions, ReleaseOutput } from '../types.js';
 import { publishableUpdates, syncVersionDisplay } from '../version-display.js';
+import { extractNotesRegions, mergeNotesRegions, renderNotesRegion } from './notes-region.js';
 import { postStandingPRStatusSafe } from './status.js';
 
 const MANIFEST_MARKER = '<!-- releasekit-manifest -->';
@@ -327,7 +328,7 @@ function deleteReleaseBranch(releaseBranch: string, cwd: string): void {
   }
 }
 
-function renderPrBody(versionOutput: VersionOutput, supersedeWarning?: string[]): string {
+function renderPrBody(versionOutput: VersionOutput, supersedeWarning?: string[], notesRegion?: string): string {
   const lines: string[] = ['## Release', ''];
 
   // While a prior release remains partially published, lead with the supersede warning so the
@@ -360,6 +361,9 @@ function renderPrBody(versionOutput: VersionOutput, supersedeWarning?: string[])
 
   const changelog = renderChangelogSection(versionOutput);
   if (changelog) lines.push('', changelog, '');
+  // The editable release-notes region (opt-in via the preview-notes label) sits below the changelog
+  // and above the merge instructions, so a reviewer reads/edits it in the natural place.
+  if (notesRegion) lines.push('', notesRegion, '');
   lines.push('---', '> Merge this PR to publish. The release will be triggered automatically.');
   lines.push('', ATTRIBUTION_FOOTER);
   return lines.join('\n');
@@ -651,6 +655,11 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
     }
   }
 
+  // Preview-notes opt-in (#200): when the standing PR carries the preview-notes label, generate LLM
+  // release notes on demand into an editable region in the PR body. Default path stays LLM-free.
+  const previewNotesLabel = (ciConfig?.labels ?? DEFAULT_LABELS).previewNotes;
+  const previewNotesEnabled = (existingStandingPr?.labels ?? []).includes(previewNotesLabel);
+
   const overrides = resolveStandingPrLabelOverrides(existingStandingPr?.labels ?? [], ciConfig);
   if (overrides.bump) info(`Standing PR label override: bump=${overrides.bump}`);
   if (overrides.target) info(`Standing PR label override: target=${overrides.target}`);
@@ -741,11 +750,33 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
   const writeOptions = buildBaseReleaseOptions(options, false, buildExtras);
   const versionOutput = await runVersionStep(writeOptions);
 
-  // Generate per-package CHANGELOG.md only — release-notes generation (LLM + RELEASE_NOTES.md)
-  // is deferred to publish time. This decouples standing-PR updates from LLM availability and
-  // avoids paying for an LLM call on every push to main when only the final publish needs it.
+  // With the preview-notes label, pull any release notes a human has already edited into the live PR
+  // body so they survive this regenerate-and-force-push. Marker slicing only — never parse the prose.
+  const previewPackages = publishableUpdates(versionOutput).map((u) => u.packageName);
+  let editedNotes: Record<string, string> = {};
+  if (previewNotesEnabled && existingStandingPr && githubContext?.token) {
+    try {
+      const previewOctokit = createOctokit(githubContext.token);
+      const { data: livePr } = await previewOctokit.rest.pulls.get({
+        owner: githubContext.owner,
+        repo: githubContext.repo,
+        pull_number: existingStandingPr.number,
+      });
+      editedNotes = extractNotesRegions(livePr.body ?? '', previewPackages);
+    } catch (err) {
+      warn(
+        `Could not read current PR body to preserve note edits: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  // Generate per-package CHANGELOG.md always; LLM release notes only when previewing. To keep LLM
+  // load low (#200), skip generation when every releasing package already has an edited region —
+  // notes are seeded once when the label is first applied, then preserved on later pushes.
   info('Generating changelog...');
-  const notesOptions = { ...writeOptions, skipNotes: false, skipReleaseNotes: true };
+  const allPackagesHaveRegions = previewPackages.length > 0 && previewPackages.every((p) => p in editedNotes);
+  const generateReleaseNotes = previewNotesEnabled && !allPackagesHaveRegions;
+  const notesOptions = { ...writeOptions, skipNotes: false, skipReleaseNotes: !generateReleaseNotes };
   const notesResult = await runNotesStep(versionOutput, notesOptions);
 
   // Commit and force-push the release branch
@@ -809,7 +840,17 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
     warn(`Could not check for unresolved publish failures: ${err instanceof Error ? err.message : String(err)}`);
   }
 
-  const body = renderPrBody(versionOutput, supersedeWarning);
+  // Edited notes win per package; packages new since the last edit fall back to freshly generated.
+  // The read-modify-write here has a small window: a human edit landing between the pulls.get above
+  // and the pulls.update below can be overwritten. Standing-PR updates are infrequent (push-driven),
+  // so we accept it rather than add optimistic-concurrency machinery.
+  let notesRegion: string | undefined;
+  if (previewNotesEnabled) {
+    const merged = mergeNotesRegions(notesResult.releaseNotes ?? {}, editedNotes);
+    if (Object.keys(merged).length > 0) notesRegion = renderNotesRegion(merged);
+  }
+
+  const body = renderPrBody(versionOutput, supersedeWarning, notesRegion);
 
   let prNumber: number;
   let prUrl: string;
@@ -1017,6 +1058,21 @@ export async function publishFromManifest(prNumber: number, options: StandingPRO
     projectDir: cwd,
   };
 
+  // Pull any human-edited release notes from the live (now-merged, still-readable) PR body (#200).
+  // Marker slicing only — the manifest never stores prose, so "manifest = machine state only" holds.
+  let editedNotes: Record<string, string> = {};
+  try {
+    const { data: livePr } = await octokit.rest.pulls.get({ owner, repo, pull_number: prNumber });
+    editedNotes = extractNotesRegions(
+      livePr.body ?? '',
+      publishableUpdates(manifest.versionOutput).map((u) => u.packageName),
+    );
+  } catch (err) {
+    warn(
+      `Could not read PR #${prNumber} body for edited release notes: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
   let releaseNotes: Record<string, string> = {};
   let notesFiles: string[] = [...manifest.notesFiles];
   try {
@@ -1039,6 +1095,13 @@ export async function publishFromManifest(prNumber: number, options: StandingPRO
   } catch (err) {
     warn(`Release notes generation failed: ${err instanceof Error ? err.message : String(err)}`);
     warn('Publish will proceed with empty release notes; GitHub release will use auto-generated notes.');
+  }
+
+  // Human-edited notes win per package for the GitHub release body. Applied after regeneration so
+  // edits override fresh prose, and so a regeneration failure still yields the edited content.
+  if (Object.keys(editedNotes).length > 0) {
+    releaseNotes = { ...releaseNotes, ...editedNotes };
+    info(`Using human-edited release notes for ${Object.keys(editedNotes).length} package(s) from the PR body.`);
   }
 
   // Create the release tags at HEAD before invoking the publish pipeline. The pipeline's

--- a/packages/release/test/unit/labels-command.spec.ts
+++ b/packages/release/test/unit/labels-command.spec.ts
@@ -112,6 +112,7 @@ describe('runLabelsSync', () => {
       'release:skip',
       'release:immediate',
       'release:retry',
+      'release:preview-notes',
       'release',
     ]);
     vi.mocked(createOctokit).mockReturnValue(octokit as never);

--- a/packages/release/test/unit/standing-pr.spec.ts
+++ b/packages/release/test/unit/standing-pr.spec.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderFailureReport, renderResolvedReport } from '../../src/failure-report/failure-report.js';
+import { renderNotesRegion } from '../../src/standing-pr/notes-region.js';
 import type { StandingPRManifest } from '../../src/standing-pr/standing-pr.js';
 import {
   createReleaseTags,
@@ -302,6 +303,7 @@ describe('runStandingPRUpdate', () => {
         prerelease: 'channel:prerelease',
         skip: 'release:skip',
         immediate: 'release:immediate',
+        previewNotes: 'release:preview-notes',
         major: 'bump:major',
         minor: 'bump:minor',
         patch: 'bump:patch',
@@ -1107,6 +1109,82 @@ describe('runStandingPRUpdate', () => {
       expect(runVersionStepMock.mock.calls[0]?.[0]).toMatchObject({ sync: true });
     });
   });
+
+  describe('preview-notes editable region (#200)', () => {
+    async function setupPreviewPR(opts: { labels: string[]; liveBody?: string; freshNotes?: Record<string, string> }) {
+      const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
+      const versionOutput = createMockVersionOutput([{ packageName: '@scope/core', newVersion: '1.2.3' }]);
+      vi.mocked(runVersionStep)
+        .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>)
+        .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>);
+      vi.mocked(runNotesStep).mockResolvedValue({
+        packageNotes: {},
+        releaseNotes: opts.freshNotes ?? {},
+        files: [],
+      });
+
+      const { createOctokit } = await import('../../src/github.js');
+      const { mocks, octokit } = createMockOctokit();
+      mocks.pullsList.mockResolvedValue({
+        data: [
+          {
+            number: 99,
+            html_url: 'https://github.com/owner/repo/pull/99',
+            labels: opts.labels.map((name) => ({ name })),
+          },
+        ],
+      });
+      mocks.pullsGet.mockResolvedValue({ data: { body: opts.liveBody ?? '' } });
+      vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+
+      return { mocks, runNotesStepMock: vi.mocked(runNotesStep) };
+    }
+
+    it('should seed generated notes into the editable region when the preview label is present', async () => {
+      const { mocks, runNotesStepMock } = await setupPreviewPR({
+        labels: ['release', 'release:preview-notes'],
+        liveBody: '',
+        freshNotes: { '@scope/core': 'Generated notes for core' },
+      });
+
+      await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
+
+      // LLM release notes were requested (skipReleaseNotes false) on the seeding run.
+      expect(runNotesStepMock.mock.calls.at(-1)?.[1]).toMatchObject({ skipReleaseNotes: false });
+      const body = mocks.pullsUpdate.mock.calls.at(-1)?.[0]?.body as string;
+      expect(body).toContain('## Release Notes');
+      expect(body).toContain('<!-- releasekit-notes:@scope/core -->');
+      expect(body).toContain('Generated notes for core');
+    });
+
+    it('should preserve a human-edited region across an update without regenerating', async () => {
+      const editedBody = renderNotesRegion({ '@scope/core': 'HUMAN EDITED notes' });
+      const { mocks, runNotesStepMock } = await setupPreviewPR({
+        labels: ['release', 'release:preview-notes'],
+        liveBody: editedBody,
+        // Even if the mock returned fresh notes, the edit must win — but generation should be skipped.
+        freshNotes: { '@scope/core': 'REGENERATED notes' },
+      });
+
+      await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
+
+      // Every releasing package already has a region → LLM generation is skipped.
+      expect(runNotesStepMock.mock.calls.at(-1)?.[1]).toMatchObject({ skipReleaseNotes: true });
+      const body = mocks.pullsUpdate.mock.calls.at(-1)?.[0]?.body as string;
+      expect(body).toContain('HUMAN EDITED notes');
+      expect(body).not.toContain('REGENERATED notes');
+    });
+
+    it('should not add a notes region when the preview label is absent', async () => {
+      const { mocks } = await setupPreviewPR({ labels: ['release'], freshNotes: {} });
+
+      await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
+
+      const body = mocks.pullsUpdate.mock.calls.at(-1)?.[0]?.body as string;
+      expect(body).not.toContain('## Release Notes');
+      expect(body).not.toContain('<!-- releasekit-notes');
+    });
+  });
 });
 
 describe('findLatestMergedStandingPR', () => {
@@ -1553,6 +1631,38 @@ describe('publishFromManifest', () => {
     await expect(
       publishFromManifest(42, { projectDir: '/test', verbose: false, quiet: false, json: false }),
     ).rejects.toThrow(/manifest not found/);
+  });
+
+  it('should use human-edited notes from the PR body at merge, overriding regenerated notes (#200)', async () => {
+    const { runNotesStep, runPublishStep } = await import('../../src/steps.js');
+    vi.mocked(runNotesStep).mockResolvedValue({
+      packageNotes: {},
+      releaseNotes: { '@scope/core': 'REGENERATED at merge' },
+      files: [],
+    });
+    vi.mocked(runPublishStep).mockResolvedValue({
+      npm: [],
+      cargo: [],
+      githubReleases: [],
+      git: { committed: true, tags: [], pushed: true },
+    } as unknown as Awaited<ReturnType<typeof runPublishStep>>);
+
+    const { createOctokit } = await import('../../src/github.js');
+    const { mocks, octokit } = createMockOctokit();
+    // Manifest comment present so publish proceeds.
+    mocks.paginate.iterator.mockReturnValue({
+      async *[Symbol.asyncIterator]() {
+        yield { data: [{ id: 77, body: serializeManifest(baseManifest) }] };
+      },
+    });
+    // The merged PR body carries a human-edited region for @scope/core.
+    mocks.pullsGet.mockResolvedValue({ data: { body: renderNotesRegion({ '@scope/core': 'EDITED AT MERGE' }) } });
+    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+
+    await publishFromManifest(99, { projectDir: '/test', verbose: false, quiet: false, json: false });
+
+    // The edited notes (not the regenerated ones) reach the publish step's release-body map.
+    expect(vi.mocked(runPublishStep).mock.calls[0]?.[2]).toMatchObject({ '@scope/core': 'EDITED AT MERGE' });
   });
 });
 

--- a/packages/release/test/unit/standing-pr/notes-region.spec.ts
+++ b/packages/release/test/unit/standing-pr/notes-region.spec.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { extractNotesRegions, mergeNotesRegions, renderNotesRegion } from '../../../src/standing-pr/notes-region.js';
+
+describe('notes-region', () => {
+  describe('renderNotesRegion', () => {
+    it('should render a keyed editable region per package', () => {
+      const rendered = renderNotesRegion({ '@scope/a': 'Notes A', '@scope/b': 'Notes B' });
+
+      expect(rendered).toContain('## Release Notes');
+      expect(rendered).toContain('<!-- releasekit-notes:@scope/a -->');
+      expect(rendered).toContain('<!-- releasekit-notes-end:@scope/a -->');
+      expect(rendered).toContain('Notes A');
+      expect(rendered).toContain('<!-- releasekit-notes:@scope/b -->');
+      expect(rendered).toContain('Notes B');
+    });
+
+    it('should return an empty string when there are no packages', () => {
+      expect(renderNotesRegion({})).toBe('');
+    });
+
+    it('should round-trip through extractNotesRegions', () => {
+      const notes = { '@scope/a': 'Notes A', pkg: 'Plain notes' };
+      const rendered = renderNotesRegion(notes);
+
+      expect(extractNotesRegions(rendered, ['@scope/a', 'pkg'])).toEqual(notes);
+    });
+  });
+
+  describe('extractNotesRegions', () => {
+    it('should extract only the requested packages and omit missing ones', () => {
+      const body = `prose\n${renderNotesRegion({ '@scope/a': 'Notes A' })}\nmore prose`;
+
+      expect(extractNotesRegions(body, ['@scope/a', '@scope/missing'])).toEqual({ '@scope/a': 'Notes A' });
+    });
+
+    it('should return an empty object when the body has no region', () => {
+      expect(extractNotesRegions('just a normal PR body', ['pkg'])).toEqual({});
+    });
+
+    it('should preserve human edits inside the markers', () => {
+      const seeded = renderNotesRegion({ pkg: 'original' });
+      const edited = seeded.replace('original', 'human edited this');
+
+      expect(extractNotesRegions(edited, ['pkg'])).toEqual({ pkg: 'human edited this' });
+    });
+  });
+
+  describe('mergeNotesRegions', () => {
+    it('should let edited notes win per package', () => {
+      const fresh = { a: 'fresh A', b: 'fresh B' };
+      const edited = { a: 'edited A' };
+
+      expect(mergeNotesRegions(fresh, edited)).toEqual({ a: 'edited A', b: 'fresh B' });
+    });
+
+    it('should fall back to fresh notes for packages with no edit', () => {
+      expect(mergeNotesRegions({ a: 'fresh A' }, {})).toEqual({ a: 'fresh A' });
+    });
+
+    it('should include edited-only packages even when fresh is empty', () => {
+      expect(mergeNotesRegions({}, { a: 'edited A' })).toEqual({ a: 'edited A' });
+    });
+  });
+});

--- a/releasekit.schema.json
+++ b/releasekit.schema.json
@@ -1121,6 +1121,11 @@
               "default": "release:retry",
               "description": "Label to retry a failed publish by re-applying it to a merged standing PR. Standing-pr mode only."
             },
+            "previewNotes": {
+              "type": "string",
+              "default": "release:preview-notes",
+              "description": "Label on the standing PR that generates LLM release notes on demand into an editable region in the PR body, for review and editing before merge. Standing-pr mode only."
+            },
             "major": {
               "type": "string",
               "default": "bump:major",


### PR DESCRIPTION
## Summary

Phase 2 of #200, **stacked on #320** (base = `feat/200-first-release-intro`). Adds opt-in **preview + edit of release notes in standing-PR mode**, reusing the general editable-region primitive from Phase 1.

> Review #320 first; this PR's diff is against that branch.

## Flow

1. **Opt-in trigger** — applying the `release:preview-notes` label to the standing PR generates LLM release notes **on demand** into a per-package, marker-delimited region in the PR body.
2. **Edit** — a human edits the prose inline between the `<!-- releasekit-notes:<pkg> -->` markers.
3. **Preserve** — subsequent standing-PR update runs (which regenerate + force-push the body) marker-slice the edits out of the live body and re-inject them. To keep LLM load low (#200), notes are generated **once** when the label is first applied and only *preserved* on later pushes — regenerated only for a newly-added package that has no region yet.
4. **Consume at merge** — `publishFromManifest` extracts the edited notes from the merged PR body and lets them **win per package** for the GitHub release body (**Option A**). The manifest is untouched ("machine state only, never store prose"); a body-read failure falls back to fresh regeneration.

## What changed

- `ci.labels.previewNotes` (default `release:preview-notes`) — schema + label-definitions (`syncLabels` creates it) + docs.
- `standing-pr/notes-region.ts` — `renderNotesRegion` / `extractNotesRegions` / `mergeNotesRegions` (edited-wins) over the core markers.
- `runStandingPRUpdate` — on-demand generation gated by the label, live-body read-modify-write to preserve edits, region slotted into `renderPrBody`.
- `publishFromManifest` — extract edited notes from the PR body, override the release-body map per package.

## Notes & trade-offs

- **Race (accepted, documented):** a human edit landing between the `pulls.get` and `pulls.update` of a standing-PR update can be overwritten. Updates are infrequent (push-driven), so no optimistic-concurrency machinery.
- Editing pre-publish is intrinsically standing-PR only (the one mode with a durable pre-publish artifact). Manual-mode draft-then-dispatch is tracked in #319.

## Verification

- `pnpm turbo run lint typecheck test` → 24/24 tasks pass
- `pnpm schema:check` → in sync
- `pnpm test:harness` → preview CI sim exits 0
- New tests: `notes-region` round-trip/merge/preserve; `runStandingPRUpdate` seed / preserve-without-regenerate / no-label; `publishFromManifest` edited-notes-win-at-merge.

Refs #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds opt-in preview and editing of LLM release notes in standing-PR mode, gated by a `release:preview-notes` label. When the label is present, release notes are generated once into marker-delimited regions in the PR body; subsequent standing-PR updates preserve human edits via marker slicing; at merge, `publishFromManifest` reads the edited regions and lets them win over freshly generated notes for each GitHub release body.

- **`notes-region.ts`** — new primitive (`renderNotesRegion` / `extractNotesRegions` / `mergeNotesRegions`) wrapping `@releasekit/core` marker helpers, with per-package keying to support monorepos.
- **`runStandingPRUpdate`** — reads the live PR body before each update, skips LLM generation when all packages already have edited regions, and slots the merged region into `renderPrBody`.
- **`publishFromManifest`** — pulls edited notes from the merged PR body and applies them as overrides after fresh generation; schema, label definitions, and docs all updated consistently.
</details>

<h3>Confidence Score: 4/5</h3>

The change is safe to merge; the opt-in label gate keeps the default code path unchanged and the core read-modify-write logic is well tested.

The standing-PR update path is correct and well covered by tests. The two issues are in publish time: publishFromManifest always runs the LLM and commits the resulting RELEASE_NOTES.md even when human-edited notes will override the GitHub release body (leaving the file and the release description out of sync), and a user who empties the content between markers will have their deletion silently ignored and overwritten on the next push. Neither breaks the core release flow, but both could surprise users working with the edited-notes feature.

The publish-time flow in `standing-pr.ts` (`publishFromManifest`, lines 1076–1105) warrants a second look for the unconditional LLM invocation and RELEASE_NOTES.md commit when all packages already have edited content. `notes-region.ts` (line 32) is worth reviewing for the empty-content edge case.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/release/src/standing-pr/standing-pr.ts | runStandingPRUpdate correctly gate-keeps LLM calls with allPackagesHaveRegions; publishFromManifest lacks an equivalent guard, so it always generates and commits LLM notes to RELEASE_NOTES.md even when human-edited notes will override the GitHub release body. |
| packages/release/src/standing-pr/notes-region.ts | New module implementing the editable notes-region primitive; logic is clean, but empty-content extraction is silently dropped (region.length > 0), which makes intentionally empty notes indistinguishable from "not yet edited." |
| packages/config/src/schema.ts | Adds previewNotes label field to CILabelsConfigSchema with default "release:preview-notes"; reformats a biome-suppressed string — no issues. |
| packages/release/test/unit/standing-pr/notes-region.spec.ts | New unit tests covering render/extract/merge round-trips; good coverage but no test for empty-content behavior (the edge case where region.length === 0 triggers regeneration). |
| packages/release/test/unit/standing-pr.spec.ts | Three new integration tests cover seed, preserve-without-regenerate, and no-label paths for runStandingPRUpdate; also adds a publishFromManifest test verifying edited notes win at merge — solid coverage of the happy paths. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Human
    participant GitHub
    participant runStandingPRUpdate
    participant publishFromManifest
    participant LLM

    Human->>GitHub: Apply release:preview-notes label
    GitHub->>runStandingPRUpdate: Push to main triggers update
    runStandingPRUpdate->>GitHub: pulls.get (read live PR body)
    GitHub-->>runStandingPRUpdate: body (no regions yet)
    runStandingPRUpdate->>LLM: "runNotesStep (seed — allPackagesHaveRegions=false)"
    LLM-->>runStandingPRUpdate: freshNotes per package
    runStandingPRUpdate->>GitHub: pulls.update (body with notes region seeded)

    Human->>GitHub: Edit prose between markers

    GitHub->>runStandingPRUpdate: Next push triggers update
    runStandingPRUpdate->>GitHub: pulls.get (read live PR body)
    GitHub-->>runStandingPRUpdate: body with human edits
    Note over runStandingPRUpdate: allPackagesHaveRegions=true → skip LLM
    runStandingPRUpdate->>GitHub: pulls.update (body preserves human edits)

    Human->>GitHub: Merge standing PR
    GitHub->>publishFromManifest: Trigger publish workflow
    publishFromManifest->>GitHub: pulls.get (read merged PR body)
    GitHub-->>publishFromManifest: body with human-edited regions
    publishFromManifest->>LLM: runNotesStep (always runs at publish)
    LLM-->>publishFromManifest: freshNotes (may commit RELEASE_NOTES.md)
    Note over publishFromManifest: editedNotes override freshNotes in memory
    publishFromManifest->>GitHub: Create GitHub release with edited notes
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Human
    participant GitHub
    participant runStandingPRUpdate
    participant publishFromManifest
    participant LLM

    Human->>GitHub: Apply release:preview-notes label
    GitHub->>runStandingPRUpdate: Push to main triggers update
    runStandingPRUpdate->>GitHub: pulls.get (read live PR body)
    GitHub-->>runStandingPRUpdate: body (no regions yet)
    runStandingPRUpdate->>LLM: "runNotesStep (seed — allPackagesHaveRegions=false)"
    LLM-->>runStandingPRUpdate: freshNotes per package
    runStandingPRUpdate->>GitHub: pulls.update (body with notes region seeded)

    Human->>GitHub: Edit prose between markers

    GitHub->>runStandingPRUpdate: Next push triggers update
    runStandingPRUpdate->>GitHub: pulls.get (read live PR body)
    GitHub-->>runStandingPRUpdate: body with human edits
    Note over runStandingPRUpdate: allPackagesHaveRegions=true → skip LLM
    runStandingPRUpdate->>GitHub: pulls.update (body preserves human edits)

    Human->>GitHub: Merge standing PR
    GitHub->>publishFromManifest: Trigger publish workflow
    publishFromManifest->>GitHub: pulls.get (read merged PR body)
    GitHub-->>publishFromManifest: body with human-edited regions
    publishFromManifest->>LLM: runNotesStep (always runs at publish)
    LLM-->>publishFromManifest: freshNotes (may commit RELEASE_NOTES.md)
    Note over publishFromManifest: editedNotes override freshNotes in memory
    publishFromManifest->>GitHub: Create GitHub release with edited notes
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Frelease%2Fsrc%2Fstanding-pr%2Fstanding-pr.ts%3A1076-1104%0A**%60publishFromManifest%60%20always%20generates%20LLM%20notes%20even%20when%20all%20packages%20have%20edited%20content**%0A%0A%60publishFromManifest%60%20hard-codes%20%60skipReleaseNotes%3A%20false%60%20and%20then%20commits%20the%20resulting%20RELEASE_NOTES.md%20via%20%60commitNotesFiles%60%2C%20regardless%20of%20whether%20every%20package%20already%20has%20human-edited%20notes%20in%20the%20PR%20body.%20The%20in-memory%20%60releaseNotes%60%20map%20is%20later%20overridden%20with%20the%20edited%20content%20for%20the%20GitHub%20release%2C%20but%20the%20committed%20RELEASE_NOTES.md%20will%20contain%20the%20fresh%20LLM%20prose%20%E2%80%94%20creating%20a%20permanent%20divergence%20between%20the%20on-disk%20file%20and%20the%20actual%20release%20description.%0A%0AUnlike%20%60runStandingPRUpdate%60%2C%20which%20skips%20generation%20when%20%60allPackagesHaveRegions%60%20is%20true%2C%20%60publishFromManifest%60%20has%20no%20equivalent%20short-circuit.%20When%20all%20packages%20have%20edited%20regions%2C%20the%20LLM%20call%20and%20file%20commit%20are%20both%20unnecessary%20and%20leave%20the%20repository%20in%20an%20inconsistent%20state.%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Frelease%2Fsrc%2Fstanding-pr%2Fnotes-region.ts%3A28-35%0A**Empty%20notes%20silently%20treated%20as%20%22no%20edit%2C%22%20triggering%20unexpected%20LLM%20regeneration**%0A%0AThe%20%60region.length%20%3E%200%60%20guard%20drops%20a%20package%20from%20%60editedNotes%60%20when%20%60extractNotesRegion%60%20returns%20an%20empty%20string%20%E2%80%94%20which%20happens%20if%20the%20user%20deletes%20all%20content%20between%20the%20markers.%20On%20the%20next%20%60runStandingPRUpdate%60%2C%20%60allPackagesHaveRegions%60%20is%20false%20for%20that%20package%2C%20so%20%60generateReleaseNotes%60%20flips%20to%20true%20and%20the%20LLM%20overwrites%20the%20intentionally-emptied%20slot.%20There%20is%20no%20way%20for%20a%20user%20to%20explicitly%20set%20empty%20release%20notes%20via%20this%20interface%3B%20the%20system%20will%20always%20regenerate%20for%20them.%0A%0A&repo=goosewobbler%2Freleasekit&pr=321&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Frelease%2Fsrc%2Fstanding-pr%2Fstanding-pr.ts%3A1076-1104%0A**%60publishFromManifest%60%20always%20generates%20LLM%20notes%20even%20when%20all%20packages%20have%20edited%20content**%0A%0A%60publishFromManifest%60%20hard-codes%20%60skipReleaseNotes%3A%20false%60%20and%20then%20commits%20the%20resulting%20RELEASE_NOTES.md%20via%20%60commitNotesFiles%60%2C%20regardless%20of%20whether%20every%20package%20already%20has%20human-edited%20notes%20in%20the%20PR%20body.%20The%20in-memory%20%60releaseNotes%60%20map%20is%20later%20overridden%20with%20the%20edited%20content%20for%20the%20GitHub%20release%2C%20but%20the%20committed%20RELEASE_NOTES.md%20will%20contain%20the%20fresh%20LLM%20prose%20%E2%80%94%20creating%20a%20permanent%20divergence%20between%20the%20on-disk%20file%20and%20the%20actual%20release%20description.%0A%0AUnlike%20%60runStandingPRUpdate%60%2C%20which%20skips%20generation%20when%20%60allPackagesHaveRegions%60%20is%20true%2C%20%60publishFromManifest%60%20has%20no%20equivalent%20short-circuit.%20When%20all%20packages%20have%20edited%20regions%2C%20the%20LLM%20call%20and%20file%20commit%20are%20both%20unnecessary%20and%20leave%20the%20repository%20in%20an%20inconsistent%20state.%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Frelease%2Fsrc%2Fstanding-pr%2Fnotes-region.ts%3A28-35%0A**Empty%20notes%20silently%20treated%20as%20%22no%20edit%2C%22%20triggering%20unexpected%20LLM%20regeneration**%0A%0AThe%20%60region.length%20%3E%200%60%20guard%20drops%20a%20package%20from%20%60editedNotes%60%20when%20%60extractNotesRegion%60%20returns%20an%20empty%20string%20%E2%80%94%20which%20happens%20if%20the%20user%20deletes%20all%20content%20between%20the%20markers.%20On%20the%20next%20%60runStandingPRUpdate%60%2C%20%60allPackagesHaveRegions%60%20is%20false%20for%20that%20package%2C%20so%20%60generateReleaseNotes%60%20flips%20to%20true%20and%20the%20LLM%20overwrites%20the%20intentionally-emptied%20slot.%20There%20is%20no%20way%20for%20a%20user%20to%20explicitly%20set%20empty%20release%20notes%20via%20this%20interface%3B%20the%20system%20will%20always%20regenerate%20for%20them.%0A%0A&pr=321&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(release): edit release notes in sta..."](https://github.com/goosewobbler/releasekit/commit/67a6c2263bdd43e9fdbc993e924e2fd1ec4f064b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37853196)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->