### PR TITLE
fix(version): unify changelog-baseline resolution behind BaselineResolver

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,25 @@
+# CONTEXT — domain glossary
+
+Shared *domain* vocabulary for releasekit. (Architecture terms — module / seam / deep / shallow — live in the deepening plans; this file names the problem domain.)
+
+## Versioning baselines — three distinct notions, kept separate
+
+Conflating these is the historical source of the `fix(version)` bug cluster (#330/#334/#339/#348). They are not one concept.
+
+- **Version source (A)** — the semver a package is bumped *from*: its own tag → manifest version → `0.1.0`, with tag/manifest mismatch detection. Owned by `getBestVersionSource`. Answers *"bump from what?"*.
+- **Changelog floor / per-package floor (B)** — the `<tag>..HEAD` revision range a package's *own* changelog entries are collected from. On prerelease→stable **graduation** the floor is the last *stable* tag (aggregate since last stable), which can differ from the version source's tag.
+- **Shared floor / repo-level floor (C)** — the range bounding *project-wide* ("shared") entries (CI, infra, shared-package changes) so an untagged package doesn't flood them with full history. Computed once per run from the nearest reachable tag.
+
+**BaselineResolver** — per-run module owning **B + C** (not A): reachability, graduation-aware floor, dual-tag handling, and the shared-floor cache. Receives already-discovered tag facts; returns `{ revisionRange, sharedRevisionRange, previousVersion, baselineUnreachable }` per package.
+
+## Tags
+
+- **Consumer tag** — user-facing release tag from `tagTemplate` (e.g. `v1.2.3`); drives GitHub Releases.
+- **Baseline (marker) tag** — internal tag from `baselineTagTemplate` (e.g. `release/v1.2.3`); stays on branch history for range math when the consumer tag is force-moved off it. `previousVersion` is the floor tag display-stripped back to consumer form.
+- **baselineUnreachable** — the configured floor ref exists but isn't reachable from HEAD (shallow clone / unpushed), or is a manifest-fallback synthetic tag; the range collapses to full history and `previousVersion` is suppressed.
+
+## Release taxonomy (feature: grouped / prerequisite releases)
+
+- **Explicit group** — a declared coordination invariant over related packages: `fixed` (shared version, all move) · `linked` (shared version, changed-only) · `independent` (own version lines, changed-only, atomic).
+- **Prerequisite** — *derived* from the dependency graph at release time; keeps its own commit-driven bump; pulled in only if changed; dependency-ordered.
+- **Selection** — orthogonal *"what to act on now"* (scope labels / checkboxes / CLI). Under this taxonomy, scope labels revert to pure selection — they are not the home for co-release coupling.

--- a/packages/version/src/core/baselineResolver.ts
+++ b/packages/version/src/core/baselineResolver.ts
@@ -1,0 +1,176 @@
+import { getLatestStableTag, getLatestStableTagForPackage, getNearestReachableTag } from '../git/tagsAndBranches.js';
+import { verifyTag } from '../git/tagVerification.js';
+import { displayTag } from '../utils/formatting.js';
+import { log } from '../utils/logging.js';
+import { isStableTag, isStableVersion } from '../utils/versionUtils.js';
+
+/**
+ * Per-run configuration for {@link BaselineResolver}. Mirrors the slice of version config the
+ * floor algorithm reads — held once so the shared floor (C) is computed a single time per run.
+ */
+export interface BaselineResolverOptions {
+  /** Consumer-facing version prefix, already normalised via `formatVersionPrefix` (e.g. `v`). */
+  versionPrefix: string;
+  /** Per-package tag template — used by the graduation stable-tag lookup in the package-specific series. */
+  tagTemplate?: string;
+  packageSpecificTags: boolean;
+  strictReachable: boolean;
+  /**
+   * Advisory standing-PR base SHA. When set it overrides the floor and is treated as always
+   * intended — verification failures still bound the range rather than throwing under strictReachable.
+   */
+  baseRef?: string;
+  /** CWD for the repo-level nearest-reachable floor lookup (shared floor). Defaults to `process.cwd()`. */
+  sharedFloorCwd?: string;
+}
+
+/**
+ * Per-package facts the caller has already discovered (tag lookup is shared with version calculation,
+ * so the resolver receives the result rather than re-running discovery).
+ */
+export interface BaselineInput {
+  /** Directory to run git from — the package dir, or the changelog root in sync mode. */
+  pkgDir: string;
+  /** The package's discovered latest tag, or `''` when none. */
+  latestTag: string;
+  /** Whether `latestTag` is a real git tag (vs. a manifest-fallback synthetic tag, or empty). */
+  hasRealTag: boolean;
+  /** Whether `latestTag` came from the package-specific series — decides which stable-tag lookup graduation uses. */
+  usedPackageSpecificTag: boolean;
+  /** The version being released — drives the prerelease→stable graduation floor. */
+  nextVersion: string;
+  /** Package name for the graduation stable-tag lookup (package-specific series). */
+  graduationName?: string;
+  /** Caller-derived baseline-tag prefix (`deriveBaselineTagPrefix`) for display-stripping `previousVersion`. */
+  baselineTagPrefix: string | undefined;
+  /** Caller-derived consumer prefix (`formatVersionPrefix` output) for display. */
+  formattedPrefix: string;
+}
+
+export interface PackageBaseline {
+  /** `<floor>..HEAD`, or `'HEAD'` when there is no reachable baseline. */
+  revisionRange: string;
+  /** The floor tag in consumer-facing display form, or `null` when the baseline is unreachable/absent. */
+  previousVersion: string | null;
+  /** True when a baseline ref was resolved but is unreachable (shallow clone / unpushed / synthetic). */
+  baselineUnreachable: boolean;
+}
+
+/**
+ * Owns the changelog-floor algorithm: the previously-divergent per-call-site logic for "which
+ * `<tag>..HEAD` range a package's changelog is collected from, and is that baseline reachable" (the
+ * per-package floor, B), plus the repo-level shared floor (C). See `CONTEXT.md` for the three
+ * baseline notions; the version source (A) is a separate seam.
+ *
+ * Constructed once per version run so the shared floor is computed a single time and reused across
+ * packages. Receives already-discovered tag facts; does not re-run tag discovery.
+ *
+ * Consolidates the copies in `createSyncStrategy`, `createSingleStrategy`, `groupStrategy`, and
+ * `PackageProcessor`. Only the async path previously had the merge-base reachability check (#339)
+ * and the graduation-since-stable floor; this is now the single behaviour for every mode.
+ */
+export class BaselineResolver {
+  /** Lazy per-run cache for the repo-level shared floor (C). */
+  private sharedBaselineRange: string | undefined;
+
+  constructor(private readonly opts: BaselineResolverOptions) {}
+
+  /**
+   * Resolve the per-package changelog floor (B): the revision range, the display-form previous
+   * version, and whether the baseline turned out to be unreachable.
+   */
+  async resolve(input: BaselineInput): Promise<PackageBaseline> {
+    const { pkgDir, latestTag, hasRealTag, usedPackageSpecificTag, nextVersion, graduationName } = input;
+    const { baseRef, strictReachable, versionPrefix, tagTemplate } = this.opts;
+
+    // Graduation: when a prerelease graduates to stable, aggregate the changelog from the last
+    // *stable* tag rather than from `latestTag` (the prerelease, which usually holds only the
+    // release-prep commit). `latestTag` still drives version calculation upstream — it must see the
+    // prerelease to graduate correctly. With no prior stable tag, this stays `''` and the range
+    // falls through to all commits.
+    let changelogBaseTag = latestTag;
+    if (hasRealTag && latestTag && isStableVersion(nextVersion) && !isStableTag(latestTag)) {
+      // Follow latestTag's source (package series vs global) — the other lookup returns '' here and
+      // would over-include every commit.
+      changelogBaseTag =
+        usedPackageSpecificTag && graduationName
+          ? await getLatestStableTagForPackage(graduationName, versionPrefix, {
+              tagTemplate,
+              packageSpecificTags: true,
+            })
+          : await getLatestStableTag(versionPrefix);
+    }
+
+    let revisionRange = 'HEAD';
+    let baselineUnreachable = false;
+    // baseRef (a PR base SHA supplied in advisory standing-pr mode) takes precedence — it scopes the
+    // changelog to only this PR's commits, not all commits since the last tag.
+    const baseForRange = baseRef ?? changelogBaseTag;
+
+    if (baseForRange && (baseRef || hasRealTag)) {
+      // A real tag (or explicit baseRef): verify it. Existence alone isn't enough — a tag from a
+      // shallow clone or a non-ancestor branch can `rev-parse` but produce a meaningless range, so
+      // require ancestry (#339).
+      const verification = verifyTag(baseForRange, pkgDir);
+      if (verification.exists && verification.reachable) {
+        revisionRange = `${baseForRange}..HEAD`;
+      } else {
+        if (!baseRef && strictReachable) {
+          throw new Error(
+            `Cannot generate changelog: ref '${baseForRange}' is not reachable from the current commit. ` +
+              `When strictReachable is enabled, all refs must be reachable. ` +
+              `To allow fallback to all commits, set strictReachable to false.`,
+          );
+        }
+        // Loud, not debug: this silently produces a whole-history changelog (#339). Callers omit
+        // previousVersion when this fires (below) so the changelog doesn't claim an undiffed baseline.
+        log(
+          `Baseline ref '${baseForRange}' could not be verified from HEAD (${verification.error}) — generating ` +
+            `the changelog from ALL history instead of since the last release. The ref is likely missing from the ` +
+            `checkout (shallow clone, or never pushed). ${
+              baseRef
+                ? 'Fetch/push the ref to make it available in this checkout.'
+                : 'Fetch/push the tag, or set version.baseRef, to bound it.'
+            }`,
+          'warning',
+        );
+        revisionRange = 'HEAD';
+        baselineUnreachable = true;
+      }
+    } else if (baseForRange) {
+      // No real tag — `baseForRange` is the manifest-fallback's synthetic tag, which isn't a git ref.
+      // The caller's untagged warning (#334) already explained the full-history changelog accurately,
+      // so skip verifyTag: it would emit a second, misleading "shallow clone / unpushed" message.
+      revisionRange = 'HEAD';
+      baselineUnreachable = true;
+    }
+
+    // previousVersion is shown to users in the changelog header — strip the baseline-tag scheme back
+    // to its consumer-facing form so `release/v0.22.0` appears as `v0.22.0`. Omit it when we fell
+    // back to all-history so the changelog doesn't claim a baseline it never diffed against (#339).
+    const previousVersion =
+      changelogBaseTag && !baselineUnreachable
+        ? displayTag(changelogBaseTag, input.baselineTagPrefix, input.formattedPrefix)
+        : null;
+
+    return { revisionRange, previousVersion, baselineUnreachable };
+  }
+
+  /**
+   * Repo-level shared floor (C): the range for project-wide "shared" entries (CI, infra, shared
+   * packages). For a package whose own range collapsed to `'HEAD'` (untagged, or tag unreachable,
+   * with no baseRef), bound it by the most recent tag reachable from HEAD rather than flooding the
+   * shared section with full history (#348). Computed once per run and reused.
+   *
+   * Uses `git describe` (prefix-agnostic, reachable by construction) — NOT the semver-tag lookup,
+   * which only matches bare-semver tags and collapses to full history in per-package-tag monorepos.
+   */
+  sharedFloor(perPackageRange: string): string {
+    if (perPackageRange !== 'HEAD' || this.opts.baseRef) return perPackageRange;
+    if (this.sharedBaselineRange === undefined) {
+      const globalTag = getNearestReachableTag(this.opts.sharedFloorCwd ?? process.cwd());
+      this.sharedBaselineRange = globalTag ? `${globalTag}..HEAD` : 'HEAD';
+    }
+    return this.sharedBaselineRange;
+  }
+}

--- a/packages/version/src/core/groupStrategy.ts
+++ b/packages/version/src/core/groupStrategy.ts
@@ -24,17 +24,10 @@ import { shouldMatchPackageTargets, shouldProcessPackage as shouldProcessPackage
 import semver from 'semver';
 import { extractChangelogEntriesFromCommits } from '../changelog/commitParser.js';
 import { BaseVersionError } from '../errors/baseError.js';
-import { execSync } from '../git/commandExecutor.js';
 import { getLatestTag, getLatestTagForPackage } from '../git/tagsAndBranches.js';
 import { updatePackageVersion } from '../package/packageManagement.js';
 import type { Config } from '../types.js';
-import {
-  deriveBaselineTagPrefix,
-  displayTag,
-  formatCommitMessage,
-  formatTag,
-  formatVersionPrefix,
-} from '../utils/formatting.js';
+import { deriveBaselineTagPrefix, formatCommitMessage, formatTag, formatVersionPrefix } from '../utils/formatting.js';
 import {
   addBaselineTag,
   addChangelogData,
@@ -45,6 +38,7 @@ import {
   setVersioningStrategy,
 } from '../utils/jsonOutput.js';
 import { log } from '../utils/logging.js';
+import { BaselineResolver } from './baselineResolver.js';
 import { expandTargetsForFixedGroups, type ResolvedGroup, resolveGroups } from './groupResolution.js';
 import { calculateVersion } from './versionCalculator.js';
 import type { PackagesWithRoot } from './versionEngine.js';
@@ -76,6 +70,8 @@ interface MemberPlan {
   baseline: string;
   /** The tag the changelog/revision range is computed against, or '' when none. */
   latestTag: string;
+  /** Whether `latestTag` came from this package's own series (vs. the global fallback). */
+  usedPackageSpecificTag: boolean;
   /** Version this member would bump to on its own ('' when it earned no releasable change). */
   ownNext: string;
   /** Whether this member earned a releasable change. */
@@ -101,11 +97,13 @@ async function planMember(
   const name = pkg.packageJson.name;
 
   let latestTag = '';
+  let usedPackageSpecificTag = false;
   if (!config.baselineTagTemplate) {
     latestTag = await getLatestTagForPackage(name, formattedPrefix, {
       tagTemplate: config.tagTemplate,
       packageSpecificTags: config.packageSpecificTags,
     });
+    usedPackageSpecificTag = !!latestTag;
   }
   if (!latestTag) latestTag = globalTag;
 
@@ -127,7 +125,7 @@ async function planMember(
   const candidates = [manifestVersion, tagVersion].map(cleanBaseline).filter((v) => v !== '0.0.0');
   const baseline = candidates.length > 0 ? candidates.sort(semver.rcompare)[0] : '0.0.0';
 
-  return { pkg, baseline, latestTag, ownNext, changed: !!ownNext };
+  return { pkg, baseline, latestTag, usedPackageSpecificTag, ownNext, changed: !!ownNext };
 }
 
 /** Derive the bump magnitude a member earned by comparing its computed next version to baseline. */
@@ -207,52 +205,42 @@ function readRepoUrl(pkgDir: string): string | null {
   }
 }
 
-function extractEntries(
-  pkgDir: string,
-  latestTag: string,
-  version: string,
-  config: Config,
-): {
-  entries: ChangelogEntry[];
-  revisionRange: string;
-  baselineUnreachable: boolean;
-} {
+async function extractEntries(
+  resolver: BaselineResolver,
+  input: {
+    pkgDir: string;
+    latestTag: string;
+    usedPackageSpecificTag: boolean;
+    nextVersion: string;
+    graduationName: string;
+    baselineTagPrefix: string | undefined;
+    formattedPrefix: string;
+  },
+): Promise<{ entries: ChangelogEntry[]; revisionRange: string; previousVersion: string | null }> {
   let revisionRange = 'HEAD';
   let entries: ChangelogEntry[] = [];
-  let baselineUnreachable = false;
+  let previousVersion: string | null = null;
   try {
-    const baseForRange = config.baseRef ?? latestTag;
-    if (baseForRange) {
-      try {
-        execSync('git', ['rev-parse', '--verify', baseForRange], { cwd: pkgDir, stdio: 'ignore' });
-        revisionRange = `${baseForRange}..HEAD`;
-      } catch {
-        if (!config.baseRef && config.strictReachable) {
-          throw new Error(
-            `Cannot generate changelog: ref '${baseForRange}' is not reachable from the current commit. ` +
-              'When strictReachable is enabled, all refs must be reachable.',
-          );
-        }
-        // Loud, not silent: this produces a whole-history changelog (#339). Callers omit
-        // previousVersion when this fires so the changelog doesn't claim an undiffed baseline.
-        log(
-          `Baseline ref '${baseForRange}' could not be verified from HEAD — generating the changelog from ALL ` +
-            `history instead of since the last release. The ref is likely missing from the checkout (shallow ` +
-            `clone, or never pushed). ${config.baseRef ? 'Fetch/push the ref to make it available in this checkout.' : 'Fetch/push the tag, or set version.baseRef, to bound the changelog.'}`,
-          'warning',
-        );
-        revisionRange = 'HEAD';
-        baselineUnreachable = true;
-      }
-    }
-    entries = extractChangelogEntriesFromCommits(pkgDir, revisionRange);
+    const baseline = await resolver.resolve({
+      pkgDir: input.pkgDir,
+      latestTag: input.latestTag,
+      hasRealTag: input.latestTag !== '',
+      usedPackageSpecificTag: input.usedPackageSpecificTag,
+      nextVersion: input.nextVersion,
+      graduationName: input.graduationName,
+      baselineTagPrefix: input.baselineTagPrefix,
+      formattedPrefix: input.formattedPrefix,
+    });
+    revisionRange = baseline.revisionRange;
+    previousVersion = baseline.previousVersion;
+    entries = extractChangelogEntriesFromCommits(input.pkgDir, revisionRange);
   } catch (error) {
     log(`Error extracting changelog entries: ${error instanceof Error ? error.message : String(error)}`, 'warning');
   }
   if (entries.length === 0) {
-    entries = [{ type: 'changed', description: `Update version to ${version}` }];
+    entries = [{ type: 'changed', description: `Update version to ${input.nextVersion}` }];
   }
-  return { entries, revisionRange, baselineUnreachable };
+  return { entries, revisionRange, previousVersion };
 }
 
 /**
@@ -260,7 +248,12 @@ function extractEntries(
  * changelog data, and tag each update with the group name for downstream CI surfaces.
  * Returns the names of the packages that were written (for commit-message aggregation).
  */
-function releaseGroup(group: ResolvedGroup, computation: GroupComputation, config: Config): string[] {
+async function releaseGroup(
+  group: ResolvedGroup,
+  computation: GroupComputation,
+  config: Config,
+  baselineResolver: BaselineResolver,
+): Promise<string[]> {
   const { groupVersion, releasing } = computation;
   const formattedPrefix = formatVersionPrefix(config.versionPrefix || 'v');
   const released: string[] = [];
@@ -313,17 +306,19 @@ function releaseGroup(group: ResolvedGroup, computation: GroupComputation, confi
     setPackageUpdateGroup(name, group.name);
 
     const baselineTagPrefix = deriveBaselineTagPrefix(config.baselineTagTemplate, formattedPrefix, name);
-    const { entries, revisionRange, baselineUnreachable } = extractEntries(
-      pkg.dir,
-      plan.latestTag,
-      groupVersion,
-      config,
-    );
+    const { entries, revisionRange, previousVersion } = await extractEntries(baselineResolver, {
+      pkgDir: pkg.dir,
+      latestTag: plan.latestTag,
+      usedPackageSpecificTag: plan.usedPackageSpecificTag,
+      nextVersion: groupVersion,
+      graduationName: name,
+      baselineTagPrefix,
+      formattedPrefix,
+    });
     addChangelogData({
       packageName: name,
       version: groupVersion,
-      previousVersion:
-        plan.latestTag && !baselineUnreachable ? displayTag(plan.latestTag, baselineTagPrefix, formattedPrefix) : null,
+      previousVersion,
       revisionRange,
       repoUrl: readRepoUrl(pkg.dir),
       entries,
@@ -355,6 +350,13 @@ export function createGroupStrategy(config: Config): (packages: PackagesWithRoot
       setVersioningStrategy('group');
       const formattedPrefix = formatVersionPrefix(config.versionPrefix || 'v');
       const globalTag = await getLatestTag(deriveBaselineTagPrefix(config.baselineTagTemplate, formattedPrefix));
+      const baselineResolver = new BaselineResolver({
+        versionPrefix: formattedPrefix,
+        tagTemplate: config.tagTemplate,
+        packageSpecificTags: config.packageSpecificTags ?? false,
+        strictReachable: config.strictReachable ?? false,
+        baseRef: config.baseRef,
+      });
 
       const resolution = resolveGroups(config, packages.packages);
 
@@ -402,7 +404,7 @@ export function createGroupStrategy(config: Config): (packages: PackagesWithRoot
             `${computation.groupVersion}.`,
           'info',
         );
-        const released = releaseGroup(group, computation, config);
+        const released = await releaseGroup(group, computation, config, baselineResolver);
         for (const name of released) {
           allReleased.push(name);
           allVersions.set(name, computation.groupVersion);
@@ -428,19 +430,19 @@ export function createGroupStrategy(config: Config): (packages: PackagesWithRoot
         addTag(tag);
         setPackageUpdateTag(name, tag);
         const baselineTagPrefix = deriveBaselineTagPrefix(config.baselineTagTemplate, formattedPrefix, name);
-        const { entries, revisionRange, baselineUnreachable } = extractEntries(
-          pkg.dir,
-          plan.latestTag,
-          plan.ownNext,
-          config,
-        );
+        const { entries, revisionRange, previousVersion } = await extractEntries(baselineResolver, {
+          pkgDir: pkg.dir,
+          latestTag: plan.latestTag,
+          usedPackageSpecificTag: plan.usedPackageSpecificTag,
+          nextVersion: plan.ownNext,
+          graduationName: name,
+          baselineTagPrefix,
+          formattedPrefix,
+        });
         addChangelogData({
           packageName: name,
           version: plan.ownNext,
-          previousVersion:
-            plan.latestTag && !baselineUnreachable
-              ? displayTag(plan.latestTag, baselineTagPrefix, formattedPrefix)
-              : null,
+          previousVersion,
           revisionRange,
           repoUrl: readRepoUrl(pkg.dir),
           entries,

--- a/packages/version/src/core/groupStrategy.ts
+++ b/packages/version/src/core/groupStrategy.ts
@@ -210,6 +210,7 @@ async function extractEntries(
   input: {
     pkgDir: string;
     latestTag: string;
+    hasRealTag: boolean;
     usedPackageSpecificTag: boolean;
     nextVersion: string;
     graduationName: string;
@@ -224,7 +225,7 @@ async function extractEntries(
     const baseline = await resolver.resolve({
       pkgDir: input.pkgDir,
       latestTag: input.latestTag,
-      hasRealTag: input.latestTag !== '',
+      hasRealTag: input.hasRealTag,
       usedPackageSpecificTag: input.usedPackageSpecificTag,
       nextVersion: input.nextVersion,
       graduationName: input.graduationName,
@@ -309,6 +310,7 @@ async function releaseGroup(
     const { entries, revisionRange, previousVersion } = await extractEntries(baselineResolver, {
       pkgDir: pkg.dir,
       latestTag: plan.latestTag,
+      hasRealTag: plan.latestTag !== '',
       usedPackageSpecificTag: plan.usedPackageSpecificTag,
       nextVersion: groupVersion,
       graduationName: name,
@@ -433,6 +435,7 @@ export function createGroupStrategy(config: Config): (packages: PackagesWithRoot
         const { entries, revisionRange, previousVersion } = await extractEntries(baselineResolver, {
           pkgDir: pkg.dir,
           latestTag: plan.latestTag,
+          hasRealTag: plan.latestTag !== '',
           usedPackageSpecificTag: plan.usedPackageSpecificTag,
           nextVersion: plan.ownNext,
           graduationName: name,

--- a/packages/version/src/core/versionStrategies.ts
+++ b/packages/version/src/core/versionStrategies.ts
@@ -10,18 +10,11 @@ import { shouldMatchPackageTargets, shouldProcessPackage as shouldProcessPackage
 import { extractChangelogEntriesFromCommits } from '../changelog/commitParser.js';
 import { BaseVersionError } from '../errors/baseError.js';
 import { createVersionError, VersionErrorCode } from '../errors/versionError.js';
-import { execSync } from '../git/commandExecutor.js';
 import { getLatestTag, getLatestTagForPackage } from '../git/tagsAndBranches.js';
 import { updatePackageVersion } from '../package/packageManagement.js';
 import { PackageProcessor } from '../package/packageProcessor.js';
 import type { Config } from '../types.js';
-import {
-  deriveBaselineTagPrefix,
-  displayTag,
-  formatCommitMessage,
-  formatTag,
-  formatVersionPrefix,
-} from '../utils/formatting.js';
+import { deriveBaselineTagPrefix, formatCommitMessage, formatTag, formatVersionPrefix } from '../utils/formatting.js';
 import {
   addBaselineTag,
   addChangelogData,
@@ -31,6 +24,7 @@ import {
   setVersioningStrategy,
 } from '../utils/jsonOutput.js';
 import { log } from '../utils/logging.js';
+import { BaselineResolver } from './baselineResolver.js';
 import { hasExplicitGroups } from './groupResolution.js';
 import { createGroupStrategy } from './groupStrategy.js';
 import { calculateVersion } from './versionCalculator.js';
@@ -174,6 +168,7 @@ export function createSyncStrategy(config: Config): StrategyFunction {
       // source for the previous release in that mode, and overwriting it with a consumer-facing
       // tag (which may have been force-moved off the source branch) would re-introduce the
       // exact unreachable-tag regression baselineTagTemplate exists to fix.
+      let usedPackageSpecificTag = false;
       if (versionSourceName && !config.baselineTagTemplate) {
         const packageSpecificTag = await getLatestTagForPackage(versionSourceName, formattedPrefix, {
           tagTemplate,
@@ -182,6 +177,7 @@ export function createSyncStrategy(config: Config): StrategyFunction {
 
         if (packageSpecificTag) {
           latestTag = packageSpecificTag;
+          usedPackageSpecificTag = true;
           log(`Using package-specific tag for ${versionSourceName}: ${latestTag}`, 'debug');
         } else {
           log(`No package-specific tag found for ${versionSourceName}, using global tag: ${latestTag}`, 'debug');
@@ -282,60 +278,42 @@ export function createSyncStrategy(config: Config): StrategyFunction {
         return;
       }
 
+      // Resolve the changelog floor (range, reachability, prerelease→stable graduation).
+      const baselineResolver = new BaselineResolver({
+        versionPrefix: formattedPrefix,
+        tagTemplate,
+        packageSpecificTags: config.packageSpecificTags ?? false,
+        strictReachable: config.strictReachable ?? false,
+        baseRef: config.baseRef,
+      });
+
       // Extract changelog entries from commits
       let changelogEntries: ChangelogEntry[] = [];
       let revisionRange = 'HEAD';
-      let baselineUnreachable = false;
+      let previousVersion: string | null = null;
 
       try {
-        const baseForRange = config.baseRef ?? latestTag;
-        if (baseForRange) {
-          try {
-            execSync('git', ['rev-parse', '--verify', baseForRange], {
-              cwd: mainPkgPath,
-              stdio: 'ignore',
-            });
-            revisionRange = `${baseForRange}..HEAD`;
-          } catch {
-            if (!config.baseRef && config.strictReachable) {
-              throw new Error(
-                `Cannot generate changelog: tag '${baseForRange}' is not reachable from the current commit. ` +
-                  `When strictReachable is enabled, all tags must be reachable. ` +
-                  `To allow fallback to all commits, set strictReachable to false.`,
-              );
-            }
-            // Loud, not debug: this silently produces a whole-history changelog (#339). The resolved
-            // baseline exists as a ref but won't verify from HEAD — usually a shallow clone or an
-            // unpushed tag. Omit previousVersion below so the changelog doesn't claim this baseline.
-            log(
-              `Baseline ref '${baseForRange}' could not be verified from HEAD — generating the changelog from ALL ` +
-                `history instead of since the last release. The ref is likely missing from the checkout (shallow ` +
-                `clone, or never pushed). ${config.baseRef ? 'Fetch/push the ref to make it available in this checkout.' : 'Fetch/push the tag, or set version.baseRef, to bound the changelog.'}`,
-              'warning',
-            );
-            revisionRange = 'HEAD';
-            baselineUnreachable = true;
-          }
-        }
+        const baseline = await baselineResolver.resolve({
+          pkgDir: mainPkgPath,
+          latestTag,
+          hasRealTag: latestTag !== '',
+          usedPackageSpecificTag,
+          nextVersion,
+          graduationName: versionSourceName,
+          baselineTagPrefix,
+          formattedPrefix,
+        });
+        revisionRange = baseline.revisionRange;
+        previousVersion = baseline.previousVersion;
 
         changelogEntries = extractChangelogEntriesFromCommits(mainPkgPath, revisionRange);
 
         if (changelogEntries.length === 0) {
-          changelogEntries = [
-            {
-              type: 'changed',
-              description: `Update version to ${nextVersion}`,
-            },
-          ];
+          changelogEntries = [{ type: 'changed', description: `Update version to ${nextVersion}` }];
         }
       } catch (error) {
         log(`Error extracting changelog entries: ${error instanceof Error ? error.message : String(error)}`, 'warning');
-        changelogEntries = [
-          {
-            type: 'changed',
-            description: `Update version to ${nextVersion}`,
-          },
-        ];
+        changelogEntries = [{ type: 'changed', description: `Update version to ${nextVersion}` }];
       }
 
       // Build the commit message package name from all updated workspace packages.
@@ -379,8 +357,8 @@ export function createSyncStrategy(config: Config): StrategyFunction {
       // publish pipeline can match tags to the right release notes.
       // Omit previousVersion when we fell back to all-history (#339): claiming a baseline the
       // changelog never diffed against produces a self-contradictory "since <tag>" + full log.
-      const displayPrevious =
-        latestTag && !baselineUnreachable ? displayTag(latestTag, baselineTagPrefix, formattedPrefix) : null;
+      // previousVersion is resolved by BaselineResolver (null when we fell back to all-history, #339).
+      const displayPrevious = previousVersion;
       if (config.packageSpecificTags && workspaceNames.length > 0) {
         for (const pkgName of workspaceNames) {
           addChangelogData({
@@ -524,6 +502,9 @@ export function createSingleStrategy(config: Config): StrategyFunction {
         tagTemplate,
         packageSpecificTags: config.packageSpecificTags,
       });
+      // Whether the floor tag came from this package's own series — decides which stable-tag
+      // lookup graduation uses (must match latestTag's source).
+      const usedPackageSpecificTag = !!latestTagResult;
 
       // Fallback to global tag if no package-specific tag exists
       if (!latestTagResult) {
@@ -554,63 +535,45 @@ export function createSingleStrategy(config: Config): StrategyFunction {
         return;
       }
 
+      // Resolve the changelog floor (range, reachability, prerelease→stable graduation) for this package.
+      const baselineResolver = new BaselineResolver({
+        versionPrefix: formattedPrefix,
+        tagTemplate,
+        packageSpecificTags: config.packageSpecificTags ?? false,
+        strictReachable: config.strictReachable ?? false,
+        baseRef: config.baseRef,
+      });
+
       // Generate changelog entries from conventional commits
       let changelogEntries: ChangelogEntry[] = [];
       let revisionRange = 'HEAD';
-      let baselineUnreachable = false;
+      let previousVersion: string | null = null;
 
       try {
-        const baseForRange = config.baseRef ?? latestTag;
-        if (baseForRange) {
-          try {
-            execSync('git', ['rev-parse', '--verify', baseForRange], {
-              cwd: pkgPath,
-              stdio: 'ignore',
-            });
-            revisionRange = `${baseForRange}..HEAD`;
-          } catch {
-            if (!config.baseRef && config.strictReachable) {
-              throw new Error(
-                `Cannot generate changelog: tag '${baseForRange}' is not reachable from the current commit. ` +
-                  `When strictReachable is enabled, all tags must be reachable. ` +
-                  `To allow fallback to all commits, set strictReachable to false.`,
-              );
-            }
-            // Loud, not debug: this silently produces a whole-history changelog (#339). The resolved
-            // baseline exists as a ref but won't verify from HEAD — usually a shallow clone or an
-            // unpushed tag. Omit previousVersion below so the changelog doesn't claim this baseline.
-            log(
-              `Baseline ref '${baseForRange}' could not be verified from HEAD — generating the changelog from ALL ` +
-                `history instead of since the last release. The ref is likely missing from the checkout (shallow ` +
-                `clone, or never pushed). ${config.baseRef ? 'Fetch/push the ref to make it available in this checkout.' : 'Fetch/push the tag, or set version.baseRef, to bound the changelog.'}`,
-              'warning',
-            );
-            revisionRange = 'HEAD';
-            baselineUnreachable = true;
-          }
-        }
+        const baseline = await baselineResolver.resolve({
+          pkgDir: pkgPath,
+          latestTag,
+          hasRealTag: latestTag !== '',
+          usedPackageSpecificTag,
+          nextVersion,
+          graduationName: packageName,
+          baselineTagPrefix,
+          formattedPrefix,
+        });
+        revisionRange = baseline.revisionRange;
+        previousVersion = baseline.previousVersion;
 
         changelogEntries = extractChangelogEntriesFromCommits(pkgPath, revisionRange);
 
         // If we have no entries but we're definitely changing versions,
         // add a minimal entry about the version change
         if (changelogEntries.length === 0) {
-          changelogEntries = [
-            {
-              type: 'changed',
-              description: `Update version to ${nextVersion}`,
-            },
-          ];
+          changelogEntries = [{ type: 'changed', description: `Update version to ${nextVersion}` }];
         }
       } catch (error) {
         log(`Error extracting changelog entries: ${error instanceof Error ? error.message : String(error)}`, 'warning');
         // Fall back to minimal entry
-        changelogEntries = [
-          {
-            type: 'changed',
-            description: `Update version to ${nextVersion}`,
-          },
-        ];
+        changelogEntries = [{ type: 'changed', description: `Update version to ${nextVersion}` }];
       }
 
       // Determine repo URL from package.json or git config
@@ -639,13 +602,12 @@ export function createSingleStrategy(config: Config): StrategyFunction {
         );
       }
 
-      // Track changelog data for JSON output. Omit previousVersion when we fell back to all-history
-      // (#339) so the changelog doesn't claim a baseline it never diffed against.
+      // Track changelog data for JSON output. previousVersion is resolved by BaselineResolver and is
+      // null when we fell back to all-history (#339) so the changelog doesn't claim an undiffed baseline.
       addChangelogData({
         packageName,
         version: nextVersion,
-        previousVersion:
-          latestTag && !baselineUnreachable ? displayTag(latestTag, baselineTagPrefix, formattedPrefix) : null,
+        previousVersion,
         revisionRange,
         repoUrl: repoUrl || null,
         entries: changelogEntries,

--- a/packages/version/src/core/versionStrategies.ts
+++ b/packages/version/src/core/versionStrategies.ts
@@ -278,7 +278,6 @@ export function createSyncStrategy(config: Config): StrategyFunction {
         return;
       }
 
-      // Resolve the changelog floor (range, reachability, prerelease→stable graduation).
       const baselineResolver = new BaselineResolver({
         versionPrefix: formattedPrefix,
         tagTemplate,
@@ -535,7 +534,6 @@ export function createSingleStrategy(config: Config): StrategyFunction {
         return;
       }
 
-      // Resolve the changelog floor (range, reachability, prerelease→stable graduation) for this package.
       const baselineResolver = new BaselineResolver({
         versionPrefix: formattedPrefix,
         tagTemplate,

--- a/packages/version/src/package/packageProcessor.ts
+++ b/packages/version/src/package/packageProcessor.ts
@@ -4,22 +4,11 @@ import type { Package } from '@manypkg/get-packages';
 import type { VersionChangelogEntry } from '@releasekit/core';
 import { shouldProcessPackage } from '@releasekit/core';
 import { extractChangelogEntriesFromCommits, extractRepoLevelChangelogEntries } from '../changelog/commitParser.js';
+import { BaselineResolver } from '../core/baselineResolver.js';
 import { calculateVersion } from '../core/versionCalculator.js';
-import {
-  getLatestStableTag,
-  getLatestStableTagForPackage,
-  getLatestTagForPackage,
-  getNearestReachableTag,
-} from '../git/tagsAndBranches.js';
-import { verifyTag } from '../git/tagVerification.js';
+import { getLatestTagForPackage } from '../git/tagsAndBranches.js';
 import type { Config, VersionConfigBase } from '../types.js';
-import {
-  deriveBaselineTagPrefix,
-  displayTag,
-  formatCommitMessage,
-  formatTag,
-  formatVersionPrefix,
-} from '../utils/formatting.js';
+import { deriveBaselineTagPrefix, formatCommitMessage, formatTag, formatVersionPrefix } from '../utils/formatting.js';
 import {
   addChangelogData,
   addTag,
@@ -29,7 +18,6 @@ import {
 } from '../utils/jsonOutput.js';
 import { log } from '../utils/logging.js';
 import { getVersionFromManifests } from '../utils/manifestHelpers.js';
-import { isStableTag, isStableVersion } from '../utils/versionUtils.js';
 import { updatePackageVersion } from './packageManagement.js';
 
 type ChangelogEntry = VersionChangelogEntry;
@@ -114,12 +102,17 @@ export class PackageProcessor {
     // Accumulate repo-level entries across all packages (keyed by type+description to deduplicate)
     const sharedEntriesMap = new Map<string, ChangelogEntry>();
 
-    // (#348) Lazy-computed floor for repo-level changelog entries. When an untagged package's
-    // per-package revisionRange is 'HEAD' (all history), passing that same range to
-    // extractRepoLevelChangelogEntries floods "Project-wide changes" with the full git history.
-    // Bound it by the most recent release tag reachable from HEAD instead, computed on first
-    // need and shared across all packages in this run.
-    let _sharedBaselineRange: string | undefined;
+    // BaselineResolver owns the per-package changelog floor (B) and the repo-level shared floor (C),
+    // constructed once per run so the nearest-reachable shared floor (#348) is computed a single time
+    // and reused across packages.
+    const baselineResolver = new BaselineResolver({
+      versionPrefix: this.versionPrefix,
+      tagTemplate: this.tagTemplate,
+      packageSpecificTags: this.fullConfig.packageSpecificTags ?? false,
+      strictReachable: this.config.strictReachable ?? false,
+      baseRef: this.fullConfig.baseRef,
+      sharedFloorCwd: process.cwd(),
+    });
 
     for (const pkg of pkgsToConsider) {
       const name = pkg.packageJson.name;
@@ -202,22 +195,9 @@ export class PackageProcessor {
         continue; // No version change calculated for this package
       }
 
-      // When a prerelease graduates to stable, aggregate the changelog from the last *stable* tag
-      // rather than from `latestTag` (the prerelease, which usually holds only the release-prep
-      // commit). `latestTag` still drives version calculation above — it must see the prerelease to
-      // graduate correctly. With no prior stable tag (first stable release), `changelogBaseTag` is
-      // '' and the range falls through to all commits.
-      let changelogBaseTag = latestTag;
-      if (hasRealTag && latestTag && isStableVersion(nextVersion) && !isStableTag(latestTag)) {
-        // Follow latestTag's source (package series vs global) — the other lookup returns '' here
-        // and would over-include every commit.
-        changelogBaseTag = usedPackageSpecificTag
-          ? await getLatestStableTagForPackage(name, this.versionPrefix, {
-              tagTemplate: this.tagTemplate,
-              packageSpecificTags: true,
-            })
-          : await getLatestStableTag(this.versionPrefix);
-      }
+      // previousVersion is shown to users in the changelog header — strip the baseline-tag scheme
+      // back to its consumer-facing form so `release/v0.22.0` appears as `v0.22.0`.
+      const baselineTagPrefix = deriveBaselineTagPrefix(this.fullConfig.baselineTagTemplate, formattedPrefix, name);
 
       // #334: a package with no prior git tag has its changelog computed from the FULL git history,
       // which in standing-PR mode can push the rendered PR body past GitHub's 65,536-char limit and
@@ -237,50 +217,25 @@ export class PackageProcessor {
         );
       }
 
-      // Generate changelog entries from conventional commits
+      // Generate changelog entries from conventional commits. The changelog floor (range,
+      // reachability, prerelease→stable graduation) is resolved by BaselineResolver.
       let changelogEntries: ChangelogEntry[] = [];
       let revisionRange = 'HEAD';
-      let baselineUnreachable = false;
+      let previousVersion: string | null = null;
 
       try {
-        // Extract entries from commits between the base ref (or latest tag) and HEAD.
-        // baseRef takes precedence — it's a PR base SHA supplied in advisory standing-pr mode
-        // so the changelog is scoped to only this PR's commits, not all commits since last tag.
-        const baseForRange = this.fullConfig.baseRef ?? changelogBaseTag;
-        if (baseForRange && (this.fullConfig.baseRef || hasRealTag)) {
-          // A real tag (or an explicit baseRef) — verify it. A failure here is the #339 case: the
-          // ref genuinely exists but isn't reachable in this checkout (shallow clone / unpushed).
-          const verification = verifyTag(baseForRange, pkgPath);
-          if (verification.exists && verification.reachable) {
-            revisionRange = `${baseForRange}..HEAD`;
-          } else {
-            if (!this.fullConfig.baseRef && this.config.strictReachable) {
-              throw new Error(
-                `Cannot generate changelog: ref '${baseForRange}' is not reachable from the current commit. ` +
-                  `When strictReachable is enabled, all refs must be reachable. ` +
-                  `To allow fallback to all commits, set strictReachable to false.`,
-              );
-            }
-            // Loud, not debug: this silently produces a whole-history changelog (#339) — both this
-            // package's entries and the repo-level entries below. Omit previousVersion so the
-            // changelog doesn't claim a baseline it never diffed against.
-            log(
-              `Baseline ref '${baseForRange}' could not be verified from HEAD (${verification.error}) — generating ` +
-                `the changelog from ALL history instead of since the last release. The ref is likely missing from the ` +
-                `checkout (shallow clone, or never pushed). ${this.fullConfig.baseRef ? 'Fetch/push the ref to make it available in this checkout.' : 'Fetch/push the tag, or set version.baseRef, to bound it.'}`,
-              'warning',
-            );
-            revisionRange = 'HEAD';
-            baselineUnreachable = true;
-          }
-        } else if (baseForRange) {
-          // No real tag — `baseForRange` is the manifest-fallback's synthetic tag, which isn't a git
-          // ref. The #334 warning above already explained the full-history changelog accurately, so
-          // skip verifyTag here: running it would emit a second, misleading "could not be verified —
-          // shallow clone / unpushed" message about a tag that never existed.
-          revisionRange = 'HEAD';
-          baselineUnreachable = true;
-        }
+        const baseline = await baselineResolver.resolve({
+          pkgDir: pkgPath,
+          latestTag,
+          hasRealTag,
+          usedPackageSpecificTag,
+          nextVersion,
+          graduationName: name,
+          baselineTagPrefix,
+          formattedPrefix,
+        });
+        revisionRange = baseline.revisionRange;
+        previousVersion = baseline.previousVersion;
 
         changelogEntries = extractChangelogEntriesFromCommits(pkgPath, revisionRange);
 
@@ -293,22 +248,10 @@ export class PackageProcessor {
         const sharedPackageDirs = packages
           .filter((p) => sharedPackageNames.includes(p.packageJson.name))
           .map((p) => p.dir);
-        // Use the tighter of the per-package range (already bounded for tagged packages)
-        // or the global baseline floor — applies to untagged packages and to packages whose
-        // tag exists but is unreachable (shallow clone, #339), both of which produce revisionRange='HEAD'.
-        let sharedRevisionRange = revisionRange;
-        if (revisionRange === 'HEAD' && !this.fullConfig.baseRef) {
-          if (_sharedBaselineRange === undefined) {
-            // Most recent tag reachable from HEAD as the baseline floor — NOT `this.getLatestTag()`,
-            // which goes through git-semver-tags and only matches bare-semver tags. In monorepos that
-            // tag per package (`pkg@vX.Y.Z`) it returns '' and the floor wrongly collapsed to full
-            // history (#348). `git describe` is prefix-agnostic and reachable by construction, so the
-            // separate verifyTag check is no longer needed.
-            const globalTag = getNearestReachableTag(process.cwd());
-            _sharedBaselineRange = globalTag ? `${globalTag}..HEAD` : 'HEAD';
-          }
-          sharedRevisionRange = _sharedBaselineRange;
-        }
+        // Bound the repo-level ("shared") entries by the run's nearest-reachable floor when this
+        // package's own range collapsed to full history (untagged / unreachable), so a single
+        // untagged package doesn't flood "Project-wide changes" with the entire history (#348).
+        const sharedRevisionRange = baselineResolver.sharedFloor(revisionRange);
 
         const repoLevelEntries = extractRepoLevelChangelogEntries(
           pkgPath,
@@ -373,17 +316,12 @@ export class PackageProcessor {
         );
       }
 
-      // Track changelog data for JSON output. previousVersion is shown to users in the
-      // changelog header — strip the baseline-tag scheme back to its consumer-facing form
-      // so `release/v0.22.0` appears as `v0.22.0` rather than leaking the internal marker.
-      const baselineTagPrefix = deriveBaselineTagPrefix(this.fullConfig.baselineTagTemplate, formattedPrefix, name);
+      // Track changelog data for JSON output. previousVersion is resolved by BaselineResolver (the
+      // floor tag in consumer-facing display form, null when we fell back to all-history, #339).
       addChangelogData({
         packageName: name,
         version: nextVersion,
-        previousVersion:
-          changelogBaseTag && !baselineUnreachable
-            ? displayTag(changelogBaseTag, baselineTagPrefix, formattedPrefix)
-            : null,
+        previousVersion,
         revisionRange,
         repoUrl: repoUrl || null,
         entries: changelogEntries,

--- a/packages/version/test/unit/core/baselineResolver.spec.ts
+++ b/packages/version/test/unit/core/baselineResolver.spec.ts
@@ -1,0 +1,172 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { BaselineResolver, type BaselineResolverOptions } from '../../../src/core/baselineResolver.js';
+import {
+  getLatestStableTag,
+  getLatestStableTagForPackage,
+  getNearestReachableTag,
+} from '../../../src/git/tagsAndBranches.js';
+import { verifyTag } from '../../../src/git/tagVerification.js';
+
+// Mock only the git seams. displayTag (formatting) and isStableVersion/isStableTag (versionUtils)
+// are pure and left real so graduation + display logic is genuinely exercised.
+vi.mock('../../../src/git/tagVerification.js');
+vi.mock('../../../src/git/tagsAndBranches.js');
+vi.mock('../../../src/utils/logging.js');
+
+const reachable = { exists: true, reachable: true } as const;
+const unreachable = { exists: true, reachable: false, error: 'exists but is not an ancestor of HEAD' } as const;
+
+function makeOpts(overrides: Partial<BaselineResolverOptions> = {}): BaselineResolverOptions {
+  return { versionPrefix: 'v', packageSpecificTags: false, strictReachable: false, ...overrides };
+}
+
+function makeInput(overrides: Partial<Parameters<BaselineResolver['resolve']>[0]> = {}) {
+  return {
+    pkgDir: '/repo',
+    latestTag: 'v1.0.0',
+    hasRealTag: true,
+    usedPackageSpecificTag: false,
+    nextVersion: '1.1.0',
+    graduationName: 'pkg',
+    baselineTagPrefix: undefined,
+    formattedPrefix: 'v',
+    ...overrides,
+  };
+}
+
+describe('BaselineResolver.resolve', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should bound the range by a reachable tag and surface it as previousVersion', async () => {
+    vi.mocked(verifyTag).mockReturnValue(reachable);
+    const result = await new BaselineResolver(makeOpts()).resolve(makeInput());
+    expect(result.revisionRange).toBe('v1.0.0..HEAD');
+    expect(result.previousVersion).toBe('v1.0.0');
+    expect(result.baselineUnreachable).toBe(false);
+  });
+
+  it('should fall back to full history and null previousVersion when the tag is unreachable (#339)', async () => {
+    vi.mocked(verifyTag).mockReturnValue(unreachable);
+    const result = await new BaselineResolver(makeOpts()).resolve(makeInput());
+    expect(result.revisionRange).toBe('HEAD');
+    expect(result.previousVersion).toBeNull();
+    expect(result.baselineUnreachable).toBe(true);
+  });
+
+  it('should throw on an unreachable baseline when strictReachable is set', async () => {
+    vi.mocked(verifyTag).mockReturnValue(unreachable);
+    await expect(new BaselineResolver(makeOpts({ strictReachable: true })).resolve(makeInput())).rejects.toThrow(
+      /not reachable/,
+    );
+  });
+
+  it('should not throw under strictReachable when baseRef is set (baseRef takes precedence)', async () => {
+    vi.mocked(verifyTag).mockReturnValue(unreachable);
+    const result = await new BaselineResolver(makeOpts({ strictReachable: true, baseRef: 'abc123' })).resolve(
+      makeInput(),
+    );
+    expect(result.revisionRange).toBe('HEAD');
+    expect(result.baselineUnreachable).toBe(true);
+  });
+
+  it('should use baseRef as the floor when set, overriding the tag', async () => {
+    vi.mocked(verifyTag).mockReturnValue(reachable);
+    const result = await new BaselineResolver(makeOpts({ baseRef: 'abc123' })).resolve(makeInput());
+    expect(verifyTag).toHaveBeenCalledWith('abc123', '/repo');
+    expect(result.revisionRange).toBe('abc123..HEAD');
+  });
+
+  it('should produce full history with no previousVersion for an untagged package', async () => {
+    const result = await new BaselineResolver(makeOpts()).resolve(makeInput({ latestTag: '', hasRealTag: false }));
+    expect(result.revisionRange).toBe('HEAD');
+    expect(result.previousVersion).toBeNull();
+    expect(result.baselineUnreachable).toBe(false);
+    expect(verifyTag).not.toHaveBeenCalled();
+  });
+
+  it('should treat a manifest-fallback synthetic tag as unreachable without calling git', async () => {
+    const result = await new BaselineResolver(makeOpts()).resolve(
+      makeInput({ latestTag: 'v1.2.3', hasRealTag: false }),
+    );
+    expect(result.revisionRange).toBe('HEAD');
+    expect(result.baselineUnreachable).toBe(true);
+    expect(result.previousVersion).toBeNull();
+    expect(verifyTag).not.toHaveBeenCalled();
+  });
+
+  it('should aggregate from the last stable tag when a prerelease graduates (global series)', async () => {
+    vi.mocked(verifyTag).mockReturnValue(reachable);
+    vi.mocked(getLatestStableTag).mockResolvedValue('v0.9.0');
+    const result = await new BaselineResolver(makeOpts()).resolve(
+      makeInput({ latestTag: 'v1.0.0-next.1', nextVersion: '1.0.0' }),
+    );
+    expect(getLatestStableTag).toHaveBeenCalledWith('v');
+    expect(result.revisionRange).toBe('v0.9.0..HEAD');
+    expect(result.previousVersion).toBe('v0.9.0');
+  });
+
+  it('should use the package-specific stable lookup on graduation when the tag came from that series', async () => {
+    vi.mocked(verifyTag).mockReturnValue(reachable);
+    vi.mocked(getLatestStableTagForPackage).mockResolvedValue('pkg@v0.9.0');
+    const result = await new BaselineResolver(makeOpts({ tagTemplate: '${packageName}@${prefix}${version}' })).resolve(
+      makeInput({ latestTag: 'pkg@v1.0.0-next.1', nextVersion: '1.0.0', usedPackageSpecificTag: true }),
+    );
+    expect(getLatestStableTagForPackage).toHaveBeenCalledWith('pkg', 'v', {
+      tagTemplate: '${packageName}@${prefix}${version}',
+      packageSpecificTags: true,
+    });
+    expect(result.revisionRange).toBe('pkg@v0.9.0..HEAD');
+  });
+
+  it('should fall through to full history when graduating with no prior stable tag', async () => {
+    vi.mocked(getLatestStableTag).mockResolvedValue('');
+    const result = await new BaselineResolver(makeOpts()).resolve(
+      makeInput({ latestTag: 'v1.0.0-next.1', nextVersion: '1.0.0' }),
+    );
+    expect(result.revisionRange).toBe('HEAD');
+    expect(result.previousVersion).toBeNull();
+    expect(verifyTag).not.toHaveBeenCalled();
+  });
+
+  it('should strip a baseline marker tag back to consumer form for previousVersion (#330)', async () => {
+    vi.mocked(verifyTag).mockReturnValue(reachable);
+    const result = await new BaselineResolver(makeOpts()).resolve(
+      makeInput({ latestTag: 'release/v1.2.3', nextVersion: '1.2.4', baselineTagPrefix: 'release/v' }),
+    );
+    expect(result.revisionRange).toBe('release/v1.2.3..HEAD');
+    expect(result.previousVersion).toBe('v1.2.3');
+  });
+});
+
+describe('BaselineResolver.sharedFloor', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should return a package range unchanged when it is already bounded', () => {
+    const resolver = new BaselineResolver(makeOpts());
+    expect(resolver.sharedFloor('v1.0.0..HEAD')).toBe('v1.0.0..HEAD');
+    expect(getNearestReachableTag).not.toHaveBeenCalled();
+  });
+
+  it('should bound a HEAD range by the nearest reachable tag and cache it (#348)', () => {
+    vi.mocked(getNearestReachableTag).mockReturnValue('v1.0.0');
+    const resolver = new BaselineResolver(makeOpts());
+    expect(resolver.sharedFloor('HEAD')).toBe('v1.0.0..HEAD');
+    expect(resolver.sharedFloor('HEAD')).toBe('v1.0.0..HEAD');
+    expect(getNearestReachableTag).toHaveBeenCalledTimes(1);
+  });
+
+  it('should stay at HEAD when no reachable tag exists', () => {
+    vi.mocked(getNearestReachableTag).mockReturnValue('');
+    expect(new BaselineResolver(makeOpts()).sharedFloor('HEAD')).toBe('HEAD');
+  });
+
+  it('should not apply a shared floor when baseRef scopes the run', () => {
+    const resolver = new BaselineResolver(makeOpts({ baseRef: 'abc123' }));
+    expect(resolver.sharedFloor('HEAD')).toBe('HEAD');
+    expect(getNearestReachableTag).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What

Consolidates the changelog-baseline floor logic — previously copy-pasted across four version strategies — into a single per-run `BaselineResolver` (`packages/version/src/core/baselineResolver.ts`).

- `resolve()` owns the **per-package floor (B)**: graduation-since-stable, `verifyTag` merge-base reachability, `strictReachable`, `previousVersion` display-stripping, and the `baselineUnreachable` signal.
- `sharedFloor()` owns the **repo-level floor (C)**, computed once per run and cached.

Adds `CONTEXT.md` documenting the three distinct baseline notions (version source / per-package floor / repo-level floor). Closes #356 — see the issue for the full grilled-design rationale.

## ⚠️ Behaviour change (intended)

Tracing the call sites revealed they had **drifted**, not merely duplicated: only the **async** path (`PackageProcessor`) carried the merge-base reachability guard (#339) and graduation-since-stable. **sync / single / group** used a simpler existence-only `rev-parse --verify` check with neither.

This PR **propagates the full algorithm to every mode**, so sync/single/group now gain:

- the **#339 shallow-clone guard** — a tag that exists but isn't an ancestor of HEAD is treated as unreachable (bounded changelog, not a silent full-history dump); and
- **graduation-since-last-stable** — a prerelease→stable release aggregates the changelog from the last stable tag.

The repo-level shared floor (#348) stays async-only — it's a feature (repo-level entry split), not a floor-correctness fix, so it isn't added to the other modes.

One minor, consistent delta: on the degenerate `strictReachable`-throw path, `previousVersion` is now `null` rather than claiming an undiffed baseline (the old value was self-contradictory — a claimed baseline alongside a full-history range).

## Test

- New `baselineResolver.spec.ts` — 15 unit tests pinning #330 / #334 / #339 / #348 + graduation, package-specific vs global series, `baseRef` precedence, and the synthetic-tag guard, directly on `resolve()` / `sharedFloor()`.
- Full gate green: `pnpm turbo run lint typecheck test` (24 tasks — version 624, release 586, integration 50).

## Follow-ups (not in this PR)

- #370 — unify the per-package B-vs-C full-history fallback (still deferred; unaffected by this change).
- Latent, pre-existing in all four call sites: `strictReachable`'s `throw` is swallowed by the surrounding changelog try/catch, so it degrades a package to a minimal entry rather than aborting the run as its message implies. Worth a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR consolidates the changelog-baseline resolution logic — previously duplicated across `createSyncStrategy`, `createSingleStrategy`, `groupStrategy`, and `PackageProcessor` — into a single `BaselineResolver` class that owns both the per-package floor (B) and the repo-level shared floor (C). As a side effect it propagates the #339 merge-base reachability guard and the graduation-since-last-stable floor to all modes (previously only the async path carried them).

- **New `BaselineResolver`**: `resolve()` handles graduation, `verifyTag` reachability, `strictReachable` throws, `baseRef` precedence, and the `previousVersion` display-strip; `sharedFloor()` lazy-computes and caches the nearest-reachable global tag for the async shared-entries feature.
- **All call sites updated**: sync, single, and group strategies now construct a `BaselineResolver` and delegate to it, eliminating the duplicated `rev-parse --verify` only checks they previously used.
- **15 new unit tests** in `baselineResolver.spec.ts` directly pin the contract of `resolve()` and `sharedFloor()` covering tag reachability, graduation, synthetic tags, `strictReachable`, `baseRef` precedence, and the shared-floor cache.
</details>

<h3>Confidence Score: 5/5</h3>

The refactoring correctly unifies four previously-divergent changelog-floor implementations into a single well-tested class; all code paths trace correctly and the new behaviour is an intentional improvement for sync/single/group modes.

Every branching path in BaselineResolver — graduation, verifyTag reachability, strictReachable, baseRef precedence, synthetic-tag short-circuit, and sharedFloor caching — is pinned by unit tests whose expectations match the implementation precisely. The hasRealTag semantics are handled consistently across all four call sites (manifest-fallback correctly stays false in PackageProcessor; sync/single/group only use real git tags). No correctness regressions or new undefined-behaviour paths were found.

No files require special attention. The only previously-noted concern (hasRealTag inference in groupStrategy) was raised in a prior review thread and is a theoretical future-proofing matter rather than a current defect.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/version/src/core/baselineResolver.ts | New module that is the heart of this PR; logic is correct — graduation guard, reachability paths, baseRef precedence, synthetic-tag handling, and sharedFloor caching all trace cleanly against the unit tests. |
| packages/version/src/core/groupStrategy.ts | Constructs a BaselineResolver and delegates changelog floor resolution to it via the extractEntries helper; hasRealTag is correctly inferred as latestTag !== '' since groupStrategy only produces real git tags. |
| packages/version/src/core/versionStrategies.ts | Sync and single strategies now delegate to BaselineResolver; hasRealTag correctly uses latestTag !== '' since both strategies only use real git tags (no manifest fallback). |
| packages/version/src/package/packageProcessor.ts | The async path already had a BaselineResolver; this PR keeps it unchanged but adds sharedFloorCwd explicitly. hasRealTag semantics (false for manifest-fallback, true for real git tags) are preserved correctly. |
| packages/version/test/unit/core/baselineResolver.spec.ts | Comprehensive 15-test suite; covers all branching paths including synthetic-tag guard, graduation (global and package-specific series), baseRef precedence, strictReachable throw, and sharedFloor caching — all assertions trace correctly against the implementation. |
| CONTEXT.md | New domain glossary accurately documents the three baseline notions (A/B/C) and the tag types; no issues. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Version run starts] --> B{Strategy?}

    B -->|sync| S[createSyncStrategy]
    B -->|single| SG[createSingleStrategy]
    B -->|group| G[createGroupStrategy]
    B -->|async| PP[PackageProcessor]

    S --> BR1[new BaselineResolver]
    SG --> BR2[new BaselineResolver]
    G --> BR3[new BaselineResolver]
    PP --> BR4[new BaselineResolver\n+ sharedFloorCwd]

    BR1 --> R1[resolver.resolve]
    BR2 --> R2[resolver.resolve]
    BR3 --> EE[extractEntries helper\n→ resolver.resolve]
    BR4 --> R4[resolver.resolve]

    subgraph resolve ["BaselineResolver.resolve() — per-package floor B"]
        GRAD{Graduating\nprerelease→stable?}
        GRAD -->|yes| STAB[getLatestStableTag\nor getLatestStableTagForPackage]
        GRAD -->|no| BASE[changelogBaseTag = latestTag]
        STAB --> BASE
        BASE --> REAL{hasRealTag\nor baseRef?}
        REAL -->|yes| VT[verifyTag — existence + ancestry]
        VT -->|reachable| RANGE[revisionRange = tag..HEAD\nbaselineUnreachable = false]
        VT -->|unreachable + strictReachable| THROW[throw Error]
        VT -->|unreachable| WARN[warn + revisionRange = HEAD\nbaselineUnreachable = true]
        REAL -->|synthetic tag| SYNTH[revisionRange = HEAD\nbaselineUnreachable = true]
        REAL -->|no tag| EMPTY[revisionRange = HEAD\nbaselineUnreachable = false]
    end

    R4 --> SF[resolver.sharedFloor\nasync only — repo-level floor C]
    SF --> NRT{perPackageRange\n= HEAD?}
    NRT -->|no| PASSTHRU[return perPackageRange unchanged]
    NRT -->|yes, no baseRef| GNT[getNearestReachableTag\ncached per run]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Version run starts] --> B{Strategy?}

    B -->|sync| S[createSyncStrategy]
    B -->|single| SG[createSingleStrategy]
    B -->|group| G[createGroupStrategy]
    B -->|async| PP[PackageProcessor]

    S --> BR1[new BaselineResolver]
    SG --> BR2[new BaselineResolver]
    G --> BR3[new BaselineResolver]
    PP --> BR4[new BaselineResolver\n+ sharedFloorCwd]

    BR1 --> R1[resolver.resolve]
    BR2 --> R2[resolver.resolve]
    BR3 --> EE[extractEntries helper\n→ resolver.resolve]
    BR4 --> R4[resolver.resolve]

    subgraph resolve ["BaselineResolver.resolve() — per-package floor B"]
        GRAD{Graduating\nprerelease→stable?}
        GRAD -->|yes| STAB[getLatestStableTag\nor getLatestStableTagForPackage]
        GRAD -->|no| BASE[changelogBaseTag = latestTag]
        STAB --> BASE
        BASE --> REAL{hasRealTag\nor baseRef?}
        REAL -->|yes| VT[verifyTag — existence + ancestry]
        VT -->|reachable| RANGE[revisionRange = tag..HEAD\nbaselineUnreachable = false]
        VT -->|unreachable + strictReachable| THROW[throw Error]
        VT -->|unreachable| WARN[warn + revisionRange = HEAD\nbaselineUnreachable = true]
        REAL -->|synthetic tag| SYNTH[revisionRange = HEAD\nbaselineUnreachable = true]
        REAL -->|no tag| EMPTY[revisionRange = HEAD\nbaselineUnreachable = false]
    end

    R4 --> SF[resolver.sharedFloor\nasync only — repo-level floor C]
    SF --> NRT{perPackageRange\n= HEAD?}
    NRT -->|no| PASSTHRU[return perPackageRange unchanged]
    NRT -->|yes, no baseRef| GNT[getNearestReachableTag\ncached per run]
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["refactor(version): drop two redundant ch..."](https://github.com/goosewobbler/releasekit/commit/5a71ee522602cf86132a6ee54dfa5a0f9e37f290) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38886091)</sub>

<!-- /greptile_comment -->