### PR TITLE
fix(ci): don't let the pull_request run cancel the standing-PR publish dispatch

### DIFF
--- a/.github/workflows/standing-pr.yml
+++ b/.github/workflows/standing-pr.yml
@@ -8,8 +8,14 @@ on:
     branches: [main]
   workflow_dispatch: {}
 
+# Keyed by event so the no-op `pull_request: closed` run can't supersede a queued `push` run.
+# The publish dispatch (detect-release-merge → trigger-publish) rides the `push` event; when a
+# prior update run holds the group, the merge's push run queues — and a same-group `pull_request`
+# run would otherwise cancel it (GitHub keeps only the latest pending run per group), silently
+# dropping the publish (see #322). Push runs still share one group, preserving the
+# update-vs-publish serialization this gate was created for.
 concurrency:
-  group: standing-release-pr
+  group: standing-release-pr-${{ github.event_name }}
   cancel-in-progress: false
 
 permissions:

--- a/.github/workflows/standing-pr.yml
+++ b/.github/workflows/standing-pr.yml
@@ -8,14 +8,16 @@ on:
     branches: [main]
   workflow_dispatch: {}
 
-# Keyed by event so the no-op `pull_request: closed` run can't supersede a queued `push` run.
-# The publish dispatch (detect-release-merge → trigger-publish) rides the `push` event; when a
-# prior update run holds the group, the merge's push run queues — and a same-group `pull_request`
-# run would otherwise cancel it (GitHub keeps only the latest pending run per group), silently
-# dropping the publish (see #322). Push runs still share one group, preserving the
-# update-vs-publish serialization this gate was created for.
+# Isolate only the `pull_request: closed` event into its own group; `push` and `workflow_dispatch`
+# stay together. The publish dispatch (detect-release-merge → trigger-publish) and the
+# update-release-pr work ride `push`/`workflow_dispatch` and MUST serialize. The `pull_request` run
+# is a no-op for normal merges (it only handles `release:immediate`) — but sharing the queue let it
+# supersede a queued publish-dispatch push run (GitHub keeps only the latest pending run per group),
+# silently dropping the publish (see #322). Mapping just `pull_request` to a separate group fixes
+# that without separating `workflow_dispatch` from `push` (which would let a manual re-trigger race
+# an in-flight push run).
 concurrency:
-  group: standing-release-pr-${{ github.event_name }}
+  group: standing-release-pr-${{ github.event_name == 'pull_request' && 'pull-request' || 'main' }}
   cancel-in-progress: false
 
 permissions:


### PR DESCRIPTION
Closes #322.

## Problem
When the standing PR is merged while another merge's `update-release-pr` run is still in flight, the publish is **silently dropped** — no tag, no GitHub release, no npm — even though the version bump lands on `main`.

The publish dispatch rides the `push` event (`detect-release-merge` → `trigger-publish` → `gh workflow run release.yml`). With one shared concurrency group (`cancel-in-progress: false`):
- a prior update run holds the group,
- the merge's **push** run queues,
- the trailing **`pull_request: closed`** run for the same merge enters the same group and supersedes the queued push run (GitHub keeps only the latest pending run per group),
- so the push run is **cancelled while queued (zero jobs)** → `trigger-publish` never runs → `release.yml` never dispatched.

This took down v0.29.0 (companion double-bump: #323).

## Fix
Key the concurrency group by event name (`standing-release-pr-${{ github.event_name }}`). `push` and `pull_request` runs no longer share a queue, so the no-op `pull_request` run can't cancel the queued publish-dispatch push run. Push runs still serialize among themselves, preserving the update-vs-publish ordering the group was created for.

## Residual / follow-up
This fixes the observed failure (a `pull_request` run cancelling the publish dispatch). A narrower window remains — a second *non-release* push arriving while the publish-dispatch push run is still queued could supersede it. A belt-and-suspenders follow-up would also run `detect-release-merge`+`trigger-publish` on the `pull_request: closed` event (idempotent double-dispatch is safe via release.yml's own `release` concurrency group). Not included here to keep the change minimal and faithful to the existing serialization model.

Related: #323

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a silent publish drop caused by a `pull_request: closed` run superseding a queued `push` run within a shared concurrency group, preventing `trigger-publish` from ever executing.

- The concurrency group expression is changed from the flat string `standing-release-pr` to `standing-release-pr-${{ github.event_name == 'pull_request' && 'pull-request' || 'main' }}`, routing only `pull_request` events to a separate group while keeping `push` and `workflow_dispatch` serialized together in `standing-release-pr-main`.
- A detailed comment is added above the `concurrency` block explaining the race, the fix, and the deliberate choice to keep `workflow_dispatch` co-grouped with `push`.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a single-line expression tweak with a correct ternary that keeps push and workflow_dispatch co-serialized and only moves pull_request events to a separate group.

The expression correctly routes push and workflow_dispatch to standing-release-pr-main and pull_request to standing-release-pr-pull-request. The root-cause race is directly eliminated, cancel-in-progress remains false, and all per-job event-name guards are unchanged and still correct.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/standing-pr.yml | Concurrency group expression updated to isolate pull_request events into their own group, fixing a silent publish-dispatch cancellation; push and workflow_dispatch correctly remain co-serialized. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant GH as GitHub Events
    participant PushGroup as Concurrency Group standing-release-pr-main
    participant PRGroup as Concurrency Group standing-release-pr-pull-request
    participant Jobs as Workflow Jobs

    Note over GH,Jobs: Before fix — all events share one group
    GH->>PushGroup: push (release merge) — queued behind running update
    GH->>PushGroup: pull_request:closed — supersedes queued push!
    PushGroup-->>Jobs: push run CANCELLED, trigger-publish never runs

    Note over GH,Jobs: After fix — pull_request isolated to own group
    GH->>PushGroup: push (release merge) — serialises with other push/workflow_dispatch
    GH->>PRGroup: pull_request:closed — independent group, no interference
    PushGroup->>Jobs: detect-release-merge, trigger-publish, gh workflow run release.yml
    PRGroup->>Jobs: trigger-immediate (if release:immediate label)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant GH as GitHub Events
    participant PushGroup as Concurrency Group standing-release-pr-main
    participant PRGroup as Concurrency Group standing-release-pr-pull-request
    participant Jobs as Workflow Jobs

    Note over GH,Jobs: Before fix — all events share one group
    GH->>PushGroup: push (release merge) — queued behind running update
    GH->>PushGroup: pull_request:closed — supersedes queued push!
    PushGroup-->>Jobs: push run CANCELLED, trigger-publish never runs

    Note over GH,Jobs: After fix — pull_request isolated to own group
    GH->>PushGroup: push (release merge) — serialises with other push/workflow_dispatch
    GH->>PRGroup: pull_request:closed — independent group, no interference
    PushGroup->>Jobs: detect-release-merge, trigger-publish, gh workflow run release.yml
    PRGroup->>Jobs: trigger-immediate (if release:immediate label)
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(ci): keep workflow\_dispatch serializ..."](https://github.com/goosewobbler/releasekit/commit/d971b13a75ab4f0f0d31e3813dd771bd8b1e18fb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37867830)</sub>

<!-- /greptile_comment -->