### PR TITLE
fix(version): apply bump/stable/prereleaseIdentifier on first release (#347)

### DIFF
--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -357,7 +357,7 @@ function deleteReleaseBranch(releaseBranch: string, cwd: string): void {
 // GitHub rejects a PR body over 65,536 chars with a 422. Cap below that (with margin) so an
 // oversized changelog — almost always a package with no baseline tag whose changelog spans the
 // entire git history (#333) — truncates gracefully instead of failing PR creation outright.
-const STANDING_PR_BODY_CAP = 64000;
+export const STANDING_PR_BODY_CAP = 64000;
 
 function truncateAtLineBoundary(text: string, maxChars: number): string {
   if (text.length <= maxChars) return text;
@@ -420,7 +420,11 @@ function renderPrBody(versionOutput: VersionOutput, supersedeWarning?: string[],
     "Each package's complete changelog is in its `CHANGELOG.md`. This usually means a package has no prior " +
     'release tag, so its changelog spans the entire git history — create baseline tags to scope it.';
   const room = STANDING_PR_BODY_CAP - build('').length - notice.length - 8;
-  if (room <= 0) return build(notice);
+  // No room for any changelog: the non-changelog content (package table / notes region) already
+  // fills the budget. Drop the changelog entirely rather than appending the notice, which would only
+  // add to the overflow. (A package table that alone exceeds the cap would need its own truncation —
+  // that's thousands of packages and out of scope here.)
+  if (room <= 0) return build('');
   return build(`${truncateAtLineBoundary(changelog, room)}\n\n${notice}`);
 }
 

--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -354,45 +354,74 @@ function deleteReleaseBranch(releaseBranch: string, cwd: string): void {
   }
 }
 
+// GitHub rejects a PR body over 65,536 chars with a 422. Cap below that (with margin) so an
+// oversized changelog — almost always a package with no baseline tag whose changelog spans the
+// entire git history (#333) — truncates gracefully instead of failing PR creation outright.
+const STANDING_PR_BODY_CAP = 64000;
+
+function truncateAtLineBoundary(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text;
+  const slice = text.slice(0, maxChars);
+  const lastNewline = slice.lastIndexOf('\n');
+  return lastNewline > 0 ? slice.slice(0, lastNewline) : slice;
+}
+
 function renderPrBody(versionOutput: VersionOutput, supersedeWarning?: string[], notesRegion?: string): string {
-  const lines: string[] = ['## Release', ''];
+  // Build the body around a given changelog section so we can re-render with a truncated changelog
+  // if the full one would exceed GitHub's limit, without disturbing the editable notes region.
+  const build = (changelogSection: string): string => {
+    const lines: string[] = ['## Release', ''];
 
-  // While a prior release remains partially published, lead with the supersede warning so the
-  // maintainer sees the retry-vs-supersede choice before the package list.
-  if (supersedeWarning && supersedeWarning.length > 0) {
-    lines.push(...supersedeWarning);
-  }
-
-  // The root lockstep bump (sync mode) is never published — keep it out of the package list.
-  const updates = publishableUpdates(versionOutput);
-
-  if (versionOutput.strategy === 'sync') {
-    // Sync releases move as one unit — lead with the version; a per-row version column
-    // would repeat the same value for every package.
-    lines.push(`Merging this PR will publish **${syncVersionDisplay(versionOutput)}**:`, '');
-    for (const update of updates) {
-      lines.push(`- \`${update.packageName}\``);
+    // While a prior release remains partially published, lead with the supersede warning so the
+    // maintainer sees the retry-vs-supersede choice before the package list.
+    if (supersedeWarning && supersedeWarning.length > 0) {
+      lines.push(...supersedeWarning);
     }
-  } else {
-    lines.push(
-      'Merging this PR will publish the following packages:',
-      '',
-      '| Package | Version |',
-      '|---------|---------|',
-    );
-    for (const update of updates) {
-      lines.push(`| \`${update.packageName}\` | ${update.newVersion} |`);
+
+    // The root lockstep bump (sync mode) is never published — keep it out of the package list.
+    const updates = publishableUpdates(versionOutput);
+
+    if (versionOutput.strategy === 'sync') {
+      // Sync releases move as one unit — lead with the version; a per-row version column
+      // would repeat the same value for every package.
+      lines.push(`Merging this PR will publish **${syncVersionDisplay(versionOutput)}**:`, '');
+      for (const update of updates) {
+        lines.push(`- \`${update.packageName}\``);
+      }
+    } else {
+      lines.push(
+        'Merging this PR will publish the following packages:',
+        '',
+        '| Package | Version |',
+        '|---------|---------|',
+      );
+      for (const update of updates) {
+        lines.push(`| \`${update.packageName}\` | ${update.newVersion} |`);
+      }
     }
-  }
+
+    if (changelogSection) lines.push('', changelogSection, '');
+    // The editable release-notes region (opt-in via the preview-notes label) sits below the changelog
+    // and above the merge instructions, so a reviewer reads/edits it in the natural place.
+    if (notesRegion) lines.push('', notesRegion, '');
+    lines.push('---', '> Merge this PR to publish. The release will be triggered automatically.');
+    lines.push('', ATTRIBUTION_FOOTER);
+    return lines.join('\n');
+  };
 
   const changelog = renderChangelogSection(versionOutput);
-  if (changelog) lines.push('', changelog, '');
-  // The editable release-notes region (opt-in via the preview-notes label) sits below the changelog
-  // and above the merge instructions, so a reviewer reads/edits it in the natural place.
-  if (notesRegion) lines.push('', notesRegion, '');
-  lines.push('---', '> Merge this PR to publish. The release will be triggered automatically.');
-  lines.push('', ATTRIBUTION_FOOTER);
-  return lines.join('\n');
+  const body = build(changelog);
+  if (body.length <= STANDING_PR_BODY_CAP || !changelog) return body;
+
+  // Too long: truncate the changelog and point to each package's CHANGELOG.md for the rest. The
+  // root cause is almost always a package with no baseline tag (#333/#334) — say so.
+  const notice =
+    "> **Changelog truncated** — the full changelog exceeded GitHub's PR-body limit and was shortened here. " +
+    "Each package's complete changelog is in its `CHANGELOG.md`. This usually means a package has no prior " +
+    'release tag, so its changelog spans the entire git history — create baseline tags to scope it.';
+  const room = STANDING_PR_BODY_CAP - build('').length - notice.length - 8;
+  if (room <= 0) return build(notice);
+  return build(`${truncateAtLineBoundary(changelog, room)}\n\n${notice}`);
 }
 
 export function serializeManifest(m: StandingPRManifest): string {

--- a/packages/release/test/unit/standing-pr.spec.ts
+++ b/packages/release/test/unit/standing-pr.spec.ts
@@ -643,6 +643,44 @@ describe('runStandingPRUpdate', () => {
     expect(createCall?.body).toContain('@scope/core — 1.2.2 → 1.2.3');
   });
 
+  it("should truncate the PR body when the changelog would exceed GitHub's limit (#333)", async () => {
+    const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
+    // A no-baseline-tag package's full-history changelog: thousands of entries blow past 65,536 chars.
+    const hugeEntries = Array.from({ length: 4000 }, (_, i) => ({
+      type: 'added',
+      description: `feature number ${i} with some descriptive text to pad the changelog body length`,
+    }));
+    const versionOutput = {
+      ...createMockVersionOutput([{ packageName: '@scope/core', newVersion: '1.0.0' }]),
+      changelogs: [
+        {
+          packageName: '@scope/core',
+          version: '1.0.0',
+          previousVersion: null,
+          revisionRange: 'HEAD',
+          entries: hugeEntries,
+        },
+      ],
+    };
+    vi.mocked(runVersionStep)
+      .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>)
+      .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>);
+    vi.mocked(runNotesStep).mockResolvedValue({ packageNotes: {}, releaseNotes: {}, files: [] });
+
+    const { createOctokit } = await import('../../src/github.js');
+    const { mocks, octokit } = createMockOctokit();
+    mocks.pullsList.mockResolvedValue({ data: [] });
+    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+
+    await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
+
+    const body = mocks.pullsCreate.mock.calls[0]?.[0]?.body as string;
+    expect(body.length).toBeLessThanOrEqual(65536);
+    expect(body).toContain('Changelog truncated');
+    // The package table above the changelog is preserved so the PR is still usable.
+    expect(body).toContain('| `@scope/core` | 1.0.0 |');
+  });
+
   it('should omit the ### Changelog section when all updates are sync-bumped (no entries)', async () => {
     const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
     // sync-bumped: updates present but changelogs array is empty

--- a/packages/release/test/unit/standing-pr.spec.ts
+++ b/packages/release/test/unit/standing-pr.spec.ts
@@ -10,6 +10,7 @@ import {
   runStandingPRMerge,
   runStandingPRPublish,
   runStandingPRUpdate,
+  STANDING_PR_BODY_CAP,
   serializeManifest,
 } from '../../src/standing-pr/standing-pr.js';
 
@@ -675,7 +676,9 @@ describe('runStandingPRUpdate', () => {
     await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
 
     const body = mocks.pullsCreate.mock.calls[0]?.[0]?.body as string;
-    expect(body.length).toBeLessThanOrEqual(65536);
+    // Assert against the module's cap (well under GitHub's 65,536), so a truncation that leaks into
+    // the 64,001–65,535 safety margin still fails the test.
+    expect(body.length).toBeLessThanOrEqual(STANDING_PR_BODY_CAP);
     expect(body).toContain('Changelog truncated');
     // The package table above the changelog is preserved so the PR is still usable.
     expect(body).toContain('| `@scope/core` | 1.0.0 |');

--- a/packages/version/src/core/versionCalculator.ts
+++ b/packages/version/src/core/versionCalculator.ts
@@ -148,22 +148,16 @@ export async function calculateVersion(config: Config, options: VersionOptions):
       return versionSource.version;
     }
 
-    // First release scenario: no previous tag + explicit type provided
+    // First release scenario: no previous tag. Emit a warning but fall through to normal
+    // bump/stable/prerelease logic using the manifest version as the base. Returning the
+    // manifest verbatim here would silently ignore --stable, --bump, and prereleaseIdentifier
+    // inputs, causing wrong identifiers or missed graduations on first release (#347).
     log(
       `Checking first release scenario: latestTag=${latestTag}, type=${type}, stableOnly=${config.stableOnly}`,
       'debug',
     );
     if (hasNoTags && type) {
-      log(`First release scenario detected`, 'debug');
-      const currentVersion = getCurrentVersionFromSource();
-      log(`Current version for first release: ${currentVersion}`, 'debug');
       log(`No previous tag found for ${name || 'project'} - this appears to be a first release`, 'warning');
-      // For first release, return the version directly from package.json - no bumping needed.
-      // This ensures the release proceeds regardless of version changes (prerelease versions
-      // may not actually change when bumped). The version in package.json is already the
-      // intended release version.
-      log(`First release version: ${currentVersion}`, 'debug');
-      return currentVersion;
     }
 
     // Handle stableOnly mode: graduate prerelease → stable base; skip already-stable packages.

--- a/packages/version/src/package/packageProcessor.ts
+++ b/packages/version/src/package/packageProcessor.ts
@@ -207,6 +207,24 @@ export class PackageProcessor {
           : await getLatestStableTag(this.versionPrefix);
       }
 
+      // #334: a package with no prior git tag has its changelog computed from the FULL git history,
+      // which in standing-PR mode can push the rendered PR body past GitHub's 65,536-char limit and
+      // fail PR creation with an opaque 422 (#333). Surface it loudly with an actionable baseline-tag
+      // suggestion. (baseRef-scoped runs — advisory preview — are bounded to the PR, so skip them.)
+      if (!hasRealTag && !this.fullConfig.baseRef) {
+        const currentVersion = pkg.packageJson.version;
+        const suggestedTag = currentVersion
+          ? formatTag(currentVersion, formattedPrefix, name, this.tagTemplate, this.fullConfig.packageSpecificTags)
+          : undefined;
+        log(
+          `No prior tag found for ${name} — its changelog will include the full git history.` +
+            (suggestedTag
+              ? ` Create a baseline tag to scope it: git tag ${suggestedTag} <release-sha> && git push origin ${suggestedTag}`
+              : ''),
+          'warning',
+        );
+      }
+
       // Generate changelog entries from conventional commits
       let changelogEntries: ChangelogEntry[] = [];
       let revisionRange = 'HEAD';

--- a/packages/version/src/package/packageProcessor.ts
+++ b/packages/version/src/package/packageProcessor.ts
@@ -235,7 +235,9 @@ export class PackageProcessor {
         // baseRef takes precedence — it's a PR base SHA supplied in advisory standing-pr mode
         // so the changelog is scoped to only this PR's commits, not all commits since last tag.
         const baseForRange = this.fullConfig.baseRef ?? changelogBaseTag;
-        if (baseForRange) {
+        if (baseForRange && (this.fullConfig.baseRef || hasRealTag)) {
+          // A real tag (or an explicit baseRef) — verify it. A failure here is the #339 case: the
+          // ref genuinely exists but isn't reachable in this checkout (shallow clone / unpushed).
           const verification = verifyTag(baseForRange, pkgPath);
           if (verification.exists && verification.reachable) {
             revisionRange = `${baseForRange}..HEAD`;
@@ -259,6 +261,13 @@ export class PackageProcessor {
             revisionRange = 'HEAD';
             baselineUnreachable = true;
           }
+        } else if (baseForRange) {
+          // No real tag — `baseForRange` is the manifest-fallback's synthetic tag, which isn't a git
+          // ref. The #334 warning above already explained the full-history changelog accurately, so
+          // skip verifyTag here: running it would emit a second, misleading "could not be verified —
+          // shallow clone / unpushed" message about a tag that never existed.
+          revisionRange = 'HEAD';
+          baselineUnreachable = true;
         }
 
         changelogEntries = extractChangelogEntriesFromCommits(pkgPath, revisionRange);

--- a/packages/version/test/unit/core/versionCalculator.spec.ts
+++ b/packages/version/test/unit/core/versionCalculator.spec.ts
@@ -244,8 +244,11 @@ describe('Version Calculator', () => {
     vi.restoreAllMocks();
   });
 
-  describe('Specified version type (explicit bump)', () => {
-    it('should return initial version if no latestTag and type provided', async () => {
+  describe('First release (no prior tag)', () => {
+    it('should apply bump to initial version when no tag exists', async () => {
+      // No path → versionSource undefined → falls back to initialVersion ('0.1.0')
+      vi.spyOn(versionUtils, 'bumpVersion').mockReturnValue('0.2.0');
+
       const options: VersionOptions = {
         // @ts-expect-error - Testing with null latestTag
         latestTag: null,
@@ -255,9 +258,124 @@ describe('Version Calculator', () => {
 
       const version = await calculateVersion(defaultConfig as Config, options);
 
+      expect(versionUtils.bumpVersion).toHaveBeenCalledWith('0.1.0', 'minor', undefined);
+      expect(version).toBe('0.2.0');
+    });
+
+    it('should graduate a prerelease manifest version to stable when --stable is passed', async () => {
+      // manifest=0.1.0-next.0, stable=true, bump=minor → 0.1.0
+      vi.spyOn(versionUtils, 'getBestVersionSource').mockResolvedValue({
+        source: 'package',
+        version: '0.1.0-next.0',
+        reason: 'No git tag provided',
+      });
+      vi.spyOn(manifestHelpers, 'getVersionFromManifests').mockReturnValue({
+        version: '0.1.0-next.0',
+        manifestFound: true,
+        manifestPath: '/repo/packages/pkg/package.json',
+        manifestType: 'package.json',
+      });
+      vi.spyOn(semver, 'prerelease').mockReturnValue(['next', 0]);
+      vi.spyOn(semver, 'parse').mockReturnValue({
+        major: 0,
+        minor: 1,
+        patch: 0,
+        prerelease: ['next', 0],
+      } as unknown as semver.SemVer);
+
+      const config = { ...defaultConfig, stableOnly: true, type: 'minor' as const };
+      const options: VersionOptions = {
+        latestTag: '',
+        hasRealTag: false,
+        type: 'minor',
+        versionPrefix: 'v',
+        path: '/repo/packages/pkg',
+        name: 'my-pkg',
+      };
+
+      const version = await calculateVersion(config as Config, options);
+
       expect(version).toBe('0.1.0');
     });
 
+    it('should normalize prerelease identifier on first release when manifest has different identifier', async () => {
+      // manifest=1.0.0-rc.0, bump=major, isPrerelease=true, prereleaseIdentifier=next → 1.0.0-next.0
+      vi.spyOn(versionUtils, 'getBestVersionSource').mockResolvedValue({
+        source: 'package',
+        version: '1.0.0-rc.0',
+        reason: 'No git tag provided',
+      });
+      vi.spyOn(manifestHelpers, 'getVersionFromManifests').mockReturnValue({
+        version: '1.0.0-rc.0',
+        manifestFound: true,
+        manifestPath: '/repo/crates/pkg/Cargo.toml',
+        manifestType: 'Cargo.toml',
+      });
+      vi.spyOn(semver, 'prerelease').mockReturnValue(['rc', 0]);
+      vi.spyOn(versionUtils, 'normalizePrereleaseIdentifier').mockReturnValue('next');
+      vi.spyOn(versionUtils, 'bumpVersion').mockReturnValue('1.0.0-next.0');
+
+      const config = {
+        ...defaultConfig,
+        type: 'major' as const,
+        isPrerelease: true,
+        prereleaseIdentifier: 'next',
+      };
+      const options: VersionOptions = {
+        latestTag: '',
+        hasRealTag: false,
+        type: 'major',
+        versionPrefix: 'v',
+        path: '/repo/crates/pkg',
+        name: 'my-crate',
+      };
+
+      const version = await calculateVersion(config as Config, options);
+
+      expect(versionUtils.bumpVersion).toHaveBeenCalledWith('1.0.0-rc.0', 'major', 'next');
+      expect(version).toBe('1.0.0-next.0');
+    });
+
+    it('should apply major bump with prerelease identifier on first release from stable manifest', async () => {
+      // manifest=0.0.0, bump=major, isPrerelease=true, prereleaseIdentifier=next → 1.0.0-next.0
+      vi.spyOn(versionUtils, 'getBestVersionSource').mockResolvedValue({
+        source: 'package',
+        version: '0.0.0',
+        reason: 'No git tag provided',
+      });
+      vi.spyOn(manifestHelpers, 'getVersionFromManifests').mockReturnValue({
+        version: '0.0.0',
+        manifestFound: true,
+        manifestPath: '/repo/packages/pkg/package.json',
+        manifestType: 'package.json',
+      });
+      vi.spyOn(semver, 'prerelease').mockReturnValue(null);
+      vi.spyOn(versionUtils, 'normalizePrereleaseIdentifier').mockReturnValue('next');
+      vi.spyOn(versionUtils, 'bumpVersion').mockReturnValue('1.0.0-next.0');
+
+      const config = {
+        ...defaultConfig,
+        type: 'major' as const,
+        isPrerelease: true,
+        prereleaseIdentifier: 'next',
+      };
+      const options: VersionOptions = {
+        latestTag: '',
+        hasRealTag: false,
+        type: 'major',
+        versionPrefix: 'v',
+        path: '/repo/packages/pkg',
+        name: 'my-pkg',
+      };
+
+      const version = await calculateVersion(config as Config, options);
+
+      expect(versionUtils.bumpVersion).toHaveBeenCalledWith('0.0.0', 'major', 'next');
+      expect(version).toBe('1.0.0-next.0');
+    });
+  });
+
+  describe('Specified version type (explicit bump)', () => {
     it('should increment version based on specified type', async () => {
       const options: VersionOptions = {
         latestTag: 'v1.0.0',
@@ -1122,8 +1240,8 @@ describe('Version Calculator', () => {
       vi.clearAllMocks();
     });
 
-    it('should return package.json version directly for first release with explicit bump', async () => {
-      // Mock both functions properly
+    it('should apply bump to manifest version for first release with explicit bump', async () => {
+      // After #347 fix: first release no longer returns manifest verbatim; bump is applied.
       vi.spyOn(manifestHelpers, 'getVersionFromManifests').mockReturnValue({
         version: '1.0.0-beta.1',
         manifestFound: true,
@@ -1135,6 +1253,7 @@ describe('Version Calculator', () => {
         version: '1.0.0-beta.1',
         reason: 'No git tag provided',
       });
+      vi.spyOn(versionUtils, 'bumpVersion').mockReturnValue('2.0.0');
 
       const options: VersionOptions = {
         latestTag: '',
@@ -1145,12 +1264,13 @@ describe('Version Calculator', () => {
 
       const version = await calculateVersion(defaultConfig as Config, options);
 
-      expect(version).toBe('1.0.0-beta.1');
+      expect(versionUtils.bumpVersion).toHaveBeenCalledWith('1.0.0-beta.1', 'major', undefined);
+      expect(version).toBe('2.0.0');
       expect(logging.log).toHaveBeenCalledWith(expect.stringContaining('Using version source: package'), 'info');
     });
 
-    it('should return prerelease version from package.json for first release with major type', async () => {
-      // Mock both dependencies properly
+    it('should apply bump to prerelease manifest version on first release', async () => {
+      // After #347 fix: bump is applied to the manifest version as the base.
       vi.spyOn(manifestHelpers, 'getVersionFromManifests').mockReturnValue({
         version: '1.0.0-next.0',
         manifestFound: true,
@@ -1162,6 +1282,7 @@ describe('Version Calculator', () => {
         version: '1.0.0-next.0',
         reason: 'No git tag provided',
       });
+      vi.spyOn(versionUtils, 'bumpVersion').mockReturnValue('2.0.0');
 
       const config: Partial<Config> = {
         ...defaultConfig,
@@ -1175,11 +1296,12 @@ describe('Version Calculator', () => {
       };
 
       const version = await calculateVersion(config as Config, options);
-      expect(version).toBe('1.0.0-next.0');
+      expect(versionUtils.bumpVersion).toHaveBeenCalledWith('1.0.0-next.0', 'major', undefined);
+      expect(version).toBe('2.0.0');
     });
 
-    it('should return package.json version for first release with conventional commits preset', async () => {
-      // Mock both dependencies properly
+    it('should apply bump to stable manifest version on first release', async () => {
+      // After #347 fix: bump is applied even when the manifest is already stable.
       vi.spyOn(manifestHelpers, 'getVersionFromManifests').mockReturnValue({
         version: '1.0.0',
         manifestFound: true,
@@ -1191,6 +1313,8 @@ describe('Version Calculator', () => {
         version: '1.0.0',
         reason: 'No git tag provided',
       });
+      vi.spyOn(semver, 'prerelease').mockReturnValue(null);
+      vi.spyOn(versionUtils, 'bumpVersion').mockReturnValue('1.0.1');
 
       const config: Partial<Config> = {
         ...defaultConfig,
@@ -1204,7 +1328,8 @@ describe('Version Calculator', () => {
       };
 
       const version = await calculateVersion(config as Config, options);
-      expect(version).toBe('1.0.0');
+      expect(versionUtils.bumpVersion).toHaveBeenCalledWith('1.0.0', 'patch', undefined);
+      expect(version).toBe('1.0.1');
     });
 
     it('should throw error if package.json does not exist', async () => {
@@ -1417,8 +1542,8 @@ describe('Version Calculator', () => {
       expect(version).toBe('1.2.1'); // Will be bumped from 1.2.0 to 1.2.1
     });
 
-    it('should return package.json version for first release when hasNoTags is true', async () => {
-      // Mock getBestVersionSource for this test
+    it('should apply bump to package.json version for first release when hasNoTags is true', async () => {
+      // After #347 fix: first release applies bump/stable/prerelease logic, not verbatim.
       vi.spyOn(versionUtils, 'getBestVersionSource').mockResolvedValueOnce({
         source: 'package',
         version: '1.0.0',
@@ -1427,7 +1552,7 @@ describe('Version Calculator', () => {
 
       const config: Partial<Config> = {
         ...defaultConfig,
-        type: 'patch', // Explicitly specify type to bypass conventional commits
+        type: 'patch',
       };
 
       const options: VersionOptions = {
@@ -1437,7 +1562,7 @@ describe('Version Calculator', () => {
       };
 
       const version = await calculateVersion(config as Config, options);
-      expect(version).toBe('1.0.0');
+      expect(version).toBe('1.0.1');
     });
 
     it('should not warn when no manifest is found', async () => {

--- a/packages/version/test/unit/package/packageProcessor.spec.ts
+++ b/packages/version/test/unit/package/packageProcessor.spec.ts
@@ -535,6 +535,31 @@ describe('Package Processor', () => {
       expect(calls[0][0]).toMatchObject({ previousVersion: 'v1.0.0' });
     });
 
+    it('should warn when a package has no prior tag (full-history changelog, #334)', async () => {
+      // No package tag and no global tag — only the manifest version is available, so hasRealTag is
+      // false and the changelog spans the full history. The warning makes this visible (and heads off
+      // the opaque oversized-PR-body 422 in #333).
+      vi.spyOn(gitTags, 'getLatestTagForPackage').mockResolvedValue('');
+      vi.spyOn(manifestHelpers, 'getVersionFromManifests').mockReturnValue({
+        version: '0.1.0',
+        manifestFound: true,
+        manifestPath: 'package.json',
+        manifestType: 'package.json',
+      });
+      vi.spyOn(calculator, 'calculateVersion').mockResolvedValue('0.1.1');
+      vi.spyOn(versionCalculatorModule, 'calculateVersion').mockResolvedValue('0.1.1');
+
+      const processor = new PackageProcessor({
+        ...defaultOptions,
+        getLatestTag: vi.fn().mockResolvedValue(null), // no global tag either
+        fullConfig: { ...mockConfig, packageSpecificTags: true, writeChangelog: false },
+      });
+
+      await processor.processPackages([mockPackages[1]]);
+
+      expect(logging.log).toHaveBeenCalledWith(expect.stringContaining('No prior tag found for package-b'), 'warning');
+    });
+
     it('should emit repo-level entries as sharedEntries, not in individual package changelogs', async () => {
       const repoLevelEntry = { type: 'chore', description: 'Update CI workflow' };
       const pkgAEntry = { type: 'added', description: 'New feature in pkg-a' };

--- a/packages/version/test/unit/package/packageProcessor.spec.ts
+++ b/packages/version/test/unit/package/packageProcessor.spec.ts
@@ -558,6 +558,12 @@ describe('Package Processor', () => {
       await processor.processPackages([mockPackages[1]]);
 
       expect(logging.log).toHaveBeenCalledWith(expect.stringContaining('No prior tag found for package-b'), 'warning');
+      // ...and NOT the misleading #339 "shallow clone / unpushed" warning about the synthetic
+      // manifest-fallback tag, which never existed as a git ref.
+      expect(logging.log).not.toHaveBeenCalledWith(
+        expect.stringContaining('could not be verified from HEAD'),
+        'warning',
+      );
     });
 
     it('should emit repo-level entries as sharedEntries, not in individual package changelogs', async () => {


### PR DESCRIPTION
## Summary

On first release (no prior git tag), the version-calculator was short-circuiting at `calculateVersion` to return the manifest version verbatim — silently ignoring `--bump`, `--stable`, and `prereleaseIdentifier` inputs.

**Root cause**: lines 156–167 of `versionCalculator.ts` had an early return that said "first release: return manifest as-is". This caused two concrete failures in production:

- Cargo crates with `version = "1.0.0-rc.0"` in their manifest published as `rc.0` instead of `next.0` when `prereleaseIdentifier: next` was in config.
- Packages with `"version": "0.1.0-next.0"` ignored `--stable --bump minor` and published the prerelease verbatim instead of graduating to `0.1.0`.

**Fix**: Remove the early return. The existing bump/stable/prerelease logic already handles these cases correctly when using the manifest version as the base — which is exactly what `getBestVersionSource` returns when there's no prior tag.

**Expected behaviour after fix**:
- `manifest=0.1.0-next.0` + `--stable --bump minor` → `0.1.0`
- `manifest=1.0.0-rc.0` + `--bump major --prerelease` + `prereleaseIdentifier: next` → `1.0.0-next.0`
- `manifest=0.0.0` + `--bump major --prerelease` + `prereleaseIdentifier: next` → `1.0.0-next.0`

## Test plan

- [ ] New unit tests cover the three expected-behaviour examples from the issue
- [ ] Four pre-existing tests that asserted the (now-wrong) verbatim behaviour updated to reflect correct expectations
- [ ] `pnpm turbo run lint typecheck test` — all 24 tasks pass

Closes #347

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes two related "first release" regressions by removing an early return in `versionCalculator.ts` that silently ignored `--bump`, `--stable`, and `prereleaseIdentifier` when no prior git tag existed, and adds defensive plumbing in `packageProcessor.ts` and `standing-pr.ts` to avoid a misleading shallow-clone warning and a GitHub 422 for packages whose full-history changelog blows past the 65,536-char PR body limit.

- **Core fix (`versionCalculator.ts`)**: The `if (hasNoTags && type) { return currentVersion; }` early return is replaced with a warning log; the manifest version is now used as the bump base, letting the existing bump/stable/prerelease code paths run correctly on first release.
- **Changelog guard (`packageProcessor.ts`)**: `verifyTag` is now skipped for synthetic manifest-fallback "tags" (they're never real git refs), and a `baselineUnreachable = true` path is added so the `previousVersion` in changelog data is correctly set to `null` rather than the synthetic version string.
- **PR body cap (`standing-pr.ts`)**: `renderPrBody` is refactored around an inner `build()` closure that can re-render with a truncated changelog; a 64,000-char `STANDING_PR_BODY_CAP` prevents opaque 422 failures for repositories with no baseline tag.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a targeted removal of an early return that was silently swallowing inputs, the surrounding logic already handled these cases correctly, and the new behaviour is fully covered by tests.

The core change in `versionCalculator.ts` is minimal: one `if` block's return statement is removed and replaced by a warning log. All three downstream code paths (stableOnly graduation, explicit-type bump, conventional-commits bump) were already correct — the early return was simply bypassing them. The `packageProcessor.ts` and `standing-pr.ts` additions are additive guards with no behaviour change for repos that already have baseline tags. Four updated tests and seven new tests cover both the previously wrong and the now-correct outcomes.

No files require special attention — the changes are surgical and well-tested across all six files.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/version/src/core/versionCalculator.ts | Removes the early-return inside `if (hasNoTags && type)` so bump/stable/prerelease logic runs on first release using the manifest version as the base; replaces the return with a warning log only. |
| packages/version/src/package/packageProcessor.ts | Adds a baseline-tag warning for packages with no prior git tag, guards `verifyTag` behind `hasRealTag` to avoid a spurious "shallow clone" warning for synthetic manifest-fallback tags, and adds an `else if` branch that sets `revisionRange = 'HEAD'` / `baselineUnreachable = true` for that case. |
| packages/release/src/standing-pr/standing-pr.ts | Refactors `renderPrBody` around an inner `build()` closure and adds changelog truncation at a 64,000-char cap (with a user-facing notice) to prevent GitHub 422s from oversized PR bodies. |
| packages/version/test/unit/core/versionCalculator.spec.ts | Adds three new first-release scenarios (bump, stable graduation, identifier normalisation) and updates four existing tests that previously asserted the now-removed verbatim-manifest behaviour. |
| packages/version/test/unit/package/packageProcessor.spec.ts | Adds a test asserting the full-history-changelog warning fires when a package has no prior tag, and asserts the misleading "could not be verified" message does NOT fire. |
| packages/release/test/unit/standing-pr.spec.ts | Adds a truncation integration test with a 4,000-entry changelog, asserting the body stays within `STANDING_PR_BODY_CAP` and contains the truncation notice while keeping the package table intact. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[calculateVersion called] --> B{hasNoTags?}
    B -- "Yes (first release)" --> C[Log warning: first release detected]
    C --> D{config.stableOnly?}
    B -- No --> D
    D -- Yes --> E{currentVersion is prerelease?}
    E -- Yes --> F[Return stable base\ne.g. 0.1.0-next.0 → 0.1.0]
    E -- "No, no type" --> G[Return '' — skip]
    E -- "No, has type" --> H
    D -- No --> H{specifiedType provided?}
    H -- Yes --> I[bumpVersion with\nprereleaseIdentifier]
    H -- No --> J[Conventional commits bumper]
    J --> K{releaseTypeFromCommits?}
    K -- No --> L[Return '' — no bump]
    K -- Yes --> I
    I --> M[Return bumped version]

    subgraph "OLD behaviour (removed)"
        OLD[hasNoTags && type\n→ return manifest verbatim]
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[calculateVersion called] --> B{hasNoTags?}
    B -- "Yes (first release)" --> C[Log warning: first release detected]
    C --> D{config.stableOnly?}
    B -- No --> D
    D -- Yes --> E{currentVersion is prerelease?}
    E -- Yes --> F[Return stable base\ne.g. 0.1.0-next.0 → 0.1.0]
    E -- "No, no type" --> G[Return '' — skip]
    E -- "No, has type" --> H
    D -- No --> H{specifiedType provided?}
    H -- Yes --> I[bumpVersion with\nprereleaseIdentifier]
    H -- No --> J[Conventional commits bumper]
    J --> K{releaseTypeFromCommits?}
    K -- No --> L[Return '' — no bump]
    K -- Yes --> I
    I --> M[Return bumped version]

    subgraph "OLD behaviour (removed)"
        OLD[hasNoTags && type\n→ return manifest verbatim]
    end
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(version): apply bump/stable/prerelea..."](https://github.com/goosewobbler/releasekit/commit/9c9920411e1b0b0f92d690bd3d114c0aa4ca7d99) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38157963)</sub>

<!-- /greptile_comment -->