### PR TITLE
feat(release): warn on missing baseline tags + truncate oversized standing-PR body (#333, #334)

### DIFF
--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -357,7 +357,7 @@ function deleteReleaseBranch(releaseBranch: string, cwd: string): void {
 // GitHub rejects a PR body over 65,536 chars with a 422. Cap below that (with margin) so an
 // oversized changelog — almost always a package with no baseline tag whose changelog spans the
 // entire git history (#333) — truncates gracefully instead of failing PR creation outright.
-const STANDING_PR_BODY_CAP = 64000;
+export const STANDING_PR_BODY_CAP = 64000;
 
 function truncateAtLineBoundary(text: string, maxChars: number): string {
   if (text.length <= maxChars) return text;
@@ -420,7 +420,11 @@ function renderPrBody(versionOutput: VersionOutput, supersedeWarning?: string[],
     "Each package's complete changelog is in its `CHANGELOG.md`. This usually means a package has no prior " +
     'release tag, so its changelog spans the entire git history — create baseline tags to scope it.';
   const room = STANDING_PR_BODY_CAP - build('').length - notice.length - 8;
-  if (room <= 0) return build(notice);
+  // No room for any changelog: the non-changelog content (package table / notes region) already
+  // fills the budget. Drop the changelog entirely rather than appending the notice, which would only
+  // add to the overflow. (A package table that alone exceeds the cap would need its own truncation —
+  // that's thousands of packages and out of scope here.)
+  if (room <= 0) return build('');
   return build(`${truncateAtLineBoundary(changelog, room)}\n\n${notice}`);
 }
 

--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -354,45 +354,74 @@ function deleteReleaseBranch(releaseBranch: string, cwd: string): void {
   }
 }
 
+// GitHub rejects a PR body over 65,536 chars with a 422. Cap below that (with margin) so an
+// oversized changelog — almost always a package with no baseline tag whose changelog spans the
+// entire git history (#333) — truncates gracefully instead of failing PR creation outright.
+const STANDING_PR_BODY_CAP = 64000;
+
+function truncateAtLineBoundary(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text;
+  const slice = text.slice(0, maxChars);
+  const lastNewline = slice.lastIndexOf('\n');
+  return lastNewline > 0 ? slice.slice(0, lastNewline) : slice;
+}
+
 function renderPrBody(versionOutput: VersionOutput, supersedeWarning?: string[], notesRegion?: string): string {
-  const lines: string[] = ['## Release', ''];
+  // Build the body around a given changelog section so we can re-render with a truncated changelog
+  // if the full one would exceed GitHub's limit, without disturbing the editable notes region.
+  const build = (changelogSection: string): string => {
+    const lines: string[] = ['## Release', ''];
 
-  // While a prior release remains partially published, lead with the supersede warning so the
-  // maintainer sees the retry-vs-supersede choice before the package list.
-  if (supersedeWarning && supersedeWarning.length > 0) {
-    lines.push(...supersedeWarning);
-  }
-
-  // The root lockstep bump (sync mode) is never published — keep it out of the package list.
-  const updates = publishableUpdates(versionOutput);
-
-  if (versionOutput.strategy === 'sync') {
-    // Sync releases move as one unit — lead with the version; a per-row version column
-    // would repeat the same value for every package.
-    lines.push(`Merging this PR will publish **${syncVersionDisplay(versionOutput)}**:`, '');
-    for (const update of updates) {
-      lines.push(`- \`${update.packageName}\``);
+    // While a prior release remains partially published, lead with the supersede warning so the
+    // maintainer sees the retry-vs-supersede choice before the package list.
+    if (supersedeWarning && supersedeWarning.length > 0) {
+      lines.push(...supersedeWarning);
     }
-  } else {
-    lines.push(
-      'Merging this PR will publish the following packages:',
-      '',
-      '| Package | Version |',
-      '|---------|---------|',
-    );
-    for (const update of updates) {
-      lines.push(`| \`${update.packageName}\` | ${update.newVersion} |`);
+
+    // The root lockstep bump (sync mode) is never published — keep it out of the package list.
+    const updates = publishableUpdates(versionOutput);
+
+    if (versionOutput.strategy === 'sync') {
+      // Sync releases move as one unit — lead with the version; a per-row version column
+      // would repeat the same value for every package.
+      lines.push(`Merging this PR will publish **${syncVersionDisplay(versionOutput)}**:`, '');
+      for (const update of updates) {
+        lines.push(`- \`${update.packageName}\``);
+      }
+    } else {
+      lines.push(
+        'Merging this PR will publish the following packages:',
+        '',
+        '| Package | Version |',
+        '|---------|---------|',
+      );
+      for (const update of updates) {
+        lines.push(`| \`${update.packageName}\` | ${update.newVersion} |`);
+      }
     }
-  }
+
+    if (changelogSection) lines.push('', changelogSection, '');
+    // The editable release-notes region (opt-in via the preview-notes label) sits below the changelog
+    // and above the merge instructions, so a reviewer reads/edits it in the natural place.
+    if (notesRegion) lines.push('', notesRegion, '');
+    lines.push('---', '> Merge this PR to publish. The release will be triggered automatically.');
+    lines.push('', ATTRIBUTION_FOOTER);
+    return lines.join('\n');
+  };
 
   const changelog = renderChangelogSection(versionOutput);
-  if (changelog) lines.push('', changelog, '');
-  // The editable release-notes region (opt-in via the preview-notes label) sits below the changelog
-  // and above the merge instructions, so a reviewer reads/edits it in the natural place.
-  if (notesRegion) lines.push('', notesRegion, '');
-  lines.push('---', '> Merge this PR to publish. The release will be triggered automatically.');
-  lines.push('', ATTRIBUTION_FOOTER);
-  return lines.join('\n');
+  const body = build(changelog);
+  if (body.length <= STANDING_PR_BODY_CAP || !changelog) return body;
+
+  // Too long: truncate the changelog and point to each package's CHANGELOG.md for the rest. The
+  // root cause is almost always a package with no baseline tag (#333/#334) — say so.
+  const notice =
+    "> **Changelog truncated** — the full changelog exceeded GitHub's PR-body limit and was shortened here. " +
+    "Each package's complete changelog is in its `CHANGELOG.md`. This usually means a package has no prior " +
+    'release tag, so its changelog spans the entire git history — create baseline tags to scope it.';
+  const room = STANDING_PR_BODY_CAP - build('').length - notice.length - 8;
+  if (room <= 0) return build(notice);
+  return build(`${truncateAtLineBoundary(changelog, room)}\n\n${notice}`);
 }
 
 export function serializeManifest(m: StandingPRManifest): string {

--- a/packages/release/test/unit/standing-pr.spec.ts
+++ b/packages/release/test/unit/standing-pr.spec.ts
@@ -643,6 +643,44 @@ describe('runStandingPRUpdate', () => {
     expect(createCall?.body).toContain('@scope/core — 1.2.2 → 1.2.3');
   });
 
+  it("should truncate the PR body when the changelog would exceed GitHub's limit (#333)", async () => {
+    const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
+    // A no-baseline-tag package's full-history changelog: thousands of entries blow past 65,536 chars.
+    const hugeEntries = Array.from({ length: 4000 }, (_, i) => ({
+      type: 'added',
+      description: `feature number ${i} with some descriptive text to pad the changelog body length`,
+    }));
+    const versionOutput = {
+      ...createMockVersionOutput([{ packageName: '@scope/core', newVersion: '1.0.0' }]),
+      changelogs: [
+        {
+          packageName: '@scope/core',
+          version: '1.0.0',
+          previousVersion: null,
+          revisionRange: 'HEAD',
+          entries: hugeEntries,
+        },
+      ],
+    };
+    vi.mocked(runVersionStep)
+      .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>)
+      .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>);
+    vi.mocked(runNotesStep).mockResolvedValue({ packageNotes: {}, releaseNotes: {}, files: [] });
+
+    const { createOctokit } = await import('../../src/github.js');
+    const { mocks, octokit } = createMockOctokit();
+    mocks.pullsList.mockResolvedValue({ data: [] });
+    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+
+    await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
+
+    const body = mocks.pullsCreate.mock.calls[0]?.[0]?.body as string;
+    expect(body.length).toBeLessThanOrEqual(65536);
+    expect(body).toContain('Changelog truncated');
+    // The package table above the changelog is preserved so the PR is still usable.
+    expect(body).toContain('| `@scope/core` | 1.0.0 |');
+  });
+
   it('should omit the ### Changelog section when all updates are sync-bumped (no entries)', async () => {
     const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
     // sync-bumped: updates present but changelogs array is empty

--- a/packages/release/test/unit/standing-pr.spec.ts
+++ b/packages/release/test/unit/standing-pr.spec.ts
@@ -10,6 +10,7 @@ import {
   runStandingPRMerge,
   runStandingPRPublish,
   runStandingPRUpdate,
+  STANDING_PR_BODY_CAP,
   serializeManifest,
 } from '../../src/standing-pr/standing-pr.js';
 
@@ -675,7 +676,9 @@ describe('runStandingPRUpdate', () => {
     await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
 
     const body = mocks.pullsCreate.mock.calls[0]?.[0]?.body as string;
-    expect(body.length).toBeLessThanOrEqual(65536);
+    // Assert against the module's cap (well under GitHub's 65,536), so a truncation that leaks into
+    // the 64,001–65,535 safety margin still fails the test.
+    expect(body.length).toBeLessThanOrEqual(STANDING_PR_BODY_CAP);
     expect(body).toContain('Changelog truncated');
     // The package table above the changelog is preserved so the PR is still usable.
     expect(body).toContain('| `@scope/core` | 1.0.0 |');

--- a/packages/version/src/package/packageProcessor.ts
+++ b/packages/version/src/package/packageProcessor.ts
@@ -207,6 +207,24 @@ export class PackageProcessor {
           : await getLatestStableTag(this.versionPrefix);
       }
 
+      // #334: a package with no prior git tag has its changelog computed from the FULL git history,
+      // which in standing-PR mode can push the rendered PR body past GitHub's 65,536-char limit and
+      // fail PR creation with an opaque 422 (#333). Surface it loudly with an actionable baseline-tag
+      // suggestion. (baseRef-scoped runs — advisory preview — are bounded to the PR, so skip them.)
+      if (!hasRealTag && !this.fullConfig.baseRef) {
+        const currentVersion = pkg.packageJson.version;
+        const suggestedTag = currentVersion
+          ? formatTag(currentVersion, formattedPrefix, name, this.tagTemplate, this.fullConfig.packageSpecificTags)
+          : undefined;
+        log(
+          `No prior tag found for ${name} — its changelog will include the full git history.` +
+            (suggestedTag
+              ? ` Create a baseline tag to scope it: git tag ${suggestedTag} <release-sha> && git push origin ${suggestedTag}`
+              : ''),
+          'warning',
+        );
+      }
+
       // Generate changelog entries from conventional commits
       let changelogEntries: ChangelogEntry[] = [];
       let revisionRange = 'HEAD';

--- a/packages/version/src/package/packageProcessor.ts
+++ b/packages/version/src/package/packageProcessor.ts
@@ -235,7 +235,9 @@ export class PackageProcessor {
         // baseRef takes precedence — it's a PR base SHA supplied in advisory standing-pr mode
         // so the changelog is scoped to only this PR's commits, not all commits since last tag.
         const baseForRange = this.fullConfig.baseRef ?? changelogBaseTag;
-        if (baseForRange) {
+        if (baseForRange && (this.fullConfig.baseRef || hasRealTag)) {
+          // A real tag (or an explicit baseRef) — verify it. A failure here is the #339 case: the
+          // ref genuinely exists but isn't reachable in this checkout (shallow clone / unpushed).
           const verification = verifyTag(baseForRange, pkgPath);
           if (verification.exists && verification.reachable) {
             revisionRange = `${baseForRange}..HEAD`;
@@ -259,6 +261,13 @@ export class PackageProcessor {
             revisionRange = 'HEAD';
             baselineUnreachable = true;
           }
+        } else if (baseForRange) {
+          // No real tag — `baseForRange` is the manifest-fallback's synthetic tag, which isn't a git
+          // ref. The #334 warning above already explained the full-history changelog accurately, so
+          // skip verifyTag here: running it would emit a second, misleading "could not be verified —
+          // shallow clone / unpushed" message about a tag that never existed.
+          revisionRange = 'HEAD';
+          baselineUnreachable = true;
         }
 
         changelogEntries = extractChangelogEntriesFromCommits(pkgPath, revisionRange);

--- a/packages/version/test/unit/package/packageProcessor.spec.ts
+++ b/packages/version/test/unit/package/packageProcessor.spec.ts
@@ -535,6 +535,31 @@ describe('Package Processor', () => {
       expect(calls[0][0]).toMatchObject({ previousVersion: 'v1.0.0' });
     });
 
+    it('should warn when a package has no prior tag (full-history changelog, #334)', async () => {
+      // No package tag and no global tag — only the manifest version is available, so hasRealTag is
+      // false and the changelog spans the full history. The warning makes this visible (and heads off
+      // the opaque oversized-PR-body 422 in #333).
+      vi.spyOn(gitTags, 'getLatestTagForPackage').mockResolvedValue('');
+      vi.spyOn(manifestHelpers, 'getVersionFromManifests').mockReturnValue({
+        version: '0.1.0',
+        manifestFound: true,
+        manifestPath: 'package.json',
+        manifestType: 'package.json',
+      });
+      vi.spyOn(calculator, 'calculateVersion').mockResolvedValue('0.1.1');
+      vi.spyOn(versionCalculatorModule, 'calculateVersion').mockResolvedValue('0.1.1');
+
+      const processor = new PackageProcessor({
+        ...defaultOptions,
+        getLatestTag: vi.fn().mockResolvedValue(null), // no global tag either
+        fullConfig: { ...mockConfig, packageSpecificTags: true, writeChangelog: false },
+      });
+
+      await processor.processPackages([mockPackages[1]]);
+
+      expect(logging.log).toHaveBeenCalledWith(expect.stringContaining('No prior tag found for package-b'), 'warning');
+    });
+
     it('should emit repo-level entries as sharedEntries, not in individual package changelogs', async () => {
       const repoLevelEntry = { type: 'chore', description: 'Update CI workflow' };
       const pkgAEntry = { type: 'added', description: 'New feature in pkg-a' };

--- a/packages/version/test/unit/package/packageProcessor.spec.ts
+++ b/packages/version/test/unit/package/packageProcessor.spec.ts
@@ -558,6 +558,12 @@ describe('Package Processor', () => {
       await processor.processPackages([mockPackages[1]]);
 
       expect(logging.log).toHaveBeenCalledWith(expect.stringContaining('No prior tag found for package-b'), 'warning');
+      // ...and NOT the misleading #339 "shallow clone / unpushed" warning about the synthetic
+      // manifest-fallback tag, which never existed as a git ref.
+      expect(logging.log).not.toHaveBeenCalledWith(
+        expect.stringContaining('could not be verified from HEAD'),
+        'warning',
+      );
     });
 
     it('should emit repo-level entries as sharedEntries, not in individual package changelogs', async () => {


### PR DESCRIPTION
-

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR addresses two related issues: it adds an actionable warning when a package has no prior git tag (causing its changelog to span the full git history), and it truncates oversized PR bodies before hitting GitHub's 65,536-char 422 limit.

- **`standing-pr.ts`**: Refactors `renderPrBody` around an inner `build(changelogSection)` closure, measures the body with and without the changelog, and truncates the changelog at a line boundary if it would push the body past `STANDING_PR_BODY_CAP` (64,000). A user-visible notice is appended pointing to each package's `CHANGELOG.md` and explaining the root cause.
- **`packageProcessor.ts`**: Emits a warning with a concrete `git tag` suggestion when a package has no real prior tag; also skips calling `verifyTag` on the manifest-fallback's synthetic tag to avoid a second, misleading \"shallow clone / unpushed\" warning.
- Tests updated to assert against `STANDING_PR_BODY_CAP` and to verify the new warning fires (and the spurious one does not).
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the truncation math is correct (room formula gives a 3-char safety margin), the synthetic-tag bypass is logically sound, and the test now validates against the module's own cap.

The truncation arithmetic holds up under analysis: build(x).length = build('').length + x.length + 3, so the room formula of CAP − build('').length − notice.length − 8 guarantees the final body stays 3 chars under the cap. The else-if branch for synthetic tags correctly skips verifyTag and sets baselineUnreachable, which propagates to null previousVersion. No new defects introduced.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/release/src/standing-pr/standing-pr.ts | Adds STANDING_PR_BODY_CAP constant and truncation logic inside renderPrBody; the room formula is mathematically correct (overhead is 5 chars, -8 gives 3-char safety margin). |
| packages/version/src/package/packageProcessor.ts | Adds warning for packages without a real git tag and correctly skips verifyTag on manifest-fallback synthetic tags; baselineUnreachable=true in the new else-if branch correctly suppresses previousVersion. |
| packages/release/test/unit/standing-pr.spec.ts | New truncation test now asserts against STANDING_PR_BODY_CAP (not GitHub's 65,536 raw limit), closing the gap flagged in the previous review. |
| packages/version/test/unit/package/packageProcessor.spec.ts | New test verifies that the 'No prior tag' warning fires and that the spurious 'could not be verified' message does not, covering the key regression from the synthetic-tag path. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["renderPrBody()"] --> B["build(changelog) → body"]
    B --> C{body.length ≤ STANDING_PR_BODY_CAP OR no changelog?}
    C -- yes --> D["Return full body"]
    C -- no --> E["Compute room = CAP − build('').length − notice.length − 8"]
    E --> F{room ≤ 0?}
    F -- yes --> G["Return build('') — no changelog"]
    F -- no --> H["truncateAtLineBoundary(changelog, room)"]
    H --> I["build(truncated + newline + notice)"]
    I --> J["Return truncated body ≤ CAP"]
    K["processPackage()"] --> L{hasRealTag?}
    L -- no --> M["Warn: No prior tag — full history + git tag suggestion"]
    M --> N{baseForRange truthy?}
    L -- yes --> N
    N -- "yes AND (baseRef OR hasRealTag)" --> O["verifyTag(baseForRange) — set revisionRange"]
    N -- "yes AND synthetic tag" --> P["Skip verifyTag, revisionRange=HEAD, baselineUnreachable=true"]
    N -- no --> Q["revisionRange = HEAD (default)"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["renderPrBody()"] --> B["build(changelog) → body"]
    B --> C{body.length ≤ STANDING_PR_BODY_CAP OR no changelog?}
    C -- yes --> D["Return full body"]
    C -- no --> E["Compute room = CAP − build('').length − notice.length − 8"]
    E --> F{room ≤ 0?}
    F -- yes --> G["Return build('') — no changelog"]
    F -- no --> H["truncateAtLineBoundary(changelog, room)"]
    H --> I["build(truncated + newline + notice)"]
    I --> J["Return truncated body ≤ CAP"]
    K["processPackage()"] --> L{hasRealTag?}
    L -- no --> M["Warn: No prior tag — full history + git tag suggestion"]
    M --> N{baseForRange truthy?}
    L -- yes --> N
    N -- "yes AND (baseRef OR hasRealTag)" --> O["verifyTag(baseForRange) — set revisionRange"]
    N -- "yes AND synthetic tag" --> P["Skip verifyTag, revisionRange=HEAD, baselineUnreachable=true"]
    N -- no --> Q["revisionRange = HEAD (default)"]
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(version): suppress the misleading se..."](https://github.com/goosewobbler/releasekit/commit/c83df05876a9650ec37a344c67dd0152ad143f76) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38029366)</sub>

<!-- /greptile_comment -->