### PR TITLE
docs: polish root README (header, pipeline visual, downloads, support)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,12 +73,14 @@ See [Getting Started](./docs/getting-started.md) for prerequisites, config optio
 
 ## Packages
 
-| Package | Version | Downloads | Description |
-|---------|---------|-----------|-------------|
-| [@releasekit/release](./packages/release) | [![npm](https://img.shields.io/npm/v/@releasekit/release.svg)](https://www.npmjs.com/package/@releasekit/release) | [![downloads](https://img.shields.io/npm/dw/@releasekit/release.svg)](https://www.npmjs.com/package/@releasekit/release) | **Unified CLI** — run version, notes, and publish in a single command |
-| [@releasekit/version](./packages/version) | [![npm](https://img.shields.io/npm/v/@releasekit/version.svg)](https://www.npmjs.com/package/@releasekit/version) | [![downloads](https://img.shields.io/npm/dw/@releasekit/version.svg)](https://www.npmjs.com/package/@releasekit/version) | Semantic versioning based on Git history and conventional commits |
-| [@releasekit/notes](./packages/notes) | [![npm](https://img.shields.io/npm/v/@releasekit/notes.svg)](https://www.npmjs.com/package/@releasekit/notes) | [![downloads](https://img.shields.io/npm/dw/@releasekit/notes.svg)](https://www.npmjs.com/package/@releasekit/notes) | Changelog generation with LLM-powered enhancement and flexible templating |
-| [@releasekit/publish](./packages/publish) | [![npm](https://img.shields.io/npm/v/@releasekit/publish.svg)](https://www.npmjs.com/package/@releasekit/publish) | [![downloads](https://img.shields.io/npm/dw/@releasekit/publish.svg)](https://www.npmjs.com/package/@releasekit/publish) | Publish packages to npm, crates.io, and pub.dev with git tagging and GitHub releases |
+All four packages share a single version (sync versioning) — see the version badge above.
+
+| Package | Downloads | Description |
+|---------|-----------|-------------|
+| [@releasekit/release](./packages/release) | [![downloads](https://img.shields.io/npm/dw/@releasekit/release.svg)](https://www.npmjs.com/package/@releasekit/release) | **Unified CLI** — run version, notes, and publish in a single command |
+| [@releasekit/version](./packages/version) | [![downloads](https://img.shields.io/npm/dw/@releasekit/version.svg)](https://www.npmjs.com/package/@releasekit/version) | Semantic versioning based on Git history and conventional commits |
+| [@releasekit/notes](./packages/notes) | [![downloads](https://img.shields.io/npm/dw/@releasekit/notes.svg)](https://www.npmjs.com/package/@releasekit/notes) | Changelog generation with LLM-powered enhancement and flexible templating |
+| [@releasekit/publish](./packages/publish) | [![downloads](https://img.shields.io/npm/dw/@releasekit/publish.svg)](https://www.npmjs.com/package/@releasekit/publish) | Publish packages to npm, crates.io, and pub.dev with git tagging and GitHub releases |
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,43 @@
-# ReleaseKit
+<h1 align="center">ReleaseKit</h1>
 
-[![npm](https://img.shields.io/npm/v/@releasekit/release.svg)](https://www.npmjs.com/package/@releasekit/release)
-[![CI](https://github.com/goosewobbler/releasekit/actions/workflows/ci.yml/badge.svg)](https://github.com/goosewobbler/releasekit/actions/workflows/ci.yml)
-[![Node](https://img.shields.io/node/v/@releasekit/release.svg)](https://www.npmjs.com/package/@releasekit/release)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
+<p align="center"><em>Versioning, changelogs, and publishing for whatever you ship — driven by Conventional Commits, built for CI.</em></p>
 
-Versioning, changelogs, and publishing for whatever you ship — driven by Conventional Commits, built for CI. Releases to npm, crates.io, and pub.dev today, with more ecosystems on the way.
+<p align="center">
+  <a href="https://www.npmjs.com/package/@releasekit/release"><img alt="npm" src="https://img.shields.io/npm/v/@releasekit/release.svg"></a>
+  <a href="https://github.com/goosewobbler/releasekit/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/goosewobbler/releasekit/actions/workflows/ci.yml/badge.svg"></a>
+  <a href="https://www.npmjs.com/package/@releasekit/release"><img alt="Node" src="https://img.shields.io/node/v/@releasekit/release.svg"></a>
+  <a href="./LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/License-MIT-yellow.svg"></a>
+</p>
+
+<p align="center">
+  <a href="#why-releasekit">Why</a> ·
+  <a href="#quickstart">Quickstart</a> ·
+  <a href="#packages">Packages</a> ·
+  <a href="#documentation">Docs</a> ·
+  <a href="./CONTRIBUTING.md">Contributing</a>
+</p>
+
+Releases to npm, crates.io, and pub.dev today, with more ecosystems on the way.
+
+```text
+   from Conventional Commits:
+
+   ┌─────────┐     ┌─────────┐     ┌─────────┐
+   │ version │ ──▶ │  notes  │ ──▶ │ publish │
+   └─────────┘     └─────────┘     └─────────┘
+    semver bumps    changelog +     npm · crates.io · pub.dev
+    per package     LLM notes       git tags · GitHub Release
+
+   Independent CLIs, piped via a VersionOutput JSON contract — run one stage or all three.
+```
 
 ## Why ReleaseKit
 
 - **One config, every ecosystem** — npm (JavaScript/TypeScript), crates.io (Rust), and pub.dev (Dart/Flutter) packages release from the same `releasekit.config.json`, including mixed monorepos. The pipeline is registry-agnostic — new ecosystems plug in without changing your workflow.
 - **Composable, not opinionated** — three independent CLIs (`version`, `notes`, `publish`) you can pipe together, or a unified `release` command if you want the full pipeline.
 - **CI-native** — JSON output, OIDC publishing, PR preview comments, and label- or commit-driven triggers without bolting on extra tools.
+
+> **Coming from semantic-release or changesets?** See the [Migration guide](./docs/migration.md) for a mapping of concepts and a step-by-step switch.
 
 ## Quickstart
 
@@ -47,20 +73,20 @@ See [Getting Started](./docs/getting-started.md) for prerequisites, config optio
 
 ## Packages
 
-| Package | Version | Description |
-|---------|---------|-------------|
-| [@releasekit/release](./packages/release) | [![npm](https://img.shields.io/npm/v/@releasekit/release.svg)](https://www.npmjs.com/package/@releasekit/release) | **Unified CLI** — run version, notes, and publish in a single command |
-| [@releasekit/version](./packages/version) | [![npm](https://img.shields.io/npm/v/@releasekit/version.svg)](https://www.npmjs.com/package/@releasekit/version) | Semantic versioning based on Git history and conventional commits |
-| [@releasekit/notes](./packages/notes) | [![npm](https://img.shields.io/npm/v/@releasekit/notes.svg)](https://www.npmjs.com/package/@releasekit/notes) | Changelog generation with LLM-powered enhancement and flexible templating |
-| [@releasekit/publish](./packages/publish) | [![npm](https://img.shields.io/npm/v/@releasekit/publish.svg)](https://www.npmjs.com/package/@releasekit/publish) | Publish packages to npm, crates.io, and pub.dev with git tagging and GitHub releases |
+| Package | Version | Downloads | Description |
+|---------|---------|-----------|-------------|
+| [@releasekit/release](./packages/release) | [![npm](https://img.shields.io/npm/v/@releasekit/release.svg)](https://www.npmjs.com/package/@releasekit/release) | [![downloads](https://img.shields.io/npm/dw/@releasekit/release.svg)](https://www.npmjs.com/package/@releasekit/release) | **Unified CLI** — run version, notes, and publish in a single command |
+| [@releasekit/version](./packages/version) | [![npm](https://img.shields.io/npm/v/@releasekit/version.svg)](https://www.npmjs.com/package/@releasekit/version) | [![downloads](https://img.shields.io/npm/dw/@releasekit/version.svg)](https://www.npmjs.com/package/@releasekit/version) | Semantic versioning based on Git history and conventional commits |
+| [@releasekit/notes](./packages/notes) | [![npm](https://img.shields.io/npm/v/@releasekit/notes.svg)](https://www.npmjs.com/package/@releasekit/notes) | [![downloads](https://img.shields.io/npm/dw/@releasekit/notes.svg)](https://www.npmjs.com/package/@releasekit/notes) | Changelog generation with LLM-powered enhancement and flexible templating |
+| [@releasekit/publish](./packages/publish) | [![npm](https://img.shields.io/npm/v/@releasekit/publish.svg)](https://www.npmjs.com/package/@releasekit/publish) | [![downloads](https://img.shields.io/npm/dw/@releasekit/publish.svg)](https://www.npmjs.com/package/@releasekit/publish) | Publish packages to npm, crates.io, and pub.dev with git tagging and GitHub releases |
 
 ## Features
 
-- **Versioning** — derives semver bumps from Conventional Commits; supports JavaScript/TypeScript (`package.json`), Rust (`Cargo.toml`), Dart/Flutter (`pubspec.yaml`), and monorepos with per-package tags
-- **Release notes** — generates changelogs from commit history, with optional LLM enhancement (Anthropic, OpenAI, or local models)
-- **Publishing** — pushes to npm (OIDC or token), crates.io, and pub.dev, tags the release, and creates a GitHub Release
-- **CI/CD first** — JSON output for scripting, PR preview comments, and config-driven triggers (commit vs label)
-- **Composable** — use each tool independently or pipe them together
+- 🔖 **Versioning** — derives semver bumps from Conventional Commits; supports JavaScript/TypeScript (`package.json`), Rust (`Cargo.toml`), Dart/Flutter (`pubspec.yaml`), and monorepos with per-package tags
+- 📝 **Release notes** — generates changelogs from commit history, with optional LLM enhancement (Anthropic, OpenAI, or local models)
+- 📦 **Publishing** — pushes to npm (OIDC or token), crates.io, and pub.dev, tags the release, and creates a GitHub Release
+- ⚙️ **CI/CD first** — JSON output for scripting, PR preview comments, and config-driven triggers (commit vs label)
+- 🧩 **Composable** — use each tool independently or pipe them together
 
 ## Usage
 
@@ -143,6 +169,13 @@ See the [package docs](#documentation) for the full option reference.
 ## Development
 
 `pnpm install && pnpm build && pnpm test` — see [CONTRIBUTING.md](./CONTRIBUTING.md) for the full guide.
+
+## Support
+
+- [GitHub Issues](https://github.com/goosewobbler/releasekit/issues) — bug reports and feature requests
+- [Contributing](./CONTRIBUTING.md) — development setup and PR guidelines
+- [Security policy](./SECURITY.md) — reporting vulnerabilities
+- [Code of Conduct](./CODE_OF_CONDUCT.md)
 
 ## License
 


### PR DESCRIPTION
Polish pass on the root README, drawing on the patterns from the zubridge and wdio-desktop-mobile READMEs.

## Changes
- **Centered header** — title, italic tagline, badges, and a nav row (Why · Quickstart · Packages · Docs · Contributing).
- **Pipeline visual** — a `version → notes → publish` diagram up top, surfacing the composable-pipeline identity and the `VersionOutput` JSON contract between stages.
- **Positioning pointer** — a 'coming from semantic-release or changesets?' callout linking the migration guide, near *Why*.
- **Downloads column** on the Packages table (adoption signal; now meaningful with 0.29.0 live).
- **Emoji Features bullets** for scannability (wdio style).
- **Support section** — links Issues, CONTRIBUTING, SECURITY, Code of Conduct (all already in the repo, previously unlinked from the README).

## Deliberately skipped
- wdio's status-tiered package tables (releasekit's four packages release in lockstep under sync versioning — tiers don't apply).
- A hero image (no logo asset exists) and an ASCII repo tree (the pipeline diagram is the better fit for a tool).

All links/anchors point to existing files and sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR is a documentation-only polish pass on the root README, adding a centered HTML header with tagline and nav row, a text-art pipeline diagram, a migration callout, a downloads column in the packages table, emoji bullets in the Features list, and a new Support section.

- All linked files (`CONTRIBUTING.md`, `SECURITY.md`, `CODE_OF_CONDUCT.md`, `docs/migration.md`, etc.) and all in-page anchors (`#why-releasekit`, `#quickstart`, `#packages`, `#documentation`) have been verified to exist in the repository.
- No code changes are included; this is a pure documentation update.
</details>

<h3>Confidence Score: 5/5</h3>

Documentation-only change with no code modifications — safe to merge.

Every linked file and in-page anchor was verified to exist in the repository. The changes are purely additive documentation improvements with no logic, config, or dependency changes.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| README.md | Documentation-only polish pass: centered HTML header, pipeline diagram, downloads badge column, emoji Features bullets, migration callout, and Support section. All referenced files and anchors verified to exist. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    CC[Conventional Commits] --> V
    V[version\nsemver bumps per package] --> N[notes\nchangelog + LLM notes]
    N --> P[publish\nnpm · crates.io · pub.dev\ngit tags · GitHub Release]
    V -->|VersionOutput JSON| N
    N -->|VersionOutput JSON| P
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart LR
    CC[Conventional Commits] --> V
    V[version\nsemver bumps per package] --> N[notes\nchangelog + LLM notes]
    N --> P[publish\nnpm · crates.io · pub.dev\ngit tags · GitHub Release]
    V -->|VersionOutput JSON| N
    N -->|VersionOutput JSON| P
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["docs: drop redundant per-package version..."](https://github.com/goosewobbler/releasekit/commit/8a3bf5eb3fd76c862a4f408b240e8fa2a23ba3b1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37897773)</sub>

<!-- /greptile_comment -->