### PR TITLE
docs(examples): document release-notes editing + demo isFirstRelease in the template

### DIFF
--- a/examples/ci/standing-pr/README.md
+++ b/examples/ci/standing-pr/README.md
@@ -12,6 +12,12 @@ One workflow file (`standing-pr.yml`) carries three jobs:
 | `publish` | the standing PR being **merged** | publishes the reviewed manifest, tags, GitHub Releases |
 | `retry-publish` | `release:retry` label on the **merged** standing PR | idempotently re-publishes whatever the failed run left unfinished |
 
+## Editing release notes before merge (optional)
+
+By default the standing PR carries changelogs only; release notes are generated at publish time. To **review and edit** them first, label the standing PR **`release:preview-notes`**: the next `update` run generates LLM release notes into an editable, per-package region in the PR body (delimited by `<!-- releasekit-notes:<package> -->` markers). Edit the prose between the markers — your edits are preserved across update runs and win at merge.
+
+Needs `notes.releaseNotes.llm` configured and the matching LLM secret uncommented on the `update` job. Standing-pr mode only — see [Previewing and editing release notes](../../../packages/release/docs/ci-setup.md#previewing-and-editing-release-notes).
+
 ## Files
 
 | File | Copy to |

--- a/packages/notes/test/unit/templates.spec.ts
+++ b/packages/notes/test/unit/templates.spec.ts
@@ -142,6 +142,20 @@ describe('release.liquid template', () => {
     expect(result).toContain('**Full Changelog**: https://github.com/test/test-pkg/compare/v0.9.0...v1.0.0');
   });
 
+  it('should lead with a first-release line when isFirstRelease is true', () => {
+    const first: DocumentContext = {
+      project: { name: 'test-pkg' },
+      versions: [{ ...sampleContext, isFirstRelease: true }],
+    };
+    expect(renderLiquid(template, first)).toContain('_First release of `test-pkg`._');
+
+    const subsequent: DocumentContext = {
+      project: { name: 'test-pkg' },
+      versions: [{ ...sampleContext, isFirstRelease: false }],
+    };
+    expect(renderLiquid(template, subsequent)).not.toContain('First release of');
+  });
+
   it('should skip empty categories', () => {
     const ctx: DocumentContext = {
       project: { name: 'test-pkg' },

--- a/templates/release-notes/release.liquid
+++ b/templates/release-notes/release.liquid
@@ -8,6 +8,11 @@ Developer entries use bolded subcategory labels.
 
 ## `{{ version.packageName }}` @ {{ version.version }}
 {%- endunless %}
+{%- comment -%}`isFirstRelease` is true when the package has no prior version — lead with a debut line.{%- endcomment -%}
+{%- if version.isFirstRelease %}
+
+_First release of `{{ version.packageName }}`._
+{%- endif %}
 
 {%- if version.enhanced.categories %}
 {%- for cat in version.enhanced.categories %}


### PR DESCRIPTION
Follow-up to #200 — surface the release-notes editing feature and the first-release hook on the example surfaces.

## Changes
- **`examples/ci/standing-pr/README.md`** — new "Editing release notes before merge" note: the `release:preview-notes` label generates LLM notes into an editable per-package region in the PR body, edits preserved across update runs and winning at merge. Notes the LLM-secret requirement and links to the ci-setup guide. No workflow/config change — it's label-driven behavior on the existing `update` job, so there's no new scenario to validate.
- **`templates/release-notes/release.liquid`** — demonstrate the `isFirstRelease` flag with a debut line, so template authors see the first-release hook. Covered by a new `templates.spec` case (true → debut line; false → none).

## Verification
`pnpm turbo run lint typecheck test` → 24/24 pass (notes +1 template test).

Refs #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR surfaces two features for template authors and CI operators: (1) the `release:preview-notes` label workflow (documented in the standing-PR README), and (2) the `isFirstRelease` template hook (added to `release.liquid` with a test).

- **`examples/ci/standing-pr/README.md`** — adds a prose description of the label-driven preview-notes flow, including the LLM secret requirement and a correctly linked anchor to `ci-setup.md`.
- **`templates/release-notes/release.liquid`** — inserts an `{%- if version.isFirstRelease %}` block that emits `_First release of \`<pkg>\`._`; Liquid whitespace stripping (`{%-`) is consistent with the surrounding blocks.
- **`packages/notes/test/unit/templates.spec.ts`** — adds a two-part assertion (true → debut line present; false → absent) that fully covers the new branch.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are limited to documentation, a two-line Liquid template addition, and a new test case that all pass.

All three files are low-risk: the README adds prose and a verified internal link, the template change is a straightforward conditional block using Liquid whitespace stripping consistent with the rest of the file, and the new test exercises both branches of the condition. No logic paths, APIs, or data flows are modified.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| examples/ci/standing-pr/README.md | Adds a new "Editing release notes before merge" section; link to ci-setup.md#previewing-and-editing-release-notes is confirmed valid. |
| templates/release-notes/release.liquid | Adds an `isFirstRelease` debut-line block with correct Liquid whitespace stripping; placement and whitespace handling produce well-formed Markdown output. |
| packages/notes/test/unit/templates.spec.ts | New test correctly exercises both `isFirstRelease: true` (debut line present) and `false` (absent) against the full template; no regressions to existing cases. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[release.liquid rendering] --> B{perPackage?}
    B -- false --> C["## package @ version header"]
    B -- true --> D[skip header]
    C --> E{isFirstRelease?}
    D --> E
    E -- true --> F["_First release of package._"]
    E -- false --> G[skip debut line]
    F --> H{enhanced.categories?}
    G --> H
    H -- yes --> I[render LLM category sections]
    H -- no --> J[render fallback type-based sections]
    I --> K{compareUrl?}
    J --> K
    K -- yes --> L["**Full Changelog**: url"]
    K -- no --> M[end version block]
    L --> M
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[release.liquid rendering] --> B{perPackage?}
    B -- false --> C["## package @ version header"]
    B -- true --> D[skip header]
    C --> E{isFirstRelease?}
    D --> E
    E -- true --> F["_First release of package._"]
    E -- false --> G[skip debut line]
    F --> H{enhanced.categories?}
    G --> H
    H -- yes --> I[render LLM category sections]
    H -- no --> J[render fallback type-based sections]
    I --> K{compareUrl?}
    J --> K
    K -- yes --> L["**Full Changelog**: url"]
    K -- no --> M[end version block]
    L --> M
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(examples): document release-notes e..."](https://github.com/goosewobbler/releasekit/commit/1db095661f32f92097263f5d0326f210a000af58) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37896489)</sub>

<!-- /greptile_comment -->