### PR TITLE
fix(version): bound changelog baseline by nearest reachable tag, not bare-semver tag (#348)

### DIFF
--- a/packages/version/src/git/tagsAndBranches.ts
+++ b/packages/version/src/git/tagsAndBranches.ts
@@ -67,6 +67,28 @@ export function refExists(ref: string, cwd?: string): boolean {
 }
 
 /**
+ * The most recent tag reachable from HEAD, regardless of package prefix or version scheme.
+ *
+ * Unlike `getLatestTag` — which goes through git-semver-tags and only matches *bare* semver tags
+ * (`v1.2.3`) — this walks HEAD's ancestors via `git describe`, so it also finds the per-package
+ * tags monorepos actually use (`pkg@vX.Y.Z`, `release/vX.Y.Z`). The result is reachable by
+ * construction, which is exactly what a `<tag>..HEAD` baseline floor needs (#348).
+ *
+ * @returns The nearest reachable tag, or '' when none is reachable (no releases yet / shallow clone).
+ */
+export function getNearestReachableTag(cwd?: string): string {
+  try {
+    return execSync('git', ['describe', '--tags', '--abbrev=0'], {
+      ...(cwd ? { cwd } : {}),
+    })
+      .toString()
+      .trim();
+  } catch {
+    return '';
+  }
+}
+
+/**
  * Get the latest semver tag from the repository sorted by semantic version
  * This function prioritizes semantic ordering over chronological ordering to handle
  * cases where tags were created out of order (e.g., v0.7.1 created after v0.8.0)

--- a/packages/version/src/package/packageProcessor.ts
+++ b/packages/version/src/package/packageProcessor.ts
@@ -5,7 +5,12 @@ import type { VersionChangelogEntry } from '@releasekit/core';
 import { shouldProcessPackage } from '@releasekit/core';
 import { extractChangelogEntriesFromCommits, extractRepoLevelChangelogEntries } from '../changelog/commitParser.js';
 import { calculateVersion } from '../core/versionCalculator.js';
-import { getLatestStableTag, getLatestStableTagForPackage, getLatestTagForPackage } from '../git/tagsAndBranches.js';
+import {
+  getLatestStableTag,
+  getLatestStableTagForPackage,
+  getLatestTagForPackage,
+  getNearestReachableTag,
+} from '../git/tagsAndBranches.js';
 import { verifyTag } from '../git/tagVerification.js';
 import type { Config, VersionConfigBase } from '../types.js';
 import {
@@ -294,17 +299,13 @@ export class PackageProcessor {
         let sharedRevisionRange = revisionRange;
         if (revisionRange === 'HEAD' && !this.fullConfig.baseRef) {
           if (_sharedBaselineRange === undefined) {
-            try {
-              const globalTag = await this.getLatestTag();
-              if (globalTag) {
-                const gv = verifyTag(globalTag, process.cwd());
-                _sharedBaselineRange = gv.exists && gv.reachable ? `${globalTag}..HEAD` : 'HEAD';
-              } else {
-                _sharedBaselineRange = 'HEAD';
-              }
-            } catch {
-              _sharedBaselineRange = 'HEAD';
-            }
+            // Most recent tag reachable from HEAD as the baseline floor — NOT `this.getLatestTag()`,
+            // which goes through git-semver-tags and only matches bare-semver tags. In monorepos that
+            // tag per package (`pkg@vX.Y.Z`) it returns '' and the floor wrongly collapsed to full
+            // history (#348). `git describe` is prefix-agnostic and reachable by construction, so the
+            // separate verifyTag check is no longer needed.
+            const globalTag = getNearestReachableTag(process.cwd());
+            _sharedBaselineRange = globalTag ? `${globalTag}..HEAD` : 'HEAD';
           }
           sharedRevisionRange = _sharedBaselineRange;
         }

--- a/packages/version/test/unit/package/packageProcessor.spec.ts
+++ b/packages/version/test/unit/package/packageProcessor.spec.ts
@@ -566,19 +566,21 @@ describe('Package Processor', () => {
       );
     });
 
-    it('should bound repo-level changelog range by global baseline when a package has no real tag (#348)', async () => {
-      // package-a has no specific tag; getVersionFromManifests returns a manifest version via
-      // the global beforeEach mock, making hasRealTag=false and revisionRange='HEAD'.
-      // The shared-entries call should use the global baseline floor, not 'HEAD'.
+    it('should bound repo-level changelog by the nearest reachable tag, even when getLatestTag is prefix-blind (#348)', async () => {
+      // package-a has no specific tag; getVersionFromManifests returns a manifest version via the
+      // global beforeEach mock, making hasRealTag=false and revisionRange='HEAD'. The baseline floor
+      // must come from getNearestReachableTag (git describe), which finds per-package prefixed tags.
+      // The injected getLatestTag (git-semver-tags, bare-semver only) returns '' for such repos —
+      // sourcing the floor from it collapsed the range to full history, the bug this guards against.
       vi.spyOn(gitTags, 'getLatestTagForPackage').mockResolvedValue('');
+      vi.spyOn(gitTags, 'getNearestReachableTag').mockReturnValue('wdio-dioxus-bridge@v1.0.0-next.2');
       vi.spyOn(calculator, 'calculateVersion').mockResolvedValue('1.1.0');
       vi.spyOn(versionCalculatorModule, 'calculateVersion').mockResolvedValue('1.1.0');
       const extractSharedSpy = vi.spyOn(commitParser, 'extractRepoLevelChangelogEntries').mockReturnValue([]);
 
-      const globalTag = 'v1.0.0';
       const processor = new PackageProcessor({
         ...defaultOptions,
-        getLatestTag: vi.fn().mockResolvedValue(globalTag),
+        getLatestTag: vi.fn().mockResolvedValue(''), // prefix-blind: no bare-semver tag in this repo
         fullConfig: { ...mockConfig, packageSpecificTags: true, writeChangelog: false },
       });
 
@@ -586,21 +588,21 @@ describe('Package Processor', () => {
 
       expect(extractSharedSpy).toHaveBeenCalledWith(
         expect.any(String),
-        `${globalTag}..HEAD`,
+        'wdio-dioxus-bridge@v1.0.0-next.2..HEAD',
         expect.any(Array),
         expect.any(Array),
       );
     });
 
-    it('should fall back to HEAD range for shared entries when getLatestTag rejects (#348)', async () => {
+    it('should fall back to HEAD range for shared entries when no tag is reachable (#348)', async () => {
       vi.spyOn(gitTags, 'getLatestTagForPackage').mockResolvedValue('');
+      vi.spyOn(gitTags, 'getNearestReachableTag').mockReturnValue('');
       vi.spyOn(calculator, 'calculateVersion').mockResolvedValue('1.1.0');
       vi.spyOn(versionCalculatorModule, 'calculateVersion').mockResolvedValue('1.1.0');
       const extractSharedSpy = vi.spyOn(commitParser, 'extractRepoLevelChangelogEntries').mockReturnValue([]);
 
       const processor = new PackageProcessor({
         ...defaultOptions,
-        getLatestTag: vi.fn().mockRejectedValue(new Error('git failure')),
         fullConfig: { ...mockConfig, packageSpecificTags: true, writeChangelog: false },
       });
 


### PR DESCRIPTION
## Summary

Follow-up to #351. That PR added a project-wide changelog **baseline floor** so an untagged package can't flood the standing PR with full git history. It works in releasekit's own repo, but **does not generalise to monorepos that tag per package** — the floor silently collapses back to full history there.

**Root cause:** the floor was sourced from `getLatestTag()`, which goes through `git-semver-tags` and only matches **bare** semver tags (`v1.2.3`). A monorepo whose `tagTemplate` is `${packageName}@v${version}` (or `release/v${version}`) has *zero* bare-semver tags, so `getLatestTag()` returns `''` and the baseline logic falls into its `'HEAD'` fallback → unbounded → the exact flood #348 set out to prevent.

Releasekit's own standing PR avoids this only by accident: every releasekit package is already tagged, so the untagged-package path that computes the floor never runs. Any consumer with a brand-new (untagged) package hits it immediately.

### Evidence (a downstream consumer using `${packageName}@v${version}` tags)

| Check | Result |
|---|---|
| `getSemverTags({ tagPrefix: undefined })` | `[]` |
| `getSemverTags({ tagPrefix: 'v' })` | `[]` |
| bare-semver tags in repo | none (all 95 are `pkg@vX.Y.Z`) |
| `git rev-list --count HEAD` | **494** ← the flood (~500-entry changelog) |
| `git describe --tags --abbrev=0` | `wdio-dioxus-bridge@v1.0.0-next.2` |
| `git rev-list --count <that tag>..HEAD` | **3** ← what the floor should yield |

## Fix

Replace the floor lookup with a new `getNearestReachableTag()` (`git describe --tags --abbrev=0`):

- **prefix-agnostic** — finds `pkg@vX.Y.Z` / `release/vX.Y.Z` as well as bare `vX.Y.Z`;
- **reachable by construction** — `git describe` only walks HEAD's ancestors, so the separate `verifyTag` reachability check is now redundant and is dropped from this path;
- returns `''` when no tag is reachable (no releases yet / shallow clone) → `'HEAD'` fallback, unchanged.

`this.getLatestTag()` is left untouched for its other use (the per-package version fallback at `packageProcessor.ts:168`).

## Tests

The previous happy-path test mocked the injected `getLatestTag` to return a **bare** `v1.0.0`, which masked the bug. Both #348 tests are reworked:

- the happy path now drives the floor through `getNearestReachableTag` returning a **per-package prefixed** tag (`wdio-dioxus-bridge@v1.0.0-next.2`) — the real-world case — and asserts the shared range is `…-next.2..HEAD`;
- the fallback test asserts `'HEAD'` when no tag is reachable.

`@releasekit/version`: typecheck clean, Biome clean, **601/601** unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes the changelog baseline floor introduced in #351 so it works for monorepos that use per-package tag naming (e.g. `pkg@vX.Y.Z`). The old floor used `getLatestTag()` via `git-semver-tags`, which only matches bare semver tags and returns `''` in repos that use prefix-namespaced tags — silently collapsing back to full git history.

- Adds `getNearestReachableTag()` backed by `git describe --tags --abbrev=0`, which is prefix-agnostic and reachable by construction (eliminating the need for the separate `verifyTag` check).
- Swaps the floor lookup in `packageProcessor.ts` from the async `getLatestTag()` path (with try/catch) to a synchronous `getNearestReachableTag()` call.
- Reworks both #348 tests: the happy-path now drives the floor through a prefixed tag, and the fallback test uses an empty `getNearestReachableTag` rather than a rejected `getLatestTag` promise.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change narrows an existing safety mechanism and has no effect on already-tagged packages.

The fix is targeted and well-contained: one new synchronous helper, one call-site swap, and two updated tests. The synchronous `getNearestReachableTag` swallows all errors and returns `''`, so the worst-case outcome is identical to the pre-existing fallback (`'HEAD'`). The removed `verifyTag` check was genuinely redundant given `git describe` only returns ancestors of HEAD. Tests now cover the real-world prefixed-tag case that previously masked the bug.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/version/src/git/tagsAndBranches.ts | Adds `getNearestReachableTag()` using `git describe --tags --abbrev=0`; synchronous, catches errors and returns `''`, mirrors the existing `getCommitsLength` fallback path in the same file. |
| packages/version/src/package/packageProcessor.ts | Replaces the async `getLatestTag` + `verifyTag` baseline floor logic with a synchronous `getNearestReachableTag` call; simpler, error-safe, and prefix-agnostic. |
| packages/version/test/unit/package/packageProcessor.spec.ts | Tests updated to mock `getNearestReachableTag` directly; happy-path now uses a realistic prefixed tag, fallback test checks the empty-return path instead of a rejected promise. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[processPackages: revisionRange = 'HEAD'] --> B{baseRef set?}
    B -- yes --> C[use revisionRange as-is]
    B -- no --> D{_sharedBaselineRange cached?}
    D -- yes --> E[use cached range]
    D -- no --> F[getNearestReachableTag\ngit describe --tags --abbrev=0]
    F --> G{tag found?}
    G -- yes --> H["_sharedBaselineRange = tag..HEAD"]
    G -- no / error --> I["_sharedBaselineRange = 'HEAD'"]
    H --> J[extractRepoLevelChangelogEntries\nwith bounded range]
    I --> J
    E --> J
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[processPackages: revisionRange = 'HEAD'] --> B{baseRef set?}
    B -- yes --> C[use revisionRange as-is]
    B -- no --> D{_sharedBaselineRange cached?}
    D -- yes --> E[use cached range]
    D -- no --> F[getNearestReachableTag\ngit describe --tags --abbrev=0]
    F --> G{tag found?}
    G -- yes --> H["_sharedBaselineRange = tag..HEAD"]
    G -- no / error --> I["_sharedBaselineRange = 'HEAD'"]
    H --> J[extractRepoLevelChangelogEntries\nwith bounded range]
    I --> J
    E --> J
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(version): bound changelog baseline b..."](https://github.com/goosewobbler/releasekit/commit/8bf7cd876d877aa28bb76a17e2aaaa10b846737f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38393749)</sub>

<!-- /greptile_comment -->