### PR TITLE
fix(notes): derive compare-link 'to' ref for sanitized "@v" package tags (#338)

### DIFF
--- a/packages/notes/src/core/pipeline.ts
+++ b/packages/notes/src/core/pipeline.ts
@@ -75,6 +75,17 @@ function findCompoundTagSepPos(tag: string): number {
   return -1;
 }
 
+/** True when position `i` in `tag` begins a semver version: a digit, or a `v` immediately followed by a digit. */
+function isVersionStartAt(tag: string, i: number): boolean {
+  const c = tag.charCodeAt(i);
+  if (c >= 48 && c <= 57) return true;
+  if (tag[i] === 'v') {
+    const n = tag.charCodeAt(i + 1);
+    return n >= 48 && n <= 57;
+  }
+  return false;
+}
+
 function generateCompareUrl(repoUrl: string, from: string, to: string, packageName?: string): string {
   // Check if using package-specific tags (from version contains @ and package name)
   const isPackageSpecific = from.includes('@') && packageName && from.includes(packageName);
@@ -93,8 +104,16 @@ function generateCompareUrl(repoUrl: string, from: string, to: string, packageNa
     // Use index-based string operations instead of regex to avoid ReDoS on inputs with
     // many repeated digits (polynomial backtracking with lazy + greedy quantifiers).
     const toClean = to.replace(/^v/, '');
+    const atPos = from.lastIndexOf('@');
     const dashVPos = from.lastIndexOf('-v');
-    if (dashVPos > 0 && from.charCodeAt(dashVPos + 2) >= 48 && from.charCodeAt(dashVPos + 2) <= 57) {
+    if (atPos > 0 && isVersionStartAt(from, atPos + 1)) {
+      // Sanitized package-specific tag: "<de-scoped-name>@[v]<version>" (e.g. "scope-pkg@v1.2.3").
+      // formatTag always strips the "@scope/", so the raw package name never appears literally and
+      // the isPackageSpecific check above can't match it. Keep the "<name>@" prefix and re-attach the
+      // new version, preserving a "v" only if the original tag had one (#338).
+      fromVersion = from;
+      toVersion = `${from.slice(0, atPos + 1)}${from[atPos + 1] === 'v' ? 'v' : ''}${toClean}`;
+    } else if (dashVPos > 0 && from.charCodeAt(dashVPos + 2) >= 48 && from.charCodeAt(dashVPos + 2) <= 57) {
       // "-v" followed by a digit → compound tag with explicit "v" prefix
       fromVersion = from;
       toVersion = `${from.slice(0, dashVPos + 1)}v${toClean}`;

--- a/packages/notes/test/integration/pipeline.spec.ts
+++ b/packages/notes/test/integration/pipeline.spec.ts
@@ -164,6 +164,39 @@ describe('compareUrl: platform detection', () => {
     );
   });
 
+  it('should generate compare URL for sanitized "@v" package-specific tags (#338)', () => {
+    // formatTag strips "@scope/" -> "scope-name", so a `${packageName}@v${version}` template
+    // yields "zubridge-electron@v3.0.0". The raw "@zubridge/electron" never appears in the tag,
+    // so the `to` ref must be derived from the tag's own prefix, not the package name.
+    const ctx = createTemplateContext({
+      packageName: '@zubridge/electron',
+      version: '3.1.0',
+      previousVersion: 'zubridge-electron@v3.0.0',
+      revisionRange: 'zubridge-electron@v3.0.0..HEAD',
+      repoUrl: 'https://github.com/goosewobbler/zubridge',
+      date: '2026-01-01',
+      entries: [],
+    });
+    expect(ctx.compareUrl).toBe(
+      'https://github.com/goosewobbler/zubridge/compare/zubridge-electron@v3.0.0...zubridge-electron@v3.1.0',
+    );
+  });
+
+  it('should generate compare URL for sanitized "@v" tags across a prerelease escalation (#338)', () => {
+    const ctx = createTemplateContext({
+      packageName: '@zubridge/tauri',
+      version: '2.0.0-next.0',
+      previousVersion: 'zubridge-tauri@v1.1.1-next.1',
+      revisionRange: 'zubridge-tauri@v1.1.1-next.1..HEAD',
+      repoUrl: 'https://github.com/goosewobbler/zubridge',
+      date: '2026-01-01',
+      entries: [],
+    });
+    expect(ctx.compareUrl).toBe(
+      'https://github.com/goosewobbler/zubridge/compare/zubridge-tauri@v1.1.1-next.1...zubridge-tauri@v2.0.0-next.0',
+    );
+  });
+
   it('should omit compareUrl when no previousVersion', () => {
     const ctx = createTemplateContext({
       packageName: 'pkg',


### PR DESCRIPTION
-

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes the `to` reference derivation in compare-link generation for sanitized `@v`-prefixed package tags — tags like `"zubridge-electron@v3.0.0"` that result from `formatTag` stripping the npm scope prefix, leaving a form that the existing `isPackageSpecific` check cannot match. The fix adds an `atPos`-based branch that detects these tags and reconstructs the `toVersion` by reusing the `<name>@[v]` prefix from `from`, with two new integration tests covering a normal release and a prerelease escalation.

- **`isVersionStartAt` helper** — tiny, index-safe utility that identifies whether a character position begins a semver version component (digit, or `v` followed by digit), deliberately avoiding regex to prevent ReDoS.
- **New `atPos` branch** in `generateCompareUrl` — slots in before the existing `-v` compound-tag branch and preserves the `v` prefix from the original tag rather than hardcoding it.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is narrowly scoped to a single new branch in the compare-URL builder and does not touch any shared state or other pipeline stages.

The new `atPos` branch correctly identifies sanitized `@v` package tags, preserves the `v` prefix only when the original tag had one, and is guarded by `atPos > 0` to avoid matching plain scoped tags handled upstream. The `isVersionStartAt` helper is index-safe (out-of-bounds `charCodeAt` returns `NaN`, which fails the range check). Two focused integration tests confirm the happy path and a prerelease escalation. Existing branches are unchanged.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/notes/src/core/pipeline.ts | Adds `isVersionStartAt` helper and an `atPos`-based branch in `generateCompareUrl` to correctly derive the compare-link `to` ref for sanitized `@v` package tags; logic is clean with no identifiable edge-case regressions. |
| packages/notes/test/integration/pipeline.spec.ts | Two new integration tests covering the reported `@v` tag case and a prerelease escalation; both are well-scoped and directly exercise the new code path. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["generateCompareUrl"] --> B{"isPackageSpecific"}
    B -- yes --> C["fromVersion = from\ntoVersion = packageName@v + to"]
    B -- no --> D["toClean = strip leading v from to"]
    D --> E{"atPos found and isVersionStartAt\ne.g. zubridge-electron@v3.0.0"}
    E -- yes --> F["fromVersion = from\ntoVersion = prefix@ + v + toClean\nnew branch fixing issue 338"]
    E -- no --> G{"dashVPos found\ne.g. scope-pkg-v1.2.3"}
    G -- yes --> H["fromVersion = from\ntoVersion = prefix-v + toClean"]
    G -- no --> I{"findCompoundTagSepPos found\ne.g. scope-pkg-1.2.3"}
    I -- yes --> J["fromVersion = from\ntoVersion = prefix + toClean"]
    I -- no --> K["Plain version tag\nfromVersion and toVersion are bare versions"]
    C --> L["Build platform compare URL"]
    F --> L
    H --> L
    J --> L
    K --> L
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["generateCompareUrl"] --> B{"isPackageSpecific"}
    B -- yes --> C["fromVersion = from\ntoVersion = packageName@v + to"]
    B -- no --> D["toClean = strip leading v from to"]
    D --> E{"atPos found and isVersionStartAt\ne.g. zubridge-electron@v3.0.0"}
    E -- yes --> F["fromVersion = from\ntoVersion = prefix@ + v + toClean\nnew branch fixing issue 338"]
    E -- no --> G{"dashVPos found\ne.g. scope-pkg-v1.2.3"}
    G -- yes --> H["fromVersion = from\ntoVersion = prefix-v + toClean"]
    G -- no --> I{"findCompoundTagSepPos found\ne.g. scope-pkg-1.2.3"}
    I -- yes --> J["fromVersion = from\ntoVersion = prefix + toClean"]
    I -- no --> K["Plain version tag\nfromVersion and toVersion are bare versions"]
    C --> L["Build platform compare URL"]
    F --> L
    H --> L
    J --> L
    K --> L
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(notes): derive compare-link &#39;to&#39; ref..."](https://github.com/goosewobbler/releasekit/commit/66953b4f5c5b6f3615d65fb3e9df0fbcc6cee899) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38022133)</sub>

<!-- /greptile_comment -->