### PR TITLE
fix(release): don't double-bump the standing PR when a release lands mid-update

### DIFF
--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -745,6 +745,20 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
   info(`Resetting release branch '${branch}' to origin/${base}...`);
   resetReleaseBranch(branch, base, cwd);
 
+  // A release merge can land on `base` after this run started — e.g. another PR is merged moments
+  // before the standing PR. The reset above pulls that commit in, so its version bump is now on HEAD
+  // but not yet tagged; recomputing from it would double-bump (package.json ahead of the last tag →
+  // bump again under `mismatchStrategy: prefer-package`). Re-check the skip pattern post-reset and
+  // bow out — the post-release reconcile (or the next push) rebuilds the standing PR cleanly once the
+  // release has tagged. Reconcile runs are exempt: HEAD is a release commit by design there. See #323.
+  if (!options.reconcile) {
+    const resetHeadSubject = getHeadCommitMessage(cwd);
+    if (resetHeadSubject && matchesSkipPattern(resetHeadSubject, skipPatterns)) {
+      info('Skipping standing PR update: a release commit landed on the base branch during this run');
+      return { action: 'noop' };
+    }
+  }
+
   // Materialize changes on release branch
   info('Writing version bumps...');
   const writeOptions = buildBaseReleaseOptions(options, false, buildExtras);

--- a/packages/release/test/unit/standing-pr.spec.ts
+++ b/packages/release/test/unit/standing-pr.spec.ts
@@ -343,6 +343,38 @@ describe('runStandingPRUpdate', () => {
     expect(result.action).toBe('noop');
   });
 
