### PR TITLE
fix(release): escalate prerelease packages on bump:* + prerelease (#335)

### DIFF
--- a/.github/workflows/_release.reusable.yml
+++ b/.github/workflows/_release.reusable.yml
@@ -115,8 +115,10 @@ jobs:
               BUMP_FLAGS="--bump prerelease"
               PRERELEASE_FLAGS="--prerelease next"
             elif [[ "$INPUT_BUMP" == pre* ]]; then
-              BASE_BUMP="${INPUT_BUMP#pre}"
-              BUMP_FLAGS="--bump ${BASE_BUMP}"
+              # Pass the composed pre* bump through verbatim — the engine handles premajor/
+              # preminor/prepatch directly (escalating a fresh prerelease line). De-composing to
+              # "--bump <magnitude> --prerelease" would increment an existing prerelease instead (#335).
+              BUMP_FLAGS="--bump ${INPUT_BUMP}"
               PRERELEASE_FLAGS="--prerelease next"
             else
               BUMP_FLAGS="--bump $INPUT_BUMP"

--- a/README.md
+++ b/README.md
@@ -73,12 +73,14 @@ See [Getting Started](./docs/getting-started.md) for prerequisites, config optio
 
 ## Packages
 
-| Package | Version | Downloads | Description |
-|---------|---------|-----------|-------------|
-| [@releasekit/release](./packages/release) | [![npm](https://img.shields.io/npm/v/@releasekit/release.svg)](https://www.npmjs.com/package/@releasekit/release) | [![downloads](https://img.shields.io/npm/dw/@releasekit/release.svg)](https://www.npmjs.com/package/@releasekit/release) | **Unified CLI** — run version, notes, and publish in a single command |
-| [@releasekit/version](./packages/version) | [![npm](https://img.shields.io/npm/v/@releasekit/version.svg)](https://www.npmjs.com/package/@releasekit/version) | [![downloads](https://img.shields.io/npm/dw/@releasekit/version.svg)](https://www.npmjs.com/package/@releasekit/version) | Semantic versioning based on Git history and conventional commits |
-| [@releasekit/notes](./packages/notes) | [![npm](https://img.shields.io/npm/v/@releasekit/notes.svg)](https://www.npmjs.com/package/@releasekit/notes) | [![downloads](https://img.shields.io/npm/dw/@releasekit/notes.svg)](https://www.npmjs.com/package/@releasekit/notes) | Changelog generation with LLM-powered enhancement and flexible templating |
-| [@releasekit/publish](./packages/publish) | [![npm](https://img.shields.io/npm/v/@releasekit/publish.svg)](https://www.npmjs.com/package/@releasekit/publish) | [![downloads](https://img.shields.io/npm/dw/@releasekit/publish.svg)](https://www.npmjs.com/package/@releasekit/publish) | Publish packages to npm, crates.io, and pub.dev with git tagging and GitHub releases |
+All four packages share a single version (sync versioning) — see the version badge above.
+
+| Package | Downloads | Description |
+|---------|-----------|-------------|
+| [@releasekit/release](./packages/release) | [![downloads](https://img.shields.io/npm/dw/@releasekit/release.svg)](https://www.npmjs.com/package/@releasekit/release) | **Unified CLI** — run version, notes, and publish in a single command |
+| [@releasekit/version](./packages/version) | [![downloads](https://img.shields.io/npm/dw/@releasekit/version.svg)](https://www.npmjs.com/package/@releasekit/version) | Semantic versioning based on Git history and conventional commits |
+| [@releasekit/notes](./packages/notes) | [![downloads](https://img.shields.io/npm/dw/@releasekit/notes.svg)](https://www.npmjs.com/package/@releasekit/notes) | Changelog generation with LLM-powered enhancement and flexible templating |
+| [@releasekit/publish](./packages/publish) | [![downloads](https://img.shields.io/npm/dw/@releasekit/publish.svg)](https://www.npmjs.com/package/@releasekit/publish) | Publish packages to npm, crates.io, and pub.dev with git tagging and GitHub releases |
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,43 @@
-# ReleaseKit
+<h1 align="center">ReleaseKit</h1>
 
-[![npm](https://img.shields.io/npm/v/@releasekit/release.svg)](https://www.npmjs.com/package/@releasekit/release)
-[![CI](https://github.com/goosewobbler/releasekit/actions/workflows/ci.yml/badge.svg)](https://github.com/goosewobbler/releasekit/actions/workflows/ci.yml)
-[![Node](https://img.shields.io/node/v/@releasekit/release.svg)](https://www.npmjs.com/package/@releasekit/release)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
+<p align="center"><em>Versioning, changelogs, and publishing for whatever you ship — driven by Conventional Commits, built for CI.</em></p>
 
-Versioning, changelogs, and publishing for whatever you ship — driven by Conventional Commits, built for CI. Releases to npm, crates.io, and pub.dev today, with more ecosystems on the way.
+<p align="center">
+  <a href="https://www.npmjs.com/package/@releasekit/release"><img alt="npm" src="https://img.shields.io/npm/v/@releasekit/release.svg"></a>
+  <a href="https://github.com/goosewobbler/releasekit/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/goosewobbler/releasekit/actions/workflows/ci.yml/badge.svg"></a>
+  <a href="https://www.npmjs.com/package/@releasekit/release"><img alt="Node" src="https://img.shields.io/node/v/@releasekit/release.svg"></a>
+  <a href="./LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/License-MIT-yellow.svg"></a>
+</p>
+
+<p align="center">
+  <a href="#why-releasekit">Why</a> ·
+  <a href="#quickstart">Quickstart</a> ·
+  <a href="#packages">Packages</a> ·
+  <a href="#documentation">Docs</a> ·
+  <a href="./CONTRIBUTING.md">Contributing</a>
+</p>
+
+Releases to npm, crates.io, and pub.dev today, with more ecosystems on the way.
+
+```text
+   from Conventional Commits:
+
+   ┌─────────┐     ┌─────────┐     ┌─────────┐
+   │ version │ ──▶ │  notes  │ ──▶ │ publish │
+   └─────────┘     └─────────┘     └─────────┘
+    semver bumps    changelog +     npm · crates.io · pub.dev
+    per package     LLM notes       git tags · GitHub Release
+
+   Independent CLIs, piped via a VersionOutput JSON contract — run one stage or all three.
+```
 
 ## Why ReleaseKit
 
 - **One config, every ecosystem** — npm (JavaScript/TypeScript), crates.io (Rust), and pub.dev (Dart/Flutter) packages release from the same `releasekit.config.json`, including mixed monorepos. The pipeline is registry-agnostic — new ecosystems plug in without changing your workflow.
 - **Composable, not opinionated** — three independent CLIs (`version`, `notes`, `publish`) you can pipe together, or a unified `release` command if you want the full pipeline.
 - **CI-native** — JSON output, OIDC publishing, PR preview comments, and label- or commit-driven triggers without bolting on extra tools.
+
+> **Coming from semantic-release or changesets?** See the [Migration guide](./docs/migration.md) for a mapping of concepts and a step-by-step switch.
 
 ## Quickstart
 
@@ -47,20 +73,20 @@ See [Getting Started](./docs/getting-started.md) for prerequisites, config optio
 
 ## Packages
 
-| Package | Version | Description |
-|---------|---------|-------------|
-| [@releasekit/release](./packages/release) | [![npm](https://img.shields.io/npm/v/@releasekit/release.svg)](https://www.npmjs.com/package/@releasekit/release) | **Unified CLI** — run version, notes, and publish in a single command |
-| [@releasekit/version](./packages/version) | [![npm](https://img.shields.io/npm/v/@releasekit/version.svg)](https://www.npmjs.com/package/@releasekit/version) | Semantic versioning based on Git history and conventional commits |
-| [@releasekit/notes](./packages/notes) | [![npm](https://img.shields.io/npm/v/@releasekit/notes.svg)](https://www.npmjs.com/package/@releasekit/notes) | Changelog generation with LLM-powered enhancement and flexible templating |
-| [@releasekit/publish](./packages/publish) | [![npm](https://img.shields.io/npm/v/@releasekit/publish.svg)](https://www.npmjs.com/package/@releasekit/publish) | Publish packages to npm, crates.io, and pub.dev with git tagging and GitHub releases |
+| Package | Version | Downloads | Description |
+|---------|---------|-----------|-------------|
+| [@releasekit/release](./packages/release) | [![npm](https://img.shields.io/npm/v/@releasekit/release.svg)](https://www.npmjs.com/package/@releasekit/release) | [![downloads](https://img.shields.io/npm/dw/@releasekit/release.svg)](https://www.npmjs.com/package/@releasekit/release) | **Unified CLI** — run version, notes, and publish in a single command |
+| [@releasekit/version](./packages/version) | [![npm](https://img.shields.io/npm/v/@releasekit/version.svg)](https://www.npmjs.com/package/@releasekit/version) | [![downloads](https://img.shields.io/npm/dw/@releasekit/version.svg)](https://www.npmjs.com/package/@releasekit/version) | Semantic versioning based on Git history and conventional commits |
+| [@releasekit/notes](./packages/notes) | [![npm](https://img.shields.io/npm/v/@releasekit/notes.svg)](https://www.npmjs.com/package/@releasekit/notes) | [![downloads](https://img.shields.io/npm/dw/@releasekit/notes.svg)](https://www.npmjs.com/package/@releasekit/notes) | Changelog generation with LLM-powered enhancement and flexible templating |
+| [@releasekit/publish](./packages/publish) | [![npm](https://img.shields.io/npm/v/@releasekit/publish.svg)](https://www.npmjs.com/package/@releasekit/publish) | [![downloads](https://img.shields.io/npm/dw/@releasekit/publish.svg)](https://www.npmjs.com/package/@releasekit/publish) | Publish packages to npm, crates.io, and pub.dev with git tagging and GitHub releases |
 
 ## Features
 
-- **Versioning** — derives semver bumps from Conventional Commits; supports JavaScript/TypeScript (`package.json`), Rust (`Cargo.toml`), Dart/Flutter (`pubspec.yaml`), and monorepos with per-package tags
-- **Release notes** — generates changelogs from commit history, with optional LLM enhancement (Anthropic, OpenAI, or local models)
-- **Publishing** — pushes to npm (OIDC or token), crates.io, and pub.dev, tags the release, and creates a GitHub Release
-- **CI/CD first** — JSON output for scripting, PR preview comments, and config-driven triggers (commit vs label)
-- **Composable** — use each tool independently or pipe them together
+- 🔖 **Versioning** — derives semver bumps from Conventional Commits; supports JavaScript/TypeScript (`package.json`), Rust (`Cargo.toml`), Dart/Flutter (`pubspec.yaml`), and monorepos with per-package tags
+- 📝 **Release notes** — generates changelogs from commit history, with optional LLM enhancement (Anthropic, OpenAI, or local models)
+- 📦 **Publishing** — pushes to npm (OIDC or token), crates.io, and pub.dev, tags the release, and creates a GitHub Release
+- ⚙️ **CI/CD first** — JSON output for scripting, PR preview comments, and config-driven triggers (commit vs label)
+- 🧩 **Composable** — use each tool independently or pipe them together
 
 ## Usage
 
@@ -143,6 +169,13 @@ See the [package docs](#documentation) for the full option reference.
 ## Development
 
 `pnpm install && pnpm build && pnpm test` — see [CONTRIBUTING.md](./CONTRIBUTING.md) for the full guide.
+
+## Support
+
+- [GitHub Issues](https://github.com/goosewobbler/releasekit/issues) — bug reports and feature requests
+- [Contributing](./CONTRIBUTING.md) — development setup and PR guidelines
+- [Security policy](./SECURITY.md) — reporting vulnerabilities
+- [Code of Conduct](./CODE_OF_CONDUCT.md)
 
 ## License
 

--- a/packages/release/docs/ci-setup.md
+++ b/packages/release/docs/ci-setup.md
@@ -111,6 +111,14 @@ In CI, add `--check`: it exits non-zero on a missing label, catching the silent 
 > bump come from commits with the prerelease channel applied — e.g. in standing-pr mode, put
 > `channel:prerelease` alone on the standing PR.
 
+> **`channel:prerelease` is a channel modifier, never a standalone release trigger.** It does
+> nothing without a `bump:*` label in label/direct mode (it can't pick a magnitude on its own), and
+> in standing-pr mode it simply sets the channel for the next merge. `channel:stable` is the one
+> channel label that can stand alone in label/direct mode — but only because graduating a prerelease
+> resolves to exactly one version (`1.0.0-next.6` → `1.0.0`); on an already-stable package it's a
+> no-op. In standing-pr mode the *merge* is the trigger, so both channel labels are pure modifiers
+> there.
+
 ```yaml
 # .github/workflows/release.yml
 name: Release

--- a/packages/release/docs/ci-setup.md
+++ b/packages/release/docs/ci-setup.md
@@ -95,14 +95,21 @@ In CI, add `--check`: it exits non-zero on a missing label, catching the silent 
 | `channel:prerelease` + `bump:patch` | `1.0.0` | `1.0.1-next.0` |
 | `channel:prerelease` + `bump:minor` | `1.0.0` | `1.1.0-next.0` |
 | `channel:prerelease` + `bump:major` | `1.0.0` | `2.0.0-next.0` |
-| `channel:prerelease` + `bump:patch` | `1.0.0-next.6` | `1.0.0-next.7` — increments prerelease counter |
-| `channel:prerelease` + `bump:minor` | `1.0.0-next.6` | `1.0.0-next.7` — increments prerelease counter |
-| `channel:prerelease` + `bump:major` | `1.0.0-next.6` | `1.0.0-next.7` — increments prerelease counter |
+| `channel:prerelease` + `bump:patch` | `1.0.0-next.6` | `1.0.1-next.0` — starts a fresh patch prerelease line |
+| `channel:prerelease` + `bump:minor` | `1.0.0-next.6` | `1.1.0-next.0` — starts a fresh minor prerelease line |
+| `channel:prerelease` + `bump:major` | `1.0.0-next.6` | `2.0.0-next.0` — starts a fresh major prerelease line |
 | `channel:prerelease` alone | any | No release — add a `bump:*` label |
 | `channel:stable` alone | `1.0.0-next.6` | `1.0.0` |
 | `channel:stable` alone | `1.0.0` | No release — already at stable version |
 | `channel:stable` + any `bump:*` | `1.0.0-next.6` | `1.0.0` — bump label is ignored during stable promotion |
 | `channel:stable` + `bump:minor` | `1.0.0` | `1.1.0` — bump applies to already-stable packages |
+
+> **`channel:prerelease` + `bump:*` escalates — it starts a *fresh* prerelease line at the chosen
+> magnitude, even when the package is already on a prerelease.** So `bump:major` + `channel:prerelease`
+> on `1.1.1-next.1` yields `2.0.0-next.0`, not `1.1.1-next.2`. To *iterate* an existing prerelease
+> counter (`2.0.0-next.0` → `2.0.0-next.1`) without escalating, drop the `bump:*` label and let the
+> bump come from commits with the prerelease channel applied — e.g. in standing-pr mode, put
+> `channel:prerelease` alone on the standing PR.
 
 ```yaml
 # .github/workflows/release.yml

--- a/packages/release/src/gate/evaluate-pr.ts
+++ b/packages/release/src/gate/evaluate-pr.ts
@@ -1,5 +1,5 @@
 import type { CIConfig } from '@releasekit/config';
-import { detectLabelConflicts, type LabelConfig } from '../label-utils.js';
+import { composeBumpFromLabels, detectLabelConflicts, type LabelConfig } from '../label-utils.js';
 
 /**
  * Per-PR release decision. Captures whether a single PR's labels would trigger a release,
@@ -127,7 +127,7 @@ export function evaluatePR(
     };
   }
 
-  const bump = detectBumpFromLabels(labels, labelConfig);
+  const bump = composeBumpFromLabels(labels, labelConfig);
 
   if (trigger === 'label') {
     const hasBumpLabel = labels.some(
@@ -202,24 +202,4 @@ export function evaluatePR(
     reason: 'No skip label in commit mode - proceeding with release',
     hasReleaseIntent,
   };
-}
-
-function detectBumpFromLabels(labels: string[], labelConfig: LabelConfig): string | undefined {
-  const hasPrerelease = labels.includes(labelConfig.prerelease);
-  const hasStable = labels.includes(labelConfig.stable);
-
-  if (hasStable) return undefined;
-
-  if (hasPrerelease) {
-    if (labels.includes(labelConfig.major)) return 'premajor';
-    if (labels.includes(labelConfig.minor)) return 'preminor';
-    if (labels.includes(labelConfig.patch)) return 'prepatch';
-    return 'prerelease';
-  }
-
-  if (labels.includes(labelConfig.major)) return 'major';
-  if (labels.includes(labelConfig.minor)) return 'minor';
-  if (labels.includes(labelConfig.patch)) return 'patch';
-
-  return undefined;
 }

--- a/packages/release/src/label-utils.ts
+++ b/packages/release/src/label-utils.ts
@@ -51,3 +51,34 @@ export function detectLabelConflicts(prLabels: string[], labels: LabelConfig = D
     hasPrerelease,
   };
 }
+
+/**
+ * Compose the version bump from a PR's labels, including the prerelease channel. This is the
+ * single source of truth for label → bump composition; every release path (gate, preview,
+ * standing-PR) must use it so they agree on what a given label set means.
+ *
+ * When the prerelease label accompanies a `bump:*` label, the magnitude is composed into a
+ * `pre*` bump (`premajor`/`preminor`/`prepatch`) — a *fresh* prerelease line at that magnitude.
+ * Critically, `pre<type>` ESCALATES: `bump:major` + prerelease on `1.1.1-next.1` → `premajor`
+ * → `2.0.0-next.0`. Passing `major` + a separate prerelease flag would instead increment the
+ * existing prerelease (`1.1.1-next.2`) — the #335 degradation. To *iterate* an existing
+ * prerelease (`2.0.0-next.0` → `2.0.0-next.1`), use the prerelease label alone (no `bump:*`),
+ * which returns `'prerelease'`.
+ *
+ * `channel:stable` wins over everything and returns undefined (graduation is bump-less).
+ */
+export function composeBumpFromLabels(prLabels: string[], labels: LabelConfig = DEFAULT_LABELS): string | undefined {
+  if (prLabels.includes(labels.stable)) return undefined;
+
+  if (prLabels.includes(labels.prerelease)) {
+    if (prLabels.includes(labels.major)) return 'premajor';
+    if (prLabels.includes(labels.minor)) return 'preminor';
+    if (prLabels.includes(labels.patch)) return 'prepatch';
+    return 'prerelease';
+  }
+
+  if (prLabels.includes(labels.major)) return 'major';
+  if (prLabels.includes(labels.minor)) return 'minor';
+  if (prLabels.includes(labels.patch)) return 'patch';
+  return undefined;
+}

--- a/packages/release/src/preview/preview.ts
+++ b/packages/release/src/preview/preview.ts
@@ -6,7 +6,7 @@ import { renderSupersedeWarning } from '../failure-report/failure-report.js';
 import { detectUnresolvedFailure } from '../failure-report/post.js';
 import { evaluatePR } from '../gate/evaluate-pr.js';
 import { createOctokit, fetchPRLabels, postOrUpdateComment } from '../github.js';
-import { DEFAULT_LABELS, detectLabelConflicts } from '../label-utils.js';
+import { composeBumpFromLabels, DEFAULT_LABELS, detectLabelConflicts } from '../label-utils.js';
 import { runRelease } from '../release.js';
 import {
   fetchStandingPRSnapshot,
@@ -364,15 +364,14 @@ async function applyLabelOverrides(
       warn(`Conflicting labels "${labels.stable}" and "${labels.prerelease}" detected — release blocked`);
     }
     if (!labelContext.noBumpLabel) {
-      if (prLabels.includes(labels.major)) {
-        labelContext.bumpLabel = 'major';
-        result.bump = 'major';
-      } else if (prLabels.includes(labels.minor)) {
-        labelContext.bumpLabel = 'minor';
-        result.bump = 'minor';
-      } else if (prLabels.includes(labels.patch)) {
-        labelContext.bumpLabel = 'patch';
-        result.bump = 'patch';
+      // Carry the COMPOSED bump (e.g. premajor) so a major+prerelease on an existing
+      // prerelease escalates to a fresh line rather than degrading to an increment (#335).
+      // The banner still shows the magnitude.
+      const composedBump = composeBumpFromLabels(prLabels, labels);
+      const magnitude = magnitudeFromBump(composedBump);
+      if (magnitude) {
+        labelContext.bumpLabel = magnitude;
+        result.bump = composedBump;
       }
       if (prLabels.includes(labels.stable)) {
         labelContext.stable = true;
@@ -403,12 +402,13 @@ async function applyLabelOverrides(
         warn(`Conflicting labels "${labels.stable}" and "${labels.prerelease}" detected — release blocked`);
       }
     } else {
-      // Releasing — translate evaluation.bump to PreviewOptions + bumpLabel for the banner.
+      // Releasing — carry the gate's COMPOSED bump (e.g. premajor) verbatim so the preview
+      // matches what the release will compute; the banner shows the magnitude (#335).
       const magnitude = magnitudeFromBump(evaluation.bump);
       if (magnitude) {
         info(`PR label "bump:${magnitude}" detected — ${magnitude} release`);
         labelContext.bumpLabel = magnitude;
-        result.bump = magnitude;
+        result.bump = evaluation.bump;
       }
       if (evaluation.stable) {
         labelContext.stable = true;

--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -578,11 +578,16 @@ function resolveStandingPrLabelOverrides(prLabels: string[], ciConfig: CIConfig 
     }
   }
 
-  // Compose pre<magnitude> when the prerelease channel accompanies a magnitude bump, so the
-  // standing PR escalates an already-prerelease package to a fresh line (premajor →
-  // 2.0.0-next.0) instead of incrementing it (#335). Mirrors composeBumpFromLabels; kept inline
-  // here because this path layers its own conflict detection on top.
-  const composedBump = bump && prerelease ? (`pre${bump}` as const) : bump;
+  // Compose the bump to match composeBumpFromLabels (the label→bump SSOT), kept inline here
+  // because this path layers its own conflict detection on top:
+  //   - channel:stable wins and drops the bump — graduation is bump-less, so don't leak a stale
+  //     magnitude into { bump, stable } (engine ignores it today, but the contract must hold).
+  //   - prerelease + magnitude escalates to a fresh line (premajor → 2.0.0-next.0) rather than
+  //     incrementing an existing prerelease (#335).
+  // (The one deliberate divergence from the SSOT: prerelease *alone* stays commit-driven here —
+  // bump undefined + prerelease flag — rather than forcing a 'prerelease' bump, so a standing PR's
+  // channel:prerelease label still lets commits pick the magnitude.)
+  const composedBump = stable ? undefined : bump && prerelease ? (`pre${bump}` as const) : bump;
 
   return { bump: composedBump, target, stable, prerelease, conflicts };
 }

--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -528,7 +528,8 @@ export async function fetchStandingPRSnapshot(
  * surface for adjusting bump magnitude, scope, and channel — feeder PR labels are advisory.
  */
 interface StandingPrOverrides {
-  bump?: 'major' | 'minor' | 'patch';
+  /** Composed bump: a magnitude (major/minor/patch) or a `pre*` form when prerelease is also requested. */
+  bump?: 'major' | 'minor' | 'patch' | 'premajor' | 'preminor' | 'prepatch';
   target?: string;
   stable?: boolean;
   prerelease?: boolean;
@@ -577,13 +578,19 @@ function resolveStandingPrLabelOverrides(prLabels: string[], ciConfig: CIConfig 
     }
   }
 
-  return { bump, target, stable, prerelease, conflicts };
+  // Compose pre<magnitude> when the prerelease channel accompanies a magnitude bump, so the
+  // standing PR escalates an already-prerelease package to a fresh line (premajor →
+  // 2.0.0-next.0) instead of incrementing it (#335). Mirrors composeBumpFromLabels; kept inline
+  // here because this path layers its own conflict detection on top.
+  const composedBump = bump && prerelease ? (`pre${bump}` as const) : bump;
+
+  return { bump: composedBump, target, stable, prerelease, conflicts };
 }
 
 interface BuildOptionsExtras {
   /** Per-package vs synced versioning. Inherited from version.sync config (default true). */
   sync?: boolean;
-  bump?: 'major' | 'minor' | 'patch';
+  bump?: 'major' | 'minor' | 'patch' | 'premajor' | 'preminor' | 'prepatch';
   target?: string;
   stable?: boolean;
   prerelease?: boolean;

--- a/packages/release/test/unit/label-utils.spec.ts
+++ b/packages/release/test/unit/label-utils.spec.ts
@@ -15,6 +15,10 @@ describe('composeBumpFromLabels', () => {
   });
 
   it('should return prerelease when the prerelease channel is present with no magnitude (iterate an existing line)', () => {
+    // This 'prerelease' return is only consumed in commit-trigger mode (via evaluatePR). In
+    // label-trigger mode the gate rejects prerelease-alone (shouldRelease: false) before it ever
+    // reaches the version engine, and the standing-PR path keeps it commit-driven — so the value
+    // is meaningful, but which path acts on it is context-dependent.
     expect(composeBumpFromLabels(['channel:prerelease'])).toBe('prerelease');
   });
 

--- a/packages/release/test/unit/label-utils.spec.ts
+++ b/packages/release/test/unit/label-utils.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { composeBumpFromLabels, DEFAULT_LABELS } from '../../src/label-utils.js';
+
+describe('composeBumpFromLabels', () => {
+  it('should return the magnitude when only a bump label is present', () => {
+    expect(composeBumpFromLabels(['bump:major'])).toBe('major');
+    expect(composeBumpFromLabels(['bump:minor'])).toBe('minor');
+    expect(composeBumpFromLabels(['bump:patch'])).toBe('patch');
+  });
+
+  it('should compose a pre* bump when a bump label accompanies the prerelease channel', () => {
+    expect(composeBumpFromLabels(['bump:major', 'channel:prerelease'])).toBe('premajor');
+    expect(composeBumpFromLabels(['bump:minor', 'channel:prerelease'])).toBe('preminor');
+    expect(composeBumpFromLabels(['bump:patch', 'channel:prerelease'])).toBe('prepatch');
+  });
+
+  it('should return prerelease when the prerelease channel is present with no magnitude (iterate an existing line)', () => {
+    expect(composeBumpFromLabels(['channel:prerelease'])).toBe('prerelease');
+  });
+
+  it('should return undefined when channel:stable is present (graduation is bump-less), even with a bump label', () => {
+    expect(composeBumpFromLabels(['channel:stable'])).toBeUndefined();
+    expect(composeBumpFromLabels(['channel:stable', 'bump:major'])).toBeUndefined();
+  });
+
+  it('should return undefined when no bump or channel labels are present', () => {
+    expect(composeBumpFromLabels([])).toBeUndefined();
+    expect(composeBumpFromLabels(['release', 'area:ci'])).toBeUndefined();
+  });
+
+  it('should prefer major over minor over patch when several magnitudes are present', () => {
+    // Conflict detection lives in detectLabelConflicts; this helper just composes deterministically.
+    expect(composeBumpFromLabels(['bump:patch', 'bump:minor', 'bump:major'])).toBe('major');
+    expect(composeBumpFromLabels(['bump:patch', 'bump:minor', 'bump:major', 'channel:prerelease'])).toBe('premajor');
+  });
+
+  it('should honour renamed labels from a custom LabelConfig', () => {
+    const labels = { ...DEFAULT_LABELS, major: 'bump/major', prerelease: 'release:prerelease' };
+    expect(composeBumpFromLabels(['bump/major', 'release:prerelease'], labels)).toBe('premajor');
+  });
+});

--- a/packages/release/test/unit/preview.spec.ts
+++ b/packages/release/test/unit/preview.spec.ts
@@ -417,14 +417,16 @@ describe('runPreview', () => {
         expect(mockRunRelease).toHaveBeenCalledWith(expect.objectContaining({ bump: 'major' }));
       });
 
-      it('should compose bump label and prerelease label', async () => {
+      it('should compose bump label and prerelease label into a pre* bump', async () => {
         mockLoadCIConfig.mockReturnValue({ releaseTrigger: 'label' });
         mockDetectPrerelease.mockReturnValue({ isPrerelease: false });
         mockFetchPRLabels.mockResolvedValue(['bump:minor', 'channel:prerelease']);
 
         await runPreview({ projectDir: '/test', dryRun: false, target: '@test/package' });
 
-        expect(mockRunRelease).toHaveBeenCalledWith(expect.objectContaining({ bump: 'minor', prerelease: true }));
+        // minor + prerelease composes to preminor so an existing prerelease escalates a fresh
+        // line rather than degrading to a prerelease increment (#335).
+        expect(mockRunRelease).toHaveBeenCalledWith(expect.objectContaining({ bump: 'preminor', prerelease: true }));
       });
 
       it('should ignore skip label in label mode', async () => {
@@ -568,13 +570,13 @@ describe('runPreview', () => {
         expect(body).not.toContain('### Packages');
       });
 
-      it('should use minor bump when prerelease and bump:minor labels present', async () => {
+      it('should use preminor bump when prerelease and bump:minor labels present', async () => {
         mockFetchPRLabels.mockResolvedValue(['channel:prerelease', 'bump:minor']);
         mockLoadCIConfig.mockReturnValue({ releaseTrigger: 'label' });
 
         await runPreview({ projectDir: '/test', dryRun: false, target: '@test/package' });
 
-        expect(mockRunRelease).toHaveBeenCalledWith(expect.objectContaining({ bump: 'minor', prerelease: true }));
+        expect(mockRunRelease).toHaveBeenCalledWith(expect.objectContaining({ bump: 'preminor', prerelease: true }));
       });
     });
 

--- a/packages/release/test/unit/standing-pr.spec.ts
+++ b/packages/release/test/unit/standing-pr.spec.ts
@@ -1078,6 +1078,17 @@ describe('runStandingPRUpdate', () => {
       expect(runVersionStepMock.mock.calls[0]?.[0]).toMatchObject({ prerelease: true });
     });
 
+    it('should compose bump:major + channel:prerelease into a premajor bump', async () => {
+      const { runVersionStepMock } = await setupWithStandingPRLabels(['release', 'bump:major', 'channel:prerelease']);
+
+      await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
+
+      // Composed so an already-prerelease package escalates a fresh line (premajor → 2.0.0-next.0)
+      // rather than degrading to a prerelease increment (#335). Both dry-run and write calls agree.
+      expect(runVersionStepMock.mock.calls[0]?.[0]).toMatchObject({ bump: 'premajor', prerelease: true });
+      expect(runVersionStepMock.mock.calls[1]?.[0]).toMatchObject({ bump: 'premajor', prerelease: true });
+    });
+
     it('should drop conflicting bump labels and posts pending status check', async () => {
       const { mocks, runVersionStepMock } = await setupWithStandingPRLabels(['release', 'bump:patch', 'bump:major']);
 

--- a/packages/release/test/unit/standing-pr.spec.ts
+++ b/packages/release/test/unit/standing-pr.spec.ts
@@ -1089,6 +1089,17 @@ describe('runStandingPRUpdate', () => {
       expect(runVersionStepMock.mock.calls[1]?.[0]).toMatchObject({ bump: 'premajor', prerelease: true });
     });
 
+    it('should drop the bump under channel:stable (graduation is bump-less, matching the SSOT)', async () => {
+      const { runVersionStepMock } = await setupWithStandingPRLabels(['release', 'bump:major', 'channel:stable']);
+
+      await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
+
+      // channel:stable wins — bump is dropped (not leaked as 'major'), consistent with
+      // composeBumpFromLabels returning undefined for stable.
+      expect(runVersionStepMock.mock.calls[0]?.[0]).toMatchObject({ stable: true });
+      expect(runVersionStepMock.mock.calls[0]?.[0]?.bump).toBeUndefined();
+    });
+
     it('should drop conflicting bump labels and posts pending status check', async () => {
       const { mocks, runVersionStepMock } = await setupWithStandingPRLabels(['release', 'bump:patch', 'bump:major']);
 


### PR DESCRIPTION
Fixes #335.

## Problem

`bump:major` + a prerelease channel label on a package that is **already** on a prerelease degraded to a prerelease increment instead of escalating to a fresh major prerelease line:

```
1.1.1-next.1  +  bump:major + channel:prerelease
  ->  1.1.1-next.2   (was — wrong)
  ->  2.0.0-next.0   (now — correct)
```

The preview even labelled the intent correctly ("major prerelease") while computing the wrong number. Hit in the wild on a real consumer (zubridge), on both the standing-PR and immediate/direct paths.

## Root cause

The composed `premajor` was split back into separate `major` + `prerelease` before reaching the version engine, which then took the "increment existing prerelease" path (`versionUtils.ts:139-153`). Three feeders did the splitting:

- `.github/workflows/_release.reusable.yml` de-composed `premajor` → `--bump major --prerelease next`.
- `resolveStandingPrLabelOverrides` (standing-PR) returned bump + prerelease as separate fields.
- `preview.ts` stripped the magnitude via `magnitudeFromBump` before calling `runRelease`, so the preview disagreed with the eventual release.

The engine already handles `premajor`/`preminor`/`prepatch` correctly (semver escalates) — it just never received them.

## Fix

A single `composeBumpFromLabels` helper in `label-utils.ts` is now the one source of truth for label → bump composition. The gate, preview, and standing-PR paths all use it; the reusable workflow passes the composed `pre*` bump through verbatim. The composite-action path (`run-action.mjs`) was already correct.

## Behaviour change

`bump:*` + `channel:prerelease` now starts a **fresh** prerelease line at the chosen magnitude even when the package is already on a prerelease — see the updated table in `packages/release/docs/ci-setup.md`:

| Labels | Current | Result |
|--------|---------|--------|
| `channel:prerelease` + `bump:patch` | `1.0.0-next.6` | `1.0.1-next.0` |
| `channel:prerelease` + `bump:minor` | `1.0.0-next.6` | `1.1.0-next.0` |
| `channel:prerelease` + `bump:major` | `1.0.0-next.6` | `2.0.0-next.0` |

To *iterate* an existing prerelease counter (`2.0.0-next.0` → `2.0.0-next.1`), drop the `bump:*` label and let the bump come from commits with the prerelease channel applied (e.g. `channel:prerelease` alone on the standing PR). Note: in pure label/direct mode `channel:prerelease` alone remains a no-op (requires a bump label) — iterating there is out of scope for this PR.

## Tests

- New `label-utils.spec.ts` covering `composeBumpFromLabels` (magnitudes, `pre*` composition, stable/empty, custom label names).
- Updated preview + standing-PR specs to assert the composed `pre*` bump reaches the version step.
- `pnpm turbo run lint typecheck test` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a regression (#335) where `bump:*` + `channel:prerelease` on a package already on a prerelease would increment the existing prerelease counter instead of starting a fresh prerelease line at the chosen magnitude. The root cause was that the composed `premajor`/`preminor`/`prepatch` bump was being split back into a magnitude + a separate prerelease flag before reaching the version engine, which then took the "increment existing" path.

- **New `composeBumpFromLabels` SSOT** in `label-utils.ts` replaces the inline `detectBumpFromLabels` function and is now consumed by the gate (`evaluate-pr.ts`), the preview path (`preview.ts`), and the standing-PR path (`standing-pr.ts`), ensuring all three agree on label → bump composition.
- **Workflow fix** in `_release.reusable.yml` passes the `pre*` bump verbatim instead of splitting it into `--bump <magnitude> --prerelease`, closing the final decomposition site.
- **Tests** cover the new `composeBumpFromLabels` helper, and updated preview + standing-PR specs assert the composed `premajor`/`preminor`/`prepatch` value reaches the version step.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the fix is well-scoped, every release path is updated consistently, and the new tests cover the escalation contract end-to-end.

The change extracts a single helper, threads it through four callers, and adds targeted tests for each path. The logic in `composeBumpFromLabels` is identical to the function it replaces in `evaluate-pr.ts`, so there is no behaviour change on existing stable/plain-bump paths — only the `pre*` composition path is new. The workflow change is a one-liner that removes the decomposition that caused the regression. No unguarded code paths or edge cases were found during review.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/release/src/label-utils.ts | Adds `composeBumpFromLabels` as the SSOT for label→bump composition; logic is identical to the removed `detectBumpFromLabels` in evaluate-pr.ts, with clear JSDoc explaining the escalation contract. |
| packages/release/src/gate/evaluate-pr.ts | Replaces the inline `detectBumpFromLabels` with the shared `composeBumpFromLabels`; net-zero logic change — behaviour is identical. |
| packages/release/src/preview/preview.ts | Both the direct/immediate and label-trigger preview paths now carry the composed `pre*` bump through to `runRelease`; the banner still shows the human-readable magnitude via `magnitudeFromBump`. |
| packages/release/src/standing-pr/standing-pr.ts | Inlines the same composition logic as `composeBumpFromLabels` (with documented deliberate divergence for prerelease-alone) and widens the `bump` type to include `pre*` forms; stable-wins guard correctly drops the bump before it leaks. |
| .github/workflows/_release.reusable.yml | Passes composed `pre*` bump verbatim instead of de-composing to `--bump <magnitude> --prerelease`, closing the final decomposition site that caused #335. |
| packages/release/test/unit/label-utils.spec.ts | New spec covering all branches of `composeBumpFromLabels`: stable-wins, pre* composition, prerelease-alone, empty, multi-magnitude conflict, and custom label names. |
| packages/release/test/unit/standing-pr.spec.ts | Two new tests: `bump:major + channel:prerelease` → `premajor` reaching the version step, and `bump:major + channel:stable` → bump dropped (`undefined`) on both dry-run and write calls. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PR Labels] --> B{composeBumpFromLabels}
    B -->|channel:stable present| C[undefined — graduation is bump-less]
    B -->|channel:prerelease + bump:major| D[premajor]
    B -->|channel:prerelease + bump:minor| E[preminor]
    B -->|channel:prerelease + bump:patch| F[prepatch]
    B -->|channel:prerelease alone| G[prerelease]
    B -->|bump:major alone| H[major]
    B -->|bump:minor alone| I[minor]
    B -->|bump:patch alone| J[patch]
    B -->|no bump/channel labels| K[undefined]

    D --> L{Version Engine}
    E --> L
    F --> L
    L -->|premajor on 1.1.1-next.1| M["2.0.0-next.0 ✅ fresh line"]
    L -->|was: major + --prerelease on 1.1.1-next.1| N["1.1.1-next.2 ❌ #335 degradation"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[PR Labels] --> B{composeBumpFromLabels}
    B -->|channel:stable present| C[undefined — graduation is bump-less]
    B -->|channel:prerelease + bump:major| D[premajor]
    B -->|channel:prerelease + bump:minor| E[preminor]
    B -->|channel:prerelease + bump:patch| F[prepatch]
    B -->|channel:prerelease alone| G[prerelease]
    B -->|bump:major alone| H[major]
    B -->|bump:minor alone| I[minor]
    B -->|bump:patch alone| J[patch]
    B -->|no bump/channel labels| K[undefined]

    D --> L{Version Engine}
    E --> L
    F --> L
    L -->|premajor on 1.1.1-next.1| M["2.0.0-next.0 ✅ fresh line"]
    L -->|was: major + --prerelease on 1.1.1-next.1| N["1.1.1-next.2 ❌ #335 degradation"]
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(release): drop bump under channel:st..."](https://github.com/goosewobbler/releasekit/commit/8e46d7f52df18769c6a70bcee04d709cbee87573) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38011770)</sub>

<!-- /greptile_comment -->