### PR TITLE
feat(release): apply standing-PR override labels immediately + guard stale manifests (#336, #337)

### DIFF
--- a/.github/workflows/standing-pr.yml
+++ b/.github/workflows/standing-pr.yml
@@ -148,8 +148,11 @@ jobs:
   # succeeds, replacing what used to be the `reconcile-standing-pr` job here.
   trigger-immediate:
     name: Trigger immediate release via release.yml
+    # action == 'closed' matters now that labeled/unlabeled are subscribed: a label added to the
+    # already-merged immediate PR also satisfies merged == true and would dispatch a second publish.
     if: >
       github.event_name == 'pull_request' &&
+      github.event.action == 'closed' &&
       github.event.pull_request.merged == true &&
       contains(github.event.pull_request.labels.*.name, 'release:immediate')
     runs-on: ubuntu-latest

--- a/.github/workflows/standing-pr.yml
+++ b/.github/workflows/standing-pr.yml
@@ -4,7 +4,9 @@ on:
   push:
     branches: [main]
   pull_request:
-    types: [closed]
+    # closed: merge handling (publish dispatch / immediate). labeled/unlabeled: re-run the
+    # standing-PR update so override labels on the OPEN PR apply immediately (#336).
+    types: [closed, labeled, unlabeled]
     branches: [main]
   workflow_dispatch: {}
 
@@ -112,6 +114,25 @@ jobs:
     name: Update Release PR
     needs: detect-release-merge
     if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && needs.detect-release-merge.outputs.pr_number == ''
+    uses: ./.github/workflows/_standing-pr-update.reusable.yml
+    permissions:
+      contents: write
+      pull-requests: write
+    secrets:
+      OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
+
+  # A label change on the OPEN standing PR re-runs the update so bump/scope/channel overrides apply
+  # within seconds instead of waiting for the next push (#336). Separate from update-release-pr
+  # because that one depends on detect-release-merge, which is skipped on pull_request events.
+  # `state == 'open'` keeps this off the merged-PR label events handled by trigger-immediate. The
+  # CLI bypasses the skip-pattern guard on label events (the checked-out HEAD is the prep commit).
+  update-on-label:
+    name: Update Release PR (label change)
+    if: >-
+      github.event_name == 'pull_request' &&
+      (github.event.action == 'labeled' || github.event.action == 'unlabeled') &&
+      github.event.pull_request.state == 'open' &&
+      startsWith(github.event.pull_request.head.ref, 'release/')
     uses: ./.github/workflows/_standing-pr-update.reusable.yml
     permissions:
       contents: write

--- a/examples/ci/standing-pr/standing-pr.yml
+++ b/examples/ci/standing-pr/standing-pr.yml
@@ -13,9 +13,10 @@ on:
   push:
     branches: [main]
   pull_request:
-    # labeled: needed for the release:retry path, which fires on the merged
-    # (closed) standing PR.
-    types: [closed, labeled]
+    # closed: publish on merge. labeled/unlabeled: (1) apply bump/scope/channel
+    # override labels to the OPEN standing PR immediately instead of waiting for the
+    # next push or the hourly cron; (2) the release:retry path on the merged PR.
+    types: [closed, labeled, unlabeled]
     branches: [main]
   schedule:
     - cron: '0 * * * *' # hourly: advances the minAge status check as time passes
@@ -33,7 +34,19 @@ permissions:
 jobs:
   update:
     name: Update Release PR
-    if: github.event_name == 'push' || github.event_name == 'schedule'
+    # push/schedule rebuild the PR; a label change on the OPEN standing PR re-runs the update
+    # so bump/scope/channel overrides take effect within seconds. `state == 'open'` keeps this
+    # off the merged-PR label events that drive publish/retry below. The `release/` prefix is
+    # hardcoded (workflow `if` can't read config) — the in-step config is authoritative.
+    if: >-
+      github.event_name == 'push' ||
+      github.event_name == 'schedule' ||
+      (
+        github.event_name == 'pull_request' &&
+        (github.event.action == 'labeled' || github.event.action == 'unlabeled') &&
+        github.event.pull_request.state == 'open' &&
+        startsWith(github.event.pull_request.head.ref, 'release/')
+      )
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/packages/release/docs/ci-setup.md
+++ b/packages/release/docs/ci-setup.md
@@ -342,7 +342,9 @@ on:
   push:
     branches: [main]
   pull_request:
-    types: [closed, labeled]  # labeled: release:retry on the merged standing PR (fires on closed PRs)
+    # closed: publish on merge. labeled/unlabeled: apply bump/scope/channel override labels to
+    # the OPEN standing PR immediately (#336); also the release:retry path on the merged PR.
+    types: [closed, labeled, unlabeled]
     branches: [main]
   schedule:
     - cron: '0 * * * *'  # Hourly — re-evaluates minAge status check as time passes
@@ -360,7 +362,19 @@ permissions:
 jobs:
   update-release-pr:
     name: Update Release PR
-    if: github.event_name == 'push' || github.event_name == 'schedule'
+    # push/schedule rebuild the PR; a label change on the OPEN standing PR re-runs the update so
+    # bump/scope/channel overrides take effect within seconds. `state == 'open'` keeps this off the
+    # merged-PR label events that drive publish/retry. The `release/` prefix is hardcoded (workflow
+    # `if` can't read config) — the in-step config is authoritative.
+    if: >-
+      github.event_name == 'push' ||
+      github.event_name == 'schedule' ||
+      (
+        github.event_name == 'pull_request' &&
+        (github.event.action == 'labeled' || github.event.action == 'unlabeled') &&
+        github.event.pull_request.state == 'open' &&
+        startsWith(github.event.pull_request.head.ref, 'release/')
+      )
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -515,7 +529,7 @@ Labels behave differently in standing-pr mode than in direct mode. There are two
 
 **2. The standing PR itself** — labels are the **canonical override surface**.
 
-A maintainer can edit labels directly on the standing PR (via the GitHub UI or `gh pr edit <n> --add-label bump:major`). The next `standing-pr update` reads those labels and applies them as overrides:
+A maintainer can edit labels directly on the standing PR (via the GitHub UI or `gh pr edit <n> --add-label bump:major`). Adding or removing a label re-runs `standing-pr update` immediately (the `pull_request` `labeled`/`unlabeled` trigger), so the recomputed version table and status check reflect the new labels within seconds — no waiting for the next push or the hourly cron. The update reads those labels and applies them as overrides:
 
 | Label on standing PR | Effect |
 |---|---|
@@ -527,6 +541,8 @@ A maintainer can edit labels directly on the standing PR (via the GitHub UI or `
 Conflicts (e.g. both `bump:patch` and `bump:major`) surface as a `pending` `releasekit/standing-pr` status check on the release branch and a workflow warning. The override is dropped (falls back to commit-driven) until the conflict is resolved by removing one of the labels.
 
 The `standing-pr update` workflow **preserves maintainer-added labels across runs** — labels you add stick until you remove them.
+
+**Staleness guard.** The manifest records the override labels it was computed under. If the standing PR's labels are changed and it's merged before the triggered update re-runs (a narrow race), `standing-pr publish` detects that the merged PR's override labels no longer match the manifest and **refuses to publish** rather than shipping a release the labels no longer describe — re-run `standing-pr update` and merge again (or apply the retry label after updating). So a mismatched manifest can never be released, even though merge itself isn't blocked.
 
 **Why this design**: labels live in one canonical place. There's no question about which feeder PR's bump label "wins" when multiple PRs disagree — there is only the standing PR. Provenance is GitHub's own audit log (`gh pr view <n> --json events`).
 

--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -56,6 +56,12 @@ export interface StandingPRManifest {
   baseSha: string;
   /** ISO timestamp of when this standing PR was first created. Preserved across updates. Added in schema v2. */
   firstUpdatedAt?: string;
+  /**
+   * Override-relevant labels (bump/channel/scope) present on the standing PR when this manifest was
+   * computed, sorted. Lets publish refuse a manifest whose labels diverged from the merged PR (#337).
+   * Optional: absent on manifests written before this field existed — consumers must tolerate that.
+   */
+  overrideLabels?: string[];
 }
 
 function getHeadSha(cwd: string): string {
@@ -63,6 +69,26 @@ function getHeadSha(cwd: string): string {
     return execSync('git rev-parse HEAD', { encoding: 'utf-8', cwd }).trim();
   } catch (err) {
     throw new Error(`Failed to get HEAD SHA: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+/**
+ * True when this run was triggered by a label being added/removed on a PR (#336) — a maintainer
+ * adjusting the standing PR's override labels, not a commit landing. The CLI reads the event itself
+ * (rather than taking a flag) so it works whether the workflow invokes the action, the reusable
+ * workflow, or the CLI directly. Such runs must bypass the initial skip-pattern guard: a
+ * pull_request event checks out the standing PR's `chore: release preparation` commit, which matches
+ * the skip pattern, so the guard would otherwise no-op every label-driven update.
+ */
+function isLabelTriggeredRun(): boolean {
+  if (process.env.GITHUB_EVENT_NAME !== 'pull_request') return false;
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (!eventPath) return false;
+  try {
+    const event = JSON.parse(fs.readFileSync(eventPath, 'utf-8')) as { action?: string };
+    return event.action === 'labeled' || event.action === 'unlabeled';
+  } catch {
+    return false;
   }
 }
 
@@ -537,6 +563,26 @@ interface StandingPrOverrides {
   conflicts: string[];
 }
 
+/**
+ * The override-relevant labels (bump/channel/scope) present on a PR, sorted and de-duplicated.
+ * This is the set that actually drives the next release, so it's what the manifest records and what
+ * publish compares against the merged PR to detect a stale manifest (#337). The standing-PR marker
+ * label and any unrelated labels (area:*, etc.) are deliberately excluded — they don't affect output.
+ */
+function extractOverrideLabels(prLabels: string[], ciConfig: CIConfig | undefined): string[] {
+  const labels = ciConfig?.labels ?? DEFAULT_LABELS;
+  const scopeLabels = ciConfig?.scopeLabels ?? {};
+  const relevant = new Set<string>([
+    labels.major,
+    labels.minor,
+    labels.patch,
+    labels.stable,
+    labels.prerelease,
+    ...Object.keys(scopeLabels),
+  ]);
+  return [...new Set(prLabels.filter((l) => relevant.has(l)))].sort();
+}
+
 function resolveStandingPrLabelOverrides(prLabels: string[], ciConfig: CIConfig | undefined): StandingPrOverrides {
   // Return a fresh object rather than a shared constant — callers may mutate `conflicts`.
   if (!prLabels || prLabels.length === 0) return { conflicts: [] };
@@ -638,12 +684,20 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
   const base = releaseKitConfig.git?.branch ?? 'main';
   const skipPatterns = releaseKitConfig.release?.ci?.skipPatterns ?? ['chore: release '];
 
-  // Skip-pattern guard. The reconcile flag bypasses it: reconcile runs deliberately right after
-  // a release (HEAD is a release commit that matches the skip pattern by design), so the
-  // push-event noise rejection this guard provides would otherwise turn every reconcile into a
-  // no-op and leave the standing PR holding just-published versions.
-  if (options.reconcile) {
-    info('Reconcile mode: bypassing skip-pattern guard');
+  // Label-triggered runs (a maintainer added/removed an override label on the standing PR, #336)
+  // must bypass the skip-pattern guards just like reconcile: the guards reject runs reacting to a
+  // release commit on HEAD, but a label event isn't reacting to HEAD at all — skipping would leave
+  // the new override unapplied until the next push or the hourly cron.
+  const bypassSkipGuard = options.reconcile || isLabelTriggeredRun();
+
+  // Skip-pattern guard. Bypassed by reconcile (HEAD is a release commit by design then) and by
+  // label-triggered runs (the trigger is a label, not the commit on HEAD).
+  if (bypassSkipGuard) {
+    info(
+      options.reconcile
+        ? 'Reconcile mode: bypassing skip-pattern guard'
+        : 'Label-triggered run: bypassing skip-pattern guard',
+    );
   } else {
     const headSubject = getHeadCommitMessage(cwd);
     if (headSubject && matchesSkipPattern(headSubject, skipPatterns)) {
@@ -963,6 +1017,9 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
     createdAt: new Date().toISOString(),
     baseSha,
     firstUpdatedAt,
+    // Record the labels this manifest was computed under so publish can detect a stale manifest if
+    // they're changed after this update without a re-run (#337).
+    overrideLabels: extractOverrideLabels(existingStandingPr?.labels ?? [], ciConfig),
   };
 
   const manifestBody = serializeManifest(manifest);
@@ -1084,18 +1141,43 @@ export async function publishFromManifest(prNumber: number, options: StandingPRO
     projectDir: cwd,
   };
 
-  // Pull any human-edited release notes from the live (now-merged, still-readable) PR body (#200).
-  // Marker slicing only — the manifest never stores prose, so "manifest = machine state only" holds.
-  let editedNotes: Record<string, string> = {};
+  // Fetch the merged (still-readable) PR once — used for both the override-label staleness guard
+  // and the human-edited release notes.
+  let livePr: Awaited<ReturnType<typeof octokit.rest.pulls.get>>['data'] | undefined;
   try {
-    const { data: livePr } = await octokit.rest.pulls.get({ owner, repo, pull_number: prNumber });
+    livePr = (await octokit.rest.pulls.get({ owner, repo, pull_number: prNumber })).data;
+  } catch (err) {
+    warn(`Could not read PR #${prNumber}: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  // Staleness guard (#337): refuse to publish a manifest whose override labels diverge from the
+  // merged PR's. This catches "label changed then merged before the standing-PR update re-ran" —
+  // publishing then would ship a release the labels no longer describe. Only enforced when the
+  // manifest actually recorded labels; manifests written before this field skip the check.
+  if (livePr && manifest.overrideLabels !== undefined) {
+    const mergedLabels = extractOverrideLabels(
+      (livePr.labels ?? []).map((l) => (typeof l === 'string' ? l : (l.name ?? ''))).filter(Boolean),
+      releaseKitConfig.ci,
+    );
+    const manifestLabels = [...manifest.overrideLabels].sort();
+    if (mergedLabels.join('\n') !== manifestLabels.join('\n')) {
+      throw new Error(
+        `Standing PR #${prNumber} override labels changed after the last update — the release manifest is stale.\n` +
+          `  manifest was computed for: [${manifestLabels.join(', ') || '(none)'}]\n` +
+          `  PR now has:                [${mergedLabels.join(', ') || '(none)'}]\n` +
+          `Re-run 'releasekit standing-pr update' so the manifest matches, then merge (or apply the retry label after ` +
+          `updating). Refusing to publish a release the labels no longer describe.`,
+      );
+    }
+  }
+
+  // Pull any human-edited release notes from the live PR body (#200). Marker slicing only — the
+  // manifest never stores prose, so "manifest = machine state only" holds.
+  let editedNotes: Record<string, string> = {};
+  if (livePr) {
     editedNotes = extractNotesRegions(
       livePr.body ?? '',
       publishableUpdates(manifest.versionOutput).map((u) => u.packageName),
-    );
-  } catch (err) {
-    warn(
-      `Could not read PR #${prNumber} body for edited release notes: ${err instanceof Error ? err.message : String(err)}`,
     );
   }
 

--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -1154,6 +1154,19 @@ export async function publishFromManifest(prNumber: number, options: StandingPRO
   // merged PR's. This catches "label changed then merged before the standing-PR update re-ran" —
   // publishing then would ship a release the labels no longer describe. Only enforced when the
   // manifest actually recorded labels; manifests written before this field skip the check.
+  //
+  // Fail closed rather than publish blind: when the manifest carried override labels but the PR is
+  // unreadable (transient API failure coinciding with the race window) we can't verify, so refuse
+  // and let the retry handle it. An empty override set has nothing a label change could contradict
+  // beyond "a label was added", which the next update would have folded in — not worth failing the
+  // common (no-override) publish on an API blip.
+  if (!livePr && manifest.overrideLabels !== undefined && manifest.overrideLabels.length > 0) {
+    throw new Error(
+      `Cannot verify standing PR #${prNumber} override labels against the manifest — the PR could not be read ` +
+        `from GitHub. Refusing to publish a manifest that carried override labels without confirming they still ` +
+        `match. Re-run once the GitHub API is reachable (or apply the retry label).`,
+    );
+  }
   if (livePr && manifest.overrideLabels !== undefined) {
     const mergedLabels = extractOverrideLabels(
       (livePr.labels ?? []).map((l) => (typeof l === 'string' ? l : (l.name ?? ''))).filter(Boolean),

--- a/packages/release/test/unit/standing-pr.spec.ts
+++ b/packages/release/test/unit/standing-pr.spec.ts
@@ -278,6 +278,17 @@ describe('serializeManifest / parseManifest', () => {
     expect(parsed.schemaVersion).toBe(2);
     expect(parsed.firstUpdatedAt).toBe('2024-06-01T12:00:00.000Z');
   });
+
+  it('should round-trip overrideLabels (#337)', () => {
+    const m = { ...baseManifest, schemaVersion: 2 as const, overrideLabels: ['bump:major', 'channel:prerelease'] };
+    const parsed = parseManifest(serializeManifest(m));
+    expect(parsed.overrideLabels).toEqual(['bump:major', 'channel:prerelease']);
+  });
+
+  it('should accept a manifest without overrideLabels (backward compat)', () => {
+    const parsed = parseManifest(serializeManifest(baseManifest));
+    expect(parsed.overrideLabels).toBeUndefined();
+  });
 });
 
 describe('runStandingPRUpdate', () => {
@@ -403,6 +414,57 @@ describe('runStandingPRUpdate', () => {
 
     expect(result.action).toBe('created');
     expect(mocks.pullsCreate).toHaveBeenCalled();
+  });
+
+  it('should bypass the initial skip-pattern guard on a pull_request label event (#336)', async () => {
+    // A label event checks out the standing PR's `chore: release preparation` commit (matches the
+    // skip pattern) — the first guard would noop. A label-triggered run must proceed. The post-reset
+    // HEAD is a normal commit, so the post-reset guard (not bypassed for label runs) passes.
+    // HEAD is the release-prep commit until the branch is reset to origin/main, after which it's a
+    // normal commit. Keying on the reset (not call count) keeps this correct whether or not the
+    // first guard runs its git-log call — the whole point is that the bypass skips that call.
+    const { execSync } = await import('node:child_process');
+    let resetDone = false;
+    vi.mocked(execSync).mockImplementation((cmd: string) => {
+      if (typeof cmd === 'string') {
+        if (cmd.includes('reset --hard')) resetDone = true;
+        if (cmd.includes('git log -1 --pretty=%s')) {
+          return resetDone ? 'feat: something (#320)' : 'chore: release preparation';
+        }
+      }
+      return 'abc123\n';
+    });
+
+    const { readFileSync } = await import('node:fs');
+    vi.mocked(readFileSync).mockReturnValue(JSON.stringify({ action: 'labeled' }));
+    const prevName = process.env.GITHUB_EVENT_NAME;
+    const prevPath = process.env.GITHUB_EVENT_PATH;
+    process.env.GITHUB_EVENT_NAME = 'pull_request';
+    process.env.GITHUB_EVENT_PATH = '/event.json';
+
+    try {
+      const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
+      const versionOutput = createMockVersionOutput([{ packageName: '@scope/core', newVersion: '1.2.3' }]);
+      vi.mocked(runVersionStep)
+        .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>)
+        .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>);
+      vi.mocked(runNotesStep).mockResolvedValue({ packageNotes: {}, releaseNotes: {}, files: [] });
+
+      const { createOctokit } = await import('../../src/github.js');
+      const { mocks, octokit } = createMockOctokit();
+      mocks.pullsList.mockResolvedValue({ data: [{ number: 99, html_url: 'https://github.com/owner/repo/pull/99' }] });
+      vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+
+      const result = await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
+
+      // Did NOT noop on the first guard — the label-triggered run proceeded to update the PR.
+      expect(result.action).not.toBe('noop');
+    } finally {
+      if (prevName === undefined) delete process.env.GITHUB_EVENT_NAME;
+      else process.env.GITHUB_EVENT_NAME = prevName;
+      if (prevPath === undefined) delete process.env.GITHUB_EVENT_PATH;
+      else process.env.GITHUB_EVENT_PATH = prevPath;
+    }
   });
 
   it('should return noop when no releasable changes found and no existing PR', async () => {
@@ -1089,6 +1151,21 @@ describe('runStandingPRUpdate', () => {
       expect(runVersionStepMock.mock.calls[1]?.[0]).toMatchObject({ bump: 'premajor', prerelease: true });
     });
 
+    it('should record the override labels in the manifest, excluding the marker label (#337)', async () => {
+      const { mocks } = await setupWithStandingPRLabels(['release', 'bump:major', 'channel:prerelease']);
+
+      await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
+
+      const writes = [...mocks.createComment.mock.calls, ...mocks.updateComment.mock.calls];
+      const manifestWrite = writes.find(
+        (c) => typeof c[0]?.body === 'string' && c[0].body.includes('<!-- releasekit-manifest -->'),
+      );
+      expect(manifestWrite).toBeDefined();
+      const manifest = parseManifest(manifestWrite?.[0]?.body as string);
+      // Sorted, marker 'release' label excluded.
+      expect(manifest.overrideLabels).toEqual(['bump:major', 'channel:prerelease']);
+    });
+
     it('should drop the bump under channel:stable (graduation is bump-less, matching the SSOT)', async () => {
       const { runVersionStepMock } = await setupWithStandingPRLabels(['release', 'bump:major', 'channel:stable']);
 
@@ -1481,6 +1558,90 @@ describe('runStandingPRPublish', () => {
       { '@scope/core': '- regenerated at publish time' },
       expect.arrayContaining(['RELEASE_NOTES.md', ...baseManifest.notesFiles]),
     );
+  });
+
+  it('should refuse to publish when override labels diverge from the manifest (#337)', async () => {
+    const { readFileSync } = await import('node:fs');
+    vi.mocked(readFileSync).mockReturnValue(
+      JSON.stringify({ pull_request: { head: { ref: 'release/next' }, number: 42, merged: true } }),
+    );
+
+    const { createOctokit } = await import('../../src/github.js');
+    const { octokit, mocks } = createMockOctokit();
+    const manifestBody = serializeManifest({ ...baseManifest, schemaVersion: 2, overrideLabels: ['bump:major'] });
+    (octokit as unknown as { paginate: { iterator: ReturnType<typeof vi.fn> } }).paginate.iterator.mockReturnValue({
+      async *[Symbol.asyncIterator]() {
+        yield { data: [{ id: 1, body: manifestBody }] };
+      },
+    });
+    // The merged PR carries a different bump label than the manifest was computed for.
+    mocks.pullsGet.mockResolvedValue({ data: { body: '', labels: [{ name: 'bump:minor' }, { name: 'release' }] } });
+    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+
+    await expect(
+      runStandingPRPublish({ projectDir: '/test', verbose: false, quiet: false, json: false }),
+    ).rejects.toThrow(/labels changed after the last update/);
+
+    const { runPublishStep } = await import('../../src/steps.js');
+    expect(vi.mocked(runPublishStep)).not.toHaveBeenCalled();
+  });
+
+  it('should publish when override labels match the manifest, ignoring non-override labels (#337)', async () => {
+    const { readFileSync } = await import('node:fs');
+    vi.mocked(readFileSync).mockReturnValue(
+      JSON.stringify({ pull_request: { head: { ref: 'release/next' }, number: 42, merged: true } }),
+    );
+
+    const { createOctokit } = await import('../../src/github.js');
+    const { octokit, mocks } = createMockOctokit();
+    const manifestBody = serializeManifest({ ...baseManifest, schemaVersion: 2, overrideLabels: ['bump:major'] });
+    (octokit as unknown as { paginate: { iterator: ReturnType<typeof vi.fn> } }).paginate.iterator.mockReturnValue({
+      async *[Symbol.asyncIterator]() {
+        yield { data: [{ id: 1, body: manifestBody }] };
+      },
+    });
+    // Same override label; the unrelated 'release' / 'area:ci' labels must not count as a mismatch.
+    mocks.pullsGet.mockResolvedValue({
+      data: { body: '', labels: [{ name: 'release' }, { name: 'bump:major' }, { name: 'area:ci' }] },
+    });
+    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+
+    const { runPublishStep } = await import('../../src/steps.js');
+    vi.mocked(runPublishStep).mockResolvedValue({ publishSucceeded: true } as unknown as Awaited<
+      ReturnType<typeof runPublishStep>
+    >);
+
+    const result = await runStandingPRPublish({ projectDir: '/test', verbose: false, quiet: false, json: false });
+    expect(result).not.toBeNull();
+    expect(vi.mocked(runPublishStep)).toHaveBeenCalled();
+  });
+
+  it('should skip the override-label check for manifests without overrideLabels (backward compat)', async () => {
+    const { readFileSync } = await import('node:fs');
+    vi.mocked(readFileSync).mockReturnValue(
+      JSON.stringify({ pull_request: { head: { ref: 'release/next' }, number: 42, merged: true } }),
+    );
+
+    const { createOctokit } = await import('../../src/github.js');
+    const { octokit, mocks } = createMockOctokit();
+    // baseManifest has no overrideLabels (pre-#337) — the check must be skipped even if labels differ.
+    const manifestBody = serializeManifest(baseManifest);
+    (octokit as unknown as { paginate: { iterator: ReturnType<typeof vi.fn> } }).paginate.iterator.mockReturnValue({
+      async *[Symbol.asyncIterator]() {
+        yield { data: [{ id: 1, body: manifestBody }] };
+      },
+    });
+    mocks.pullsGet.mockResolvedValue({ data: { body: '', labels: [{ name: 'bump:major' }] } });
+    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+
+    const { runPublishStep } = await import('../../src/steps.js');
+    vi.mocked(runPublishStep).mockResolvedValue({ publishSucceeded: true } as unknown as Awaited<
+      ReturnType<typeof runPublishStep>
+    >);
+
+    const result = await runStandingPRPublish({ projectDir: '/test', verbose: false, quiet: false, json: false });
+    expect(result).not.toBeNull();
+    expect(vi.mocked(runPublishStep)).toHaveBeenCalled();
   });
 
   it('should fall back to empty release notes when LLM regeneration fails', async () => {

--- a/packages/release/test/unit/standing-pr.spec.ts
+++ b/packages/release/test/unit/standing-pr.spec.ts
@@ -1644,6 +1644,32 @@ describe('runStandingPRPublish', () => {
     expect(vi.mocked(runPublishStep)).toHaveBeenCalled();
   });
 
+  it('should refuse to publish when the PR is unreadable but the manifest carried override labels (#337)', async () => {
+    const { readFileSync } = await import('node:fs');
+    vi.mocked(readFileSync).mockReturnValue(
+      JSON.stringify({ pull_request: { head: { ref: 'release/next' }, number: 42, merged: true } }),
+    );
+
+    const { createOctokit } = await import('../../src/github.js');
+    const { octokit, mocks } = createMockOctokit();
+    const manifestBody = serializeManifest({ ...baseManifest, schemaVersion: 2, overrideLabels: ['bump:major'] });
+    (octokit as unknown as { paginate: { iterator: ReturnType<typeof vi.fn> } }).paginate.iterator.mockReturnValue({
+      async *[Symbol.asyncIterator]() {
+        yield { data: [{ id: 1, body: manifestBody }] };
+      },
+    });
+    // The PR can't be read (transient API failure) — can't verify labels, so fail closed.
+    mocks.pullsGet.mockRejectedValue(new Error('API unavailable'));
+    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+
+    await expect(
+      runStandingPRPublish({ projectDir: '/test', verbose: false, quiet: false, json: false }),
+    ).rejects.toThrow(/could not be read/);
+
+    const { runPublishStep } = await import('../../src/steps.js');
+    expect(vi.mocked(runPublishStep)).not.toHaveBeenCalled();
+  });
+
   it('should fall back to empty release notes when LLM regeneration fails', async () => {
     const { readFileSync } = await import('node:fs');
     vi.mocked(readFileSync).mockReturnValue(

--- a/templates/workflows/standing-pr.yml
+++ b/templates/workflows/standing-pr.yml
@@ -14,7 +14,10 @@ on:
   push:
     branches: [main]  # Should match git.branch in releasekit.config.json
   pull_request:
-    types: [closed]
+    # closed: publish / immediate-release on merge. labeled/unlabeled: apply
+    # bump/scope/channel override labels to the OPEN standing PR immediately
+    # (the merge-gated jobs below add `action == 'closed'` so they ignore these).
+    types: [closed, labeled, unlabeled]
     branches: [main]
   schedule:
     - cron: '0 * * * *'  # Hourly — re-evaluates minAge status check as time passes
@@ -32,7 +35,19 @@ permissions:
 jobs:
   update-release-pr:
     name: Update Release PR
-    if: github.event_name == 'push' || github.event_name == 'schedule'
+    # push/schedule rebuild the PR; a label change on the OPEN standing PR re-runs the update so
+    # bump/scope/channel overrides apply within seconds. `state == 'open'` keeps this off the
+    # merged-PR label events that drive the jobs below. `release/` prefix hardcoded (workflow `if`
+    # can't read config) — the in-step config is authoritative.
+    if: >-
+      github.event_name == 'push' ||
+      github.event_name == 'schedule' ||
+      (
+        github.event_name == 'pull_request' &&
+        (github.event.action == 'labeled' || github.event.action == 'unlabeled') &&
+        github.event.pull_request.state == 'open' &&
+        startsWith(github.event.pull_request.head.ref, 'release/')
+      )
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -72,6 +87,7 @@ jobs:
     name: Immediate Release (bypass standing PR)
     if: >
       github.event_name == 'pull_request' &&
+      github.event.action == 'closed' &&
       github.event.pull_request.merged == true &&
       contains(github.event.pull_request.labels.*.name, 'release:immediate')
     runs-on: ubuntu-latest
@@ -121,6 +137,7 @@ jobs:
     name: Publish Release
     if: >
       github.event_name == 'pull_request' &&
+      github.event.action == 'closed' &&
       github.event.pull_request.merged == true &&
       startsWith(github.event.pull_request.head.ref, 'release/')
     runs-on: ubuntu-latest


### PR DESCRIPTION
-

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR implements two related features for the standing-PR release workflow: (1) label changes on the open standing PR now immediately re-run `standing-pr update` via new `labeled`/`unlabeled` event subscriptions, so bump/scope/channel overrides apply within seconds rather than waiting for the next push or hourly cron (#336); (2) the manifest now records the set of override labels it was computed under, and `publishFromManifest` validates that the merged PR's labels still match before publishing, failing closed when they diverge or when the PR is unreadable and override labels were set (#337).

- **Workflow changes**: `labeled`/`unlabeled` events added to all three workflow files; new `update-on-label` job added to the internal workflow; `action == 'closed'` guard added to merge-gated jobs (`trigger-immediate`, publish) to prevent label events on already-merged PRs from triggering spurious re-publishes.
- **TypeScript changes**: New `isLabelTriggeredRun()` helper bypasses the skip-pattern guard on label events; new `extractOverrideLabels()` extracts bump/channel/scope labels deterministically; `StandingPRManifest.overrideLabels` field records the label set at update time; staleness guard in `publishFromManifest` throws on mismatch and fails closed on API error when overrides were set.
- **Tests**: New unit tests cover the label-event skip-pattern bypass, manifest round-trip, override label recording, and all four staleness-guard branches (diverged labels, matching labels, old manifest without the field, and API-failure-with-overrides).
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge — both features are correctly guarded and the staleness check fails closed rather than publishing blind.

The label-event workflow conditions are correct and consistent across all three workflow files: open-PR guard (state==open) on update jobs, action==closed on merge-gated publish/immediate jobs. The staleness check in publishFromManifest correctly throws when override labels diverge and when the PR is unreadable but overrides were recorded, while gracefully skipping for old manifests without the field. Both issues flagged in prior review threads have been addressed in this PR. Tests cover the new paths thoroughly.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/standing-pr.yml | Adds labeled/unlabeled event types, a new update-on-label job with correct state==open guard, and action==closed guard on trigger-immediate — all guards are consistent and correct. |
| packages/release/src/standing-pr/standing-pr.ts | Adds isLabelTriggeredRun(), extractOverrideLabels(), overrideLabels manifest field, and staleness guard in publishFromManifest; fail-closed logic for unreadable-PR + non-empty overrides is correct. |
| examples/ci/standing-pr/standing-pr.yml | update job expanded with label-event condition; publish job correctly adds action==closed guard; retry-publish already uses action==labeled so no change needed there. |
| templates/workflows/standing-pr.yml | update-release-pr expanded with label-event condition; both immediate-release and publish jobs gain action==closed guard correctly. |
| packages/release/test/unit/standing-pr.spec.ts | Adds tests for label-event skip-bypass, manifest overrideLabels round-trip, backward compat, and all four staleness-guard branches; coverage is thorough. |
| packages/release/docs/ci-setup.md | Documentation updated to reflect labeled/unlabeled triggers, new update-release-pr condition, and staleness guard behavior; publish-release job correctly gains action==closed guard. |

</details>


</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.github/workflows/standing-pr.yml`, line 149-155 ([link](https://github.com/goosewobbler/releasekit/blob/f8306da14ca82039bc3ecf8d273d5e49b2a7875c/.github/workflows/standing-pr.yml#L149-L155)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`trigger-immediate` missing `action == 'closed'` guard**

   Now that `labeled` and `unlabeled` are subscribed, a `labeled` event on an already-merged PR that carries `release:immediate` satisfies both `event_name == 'pull_request'` and `merged == true` — triggering an unintended dispatch to `release.yml`. The template (`templates/workflows/standing-pr.yml`) correctly adds `github.event.action == 'closed' &&` to its equivalent job, but the internal workflow was not updated to match. Adding any label to a merged immediate-release PR would dispatch a second publish run.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Fstanding-pr.yml%0ALine%3A%20149-155%0A%0AComment%3A%0A**%60trigger-immediate%60%20missing%20%60action%20%3D%3D%20'closed'%60%20guard**%0A%0ANow%20that%20%60labeled%60%20and%20%60unlabeled%60%20are%20subscribed%2C%20a%20%60labeled%60%20event%20on%20an%20already-merged%20PR%20that%20carries%20%60release%3Aimmediate%60%20satisfies%20both%20%60event_name%20%3D%3D%20'pull_request'%60%20and%20%60merged%20%3D%3D%20true%60%20%E2%80%94%20triggering%20an%20unintended%20dispatch%20to%20%60release.yml%60.%20The%20template%20%28%60templates%2Fworkflows%2Fstanding-pr.yml%60%29%20correctly%20adds%20%60github.event.action%20%3D%3D%20'closed'%20%26%26%60%20to%20its%20equivalent%20job%2C%20but%20the%20internal%20workflow%20was%20not%20updated%20to%20match.%20Adding%20any%20label%20to%20a%20merged%20immediate-release%20PR%20would%20dispatch%20a%20second%20publish%20run.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=goosewobbler%2Freleasekit&pr=345&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Fstanding-pr.yml%0ALine%3A%20149-155%0A%0AComment%3A%0A**%60trigger-immediate%60%20missing%20%60action%20%3D%3D%20'closed'%60%20guard**%0A%0ANow%20that%20%60labeled%60%20and%20%60unlabeled%60%20are%20subscribed%2C%20a%20%60labeled%60%20event%20on%20an%20already-merged%20PR%20that%20carries%20%60release%3Aimmediate%60%20satisfies%20both%20%60event_name%20%3D%3D%20'pull_request'%60%20and%20%60merged%20%3D%3D%20true%60%20%E2%80%94%20triggering%20an%20unintended%20dispatch%20to%20%60release.yml%60.%20The%20template%20%28%60templates%2Fworkflows%2Fstanding-pr.yml%60%29%20correctly%20adds%20%60github.event.action%20%3D%3D%20'closed'%20%26%26%60%20to%20its%20equivalent%20job%2C%20but%20the%20internal%20workflow%20was%20not%20updated%20to%20match.%20Adding%20any%20label%20to%20a%20merged%20immediate-release%20PR%20would%20dispatch%20a%20second%20publish%20run.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=345&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix(release): harden trigger-immediate g..."](https://github.com/goosewobbler/releasekit/commit/e23dac7c44511a70b30f8032d94480a60898d3e6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38025195)</sub>

<!-- /greptile_comment -->