### PR TITLE
chore: stop Greptile auto-reviewing the standing release PR

### DIFF
--- a/greptile.json
+++ b/greptile.json
@@ -1,0 +1,8 @@
+{
+  "disabledLabels": [
+    "release"
+  ],
+  "excludeAuthors": [
+    "github-actions[bot]"
+  ]
+}


### PR DESCRIPTION
## What

Adds a repo-root `greptile.json` so Greptile stops auto-reviewing the **standing release PR** (the bot-authored, version-bump-only PR on `release/next`), while still reviewing every normal PR.

```json
{
  "disabledLabels": ["release"],
  "excludeAuthors": ["github-actions[bot]"]
}
```

## Why these filters

- **`disabledLabels: ["release"]`** — the standing PR always carries the `release` label (`packages/release/src/label-definitions.ts` defaults `standingPr.labels` to `['release']`; config doesn't override it). Ordinary PRs never carry it, so only the release PR is skipped.
- **`excludeAuthors: ["github-actions[bot]"]`** — belt-and-suspenders: matches at PR-open before any label lands, and in this repo the bot only authors the standing PR (Dependabot uses `dependabot[bot]`).

Branch filters can't isolate it: the standing PR targets `main`, and Greptile's `includeBranches`/`excludeBranches` match the *target* branch — excluding `main` would silence every PR.

## Note

`greptile.json` only takes effect once on `main` — Greptile reads it from the PR's base branch, which is `main` for the standing PR.

Ref: [Greptile — greptile.json](https://www.greptile.com/docs/code-review-bot/greptile-json)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a `greptile.json` at the repo root to stop Greptile from auto-reviewing the standing release PR, while leaving all normal PRs unaffected.

- **`disabledLabels: ["release"]`** — targets the standing PR exclusively, since `label-definitions.ts` defaults `standingPr.labels` to `['release']` and that label is never applied to ordinary feature/fix PRs.
- **`excludeAuthors: ["github-actions[bot]"]`** — belt-and-suspenders filter that fires at PR-open time before labels are applied; confirmed by Greptile docs that `[`/`]` are treated as literals, so `github-actions[bot]` matches the exact GitHub actor name without glob misinterpretation.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — a single, well-reasoned config file addition with no runtime code changes.

Both filters are correctly targeted at the standing release PR. The `release` label default is confirmed in `label-definitions.ts`, and the Greptile docs explicitly state that `[`/`]` are treated as literals, so `github-actions[bot]` matches the exact actor name without glob misinterpretation. No ordinary PR carries the `release` label, so normal review coverage is unaffected.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| greptile.json | New Greptile config that disables reviews for PRs labelled "release" or authored by github-actions[bot]; both filters are correctly scoped to the standing release PR only. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PR opened / updated] --> B{Author is github-actions bot?}
    B -- Yes --> C[Skip Greptile review - excludeAuthors]
    B -- No --> D{PR has release label?}
    D -- Yes --> E[Skip Greptile review - disabledLabels]
    D -- No --> F[Run Greptile review - normal PR]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[PR opened / updated] --> B{Author is github-actions bot?}
    B -- Yes --> C[Skip Greptile review - excludeAuthors]
    B -- No --> D{PR has release label?}
    D -- Yes --> E[Skip Greptile review - disabledLabels]
    D -- No --> F[Run Greptile review - normal PR]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: stop Greptile auto-reviewing the ..."](https://github.com/goosewobbler/releasekit/commit/c836a0369bac663abd3f1c879ef7a277a301971c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37932771)</sub>

<!-- /greptile_comment -->