### PR TITLE
fix(version): bound bump scan to the last release tag when baseRef is absent

### DIFF
--- a/packages/version/src/core/versionCalculator.ts
+++ b/packages/version/src/core/versionCalculator.ts
@@ -8,7 +8,7 @@ import { Bumper } from 'conventional-recommended-bump';
 import type { ReleaseType } from 'semver';
 import semver from 'semver';
 import { getCurrentBranch } from '../git/repository.js';
-import { getCommitsLength, lastMergeBranchName } from '../git/tagsAndBranches.js';
+import { getCommitsLength, lastMergeBranchName, refExists } from '../git/tagsAndBranches.js';
 import type { Config, VersionOptions } from '../types.js';
 import { buildTagStripPatternFromTemplate, escapeRegExp } from '../utils/formatting.js';
 import { log } from '../utils/logging.js';
@@ -302,8 +302,15 @@ export async function calculateVersion(config: Config, options: VersionOptions):
       log(`Creating bumper with preset: ${preset}`, 'debug');
       const bumper = new Bumper();
       bumper.loadPreset(preset);
-      if (config.baseRef) {
-        bumper.commits({ from: config.baseRef });
+      // Bound the commit scan to the same baseline the changelog uses (`config.baseRef ?? latestTag`).
+      // Without the latestTag fallback an absent baseRef lets conventional-recommended-bump scan the
+      // ENTIRE history — the repo's baseline tags (e.g. `release/v0.29.0`) aren't in a format its
+      // default tag-detection recognises — so accumulated historical feats inflate the bump magnitude
+      // (a docs-only window bumps minor instead of patch). Guard the tag with rev-parse so an absent
+      // ref falls back to the unbounded default rather than throwing. See #330.
+      const bumpFrom = config.baseRef ?? (latestTag && refExists(latestTag, pkgPath) ? latestTag : undefined);
+      if (bumpFrom) {
+        bumper.commits({ from: bumpFrom });
       }
       const recommendedBump = await bumper.bump();
       const releaseTypeFromCommits =

--- a/packages/version/src/git/tagsAndBranches.ts
+++ b/packages/version/src/git/tagsAndBranches.ts
@@ -46,6 +46,27 @@ export function getCommitsLength(pkgRoot: string, sinceTag?: string): number {
 }
 
 /**
+ * Whether a git ref (tag, branch, or SHA) exists and resolves to a commit in this repo.
+ * Used to guard a `from..HEAD` range before handing it to a commit walker — an absent ref
+ * should fall back to the unbounded default rather than throwing.
+ * @param ref The ref to verify
+ * @param cwd Optional working directory to run the check in
+ * @returns true if the ref resolves, false otherwise
+ */
+export function refExists(ref: string, cwd?: string): boolean {
+  if (!ref || ref.trim() === '') return false;
+  try {
+    execSync('git', ['rev-parse', '--verify', '--quiet', `${ref}^{commit}`], {
+      ...(cwd ? { cwd } : {}),
+      stdio: 'ignore',
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Get the latest semver tag from the repository sorted by semantic version
  * This function prioritizes semantic ordering over chronological ordering to handle
  * cases where tags were created out of order (e.g., v0.7.1 created after v0.8.0)

--- a/packages/version/test/unit/core/versionCalculator.spec.ts
+++ b/packages/version/test/unit/core/versionCalculator.spec.ts
@@ -770,8 +770,41 @@ describe('Version Calculator', () => {
       expect(commitsSpy).toHaveBeenCalledWith({ from: 'deadbeef123' });
     });
 
-    it('should NOT call Bumper.commits when config.baseRef is not set', async () => {
+    it('should bound the bumper to latestTag when baseRef is absent and the tag exists', async () => {
+      // Regression for #330: without baseRef the scan must still be bounded to the last release
+      // tag. Otherwise conventional-recommended-bump scans the entire history and historical feats
+      // inflate the bump magnitude (a docs-only window bumps minor instead of patch).
       const commitsSpy = vi.spyOn(Bumper.prototype, 'commits').mockReturnThis();
+      vi.spyOn(gitTags, 'refExists').mockReturnValue(true);
+      vi.spyOn(versionUtils, 'bumpVersion').mockReturnValue('1.0.1');
+
+      const options: VersionOptions = { latestTag: 'v1.0.0', versionPrefix: 'v' };
+
+      await calculateVersion(defaultConfig as Config, options);
+
+      expect(commitsSpy).toHaveBeenCalledWith({ from: 'v1.0.0' });
+    });
+
+    it('should bound the bumper to a multi-segment baseline tag when baseRef is absent', async () => {
+      // Mirrors the standing-PR / sync shape that surfaced #330: the baseline tag carries the
+      // `baselineTagTemplate` prefix (e.g. `release/v0.29.0`), which must still bound the scan.
+      const commitsSpy = vi.spyOn(Bumper.prototype, 'commits').mockReturnThis();
+      vi.spyOn(gitTags, 'refExists').mockReturnValue(true);
+      vi.spyOn(versionUtils, 'bumpVersion').mockReturnValue('0.29.1');
+
+      const config = { ...defaultConfig, baselineTagTemplate: 'release/${prefix}${version}' } as Config;
+      const options: VersionOptions = { latestTag: 'release/v0.29.0', versionPrefix: 'v' };
+
+      await calculateVersion(config, options);
+
+      expect(commitsSpy).toHaveBeenCalledWith({ from: 'release/v0.29.0' });
+    });
+
+    it('should leave the bumper unbounded when baseRef is absent and latestTag does not resolve', async () => {
+      // An absent/unreachable tag falls back to the unbounded default rather than throwing,
+      // mirroring the changelog path's rev-parse guard.
+      const commitsSpy = vi.spyOn(Bumper.prototype, 'commits').mockReturnThis();
+      vi.spyOn(gitTags, 'refExists').mockReturnValue(false);
       vi.spyOn(versionUtils, 'bumpVersion').mockReturnValue('1.0.1');
 
       const options: VersionOptions = { latestTag: 'v1.0.0', versionPrefix: 'v' };

--- a/packages/version/test/unit/git/tagsAndBranches.spec.ts
+++ b/packages/version/test/unit/git/tagsAndBranches.spec.ts
@@ -8,6 +8,7 @@ import {
   lastMergeBranchName,
   listGlobalTags,
   listPackageTags,
+  refExists,
 } from '../../../src/git/tagsAndBranches.js';
 import { log } from '../../../src/utils/logging.js';
 
@@ -59,6 +60,44 @@ describe('tagsAndBranches', () => {
       // Verify
       expect(result).toBe(0);
       expect(log).toHaveBeenCalledWith('Failed to get number of commits since last tag: Command failed', 'error');
+    });
+  });
+
+  describe('refExists', () => {
+    it('should return true when rev-parse resolves the ref', () => {
+      vi.mocked(execSync, { partial: true }).mockReturnValue(Buffer.from(''));
+
+      expect(refExists('release/v0.29.0')).toBe(true);
+      expect(execSync).toHaveBeenCalledWith(
+        'git',
+        ['rev-parse', '--verify', '--quiet', 'release/v0.29.0^{commit}'],
+        expect.objectContaining({ stdio: 'ignore' }),
+      );
+    });
+
+    it('should pass cwd through when provided', () => {
+      vi.mocked(execSync, { partial: true }).mockReturnValue(Buffer.from(''));
+
+      refExists('v1.0.0', '/repo/pkg');
+
+      expect(execSync).toHaveBeenCalledWith(
+        'git',
+        ['rev-parse', '--verify', '--quiet', 'v1.0.0^{commit}'],
+        expect.objectContaining({ cwd: '/repo/pkg', stdio: 'ignore' }),
+      );
+    });
+
+    it('should return false when the ref does not resolve', () => {
+      vi.mocked(execSync, { partial: true }).mockImplementation(() => {
+        throw new Error('fatal: Needed a single revision');
+      });
+
+      expect(refExists('does-not-exist')).toBe(false);
+    });
+
+    it('should return false for an empty ref without shelling out', () => {
+      expect(refExists('')).toBe(false);
+      expect(execSync).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
Fixes #330.

## Problem

On the standing-PR path the **bump magnitude** was computed over the **entire git history** instead of "commits since the last release", so a docs-only window that should bump **patch** came out a **minor**: standing PR #329 proposed **v0.30.0** while the two feeder PRs (#327, #328 — both `docs:`) each previewed **0.29.1**.

`calculateVersion` only bounded the conventional-commits scan when an explicit `baseRef` was set:

```ts
if (config.baseRef) {
  bumper.commits({ from: config.baseRef });   // ← only bounded when baseRef is set
}
```

The standing-PR update never passes a `baseRef` (`buildBaseReleaseOptions` doesn't set one), so `conventional-recommended-bump` fell back to its default scan. The repo's baseline tags (`release/v0.29.0`, consumer tags like `@releasekit/version@v0.3.0`) aren't in a format its default tag-detection recognises, so it scanned from the start of history. Reproduced at `main` HEAD:

```
NO from (default scan)  -> major  ("2 BREAKING CHANGES and 73 features")
from=release/v0.29.0    -> patch  ("0 BREAKING CHANGES and 0 features")
```

`major` → `minor` via the pre-1.0 `zeroMajor: 'spec'` rule → `0.30.0`.

The tell: the standing PR's **changelog** was correct (only the two docs entries) while the **version** was wrong — because changelog extraction already falls back to `latestTag` (`config.baseRef ?? latestTag`) but the bump path had no such fallback. That asymmetry is the bug.

## Fix

Default the bumper's `from` to the same baseline the changelog uses — `config.baseRef ?? latestTag` — guarded by a `rev-parse --verify` existence check (`refExists`) so an absent/unreachable ref falls back to the unbounded default instead of throwing (mirroring the changelog's own guard). The explicit-`baseRef` path (preview) is unchanged.

## Tests

- `versionCalculator.spec.ts`: bumper is now bounded to `latestTag` when `baseRef` is absent and the tag exists (incl. a multi-segment `release/v0.29.0` baseline tag matching the standing-PR shape); stays unbounded when the tag doesn't resolve.
- `tagsAndBranches.spec.ts`: unit coverage for the new `refExists` helper (resolves / cwd passthrough / non-existent / empty).
- `pnpm turbo run lint typecheck test` → all 24 tasks pass.

## Impact

Every standing-PR run was scanning full history, effectively flooring releases to at least `minor`. Masked until now because a pre-1.0 project bumps minors constantly; a docs-only window is the rare case that exposed it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where the conventional-commits bump magnitude was computed over the entire git history on the standing-PR path, causing a docs-only window to bump `minor` instead of `patch`. The root cause was an asymmetry: the changelog already fell back to `latestTag` when `baseRef` was absent, but the bumper did not.

- **`versionCalculator.ts`**: The bump scan is now bounded to `config.baseRef ?? latestTag`, guarded by a synchronous `refExists` call so an unresolvable ref silently falls back to the unbounded default rather than throwing.
- **`tagsAndBranches.ts`**: Adds the `refExists` helper (`git rev-parse --verify --quiet ${ref}^{commit}`) with an early-exit for empty strings and full exception swallowing, matching the contract needed by the caller.
- **Tests**: Three new regression cases in `versionCalculator.spec.ts` (latestTag present, multi-segment baseline tag, unresolvable tag) plus four unit tests for `refExists` in `tagsAndBranches.spec.ts`.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — a narrow, well-targeted fix to a single asymmetry in the bump path.

The change is minimal: one new exported helper (`refExists`) and a one-liner that mirrors the already-working changelog fallback. The `^{commit}` dereference is the correct form for verifying a ref resolves to a commit, the empty-ref early-exit prevents unnecessary shell invocations, and all exception paths return `false` rather than propagating. The three new regression tests cover the exact shape that surfaced the original bug (including a multi-segment `release/v0.29.0` baseline tag). The explicit-`baseRef` path is structurally unchanged.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/version/src/git/tagsAndBranches.ts | Adds the `refExists` helper that synchronously verifies a git ref resolves to a commit, with an early-exit guard for empty refs and full exception swallowing. |
| packages/version/src/core/versionCalculator.ts | Bounds the conventional-commits bump scan to `config.baseRef ?? latestTag` (guarded by `refExists`) so standing-PR runs no longer scan full history when `baseRef` is absent. |
| packages/version/test/unit/core/versionCalculator.spec.ts | Replaces the single "not-called" assertion with three targeted regression tests covering: latestTag exists, multi-segment baseline tag, and unresolvable tag fallback. |
| packages/version/test/unit/git/tagsAndBranches.spec.ts | Adds four unit tests for `refExists` covering resolve, `cwd` passthrough, non-existent ref, and empty-string early exit. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[calculateVersion called] --> B{config.baseRef set?}
    B -- Yes --> C[bumpFrom = config.baseRef]
    B -- No --> D{latestTag present?}
    D -- No --> E[bumpFrom = undefined]
    D -- Yes --> F{refExists latestTag, pkgPath ?}
    F -- false --> E
    F -- true --> G[bumpFrom = latestTag]
    C --> H{bumpFrom truthy?}
    G --> H
    E --> H
    H -- Yes --> I[bumper.commits from bumpFrom]
    H -- No --> J[bumper unbounded — scans full history]
    I --> K[bumper.bump]
    J --> K
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[calculateVersion called] --> B{config.baseRef set?}
    B -- Yes --> C[bumpFrom = config.baseRef]
    B -- No --> D{latestTag present?}
    D -- No --> E[bumpFrom = undefined]
    D -- Yes --> F{refExists latestTag, pkgPath ?}
    F -- false --> E
    F -- true --> G[bumpFrom = latestTag]
    C --> H{bumpFrom truthy?}
    G --> H
    E --> H
    H -- Yes --> I[bumper.commits from bumpFrom]
    H -- No --> J[bumper unbounded — scans full history]
    I --> K[bumper.bump]
    J --> K
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(version): bound bump scan to the las..."](https://github.com/goosewobbler/releasekit/commit/d3223c8c0acacc35225d0d34045f72f2c803f484) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37925762)</sub>

<!-- /greptile_comment -->