+  it('should return noop when a release commit lands on the base branch during the run (#323)', async () => {
+    // Top-of-function guard sees a non-release HEAD (passes), but after resetting to origin/main a
+    // release commit is now HEAD — a release merged mid-run. The post-reset recheck must bow out so
+    // the standing PR doesn't double-bump off the just-merged-but-untagged version bump.
+    const { execSync } = await import('node:child_process');
+    let logCalls = 0;
+    vi.mocked(execSync).mockImplementation((cmd: string) => {
+      if (typeof cmd === 'string' && cmd.includes('git log -1 --pretty=%s')) {
+        logCalls += 1;
+        return logCalls === 1 ? 'feat: something (#320)' : 'chore: release v0.29.0 (#318)';
+      }
+      return 'abc123\n';
+    });
+
+    const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
+    const versionOutput = createMockVersionOutput([{ packageName: '@scope/core', newVersion: '0.29.0' }]);
+    vi.mocked(runVersionStep).mockResolvedValue(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>);
+    vi.mocked(runNotesStep).mockResolvedValue({ packageNotes: {}, releaseNotes: {}, files: [] });
+
+    const { createOctokit } = await import('../../src/github.js');
+    const { mocks, octokit } = createMockOctokit();
+    mocks.pullsList.mockResolvedValue({ data: [{ number: 99, html_url: 'https://github.com/owner/repo/pull/99' }] });
+    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+
+    const result = await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
+
+    expect(result.action).toBe('noop');
+    // No PR write — the update bowed out before force-push / PR update.
+    expect(mocks.pullsUpdate).not.toHaveBeenCalled();
+    expect(mocks.pullsCreate).not.toHaveBeenCalled();
+  });
+
   it('should bypass the skip-pattern guard when reconcile is set', async () => {
     // HEAD is a release commit (matches the skip pattern) — the post-release reconcile scenario.
     // Without reconcile this would noop; with reconcile it must proceed and create the PR.


### PR DESCRIPTION
Closes #323.

## Problem
When a release merge lands on `main` **during** an in-flight `update-release-pr` run, the standing PR double-bumps (e.g. intended 0.29.0 → 0.30.0). The reset-to-`origin/main` pulls in the just-merged version bump (on HEAD, not yet tagged), and the write-pass version calc under `mismatchStrategy: prefer-package` baselines off `package.json` (ahead of the last tag) and bumps again. This took down the v0.29.0 release (see #322 for the companion publish-drop).

## Fix
Re-check the skip pattern immediately after `resetReleaseBranch`: if HEAD is now a release commit, a release merged mid-run — bow out (`noop`). The post-release reconcile or the next push rebuilds the standing PR cleanly once the release has tagged. Reconcile runs stay exempt, matching the existing top-of-function guard.

## Test
`should return noop when a release commit lands on the base branch during the run (#323)` — top guard sees a feature commit (passes), post-reset sees a release commit (bows out, no PR write).

## Verification
`pnpm turbo run lint typecheck test` → 24/24 pass.

Related: #322

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a race condition in `runStandingPRUpdate` where a release merge landing on `main` mid-run causes the standing PR to double-bump its version. After `resetReleaseBranch` pulls in the just-merged release commit, the write-pass version calculation baselines off `package.json` (ahead of the last tag) and bumps again under `mismatchStrategy: prefer-package`.

- Adds a post-reset skip-pattern check: if the release branch HEAD is now a release commit after the reset, the function returns `noop` immediately, deferring to the next reconcile or push to rebuild the standing PR cleanly.
- Reconcile runs are explicitly exempted from the new guard (matching the existing top-of-function behaviour), since reconcile intentionally runs after a release commit is HEAD.
- A new unit test covers the exact scenario: first `git log` call returns a feature commit (passes the top guard), second call returns a release commit (triggers the new guard and bows out).
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a narrow, well-placed guard that bows out early without altering any existing code paths.

The fix is surgical: 14 lines inserted at exactly the right point in the function, using the same helper functions already proven elsewhere in the codebase. The reconcile exemption is preserved, the null-return from getHeadCommitMessage is handled safely (falls through rather than noop-ing), and the new test exercises the exact race-condition scenario with clear assertions. No existing tests were modified.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/release/src/standing-pr/standing-pr.ts | Adds a post-reset skip-pattern guard (14 lines) that mirrors the top-of-function guard; reconcile exemption is correctly preserved; no changes to surrounding logic. |
| packages/release/test/unit/standing-pr.spec.ts | Adds a targeted test for the mid-run release-commit race; uses a call-count approach to differentiate the two git log invocations; assertions on pullsUpdate and pullsCreate confirm the early-exit path is taken. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Run as runStandingPRUpdate
    participant Git as git (local)
    participant Origin as origin/main

    Run->>Git: getHeadCommitMessage()
    Git-->>Run: ""feat: something (#320)" (non-release)"
    Note over Run: Top guard passes ✓

    Run->>Run: runVersionStep (dry run)
    Run->>Git: getHeadSha()

    Run->>Origin: resetReleaseBranch(branch, base)
    Origin-->>Git: "pulls "chore: release v0.29.0 (#318)""
    Note over Git: Release commit now on HEAD

    alt "options.reconcile = false (normal run)"
        Run->>Git: getHeadCommitMessage()
        Git-->>Run: "chore: release v0.29.0 (#318)"
        Note over Run: matchesSkipPattern → true
        Run-->>Run: "return { action: 'noop' } — no double-bump"
    else "options.reconcile = true (post-release reconcile)"
        Note over Run: Guard skipped — reconcile expects release commit on HEAD
        Run->>Run: runVersionStep (write pass)
        Run->>Run: Update / create standing PR
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Run as runStandingPRUpdate
    participant Git as git (local)
    participant Origin as origin/main

    Run->>Git: getHeadCommitMessage()
    Git-->>Run: ""feat: something (#320)" (non-release)"
    Note over Run: Top guard passes ✓

    Run->>Run: runVersionStep (dry run)
    Run->>Git: getHeadSha()

    Run->>Origin: resetReleaseBranch(branch, base)
    Origin-->>Git: "pulls "chore: release v0.29.0 (#318)""
    Note over Git: Release commit now on HEAD

    alt "options.reconcile = false (normal run)"
        Run->>Git: getHeadCommitMessage()
        Git-->>Run: "chore: release v0.29.0 (#318)"
        Note over Run: matchesSkipPattern → true
        Run-->>Run: "return { action: 'noop' } — no double-bump"
    else "options.reconcile = true (post-release reconcile)"
        Note over Run: Guard skipped — reconcile expects release commit on HEAD
        Run->>Run: runVersionStep (write pass)
        Run->>Run: Update / create standing PR
    end
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(release): bow out of standing-PR upd..."](https://github.com/goosewobbler/releasekit/commit/c06816bcbe98bf20a717be60b5abb1bd6b5c0a7b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37867465)</sub>

<!-- /greptile_comment -->