### PR TITLE
fix(version): surface the all-history changelog fallback and omit the false baseline (#339)

### DIFF
--- a/packages/version/src/core/groupStrategy.ts
+++ b/packages/version/src/core/groupStrategy.ts
@@ -215,9 +215,11 @@ function extractEntries(
 ): {
   entries: ChangelogEntry[];
   revisionRange: string;
+  baselineUnreachable: boolean;
 } {
   let revisionRange = 'HEAD';
   let entries: ChangelogEntry[] = [];
+  let baselineUnreachable = false;
   try {
     const baseForRange = config.baseRef ?? latestTag;
     if (baseForRange) {
@@ -231,7 +233,16 @@ function extractEntries(
               'When strictReachable is enabled, all refs must be reachable.',
           );
         }
+        // Loud, not silent: this produces a whole-history changelog (#339). Callers omit
+        // previousVersion when this fires so the changelog doesn't claim an undiffed baseline.
+        log(
+          `Baseline ref '${baseForRange}' could not be verified from HEAD — generating the changelog from ALL ` +
+            `history instead of since the last release. The tag is likely missing from the checkout (shallow ` +
+            `clone, or never pushed). Fetch/push the tag, or set version.baseRef, to bound the changelog.`,
+          'warning',
+        );
         revisionRange = 'HEAD';
+        baselineUnreachable = true;
       }
     }
     entries = extractChangelogEntriesFromCommits(pkgDir, revisionRange);
@@ -241,7 +252,7 @@ function extractEntries(
   if (entries.length === 0) {
     entries = [{ type: 'changed', description: `Update version to ${version}` }];
   }
-  return { entries, revisionRange };
+  return { entries, revisionRange, baselineUnreachable };
 }
 
 /**
@@ -302,11 +313,17 @@ function releaseGroup(group: ResolvedGroup, computation: GroupComputation, confi
     setPackageUpdateGroup(name, group.name);
 
     const baselineTagPrefix = deriveBaselineTagPrefix(config.baselineTagTemplate, formattedPrefix, name);
-    const { entries, revisionRange } = extractEntries(pkg.dir, plan.latestTag, groupVersion, config);
+    const { entries, revisionRange, baselineUnreachable } = extractEntries(
+      pkg.dir,
+      plan.latestTag,
+      groupVersion,
+      config,
+    );
     addChangelogData({
       packageName: name,
       version: groupVersion,
-      previousVersion: plan.latestTag ? displayTag(plan.latestTag, baselineTagPrefix, formattedPrefix) : null,
+      previousVersion:
+        plan.latestTag && !baselineUnreachable ? displayTag(plan.latestTag, baselineTagPrefix, formattedPrefix) : null,
       revisionRange,
       repoUrl: readRepoUrl(pkg.dir),
       entries,
@@ -411,11 +428,19 @@ export function createGroupStrategy(config: Config): (packages: PackagesWithRoot
         addTag(tag);
         setPackageUpdateTag(name, tag);
         const baselineTagPrefix = deriveBaselineTagPrefix(config.baselineTagTemplate, formattedPrefix, name);
-        const { entries, revisionRange } = extractEntries(pkg.dir, plan.latestTag, plan.ownNext, config);
+        const { entries, revisionRange, baselineUnreachable } = extractEntries(
+          pkg.dir,
+          plan.latestTag,
+          plan.ownNext,
+          config,
+        );
         addChangelogData({
           packageName: name,
           version: plan.ownNext,
-          previousVersion: plan.latestTag ? displayTag(plan.latestTag, baselineTagPrefix, formattedPrefix) : null,
+          previousVersion:
+            plan.latestTag && !baselineUnreachable
+              ? displayTag(plan.latestTag, baselineTagPrefix, formattedPrefix)
+              : null,
           revisionRange,
           repoUrl: readRepoUrl(pkg.dir),
           entries,

--- a/packages/version/src/core/groupStrategy.ts
+++ b/packages/version/src/core/groupStrategy.ts
@@ -237,8 +237,8 @@ function extractEntries(
         // previousVersion when this fires so the changelog doesn't claim an undiffed baseline.
         log(
           `Baseline ref '${baseForRange}' could not be verified from HEAD — generating the changelog from ALL ` +
-            `history instead of since the last release. The tag is likely missing from the checkout (shallow ` +
-            `clone, or never pushed). Fetch/push the tag, or set version.baseRef, to bound the changelog.`,
+            `history instead of since the last release. The ref is likely missing from the checkout (shallow ` +
+            `clone, or never pushed). ${config.baseRef ? 'Fetch/push the ref to make it available in this checkout.' : 'Fetch/push the tag, or set version.baseRef, to bound the changelog.'}`,
           'warning',
         );
         revisionRange = 'HEAD';

--- a/packages/version/src/core/versionStrategies.ts
+++ b/packages/version/src/core/versionStrategies.ts
@@ -285,6 +285,7 @@ export function createSyncStrategy(config: Config): StrategyFunction {
       // Extract changelog entries from commits
       let changelogEntries: ChangelogEntry[] = [];
       let revisionRange = 'HEAD';
+      let baselineUnreachable = false;
 
       try {
         const baseForRange = config.baseRef ?? latestTag;
@@ -303,8 +304,17 @@ export function createSyncStrategy(config: Config): StrategyFunction {
                   `To allow fallback to all commits, set strictReachable to false.`,
               );
             }
-            log(`Ref ${baseForRange} doesn't exist, using all commits for changelog`, 'debug');
+            // Loud, not debug: this silently produces a whole-history changelog (#339). The resolved
+            // baseline exists as a ref but won't verify from HEAD — usually a shallow clone or an
+            // unpushed tag. Omit previousVersion below so the changelog doesn't claim this baseline.
+            log(
+              `Baseline ref '${baseForRange}' could not be verified from HEAD — generating the changelog from ALL ` +
+                `history instead of since the last release. The tag is likely missing from the checkout (shallow ` +
+                `clone, or never pushed). Fetch/push the tag, or set version.baseRef, to bound the changelog.`,
+              'warning',
+            );
             revisionRange = 'HEAD';
+            baselineUnreachable = true;
           }
         }
 
@@ -367,7 +377,10 @@ export function createSyncStrategy(config: Config): StrategyFunction {
       // In per-package tag mode, emit one changelog entry per workspace package so the
       // notes pipeline can write a CHANGELOG.md to each package directory and the
       // publish pipeline can match tags to the right release notes.
-      const displayPrevious = latestTag ? displayTag(latestTag, baselineTagPrefix, formattedPrefix) : null;
+      // Omit previousVersion when we fell back to all-history (#339): claiming a baseline the
+      // changelog never diffed against produces a self-contradictory "since <tag>" + full log.
+      const displayPrevious =
+        latestTag && !baselineUnreachable ? displayTag(latestTag, baselineTagPrefix, formattedPrefix) : null;
       if (config.packageSpecificTags && workspaceNames.length > 0) {
         for (const pkgName of workspaceNames) {
           addChangelogData({
@@ -544,6 +557,7 @@ export function createSingleStrategy(config: Config): StrategyFunction {
       // Generate changelog entries from conventional commits
       let changelogEntries: ChangelogEntry[] = [];
       let revisionRange = 'HEAD';
+      let baselineUnreachable = false;
 
       try {
         const baseForRange = config.baseRef ?? latestTag;
@@ -562,8 +576,17 @@ export function createSingleStrategy(config: Config): StrategyFunction {
                   `To allow fallback to all commits, set strictReachable to false.`,
               );
             }
-            log(`Ref ${baseForRange} doesn't exist, using all commits for changelog`, 'debug');
+            // Loud, not debug: this silently produces a whole-history changelog (#339). The resolved
+            // baseline exists as a ref but won't verify from HEAD — usually a shallow clone or an
+            // unpushed tag. Omit previousVersion below so the changelog doesn't claim this baseline.
+            log(
+              `Baseline ref '${baseForRange}' could not be verified from HEAD — generating the changelog from ALL ` +
+                `history instead of since the last release. The tag is likely missing from the checkout (shallow ` +
+                `clone, or never pushed). Fetch/push the tag, or set version.baseRef, to bound the changelog.`,
+              'warning',
+            );
             revisionRange = 'HEAD';
+            baselineUnreachable = true;
           }
         }
 
@@ -616,11 +639,13 @@ export function createSingleStrategy(config: Config): StrategyFunction {
         );
       }
 
-      // Track changelog data for JSON output
+      // Track changelog data for JSON output. Omit previousVersion when we fell back to all-history
+      // (#339) so the changelog doesn't claim a baseline it never diffed against.
       addChangelogData({
         packageName,
         version: nextVersion,
-        previousVersion: latestTag ? displayTag(latestTag, baselineTagPrefix, formattedPrefix) : null,
+        previousVersion:
+          latestTag && !baselineUnreachable ? displayTag(latestTag, baselineTagPrefix, formattedPrefix) : null,
         revisionRange,
         repoUrl: repoUrl || null,
         entries: changelogEntries,

--- a/packages/version/src/core/versionStrategies.ts
+++ b/packages/version/src/core/versionStrategies.ts
@@ -309,8 +309,8 @@ export function createSyncStrategy(config: Config): StrategyFunction {
             // unpushed tag. Omit previousVersion below so the changelog doesn't claim this baseline.
             log(
               `Baseline ref '${baseForRange}' could not be verified from HEAD — generating the changelog from ALL ` +
-                `history instead of since the last release. The tag is likely missing from the checkout (shallow ` +
-                `clone, or never pushed). Fetch/push the tag, or set version.baseRef, to bound the changelog.`,
+                `history instead of since the last release. The ref is likely missing from the checkout (shallow ` +
+                `clone, or never pushed). ${config.baseRef ? 'Fetch/push the ref to make it available in this checkout.' : 'Fetch/push the tag, or set version.baseRef, to bound the changelog.'}`,
               'warning',
             );
             revisionRange = 'HEAD';
@@ -581,8 +581,8 @@ export function createSingleStrategy(config: Config): StrategyFunction {
             // unpushed tag. Omit previousVersion below so the changelog doesn't claim this baseline.
             log(
               `Baseline ref '${baseForRange}' could not be verified from HEAD — generating the changelog from ALL ` +
-                `history instead of since the last release. The tag is likely missing from the checkout (shallow ` +
-                `clone, or never pushed). Fetch/push the tag, or set version.baseRef, to bound the changelog.`,
+                `history instead of since the last release. The ref is likely missing from the checkout (shallow ` +
+                `clone, or never pushed). ${config.baseRef ? 'Fetch/push the ref to make it available in this checkout.' : 'Fetch/push the tag, or set version.baseRef, to bound the changelog.'}`,
               'warning',
             );
             revisionRange = 'HEAD';

--- a/packages/version/src/package/packageProcessor.ts
+++ b/packages/version/src/package/packageProcessor.ts
@@ -210,6 +210,7 @@ export class PackageProcessor {
       // Generate changelog entries from conventional commits
       let changelogEntries: ChangelogEntry[] = [];
       let revisionRange = 'HEAD';
+      let baselineUnreachable = false;
 
       try {
         // Extract entries from commits between the base ref (or latest tag) and HEAD.
@@ -228,8 +229,17 @@ export class PackageProcessor {
                   `To allow fallback to all commits, set strictReachable to false.`,
               );
             }
-            log(`Ref ${baseForRange} is unreachable (${verification.error}), using all commits for changelog`, 'debug');
+            // Loud, not debug: this silently produces a whole-history changelog (#339) — both this
+            // package's entries and the repo-level entries below. Omit previousVersion so the
+            // changelog doesn't claim a baseline it never diffed against.
+            log(
+              `Baseline ref '${baseForRange}' could not be verified from HEAD (${verification.error}) — generating ` +
+                `the changelog from ALL history instead of since the last release. The tag is likely missing from the ` +
+                `checkout (shallow clone, or never pushed). Fetch/push the tag, or set version.baseRef, to bound it.`,
+              'warning',
+            );
             revisionRange = 'HEAD';
+            baselineUnreachable = true;
           }
         }
 
@@ -314,7 +324,10 @@ export class PackageProcessor {
       addChangelogData({
         packageName: name,
         version: nextVersion,
-        previousVersion: changelogBaseTag ? displayTag(changelogBaseTag, baselineTagPrefix, formattedPrefix) : null,
+        previousVersion:
+          changelogBaseTag && !baselineUnreachable
+            ? displayTag(changelogBaseTag, baselineTagPrefix, formattedPrefix)
+            : null,
         revisionRange,
         repoUrl: repoUrl || null,
         entries: changelogEntries,

--- a/packages/version/src/package/packageProcessor.ts
+++ b/packages/version/src/package/packageProcessor.ts
@@ -234,8 +234,8 @@ export class PackageProcessor {
             // changelog doesn't claim a baseline it never diffed against.
             log(
               `Baseline ref '${baseForRange}' could not be verified from HEAD (${verification.error}) — generating ` +
-                `the changelog from ALL history instead of since the last release. The tag is likely missing from the ` +
-                `checkout (shallow clone, or never pushed). Fetch/push the tag, or set version.baseRef, to bound it.`,
+                `the changelog from ALL history instead of since the last release. The ref is likely missing from the ` +
+                `checkout (shallow clone, or never pushed). ${this.fullConfig.baseRef ? 'Fetch/push the ref to make it available in this checkout.' : 'Fetch/push the tag, or set version.baseRef, to bound it.'}`,
               'warning',
             );
             revisionRange = 'HEAD';

--- a/packages/version/test/unit/core/versionStrategies.spec.ts
+++ b/packages/version/test/unit/core/versionStrategies.spec.ts
@@ -532,6 +532,30 @@ describe('Version Strategies', () => {
         );
       });
 
+      it('should warn loudly and omit previousVersion when the baseline tag is unverifiable (#339)', async () => {
+        // rev-parse on the baseline fails (e.g. shallow clone / unpushed tag); other git calls succeed.
+        vi.mocked(commandExecutor.execSync, { partial: true }).mockImplementation((_cmd, args) => {
+          if (Array.isArray(args) && args.includes('rev-parse')) {
+            throw new Error('fatal: Needed a single revision');
+          }
+          return Buffer.from('');
+        });
+
+        const config: Partial<Config> = { ...defaultConfig, sync: true };
+        const syncStrategy = strategies.createSyncStrategy(config as Config);
+
+        await syncStrategy(mockPackages);
+
+        // Range falls back to all-history...
+        expect(commitParser.extractChangelogEntriesFromCommits).toHaveBeenCalledWith('/test/workspace', 'HEAD');
+        // ...the fallback is surfaced as a warning, not a silent debug line...
+        expect(logging.log).toHaveBeenCalledWith(expect.stringContaining('could not be verified from HEAD'), 'warning');
+        // ...and previousVersion is omitted so the changelog doesn't claim a baseline it never diffed against.
+        expect(jsonOutput.addChangelogData).toHaveBeenCalledWith(
+          expect.objectContaining({ previousVersion: null, revisionRange: 'HEAD' }),
+        );
+      });
+
       it('should use mainPackage name when specified', async () => {
         const config: Partial<Config> = {
           ...defaultConfig,

--- a/packages/version/test/unit/core/versionStrategies.spec.ts
+++ b/packages/version/test/unit/core/versionStrategies.spec.ts
@@ -767,6 +767,28 @@ describe('Version Strategies', () => {
       expect(jsonOutput.setCommitMessage).toHaveBeenCalledWith('chore: release package-a v1.1.0');
     });
 
+    it('should warn and omit previousVersion when the baseline tag is unverifiable (#339)', async () => {
+      // rev-parse on the baseline fails (shallow clone / unpushed tag); other git calls succeed.
+      vi.mocked(commandExecutor.execSync, { partial: true }).mockImplementation((_cmd, args) => {
+        if (Array.isArray(args) && args.includes('rev-parse')) {
+          throw new Error('fatal: Needed a single revision');
+        }
+        return Buffer.from('');
+      });
+
+      const config: Partial<Config> = { ...defaultConfig, mainPackage: 'package-a' };
+      const singleStrategy = strategies.createSingleStrategy(config as Config);
+
+      await singleStrategy(mockPackages);
+
+      // Loud warning, all-history range, and previousVersion omitted so the changelog doesn't claim
+      // a baseline it never diffed against — same guarantee as createSyncStrategy.
+      expect(logging.log).toHaveBeenCalledWith(expect.stringContaining('could not be verified from HEAD'), 'warning');
+      expect(jsonOutput.addChangelogData).toHaveBeenCalledWith(
+        expect.objectContaining({ previousVersion: null, revisionRange: 'HEAD' }),
+      );
+    });
+
     it('should use packageName in commit message template', async () => {
       // Setup
       const config: Partial<Config> = {

--- a/packages/version/test/unit/package/packageProcessor.spec.ts
+++ b/packages/version/test/unit/package/packageProcessor.spec.ts
@@ -7,6 +7,7 @@ import * as commitParser from '../../../src/changelog/commitParser.js';
 import * as calculator from '../../../src/core/versionCalculator.js';
 import * as versionCalculatorModule from '../../../src/core/versionCalculator.js';
 import * as gitTags from '../../../src/git/tagsAndBranches.js';
+import * as tagVerification from '../../../src/git/tagVerification.js';
 import * as packageManagement from '../../../src/package/packageManagement.js';
 import { PackageProcessor } from '../../../src/package/packageProcessor.js';
 import type { Config } from '../../../src/types.js';
@@ -20,6 +21,7 @@ vi.mock('node:path');
 vi.mock('node:process');
 vi.mock('../../../src/package/packageManagement.js');
 vi.mock('../../../src/git/tagsAndBranches.js');
+vi.mock('../../../src/git/tagVerification.js');
 vi.mock('../../../src/utils/logging.js');
 vi.mock('../../../src/utils/formatting.js', () => ({
   formatVersionPrefix: vi.fn().mockReturnValue('v'),
@@ -148,6 +150,10 @@ describe('Package Processor', () => {
 
     // Path mock
     vi.spyOn(path, 'join').mockImplementation((...args) => args.join('/'));
+
+    // Baseline tag verification — default to a valid, reachable baseline so changelog ranges
+    // resolve to `<tag>..HEAD`. Tests exercising the all-history fallback (#339) override this.
+    vi.spyOn(tagVerification, 'verifyTag').mockReturnValue({ exists: true, reachable: true });
 
     // Calculator mock - fix to return a Promise
     vi.spyOn(calculator, 'calculateVersion').mockResolvedValue('1.1.0');
@@ -396,6 +402,34 @@ describe('Package Processor', () => {
       const calls = vi.mocked(jsonOutput.addChangelogData).mock.calls;
       expect(calls.length).toBeGreaterThan(0);
       expect(calls[0][0]).toMatchObject({ previousVersion: 'v1.0.0' });
+    });
+
+    it('should warn and omit previousVersion when the baseline tag is unreachable (#339)', async () => {
+      vi.spyOn(gitTags, 'getLatestTagForPackage').mockResolvedValue('release/v1.0.0');
+      vi.spyOn(formatting, 'deriveBaselineTagPrefix').mockReturnValue('release/v');
+      vi.spyOn(formatting, 'displayTag').mockImplementation((tag, baselineTagPrefix, formattedPrefix) => {
+        if (!baselineTagPrefix || !tag.startsWith(baselineTagPrefix)) return tag;
+        return `${formattedPrefix}${tag.slice(baselineTagPrefix.length)}`;
+      });
+      // Baseline resolves as a ref but can't be verified from HEAD (shallow clone / unpushed tag).
+      vi.spyOn(tagVerification, 'verifyTag').mockReturnValue({ exists: false, reachable: false, error: 'not found' });
+
+      const processor = new PackageProcessor({
+        ...defaultOptions,
+        fullConfig: {
+          ...mockConfig,
+          baselineTagTemplate: 'release/${' + 'prefix}${' + 'version}',
+          writeChangelog: false,
+        },
+      });
+
+      await processor.processPackages([mockPackages[0]]);
+
+      // Surfaced loudly (not a silent debug line)...
+      expect(logging.log).toHaveBeenCalledWith(expect.stringContaining('could not be verified from HEAD'), 'warning');
+      // ...all-history range, and previousVersion omitted so the changelog doesn't claim an undiffed baseline.
+      const calls = vi.mocked(jsonOutput.addChangelogData).mock.calls;
+      expect(calls[0][0]).toMatchObject({ previousVersion: null, revisionRange: 'HEAD' });
     });
 
     it('should aggregate the changelog from the last stable tag when a prerelease graduates', async () => {


### PR DESCRIPTION
-

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes issue #339 by surfacing the all-history changelog fallback loudly (warning instead of silent debug log) and omitting `previousVersion` when the baseline ref cannot be verified — preventing the changelog from claiming a baseline it never diffed against. The fix is applied consistently across all three code paths: `groupStrategy`, `createSyncStrategy`, and `createSingleStrategy` / `PackageProcessor`.

- **`baselineUnreachable` flag**: declared alongside `revisionRange` in each strategy and returned/propagated to callers so `addChangelogData` can set `previousVersion: null` instead of emitting a misleading baseline tag.
- **Warning promotion**: the silent `debug`-level log is replaced with a user-visible `warning` that names the ref, explains the likely cause (shallow clone / unpushed tag), and includes a context-sensitive hint.
- **Regression tests**: all three strategies gain a test verifying the warning, the all-history range, and the omitted `previousVersion`, covering the full observable contract of the fix.
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge — the fix is narrowly scoped to the fallback branch that already produced all-history changelogs; no happy-path behaviour changes.

All three code paths apply the same `baselineUnreachable` flag consistently, the warning message is clear and context-sensitive, and each path has a dedicated regression test asserting the warning log, the `HEAD` revision range, and the omitted `previousVersion`. No changes touch the normal reachable-baseline flow.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/version/src/core/groupStrategy.ts | Adds `baselineUnreachable` to the `extractEntries` return value; both call-sites in `releaseGroup` and the outer group-emit loop now gate `previousVersion` on `!baselineUnreachable`. Debug log promoted to warning with a context-sensitive hint. |
| packages/version/src/core/versionStrategies.ts | Both `createSyncStrategy` and `createSingleStrategy` gain the `baselineUnreachable` flag; `displayPrevious` / `previousVersion` are nulled when the flag is set. Warning message replaces the previous silent debug line in both paths. |
| packages/version/src/package/packageProcessor.ts | PackageProcessor now tracks `baselineUnreachable` and omits `previousVersion` when `verifyTag` returns non-reachable; warning includes the `verification.error` for extra diagnosis context. |
| packages/version/test/unit/core/versionStrategies.spec.ts | Adds regression tests for both `createSyncStrategy` and `createSingleStrategy` covering the unverifiable-baseline path; mocks `execSync` to throw on `rev-parse`, then asserts the warning log, `HEAD` range, and `previousVersion: null`. |
| packages/version/test/unit/package/packageProcessor.spec.ts | Imports and mocks `tagVerification`, adds a baseline `verifyTag` stub returning reachable, and adds a regression test for the unreachable-baseline path matching the same three-assertion contract as the strategy tests. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Determine baseForRange\nconfig.baseRef ?? latestTag] --> B{baseForRange\nexists?}
    B -- No --> E[revisionRange = 'HEAD'\nbaselineUnreachable = false]
    B -- Yes --> C[git rev-parse --verify baseForRange]
    C -- Success --> D[revisionRange = baseForRange..HEAD\nbaselineUnreachable = false]
    C -- Throws --> F{!baseRef &&\nstrictReachable?}
    F -- Yes --> G[throw Error\n'ref not reachable']
    F -- No --> H["log WARNING:\n'could not be verified from HEAD…'"]
    H --> I[revisionRange = 'HEAD'\nbaselineUnreachable = true]
    D --> J[extractChangelogEntriesFromCommits]
    E --> J
    I --> J
    J --> K{baselineUnreachable?}
    K -- Yes --> L[previousVersion = null]
    K -- No --> M["previousVersion = displayTag(latestTag)"]
    L --> N[addChangelogData]
    M --> N
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Determine baseForRange\nconfig.baseRef ?? latestTag] --> B{baseForRange\nexists?}
    B -- No --> E[revisionRange = 'HEAD'\nbaselineUnreachable = false]
    B -- Yes --> C[git rev-parse --verify baseForRange]
    C -- Success --> D[revisionRange = baseForRange..HEAD\nbaselineUnreachable = false]
    C -- Throws --> F{!baseRef &&\nstrictReachable?}
    F -- Yes --> G[throw Error\n'ref not reachable']
    F -- No --> H["log WARNING:\n'could not be verified from HEAD…'"]
    H --> I[revisionRange = 'HEAD'\nbaselineUnreachable = true]
    D --> J[extractChangelogEntriesFromCommits]
    E --> J
    I --> J
    J --> K{baselineUnreachable?}
    K -- Yes --> L[previousVersion = null]
    K -- No --> M["previousVersion = displayTag(latestTag)"]
    L --> N[addChangelogData]
    M --> N
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/version/test/unit/core/versionStrategies.spec.ts`, line 730 ([link](https://github.com/goosewobbler/releasekit/blob/2ca35472ee22f2456d81913259b4f9113ee91b3c/packages/version/test/unit/core/versionStrategies.spec.ts#L730)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Missing `#339` regression test for `createSingleStrategy`**

   `createSingleStrategy` received the exact same `baselineUnreachable` fix as `createSyncStrategy` (same `execSync rev-parse` catch, same `previousVersion` omission), but the `describe('createSingleStrategy', ...)` block has no corresponding test verifying that behaviour. If the conditional is accidentally reverted or broken in `createSingleStrategy`, no test will catch it, whereas `createSyncStrategy` is now guarded.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fversion%2Ftest%2Funit%2Fcore%2FversionStrategies.spec.ts%0ALine%3A%20730%0A%0AComment%3A%0A**Missing%20%60%23339%60%20regression%20test%20for%20%60createSingleStrategy%60**%0A%0A%60createSingleStrategy%60%20received%20the%20exact%20same%20%60baselineUnreachable%60%20fix%20as%20%60createSyncStrategy%60%20%28same%20%60execSync%20rev-parse%60%20catch%2C%20same%20%60previousVersion%60%20omission%29%2C%20but%20the%20%60describe%28'createSingleStrategy'%2C%20...%29%60%20block%20has%20no%20corresponding%20test%20verifying%20that%20behaviour.%20If%20the%20conditional%20is%20accidentally%20reverted%20or%20broken%20in%20%60createSingleStrategy%60%2C%20no%20test%20will%20catch%20it%2C%20whereas%20%60createSyncStrategy%60%20is%20now%20guarded.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=goosewobbler%2Freleasekit&pr=342&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fversion%2Ftest%2Funit%2Fcore%2FversionStrategies.spec.ts%0ALine%3A%20730%0A%0AComment%3A%0A**Missing%20%60%23339%60%20regression%20test%20for%20%60createSingleStrategy%60**%0A%0A%60createSingleStrategy%60%20received%20the%20exact%20same%20%60baselineUnreachable%60%20fix%20as%20%60createSyncStrategy%60%20%28same%20%60execSync%20rev-parse%60%20catch%2C%20same%20%60previousVersion%60%20omission%29%2C%20but%20the%20%60describe%28'createSingleStrategy'%2C%20...%29%60%20block%20has%20no%20corresponding%20test%20verifying%20that%20behaviour.%20If%20the%20conditional%20is%20accidentally%20reverted%20or%20broken%20in%20%60createSingleStrategy%60%2C%20no%20test%20will%20catch%20it%2C%20whereas%20%60createSyncStrategy%60%20is%20now%20guarded.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=342&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["test(version): add createSingleStrategy ..."](https://github.com/goosewobbler/releasekit/commit/5ad74013e8e010ddab27b3123ae15892a6abdec8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38021092)</sub>

<!-- /greptile_comment -->