### PR TITLE
fix(version): honor publish opt-outs and workspace boundaries in Cargo/pub discovery (#349)

### DIFF
--- a/packages/config/src/cargo.ts
+++ b/packages/config/src/cargo.ts
@@ -3,7 +3,8 @@ import * as path from 'node:path';
 import * as TOML from 'smol-toml';
 
 export interface CargoManifest {
-  package?: { name?: string; version?: string; [key: string]: unknown };
+  package?: { name?: string; version?: string; publish?: boolean | string[]; [key: string]: unknown };
+  workspace?: { members?: string[]; [key: string]: unknown };
   dependencies?: Record<string, unknown>;
   [key: string]: unknown;
 }

--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -357,7 +357,7 @@ function deleteReleaseBranch(releaseBranch: string, cwd: string): void {
 // GitHub rejects a PR body over 65,536 chars with a 422. Cap below that (with margin) so an
 // oversized changelog — almost always a package with no baseline tag whose changelog spans the
 // entire git history (#333) — truncates gracefully instead of failing PR creation outright.
-const STANDING_PR_BODY_CAP = 64000;
+export const STANDING_PR_BODY_CAP = 64000;
 
 function truncateAtLineBoundary(text: string, maxChars: number): string {
   if (text.length <= maxChars) return text;
@@ -420,7 +420,11 @@ function renderPrBody(versionOutput: VersionOutput, supersedeWarning?: string[],
     "Each package's complete changelog is in its `CHANGELOG.md`. This usually means a package has no prior " +
     'release tag, so its changelog spans the entire git history — create baseline tags to scope it.';
   const room = STANDING_PR_BODY_CAP - build('').length - notice.length - 8;
-  if (room <= 0) return build(notice);
+  // No room for any changelog: the non-changelog content (package table / notes region) already
+  // fills the budget. Drop the changelog entirely rather than appending the notice, which would only
+  // add to the overflow. (A package table that alone exceeds the cap would need its own truncation —
+  // that's thousands of packages and out of scope here.)
+  if (room <= 0) return build('');
   return build(`${truncateAtLineBoundary(changelog, room)}\n\n${notice}`);
 }
 

--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -354,45 +354,74 @@ function deleteReleaseBranch(releaseBranch: string, cwd: string): void {
   }
 }
 
+// GitHub rejects a PR body over 65,536 chars with a 422. Cap below that (with margin) so an
+// oversized changelog — almost always a package with no baseline tag whose changelog spans the
+// entire git history (#333) — truncates gracefully instead of failing PR creation outright.
+const STANDING_PR_BODY_CAP = 64000;
+
+function truncateAtLineBoundary(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text;
+  const slice = text.slice(0, maxChars);
+  const lastNewline = slice.lastIndexOf('\n');
+  return lastNewline > 0 ? slice.slice(0, lastNewline) : slice;
+}
+
 function renderPrBody(versionOutput: VersionOutput, supersedeWarning?: string[], notesRegion?: string): string {
-  const lines: string[] = ['## Release', ''];
+  // Build the body around a given changelog section so we can re-render with a truncated changelog
+  // if the full one would exceed GitHub's limit, without disturbing the editable notes region.
+  const build = (changelogSection: string): string => {
+    const lines: string[] = ['## Release', ''];
 
-  // While a prior release remains partially published, lead with the supersede warning so the
-  // maintainer sees the retry-vs-supersede choice before the package list.
-  if (supersedeWarning && supersedeWarning.length > 0) {
-    lines.push(...supersedeWarning);
-  }
-
-  // The root lockstep bump (sync mode) is never published — keep it out of the package list.
-  const updates = publishableUpdates(versionOutput);
-
-  if (versionOutput.strategy === 'sync') {
-    // Sync releases move as one unit — lead with the version; a per-row version column
-    // would repeat the same value for every package.
-    lines.push(`Merging this PR will publish **${syncVersionDisplay(versionOutput)}**:`, '');
-    for (const update of updates) {
-      lines.push(`- \`${update.packageName}\``);
+    // While a prior release remains partially published, lead with the supersede warning so the
+    // maintainer sees the retry-vs-supersede choice before the package list.
+    if (supersedeWarning && supersedeWarning.length > 0) {
+      lines.push(...supersedeWarning);
     }
-  } else {
-    lines.push(
-      'Merging this PR will publish the following packages:',
-      '',
-      '| Package | Version |',
-      '|---------|---------|',
-    );
-    for (const update of updates) {
-      lines.push(`| \`${update.packageName}\` | ${update.newVersion} |`);
+
+    // The root lockstep bump (sync mode) is never published — keep it out of the package list.
+    const updates = publishableUpdates(versionOutput);
+
+    if (versionOutput.strategy === 'sync') {
+      // Sync releases move as one unit — lead with the version; a per-row version column
+      // would repeat the same value for every package.
+      lines.push(`Merging this PR will publish **${syncVersionDisplay(versionOutput)}**:`, '');
+      for (const update of updates) {
+        lines.push(`- \`${update.packageName}\``);
+      }
+    } else {
+      lines.push(
+        'Merging this PR will publish the following packages:',
+        '',
+        '| Package | Version |',
+        '|---------|---------|',
+      );
+      for (const update of updates) {
+        lines.push(`| \`${update.packageName}\` | ${update.newVersion} |`);
+      }
     }
-  }
+
+    if (changelogSection) lines.push('', changelogSection, '');
+    // The editable release-notes region (opt-in via the preview-notes label) sits below the changelog
+    // and above the merge instructions, so a reviewer reads/edits it in the natural place.
+    if (notesRegion) lines.push('', notesRegion, '');
+    lines.push('---', '> Merge this PR to publish. The release will be triggered automatically.');
+    lines.push('', ATTRIBUTION_FOOTER);
+    return lines.join('\n');
+  };
 
   const changelog = renderChangelogSection(versionOutput);
-  if (changelog) lines.push('', changelog, '');
-  // The editable release-notes region (opt-in via the preview-notes label) sits below the changelog
-  // and above the merge instructions, so a reviewer reads/edits it in the natural place.
-  if (notesRegion) lines.push('', notesRegion, '');
-  lines.push('---', '> Merge this PR to publish. The release will be triggered automatically.');
-  lines.push('', ATTRIBUTION_FOOTER);
-  return lines.join('\n');
+  const body = build(changelog);
+  if (body.length <= STANDING_PR_BODY_CAP || !changelog) return body;
+
+  // Too long: truncate the changelog and point to each package's CHANGELOG.md for the rest. The
+  // root cause is almost always a package with no baseline tag (#333/#334) — say so.
+  const notice =
+    "> **Changelog truncated** — the full changelog exceeded GitHub's PR-body limit and was shortened here. " +
+    "Each package's complete changelog is in its `CHANGELOG.md`. This usually means a package has no prior " +
+    'release tag, so its changelog spans the entire git history — create baseline tags to scope it.';
+  const room = STANDING_PR_BODY_CAP - build('').length - notice.length - 8;
+  if (room <= 0) return build(notice);
+  return build(`${truncateAtLineBoundary(changelog, room)}\n\n${notice}`);
 }
 
 export function serializeManifest(m: StandingPRManifest): string {

--- a/packages/release/test/unit/standing-pr.spec.ts
+++ b/packages/release/test/unit/standing-pr.spec.ts
@@ -643,6 +643,44 @@ describe('runStandingPRUpdate', () => {
     expect(createCall?.body).toContain('@scope/core — 1.2.2 → 1.2.3');
   });
 
+  it("should truncate the PR body when the changelog would exceed GitHub's limit (#333)", async () => {
+    const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
+    // A no-baseline-tag package's full-history changelog: thousands of entries blow past 65,536 chars.
+    const hugeEntries = Array.from({ length: 4000 }, (_, i) => ({
+      type: 'added',
+      description: `feature number ${i} with some descriptive text to pad the changelog body length`,
+    }));
+    const versionOutput = {
+      ...createMockVersionOutput([{ packageName: '@scope/core', newVersion: '1.0.0' }]),
+      changelogs: [
+        {
+          packageName: '@scope/core',
+          version: '1.0.0',
+          previousVersion: null,
+          revisionRange: 'HEAD',
+          entries: hugeEntries,
+        },
+      ],
+    };
+    vi.mocked(runVersionStep)
+      .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>)
+      .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>);
+    vi.mocked(runNotesStep).mockResolvedValue({ packageNotes: {}, releaseNotes: {}, files: [] });
+
+    const { createOctokit } = await import('../../src/github.js');
+    const { mocks, octokit } = createMockOctokit();
+    mocks.pullsList.mockResolvedValue({ data: [] });
+    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+
+    await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
+
+    const body = mocks.pullsCreate.mock.calls[0]?.[0]?.body as string;
+    expect(body.length).toBeLessThanOrEqual(65536);
+    expect(body).toContain('Changelog truncated');
+    // The package table above the changelog is preserved so the PR is still usable.
+    expect(body).toContain('| `@scope/core` | 1.0.0 |');
+  });
+
   it('should omit the ### Changelog section when all updates are sync-bumped (no entries)', async () => {
     const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
     // sync-bumped: updates present but changelogs array is empty

--- a/packages/release/test/unit/standing-pr.spec.ts
+++ b/packages/release/test/unit/standing-pr.spec.ts
@@ -10,6 +10,7 @@ import {
   runStandingPRMerge,
   runStandingPRPublish,
   runStandingPRUpdate,
+  STANDING_PR_BODY_CAP,
   serializeManifest,
 } from '../../src/standing-pr/standing-pr.js';
 
@@ -675,7 +676,9 @@ describe('runStandingPRUpdate', () => {
     await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
 
     const body = mocks.pullsCreate.mock.calls[0]?.[0]?.body as string;
-    expect(body.length).toBeLessThanOrEqual(65536);
+    // Assert against the module's cap (well under GitHub's 65,536), so a truncation that leaks into
+    // the 64,001–65,535 safety margin still fails the test.
+    expect(body.length).toBeLessThanOrEqual(STANDING_PR_BODY_CAP);
     expect(body).toContain('Changelog truncated');
     // The package table above the changelog is preserved so the PR is still usable.
     expect(body).toContain('| `@scope/core` | 1.0.0 |');

--- a/packages/version/src/core/versionEngine.ts
+++ b/packages/version/src/core/versionEngine.ts
@@ -132,8 +132,9 @@ export class VersionEngine {
         // Parse Cargo.toml
         const cargoData = parseCargoToml(fullCargoPath);
 
-        // Skip crates that explicitly opt out of publishing (Cargo's `publish = false`).
-        if (cargoData.package?.publish === false) {
+        // Skip crates that explicitly opt out of publishing (`publish = false` or `publish = []`).
+        const publishField = cargoData.package?.publish;
+        if (publishField === false || (Array.isArray(publishField) && publishField.length === 0)) {
           log(`Skipping Rust package at ${packageDir}: publish = false`, 'debug');
           continue;
         }

--- a/packages/version/src/core/versionEngine.ts
+++ b/packages/version/src/core/versionEngine.ts
@@ -4,6 +4,8 @@ import { cwd } from 'node:process';
 import { getPackagesSync, type Package, type Packages } from '@manypkg/get-packages';
 import { filterPackagesByConfig, parseCargoToml, parsePubspec } from '@releasekit/config';
 import { shouldMatchPackageTargets } from '@releasekit/core';
+import { minimatch } from 'minimatch';
+import * as yaml from 'yaml';
 import { GitError } from '../errors/gitError.js';
 import { createVersionError, VersionError, VersionErrorCode } from '../errors/versionError.js';
 import type { Config, VersionRunOptions } from '../types.js';
@@ -65,9 +67,27 @@ export class VersionEngine {
   }
 
   /**
-   * Discover pure Rust packages (Cargo.toml only) in the workspace
+   * Discover pure Rust packages (Cargo.toml only) in the workspace.
+   * Skips crates with `publish = false` (Cargo's publish opt-out).
+   * When a workspace root Cargo.toml with `[workspace].members` is found, only
+   * crates inside those member globs are discovered.
    */
   private discoverCargoTomlPackages(workspaceRoot: string): PackagesWithRoot {
+    // Detect Cargo workspace members to scope discovery.
+    let workspaceMembers: string[] | null = null;
+    const rootCargoPath = path.join(workspaceRoot, 'Cargo.toml');
+    if (fs.existsSync(rootCargoPath)) {
+      try {
+        const rootCargo = parseCargoToml(rootCargoPath);
+        if (Array.isArray(rootCargo.workspace?.members) && rootCargo.workspace.members.length > 0) {
+          workspaceMembers = rootCargo.workspace.members;
+          log(`Cargo workspace members detected: ${workspaceMembers.join(', ')}`, 'debug');
+        }
+      } catch (error) {
+        log(`Could not parse root Cargo.toml for workspace members: ${error}`, 'debug');
+      }
+    }
+
     const cargoTomlPaths: string[] = [];
 
     // Recursive function to find Cargo.toml files
@@ -112,21 +132,44 @@ export class VersionEngine {
         // Parse Cargo.toml
         const cargoData = parseCargoToml(fullCargoPath);
 
+        // Skip crates that explicitly opt out of publishing (Cargo's `publish = false`).
+        if (cargoData.package?.publish === false) {
+          log(`Skipping Rust package at ${packageDir}: publish = false`, 'debug');
+          continue;
+        }
+
         if (cargoData.package?.name && typeof cargoData.package?.version === 'string') {
           // Check if this is a valid workspace package (not in target/ or other build dirs)
           const relativePath = path.relative(workspaceRoot, packageDir);
           const pathParts = relativePath.split(path.sep);
-          if (!pathParts.includes('target') && !pathParts.includes('node_modules')) {
-            rustPackages.push({
-              packageJson: {
-                name: cargoData.package.name,
-                version: cargoData.package.version,
-              },
-              dir: packageDir,
-              relativeDir: relativePath,
-            });
-            log(`Discovered Rust package: ${cargoData.package.name} at ${packageDir}`, 'debug');
+          if (pathParts.includes('target') || pathParts.includes('node_modules')) {
+            continue;
           }
+
+          // When workspace members are declared, only include packages inside those globs.
+          if (workspaceMembers !== null) {
+            const normalizedRelative = relativePath.replace(/\\/g, '/');
+            const matchesMember = workspaceMembers.some((member) =>
+              minimatch(normalizedRelative, member, { dot: true }),
+            );
+            if (!matchesMember) {
+              log(
+                `Skipping Rust package ${cargoData.package.name} at ${relativePath}: not in workspace members`,
+                'debug',
+              );
+              continue;
+            }
+          }
+
+          rustPackages.push({
+            packageJson: {
+              name: cargoData.package.name,
+              version: cargoData.package.version,
+            },
+            dir: packageDir,
+            relativeDir: relativePath,
+          });
+          log(`Discovered Rust package: ${cargoData.package.name} at ${packageDir}`, 'debug');
         }
       } catch (error) {
         log(`Failed to parse Cargo.toml at ${cargoPath}: ${error}`, 'warning');
@@ -146,8 +189,28 @@ export class VersionEngine {
    * Discover pure Dart/Flutter packages (pubspec.yaml only) in the workspace. Mirrors the Cargo
    * discovery: directories that already carry a package.json are left to @manypkg, and the merge
    * step dedupes any directory shared with a Cargo crate.
+   *
+   * Skips packages with `publish_to: none` (pub's publish opt-out).
+   * When pnpm-workspace.yaml exists at the workspace root, only packages whose paths match the
+   * declared workspace globs are discovered.
    */
   private discoverPubspecPackages(workspaceRoot: string): PackagesWithRoot {
+    // Read pnpm-workspace.yaml globs to scope pub discovery to declared paths.
+    let pnpmWorkspaceGlobs: string[] | null = null;
+    const pnpmWorkspacePath = path.join(workspaceRoot, 'pnpm-workspace.yaml');
+    if (fs.existsSync(pnpmWorkspacePath)) {
+      try {
+        const pnpmWorkspaceContent = fs.readFileSync(pnpmWorkspacePath, 'utf-8');
+        const pnpmWorkspace = yaml.parse(pnpmWorkspaceContent) as { packages?: string[] };
+        if (Array.isArray(pnpmWorkspace?.packages) && pnpmWorkspace.packages.length > 0) {
+          pnpmWorkspaceGlobs = pnpmWorkspace.packages;
+          log(`pnpm workspace globs detected for pub discovery scoping: ${pnpmWorkspaceGlobs.join(', ')}`, 'debug');
+        }
+      } catch (error) {
+        log(`Could not parse pnpm-workspace.yaml for pub discovery scoping: ${error}`, 'debug');
+      }
+    }
+
     const pubspecPaths: string[] = [];
 
     const findPubspec = (dir: string, relativePath: string = '') => {
@@ -195,18 +258,36 @@ export class VersionEngine {
 
         const pubData = parsePubspec(fullPubspecPath);
 
+        // Skip packages that explicitly opt out of publishing via pub's convention.
+        if (pubData.publish_to === 'none') {
+          log(`Skipping Dart package at ${packageDir}: publish_to: none`, 'debug');
+          continue;
+        }
+
         // Require an explicit version, like the Cargo path. A versionless pubspec is a Dart workspace
         // root or app manifest, not a publishable package — discovering it would feed a bogus baseline
         // into the version stage. (No target/node_modules path check: findPubspec already skips those
         // directories during the walk, so a found pubspec is never inside one.)
         if (pubData.name && typeof pubData.version === 'string') {
+          const relativePath = path.relative(workspaceRoot, packageDir);
+
+          // When pnpm workspace globs are declared, only include packages inside those globs.
+          if (pnpmWorkspaceGlobs !== null) {
+            const normalizedRelative = relativePath.replace(/\\/g, '/');
+            const matchesGlob = pnpmWorkspaceGlobs.some((glob) => minimatch(normalizedRelative, glob, { dot: true }));
+            if (!matchesGlob) {
+              log(`Skipping Dart package ${pubData.name} at ${relativePath}: not in pnpm workspace globs`, 'debug');
+              continue;
+            }
+          }
+
           dartPackages.push({
             packageJson: {
               name: pubData.name,
               version: pubData.version,
             },
             dir: packageDir,
-            relativeDir: path.relative(workspaceRoot, packageDir),
+            relativeDir: relativePath,
           });
           log(`Discovered Dart package: ${pubData.name} at ${packageDir}`, 'debug');
         }

--- a/packages/version/src/core/versionEngine.ts
+++ b/packages/version/src/core/versionEngine.ts
@@ -148,7 +148,9 @@ export class VersionEngine {
           }
 
           // When workspace members are declared, only include packages inside those globs.
-          if (workspaceMembers !== null) {
+          // The workspace root itself (relativePath === '') is always included — it is the
+          // package whose Cargo.toml declares [workspace], so member globs don't apply to it.
+          if (workspaceMembers !== null && relativePath !== '') {
             const normalizedRelative = relativePath.replace(/\\/g, '/');
             const matchesMember = workspaceMembers.some((member) =>
               minimatch(normalizedRelative, member, { dot: true }),

--- a/packages/version/src/package/packageProcessor.ts
+++ b/packages/version/src/package/packageProcessor.ts
@@ -207,6 +207,24 @@ export class PackageProcessor {
           : await getLatestStableTag(this.versionPrefix);
       }
 
+      // #334: a package with no prior git tag has its changelog computed from the FULL git history,
+      // which in standing-PR mode can push the rendered PR body past GitHub's 65,536-char limit and
+      // fail PR creation with an opaque 422 (#333). Surface it loudly with an actionable baseline-tag
+      // suggestion. (baseRef-scoped runs — advisory preview — are bounded to the PR, so skip them.)
+      if (!hasRealTag && !this.fullConfig.baseRef) {
+        const currentVersion = pkg.packageJson.version;
+        const suggestedTag = currentVersion
+          ? formatTag(currentVersion, formattedPrefix, name, this.tagTemplate, this.fullConfig.packageSpecificTags)
+          : undefined;
+        log(
+          `No prior tag found for ${name} — its changelog will include the full git history.` +
+            (suggestedTag
+              ? ` Create a baseline tag to scope it: git tag ${suggestedTag} <release-sha> && git push origin ${suggestedTag}`
+              : ''),
+          'warning',
+        );
+      }
+
       // Generate changelog entries from conventional commits
       let changelogEntries: ChangelogEntry[] = [];
       let revisionRange = 'HEAD';

--- a/packages/version/src/package/packageProcessor.ts
+++ b/packages/version/src/package/packageProcessor.ts
@@ -235,7 +235,9 @@ export class PackageProcessor {
         // baseRef takes precedence — it's a PR base SHA supplied in advisory standing-pr mode
         // so the changelog is scoped to only this PR's commits, not all commits since last tag.
         const baseForRange = this.fullConfig.baseRef ?? changelogBaseTag;
-        if (baseForRange) {
+        if (baseForRange && (this.fullConfig.baseRef || hasRealTag)) {
+          // A real tag (or an explicit baseRef) — verify it. A failure here is the #339 case: the
+          // ref genuinely exists but isn't reachable in this checkout (shallow clone / unpushed).
           const verification = verifyTag(baseForRange, pkgPath);
           if (verification.exists && verification.reachable) {
             revisionRange = `${baseForRange}..HEAD`;
@@ -259,6 +261,13 @@ export class PackageProcessor {
             revisionRange = 'HEAD';
             baselineUnreachable = true;
           }
+        } else if (baseForRange) {
+          // No real tag — `baseForRange` is the manifest-fallback's synthetic tag, which isn't a git
+          // ref. The #334 warning above already explained the full-history changelog accurately, so
+          // skip verifyTag here: running it would emit a second, misleading "could not be verified —
+          // shallow clone / unpushed" message about a tag that never existed.
+          revisionRange = 'HEAD';
+          baselineUnreachable = true;
         }
 
         changelogEntries = extractChangelogEntriesFromCommits(pkgPath, revisionRange);

--- a/packages/version/test/unit/core/versionEngine.spec.ts
+++ b/packages/version/test/unit/core/versionEngine.spec.ts
@@ -685,6 +685,27 @@ describe('Version Engine', () => {
       }
     });
 
+    it('should skip a Cargo crate with publish = []', async () => {
+      const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'rk-cargo-nopublish-arr-'));
+      try {
+        const crateDir = path.join(tmp, 'crates', 'private_crate');
+        fs.mkdirSync(crateDir, { recursive: true });
+        fs.writeFileSync(
+          path.join(crateDir, 'Cargo.toml'),
+          '[package]\nname = "private_crate"\nversion = "1.0.0"\npublish = []\n',
+        );
+        vi.mocked(mockCwd, { partial: true }).mockReturnValue(tmp);
+        vi.mocked(getPackagesSync).mockReturnValue({ root: tmp, packages: [] });
+
+        const engine = new VersionEngine({ ...defaultConfig, sync: false } as Config);
+        const result = await engine.getWorkspacePackages();
+
+        expect(result.packages.find((p) => p.packageJson.name === 'private_crate')).toBeUndefined();
+      } finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
+      }
+    });
+
     it('should exclude Cargo crates outside workspace members when a workspace root Cargo.toml exists', async () => {
       const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'rk-cargo-workspace-'));
       try {

--- a/packages/version/test/unit/core/versionEngine.spec.ts
+++ b/packages/version/test/unit/core/versionEngine.spec.ts
@@ -646,6 +646,91 @@ describe('Version Engine', () => {
       }
     });
 
+    it('should skip a pub package with publish_to: none', async () => {
+      const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'rk-pub-private-'));
+      try {
+        const pkgDir = path.join(tmp, 'packages', 'private_pkg');
+        fs.mkdirSync(pkgDir, { recursive: true });
+        fs.writeFileSync(path.join(pkgDir, 'pubspec.yaml'), 'name: private_pkg\nversion: 1.0.0\npublish_to: none\n');
+        vi.mocked(mockCwd, { partial: true }).mockReturnValue(tmp);
+        vi.mocked(getPackagesSync).mockReturnValue({ root: tmp, packages: [] });
+
+        const engine = new VersionEngine({ ...defaultConfig, sync: false } as Config);
+        const result = await engine.getWorkspacePackages();
+
+        expect(result.packages.find((p) => p.packageJson.name === 'private_pkg')).toBeUndefined();
+      } finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
+      }
+    });
+
+    it('should skip a Cargo crate with publish = false', async () => {
+      const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'rk-cargo-nopublish-'));
+      try {
+        const crateDir = path.join(tmp, 'crates', 'private_crate');
+        fs.mkdirSync(crateDir, { recursive: true });
+        fs.writeFileSync(
+          path.join(crateDir, 'Cargo.toml'),
+          '[package]\nname = "private_crate"\nversion = "1.0.0"\npublish = false\n',
+        );
+        vi.mocked(mockCwd, { partial: true }).mockReturnValue(tmp);
+        vi.mocked(getPackagesSync).mockReturnValue({ root: tmp, packages: [] });
+
+        const engine = new VersionEngine({ ...defaultConfig, sync: false } as Config);
+        const result = await engine.getWorkspacePackages();
+
+        expect(result.packages.find((p) => p.packageJson.name === 'private_crate')).toBeUndefined();
+      } finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
+      }
+    });
+
+    it('should exclude Cargo crates outside workspace members when a workspace root Cargo.toml exists', async () => {
+      const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'rk-cargo-workspace-'));
+      try {
+        fs.writeFileSync(path.join(tmp, 'Cargo.toml'), '[workspace]\nmembers = ["crates/member"]\n');
+        const memberDir = path.join(tmp, 'crates', 'member');
+        fs.mkdirSync(memberDir, { recursive: true });
+        fs.writeFileSync(path.join(memberDir, 'Cargo.toml'), '[package]\nname = "member_crate"\nversion = "0.1.0"\n');
+        const fixtureDir = path.join(tmp, 'fixtures', 'test_crate');
+        fs.mkdirSync(fixtureDir, { recursive: true });
+        fs.writeFileSync(path.join(fixtureDir, 'Cargo.toml'), '[package]\nname = "fixture_crate"\nversion = "0.1.0"\n');
+        vi.mocked(mockCwd, { partial: true }).mockReturnValue(tmp);
+        vi.mocked(getPackagesSync).mockReturnValue({ root: tmp, packages: [] });
+
+        const engine = new VersionEngine({ ...defaultConfig, sync: false } as Config);
+        const result = await engine.getWorkspacePackages();
+
+        expect(result.packages.find((p) => p.packageJson.name === 'member_crate')).toBeDefined();
+        expect(result.packages.find((p) => p.packageJson.name === 'fixture_crate')).toBeUndefined();
+      } finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
+      }
+    });
+
+    it('should exclude pub packages outside pnpm workspace globs when pnpm-workspace.yaml exists', async () => {
+      const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'rk-pub-workspace-'));
+      try {
+        fs.writeFileSync(path.join(tmp, 'pnpm-workspace.yaml'), 'packages:\n  - "packages/*"\n');
+        const memberDir = path.join(tmp, 'packages', 'flutter_member');
+        fs.mkdirSync(memberDir, { recursive: true });
+        fs.writeFileSync(path.join(memberDir, 'pubspec.yaml'), 'name: flutter_member\nversion: 1.0.0\n');
+        const fixtureDir = path.join(tmp, 'fixtures', 'flutter_fixture');
+        fs.mkdirSync(fixtureDir, { recursive: true });
+        fs.writeFileSync(path.join(fixtureDir, 'pubspec.yaml'), 'name: flutter_fixture\nversion: 0.0.1\n');
+        vi.mocked(mockCwd, { partial: true }).mockReturnValue(tmp);
+        vi.mocked(getPackagesSync).mockReturnValue({ root: tmp, packages: [] });
+
+        const engine = new VersionEngine({ ...defaultConfig, sync: false } as Config);
+        const result = await engine.getWorkspacePackages();
+
+        expect(result.packages.find((p) => p.packageJson.name === 'flutter_member')).toBeDefined();
+        expect(result.packages.find((p) => p.packageJson.name === 'flutter_fixture')).toBeUndefined();
+      } finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
+      }
+    });
+
     it('should include a pure Rust package when explicitly named in config.packages', async () => {
       const discoverSpy = vi.spyOn(VersionEngine.prototype as any, 'discoverCargoTomlPackages');
       discoverSpy.mockReturnValue({

--- a/packages/version/test/unit/core/versionEngine.spec.ts
+++ b/packages/version/test/unit/core/versionEngine.spec.ts
@@ -729,6 +729,30 @@ describe('Version Engine', () => {
       }
     });
 
+    it('should include a workspace root crate that also carries [package] even when workspace members are declared', async () => {
+      const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'rk-cargo-root-pkg-'));
+      try {
+        // Root Cargo.toml declares both [workspace] and [package] — a "virtual workspace root crate"
+        fs.writeFileSync(
+          path.join(tmp, 'Cargo.toml'),
+          '[workspace]\nmembers = ["crates/member"]\n\n[package]\nname = "root_crate"\nversion = "2.0.0"\n',
+        );
+        const memberDir = path.join(tmp, 'crates', 'member');
+        fs.mkdirSync(memberDir, { recursive: true });
+        fs.writeFileSync(path.join(memberDir, 'Cargo.toml'), '[package]\nname = "member_crate"\nversion = "0.1.0"\n');
+        vi.mocked(mockCwd, { partial: true }).mockReturnValue(tmp);
+        vi.mocked(getPackagesSync).mockReturnValue({ root: tmp, packages: [] });
+
+        const engine = new VersionEngine({ ...defaultConfig, sync: false } as Config);
+        const result = await engine.getWorkspacePackages();
+
+        expect(result.packages.find((p) => p.packageJson.name === 'root_crate')).toBeDefined();
+        expect(result.packages.find((p) => p.packageJson.name === 'member_crate')).toBeDefined();
+      } finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
+      }
+    });
+
     it('should exclude pub packages outside pnpm workspace globs when pnpm-workspace.yaml exists', async () => {
       const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'rk-pub-workspace-'));
       try {

--- a/packages/version/test/unit/package/packageProcessor.spec.ts
+++ b/packages/version/test/unit/package/packageProcessor.spec.ts
@@ -535,6 +535,31 @@ describe('Package Processor', () => {
       expect(calls[0][0]).toMatchObject({ previousVersion: 'v1.0.0' });
     });
 
+    it('should warn when a package has no prior tag (full-history changelog, #334)', async () => {
+      // No package tag and no global tag — only the manifest version is available, so hasRealTag is
+      // false and the changelog spans the full history. The warning makes this visible (and heads off
+      // the opaque oversized-PR-body 422 in #333).
+      vi.spyOn(gitTags, 'getLatestTagForPackage').mockResolvedValue('');
+      vi.spyOn(manifestHelpers, 'getVersionFromManifests').mockReturnValue({
+        version: '0.1.0',
+        manifestFound: true,
+        manifestPath: 'package.json',
+        manifestType: 'package.json',
+      });
+      vi.spyOn(calculator, 'calculateVersion').mockResolvedValue('0.1.1');
+      vi.spyOn(versionCalculatorModule, 'calculateVersion').mockResolvedValue('0.1.1');
+
+      const processor = new PackageProcessor({
+        ...defaultOptions,
+        getLatestTag: vi.fn().mockResolvedValue(null), // no global tag either
+        fullConfig: { ...mockConfig, packageSpecificTags: true, writeChangelog: false },
+      });
+
+      await processor.processPackages([mockPackages[1]]);
+
+      expect(logging.log).toHaveBeenCalledWith(expect.stringContaining('No prior tag found for package-b'), 'warning');
+    });
+
     it('should emit repo-level entries as sharedEntries, not in individual package changelogs', async () => {
       const repoLevelEntry = { type: 'chore', description: 'Update CI workflow' };
       const pkgAEntry = { type: 'added', description: 'New feature in pkg-a' };

--- a/packages/version/test/unit/package/packageProcessor.spec.ts
+++ b/packages/version/test/unit/package/packageProcessor.spec.ts
@@ -558,6 +558,12 @@ describe('Package Processor', () => {
       await processor.processPackages([mockPackages[1]]);
 
       expect(logging.log).toHaveBeenCalledWith(expect.stringContaining('No prior tag found for package-b'), 'warning');
+      // ...and NOT the misleading #339 "shallow clone / unpushed" warning about the synthetic
+      // manifest-fallback tag, which never existed as a git ref.
+      expect(logging.log).not.toHaveBeenCalledWith(
+        expect.stringContaining('could not be verified from HEAD'),
+        'warning',
+      );
     });
 
     it('should emit repo-level entries as sharedEntries, not in individual package changelogs', async () => {


### PR DESCRIPTION
## Summary

- Skip Cargo crates with `publish = false` during discovery (Cargo's opt-out analogue to npm `private: true`)
- Skip pub packages with `publish_to: none` during discovery (pub's opt-out)
- When a workspace root `Cargo.toml` declares `[workspace].members`, scope Cargo crate discovery to those globs only — crates outside the workspace (fixtures, test apps) are no longer discovered
- When `pnpm-workspace.yaml` exists, scope pub `pubspec.yaml` discovery to the declared workspace globs — pub packages outside the workspace are no longer discovered

This prevents fixtures and test crates/packages (e.g. `dioxus-package-test-app`, `wdio_flutter_fixture`) from leaking into the release set, being versioned/tagged, and — for Cargo — attempting a real registry publish.

Extends `CargoManifest` type to expose `publish` and `workspace.members` fields.

## Test plan

- [ ] New unit tests in `versionEngine.spec.ts` covering all four cases (Cargo `publish = false`, pub `publish_to: none`, Cargo workspace scoping, pub pnpm-workspace scoping)
- [ ] All 601 tests pass: `pnpm turbo run lint typecheck test`

Closes #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes fixture and test crates/packages leaking into the release set by honoring Cargo's `publish = false`/`[]` and pub's `publish_to: none` opt-outs during discovery, and by scoping Cargo discovery to `[workspace].members` globs and pub discovery to `pnpm-workspace.yaml` globs. It also adds a PR-body truncation guard for GitHub's 65,536-char limit and surfaces a clear actionable warning when a package has no prior git tag.

- **`versionEngine.ts`**: Reads `[workspace].members` from the root `Cargo.toml` and `packages` from `pnpm-workspace.yaml` to scope crate/package discovery; filters by `publish = false`/`[]` and `publish_to: none`.
- **`standing-pr.ts`**: Introduces `STANDING_PR_BODY_CAP = 64000`, `truncateAtLineBoundary`, and a re-renderable `build` inner function so an oversized changelog is truncated with a notice rather than failing PR creation with a 422.
- **`packageProcessor.ts`**: Emits an actionable "create a baseline tag" warning for tagless packages and skips `verifyTag` on synthetic manifest-fallback refs to eliminate the misleading shallow-clone warning.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the filtering logic is additive (it only removes unwanted packages from discovery) and each new guard is covered by a dedicated test with a real temp-directory fixture.

All four discovery changes (Cargo publish opt-out, pub publish_to opt-out, Cargo workspace scoping, pub pnpm-workspace scoping) are independently tested with real filesystem fixtures. The PR body truncation math has been verified to keep the final body below the cap. The synthetic-tag verifyTag bypass correctly avoids the misleading shallow-clone warning. No correctness issues found.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/version/src/core/versionEngine.ts | Adds `publish = false`/`[]` and `publish_to: none` opt-out filtering, plus workspace-scoped discovery for both Cargo (via `[workspace].members`) and pub (via `pnpm-workspace.yaml`). Logic is correct; edge cases handled. |
| packages/release/src/standing-pr/standing-pr.ts | Adds PR body truncation (STANDING_PR_BODY_CAP = 64000) to prevent GitHub 422 on oversized changelogs. Room calculation accounts for all structural bytes and the notice string correctly. |
| packages/version/src/package/packageProcessor.ts | Adds actionable warning when no prior git tag exists, and avoids calling verifyTag on synthetic manifest-fallback tags to eliminate the misleading 'shallow clone / unpushed' message. |
| packages/config/src/cargo.ts | Extends CargoManifest interface with `publish?: boolean | string[]` and `workspace?: { members?: string[] }` — minimal, correct type augmentation. |
| packages/version/test/unit/core/versionEngine.spec.ts | Adds integration-style tests with real temp directories covering all four new discovery behaviours. |
| packages/release/test/unit/standing-pr.spec.ts | Adds a truncation test with 4000 changelog entries; asserts body ≤ STANDING_PR_BODY_CAP, truncation notice is present, and the package table is preserved. |
| packages/version/test/unit/package/packageProcessor.spec.ts | Adds a test verifying the #334 'no prior tag' warning fires and the misleading #339 shallow-clone warning does not. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[discoverCargoTomlPackages] --> B{Root Cargo.toml exists?}
    B -- yes --> C[Parse workspace.members]
    B -- no --> D[workspaceMembers = null]
    C --> D
    D --> E[Walk tree for Cargo.toml files]
    E --> F{Has package.json in same dir?}
    F -- yes --> G[Skip - handled by manypkg]
    F -- no --> H{publish = false or empty array?}
    H -- yes --> I[Skip - opt-out]
    H -- no --> J{name and version present?}
    J -- no --> K[Skip]
    J -- yes --> L{In target/ or node_modules/?}
    L -- yes --> K
    L -- no --> M{workspaceMembers set AND relativePath not empty?}
    M -- yes --> N{minimatch against members}
    N -- no match --> O[Skip - outside workspace]
    N -- match --> P[Add to rustPackages]
    M -- no --> P

    Q[discoverPubspecPackages] --> R{pnpm-workspace.yaml exists?}
    R -- yes --> S[Parse packages globs]
    R -- no --> T[pnpmWorkspaceGlobs = null]
    S --> T
    T --> U[Walk tree for pubspec.yaml]
    U --> V{publish_to = none?}
    V -- yes --> W[Skip - opt-out]
    V -- no --> X{name and version present?}
    X -- no --> Y[Skip]
    X -- yes --> Z{pnpmWorkspaceGlobs set?}
    Z -- yes --> AA{minimatch against globs}
    AA -- no match --> AB[Skip - outside workspace]
    AA -- match --> AC[Add to dartPackages]
    Z -- no --> AC
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[discoverCargoTomlPackages] --> B{Root Cargo.toml exists?}
    B -- yes --> C[Parse workspace.members]
    B -- no --> D[workspaceMembers = null]
    C --> D
    D --> E[Walk tree for Cargo.toml files]
    E --> F{Has package.json in same dir?}
    F -- yes --> G[Skip - handled by manypkg]
    F -- no --> H{publish = false or empty array?}
    H -- yes --> I[Skip - opt-out]
    H -- no --> J{name and version present?}
    J -- no --> K[Skip]
    J -- yes --> L{In target/ or node_modules/?}
    L -- yes --> K
    L -- no --> M{workspaceMembers set AND relativePath not empty?}
    M -- yes --> N{minimatch against members}
    N -- no match --> O[Skip - outside workspace]
    N -- match --> P[Add to rustPackages]
    M -- no --> P

    Q[discoverPubspecPackages] --> R{pnpm-workspace.yaml exists?}
    R -- yes --> S[Parse packages globs]
    R -- no --> T[pnpmWorkspaceGlobs = null]
    S --> T
    T --> U[Walk tree for pubspec.yaml]
    U --> V{publish_to = none?}
    V -- yes --> W[Skip - opt-out]
    V -- no --> X{name and version present?}
    X -- no --> Y[Skip]
    X -- yes --> Z{pnpmWorkspaceGlobs set?}
    Z -- yes --> AA{minimatch against globs}
    AA -- no match --> AB[Skip - outside workspace]
    AA -- match --> AC[Add to dartPackages]
    Z -- no --> AC
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(version): include workspace root cra..."](https://github.com/goosewobbler/releasekit/commit/300260f1e593452c268afe00a3bc73a651a648a1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38159411)</sub>

<!-- /greptile_comment -->