### PR TITLE
fix(version): bound project-wide changelog by global baseline, not per-package range (#348)

### DIFF
--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -419,6 +419,7 @@ function renderPrBody(versionOutput: VersionOutput, supersedeWarning?: string[],
     "> **Changelog truncated** — the full changelog exceeded GitHub's PR-body limit and was shortened here. " +
     "Each package's complete changelog is in its `CHANGELOG.md`. This usually means a package has no prior " +
     'release tag, so its changelog spans the entire git history — create baseline tags to scope it.';
+  // 8 = 4 (\n\n before + \n\n after from push('', section, '')) + 2 (\n\n between truncated changelog and notice) + 2 safety margin
   const room = STANDING_PR_BODY_CAP - build('').length - notice.length - 8;
   // No room for any changelog: the non-changelog content (package table / notes region) already
   // fills the budget. Drop the changelog entirely rather than appending the notice, which would only

--- a/packages/version/src/package/packageProcessor.ts
+++ b/packages/version/src/package/packageProcessor.ts
@@ -289,7 +289,8 @@ export class PackageProcessor {
           .filter((p) => sharedPackageNames.includes(p.packageJson.name))
           .map((p) => p.dir);
         // Use the tighter of the per-package range (already bounded for tagged packages)
-        // or the global baseline floor (for untagged packages whose range is 'HEAD').
+        // or the global baseline floor — applies to untagged packages and to packages whose
+        // tag exists but is unreachable (shallow clone, #339), both of which produce revisionRange='HEAD'.
         let sharedRevisionRange = revisionRange;
         if (revisionRange === 'HEAD' && !this.fullConfig.baseRef) {
           if (_sharedBaselineRange === undefined) {

--- a/packages/version/src/package/packageProcessor.ts
+++ b/packages/version/src/package/packageProcessor.ts
@@ -109,6 +109,13 @@ export class PackageProcessor {
     // Accumulate repo-level entries across all packages (keyed by type+description to deduplicate)
     const sharedEntriesMap = new Map<string, ChangelogEntry>();
 
+    // (#348) Lazy-computed floor for repo-level changelog entries. When an untagged package's
+    // per-package revisionRange is 'HEAD' (all history), passing that same range to
+    // extractRepoLevelChangelogEntries floods "Project-wide changes" with the full git history.
+    // Bound it by the most recent release tag reachable from HEAD instead, computed on first
+    // need and shared across all packages in this run.
+    let _sharedBaselineRange: string | undefined;
+
     for (const pkg of pkgsToConsider) {
       const name = pkg.packageJson.name;
       const pkgPath = pkg.dir;
@@ -281,9 +288,25 @@ export class PackageProcessor {
         const sharedPackageDirs = packages
           .filter((p) => sharedPackageNames.includes(p.packageJson.name))
           .map((p) => p.dir);
+        // Use the tighter of the per-package range (already bounded for tagged packages)
+        // or the global baseline floor (for untagged packages whose range is 'HEAD').
+        let sharedRevisionRange = revisionRange;
+        if (revisionRange === 'HEAD' && !this.fullConfig.baseRef) {
+          if (_sharedBaselineRange === undefined) {
+            const globalTag = await this.getLatestTag();
+            if (globalTag) {
+              const gv = verifyTag(globalTag, process.cwd());
+              _sharedBaselineRange = gv.exists && gv.reachable ? `${globalTag}..HEAD` : 'HEAD';
+            } else {
+              _sharedBaselineRange = 'HEAD';
+            }
+          }
+          sharedRevisionRange = _sharedBaselineRange;
+        }
+
         const repoLevelEntries = extractRepoLevelChangelogEntries(
           pkgPath,
-          revisionRange,
+          sharedRevisionRange,
           allPackageDirs,
           sharedPackageDirs,
         );

--- a/packages/version/src/package/packageProcessor.ts
+++ b/packages/version/src/package/packageProcessor.ts
@@ -294,11 +294,15 @@ export class PackageProcessor {
         let sharedRevisionRange = revisionRange;
         if (revisionRange === 'HEAD' && !this.fullConfig.baseRef) {
           if (_sharedBaselineRange === undefined) {
-            const globalTag = await this.getLatestTag();
-            if (globalTag) {
-              const gv = verifyTag(globalTag, process.cwd());
-              _sharedBaselineRange = gv.exists && gv.reachable ? `${globalTag}..HEAD` : 'HEAD';
-            } else {
+            try {
+              const globalTag = await this.getLatestTag();
+              if (globalTag) {
+                const gv = verifyTag(globalTag, process.cwd());
+                _sharedBaselineRange = gv.exists && gv.reachable ? `${globalTag}..HEAD` : 'HEAD';
+              } else {
+                _sharedBaselineRange = 'HEAD';
+              }
+            } catch {
               _sharedBaselineRange = 'HEAD';
             }
           }

--- a/packages/version/test/unit/package/packageProcessor.spec.ts
+++ b/packages/version/test/unit/package/packageProcessor.spec.ts
@@ -592,6 +592,23 @@ describe('Package Processor', () => {
       );
     });
 
+    it('should fall back to HEAD range for shared entries when getLatestTag rejects (#348)', async () => {
+      vi.spyOn(gitTags, 'getLatestTagForPackage').mockResolvedValue('');
+      vi.spyOn(calculator, 'calculateVersion').mockResolvedValue('1.1.0');
+      vi.spyOn(versionCalculatorModule, 'calculateVersion').mockResolvedValue('1.1.0');
+      const extractSharedSpy = vi.spyOn(commitParser, 'extractRepoLevelChangelogEntries').mockReturnValue([]);
+
+      const processor = new PackageProcessor({
+        ...defaultOptions,
+        getLatestTag: vi.fn().mockRejectedValue(new Error('git failure')),
+        fullConfig: { ...mockConfig, packageSpecificTags: true, writeChangelog: false },
+      });
+
+      await processor.processPackages([mockPackages[0]]);
+
+      expect(extractSharedSpy).toHaveBeenCalledWith(expect.any(String), 'HEAD', expect.any(Array), expect.any(Array));
+    });
+
     it('should emit repo-level entries as sharedEntries, not in individual package changelogs', async () => {
       const repoLevelEntry = { type: 'chore', description: 'Update CI workflow' };
       const pkgAEntry = { type: 'added', description: 'New feature in pkg-a' };

--- a/packages/version/test/unit/package/packageProcessor.spec.ts
+++ b/packages/version/test/unit/package/packageProcessor.spec.ts
@@ -566,6 +566,32 @@ describe('Package Processor', () => {
       );
     });
 
+    it('should bound repo-level changelog range by global baseline when a package has no real tag (#348)', async () => {
+      // package-a has no specific tag; getVersionFromManifests returns a manifest version via
+      // the global beforeEach mock, making hasRealTag=false and revisionRange='HEAD'.
+      // The shared-entries call should use the global baseline floor, not 'HEAD'.
+      vi.spyOn(gitTags, 'getLatestTagForPackage').mockResolvedValue('');
+      vi.spyOn(calculator, 'calculateVersion').mockResolvedValue('1.1.0');
+      vi.spyOn(versionCalculatorModule, 'calculateVersion').mockResolvedValue('1.1.0');
+      const extractSharedSpy = vi.spyOn(commitParser, 'extractRepoLevelChangelogEntries').mockReturnValue([]);
+
+      const globalTag = 'v1.0.0';
+      const processor = new PackageProcessor({
+        ...defaultOptions,
+        getLatestTag: vi.fn().mockResolvedValue(globalTag),
+        fullConfig: { ...mockConfig, packageSpecificTags: true, writeChangelog: false },
+      });
+
+      await processor.processPackages([mockPackages[0]]); // package-a triggers manifest fallback
+
+      expect(extractSharedSpy).toHaveBeenCalledWith(
+        expect.any(String),
+        `${globalTag}..HEAD`,
+        expect.any(Array),
+        expect.any(Array),
+      );
+    });
+
     it('should emit repo-level entries as sharedEntries, not in individual package changelogs', async () => {
       const repoLevelEntry = { type: 'chore', description: 'Update CI workflow' };
       const pkgAEntry = { type: 'added', description: 'New feature in pkg-a' };


### PR DESCRIPTION
## Summary

- On the standing-PR path, a single untagged package caused \"Project-wide changes\" to flood with the full git history
- Root cause: `extractRepoLevelChangelogEntries` was called with the per-package `revisionRange`, which is `'HEAD'` (all history) for untagged packages; that unbounded range accumulated into the shared `sharedEntriesMap`
- Fix: lazily compute the most recent release tag reachable from HEAD as a global baseline floor; when an untagged package's per-package range is `'HEAD'`, use `<globalTag>..HEAD` for the shared/repo-level entries call instead
- Tagged packages are unaffected — their own bounded range is already tighter than the global baseline
- `getLatestTag` is only called when an untagged package is actually encountered (fully-tagged runs skip it)

## Test plan

- [ ] New unit test: `should bound repo-level changelog range by global baseline when a package has no real tag (#348)` verifies `extractRepoLevelChangelogEntries` is called with `v1.0.0..HEAD` when package has no real tag and global baseline is `v1.0.0`
- [ ] All existing packageProcessor tests pass (597 total)
- [ ] Full suite passes (`pnpm turbo run lint typecheck test` — 24/24 tasks)

Closes #348

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where an untagged package caused "Project-wide changes" to flood with the full git history by bounding `extractRepoLevelChangelogEntries` with a lazily-computed global baseline tag instead of the unbounded `'HEAD'` per-package range.

- **`packageProcessor.ts`**: Introduces `_sharedBaselineRange`, a run-scoped lazy cache that calls `getLatestTag()` on first need, verifies reachability, and produces a `<globalTag>..HEAD` range (or falls back to `'HEAD'` on rejection / unreachable tag). Tagged packages whose per-package range is already tighter than `'HEAD'` skip the block entirely.
- **`packageProcessor.spec.ts`**: Adds two focused tests for the new logic — the happy-path (global baseline applied) and the error-path (`getLatestTag` rejects → `'HEAD'` fallback).
- **`standing-pr.ts`**: Documentation-only: adds an inline comment explaining the `-8` magic constant in the truncation room formula.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change narrows an overly broad git range to prevent changelog flooding, with correct fallbacks and no data-loss paths.

The new `_sharedBaselineRange` logic is well-bounded: it only activates for the narrow `revisionRange === 'HEAD' && !baseRef` case, has a try/catch around the async `getLatestTag` call, verifies reachability before using a tag as a range boundary, and caches the result to avoid redundant git invocations. Tagged packages are entirely unaffected. The two new tests cover the success and failure paths correctly, relying on the already-established module-level `verifyTag` mock.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/version/src/package/packageProcessor.ts | Adds lazy-computed `_sharedBaselineRange` to bound repo-level changelog extraction for untagged/unreachable-tagged packages; error handling and `verifyTag` reachability check are correct. |
| packages/version/test/unit/package/packageProcessor.spec.ts | Adds two new tests: one for the happy path (untagged package uses global baseline floor) and one for the error path (getLatestTag rejects, falls back to HEAD). Both rely on the correct module-level mocks. |
| packages/release/src/standing-pr/standing-pr.ts | Minor documentation-only change: adds an inline comment explaining the `-8` magic constant used in the truncation room calculation. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[processPackages loop] --> B{revisionRange === 'HEAD'\n&& !baseRef?}
    B -- No --> G[extractRepoLevelChangelogEntries\nrevisionRange as-is]
    B -- Yes --> C{_sharedBaselineRange\n=== undefined?}
    C -- No cached --> H[sharedRevisionRange = _sharedBaselineRange]
    C -- Yes, compute --> D[getLatestTag]
    D -- throws --> E[_sharedBaselineRange = 'HEAD']
    D -- returns empty --> E
    D -- returns globalTag --> F{verifyTag reachable?}
    F -- Yes --> I["_sharedBaselineRange = globalTag..HEAD"]
    F -- No --> E
    E --> H
    I --> H
    H --> G
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[processPackages loop] --> B{revisionRange === 'HEAD'\n&& !baseRef?}
    B -- No --> G[extractRepoLevelChangelogEntries\nrevisionRange as-is]
    B -- Yes --> C{_sharedBaselineRange\n=== undefined?}
    C -- No cached --> H[sharedRevisionRange = _sharedBaselineRange]
    C -- Yes, compute --> D[getLatestTag]
    D -- throws --> E[_sharedBaselineRange = 'HEAD']
    D -- returns empty --> E
    D -- returns globalTag --> F{verifyTag reachable?}
    F -- Yes --> I["_sharedBaselineRange = globalTag..HEAD"]
    F -- No --> E
    E --> H
    I --> H
    H --> G
```

</a>
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(version): guard getLatestTag() in sh..."](https://github.com/goosewobbler/releasekit/commit/9c3c1c2c021f58961068a6a1c663a6383f78f026) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38158530)</sub>

<!-- /greptile_comment -->