### PR TITLE
feat(core): workspace dependency graph + topological publish ordering

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -172,6 +172,7 @@ NPM publishing configuration.
 | `registry` | string | `"https://registry.npmjs.org"` | NPM registry URL |
 | `copyFiles` | `string[]` | `["LICENSE"]` | Files to copy to package before publishing |
 | `tag` | string | `"latest"` | NPM dist tag |
+| `publishOrder` | `string[]` | `[]` | Explicit publish order for npm packages; empty auto-sorts dependencies first |
 
 ### `publish.cargo`
 

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -134,6 +134,10 @@ export const NpmConfigSchema = z.object({
   registry: z.string().default('https://registry.npmjs.org').describe('NPM registry URL'),
   copyFiles: z.array(z.string()).default(['LICENSE']).describe('Files to copy to package before publishing'),
   tag: z.string().default('latest').describe('NPM dist tag'),
+  publishOrder: z
+    .array(z.string())
+    .default([])
+    .describe('Explicit publish order for npm packages; empty auto-sorts dependencies first'),
 });
 
 export const CargoPublishConfigSchema = z.object({
@@ -231,6 +235,7 @@ export const PublishConfigSchema = z.object({
     registry: 'https://registry.npmjs.org',
     copyFiles: ['LICENSE'],
     tag: 'latest',
+    publishOrder: [],
   }).describe('NPM publishing configuration'),
   cargo: CargoPublishConfigSchema.default({
     enabled: false,

--- a/packages/core/src/dependencyGraph.ts
+++ b/packages/core/src/dependencyGraph.ts
@@ -1,0 +1,135 @@
+/**
+ * Workspace dependency graph — the internal (workspace-member-to-workspace-member) dependency
+ * relationships used to order publishes dependencies-first and, later, to derive prerequisite
+ * release sets. Ecosystem-agnostic: callers resolve each ecosystem's edges to workspace package
+ * names (npm dependency keys ∩ workspace; cargo `path:` deps resolved to crate names) and hand the
+ * graph already-named edges.
+ */
+
+export type Ecosystem = 'npm' | 'cargo' | 'pub';
+
+/**
+ * One workspace package as input to {@link buildDependencyGraph}. `deps` is the package's declared
+ * dependency identifiers (names); any that aren't themselves workspace members are ignored when the
+ * graph is built, so callers may pass a superset.
+ */
+export interface GraphPackage {
+  /** Canonical package name (npm name / crate name). */
+  name: string;
+  /** Absolute package directory. */
+  dir: string;
+  ecosystem: Ecosystem;
+  /** Declared internal-dependency candidate names. Filtered to workspace members on build. */
+  deps: string[];
+}
+
+export interface WorkspaceDependencyGraph {
+  /** Direct internal dependencies of `name` (workspace members it depends on). */
+  getInternalDependencies(name: string): Set<string>;
+  /** Direct internal dependents of `name` (workspace members that depend on it). */
+  getInternalDependents(name: string): Set<string>;
+  /** Transitive closure of `name`'s internal dependencies, excluding `name` itself. */
+  transitiveDependencies(name: string): Set<string>;
+  /**
+   * The given names ordered dependencies-first: a dependency always precedes anything that depends
+   * on it. Names not in the graph are dropped; only edges among the given names are considered.
+   * Cycle members can't be ordered — they are appended in input order so nothing is lost.
+   */
+  topologicalOrder(names: string[]): string[];
+  /** True when the workspace graph contains at least one dependency cycle. */
+  hasCycle(): boolean;
+}
+
+export function buildDependencyGraph(packages: GraphPackage[]): WorkspaceDependencyGraph {
+  const known = new Set(packages.map((p) => p.name));
+  const deps = new Map<string, Set<string>>();
+  const dependents = new Map<string, Set<string>>();
+  for (const p of packages) {
+    if (!deps.has(p.name)) deps.set(p.name, new Set());
+    if (!dependents.has(p.name)) dependents.set(p.name, new Set());
+  }
+  for (const p of packages) {
+    for (const d of p.deps) {
+      // Ignore self-edges and dependencies outside the workspace (the ∩-workspace filter).
+      if (d === p.name || !known.has(d)) continue;
+      deps.get(p.name)?.add(d);
+      dependents.get(d)?.add(p.name);
+    }
+  }
+
+  const getInternalDependencies = (name: string): Set<string> => new Set(deps.get(name) ?? []);
+  const getInternalDependents = (name: string): Set<string> => new Set(dependents.get(name) ?? []);
+
+  const transitiveDependencies = (name: string): Set<string> => {
+    const out = new Set<string>();
+    const stack = [...(deps.get(name) ?? [])];
+    while (stack.length > 0) {
+      const cur = stack.pop();
+      if (cur === undefined || cur === name || out.has(cur)) continue;
+      out.add(cur);
+      for (const d of deps.get(cur) ?? []) stack.push(d);
+    }
+    return out;
+  };
+
+  const topologicalOrder = (names: string[]): string[] => {
+    const subset = names.filter((n) => known.has(n));
+    const inSubset = new Set(subset);
+    const indegree = new Map<string, number>();
+    for (const n of subset) {
+      let degree = 0;
+      for (const dep of deps.get(n) ?? []) if (inSubset.has(dep)) degree++;
+      indegree.set(n, degree);
+    }
+    // Seed with nodes that have no in-subset dependencies, preserving input order for stability.
+    const ready = subset.filter((n) => indegree.get(n) === 0);
+    const result: string[] = [];
+    const emitted = new Set<string>();
+    while (ready.length > 0) {
+      const n = ready.shift();
+      if (n === undefined || emitted.has(n)) continue;
+      result.push(n);
+      emitted.add(n);
+      for (const dependent of dependents.get(n) ?? []) {
+        if (!inSubset.has(dependent) || emitted.has(dependent)) continue;
+        const next = (indegree.get(dependent) ?? 1) - 1;
+        indegree.set(dependent, next);
+        if (next === 0) ready.push(dependent);
+      }
+    }
+    // Cycle members never reach indegree 0 — append them in input order rather than dropping them.
+    for (const n of subset) if (!emitted.has(n)) result.push(n);
+    return result;
+  };
+
+  let cycle: boolean | undefined;
+  const hasCycle = (): boolean => {
+    if (cycle === undefined) {
+      // A full toposort that can't emit every node has a cycle.
+      const indegree = new Map<string, number>();
+      for (const p of packages) indegree.set(p.name, deps.get(p.name)?.size ?? 0);
+      const ready = packages.filter((p) => indegree.get(p.name) === 0).map((p) => p.name);
+      let emittedCount = 0;
+      while (ready.length > 0) {
+        const n = ready.shift();
+        if (n === undefined) break;
+        emittedCount++;
+        for (const dependent of dependents.get(n) ?? []) {
+          const next = (indegree.get(dependent) ?? 1) - 1;
+          indegree.set(dependent, next);
+          if (next === 0) ready.push(dependent);
+        }
+      }
+      cycle = emittedCount !== known.size;
+    }
+    return cycle;
+  };
+
+  return {
+    getInternalDependencies,
+    getInternalDependents,
+    transitiveDependencies,
+    topologicalOrder,
+    hasCycle,
+  };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,10 @@
 export { readPackageVersion } from './cli.js';
+export {
+  buildDependencyGraph,
+  type Ecosystem,
+  type GraphPackage,
+  type WorkspaceDependencyGraph,
+} from './dependencyGraph.js';
 export { EXIT_CODES, type ExitCode, ReleaseKitError } from './errors.js';
 export {
   debug,

--- a/packages/core/test/unit/dependencyGraph.spec.ts
+++ b/packages/core/test/unit/dependencyGraph.spec.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import { buildDependencyGraph, type GraphPackage } from '../../src/dependencyGraph.js';
+
+function pkg(name: string, deps: string[], ecosystem: GraphPackage['ecosystem'] = 'npm'): GraphPackage {
+  return { name, dir: `/ws/${name}`, ecosystem, deps };
+}
+
+// core <- utils, core <- types, {utils,types} <- app; `left-pad` is an external (non-workspace) dep.
+const workspace: GraphPackage[] = [
+  pkg('core', []),
+  pkg('utils', ['core']),
+  pkg('types', ['core']),
+  pkg('app', ['utils', 'types', 'left-pad']),
+];
+
+describe('buildDependencyGraph', () => {
+  it('should expose direct internal dependencies and dependents', () => {
+    const g = buildDependencyGraph(workspace);
+    expect([...g.getInternalDependencies('app')].sort()).toEqual(['types', 'utils']);
+    expect([...g.getInternalDependents('core')].sort()).toEqual(['types', 'utils']);
+    expect(g.getInternalDependencies('core').size).toBe(0);
+    expect(g.getInternalDependents('app').size).toBe(0);
+  });
+
+  it('should ignore dependencies that are not workspace members', () => {
+    const g = buildDependencyGraph(workspace);
+    expect(g.getInternalDependencies('app').has('left-pad')).toBe(false);
+  });
+
+  it('should ignore self-dependencies', () => {
+    const g = buildDependencyGraph([pkg('a', ['a', 'b']), pkg('b', [])]);
+    expect([...g.getInternalDependencies('a')]).toEqual(['b']);
+    expect(g.hasCycle()).toBe(false);
+  });
+
+  it('should compute the transitive dependency closure excluding self', () => {
+    const g = buildDependencyGraph(workspace);
+    expect([...g.transitiveDependencies('app')].sort()).toEqual(['core', 'types', 'utils']);
+    expect(g.transitiveDependencies('core').size).toBe(0);
+  });
+
+  it('should order names dependencies-first', () => {
+    const g = buildDependencyGraph(workspace);
+    const order = g.topologicalOrder(['app', 'core', 'utils', 'types']);
+    const idx = (n: string) => order.indexOf(n);
+    expect(order).toHaveLength(4);
+    expect(idx('core')).toBeLessThan(idx('utils'));
+    expect(idx('core')).toBeLessThan(idx('types'));
+    expect(idx('utils')).toBeLessThan(idx('app'));
+    expect(idx('types')).toBeLessThan(idx('app'));
+  });
+
+  it('should only consider edges among the requested names in topologicalOrder', () => {
+    // app depends on core only transitively (via utils/types) — with those excluded there is no
+    // direct edge, so both are roots and the subset is returned intact.
+    const g = buildDependencyGraph(workspace);
+    expect(g.topologicalOrder(['app', 'core']).sort()).toEqual(['app', 'core']);
+  });
+
+  it('should drop names that are not in the graph', () => {
+    const g = buildDependencyGraph(workspace);
+    const order = g.topologicalOrder(['app', 'ghost', 'core']);
+    expect(order).not.toContain('ghost');
+    expect(order).toHaveLength(2);
+  });
+
+  it('should order a mixed npm + cargo workspace dependencies-first', () => {
+    const g = buildDependencyGraph([
+      pkg('core-rs', [], 'cargo'),
+      pkg('plugin-rs', ['core-rs'], 'cargo'),
+      pkg('app', ['plugin-rs'], 'npm'),
+    ]);
+    const order = g.topologicalOrder(['app', 'plugin-rs', 'core-rs']);
+    expect(order.indexOf('core-rs')).toBeLessThan(order.indexOf('plugin-rs'));
+    expect(order.indexOf('plugin-rs')).toBeLessThan(order.indexOf('app'));
+  });
+
+  describe('cycles', () => {
+    it('should report a cycle via hasCycle', () => {
+      const g = buildDependencyGraph([pkg('a', ['b']), pkg('b', ['c']), pkg('c', ['a'])]);
+      expect(g.hasCycle()).toBe(true);
+    });
+
+    it('should append cycle members without dropping or hanging', () => {
+      const g = buildDependencyGraph([pkg('a', ['b']), pkg('b', ['c']), pkg('c', ['a'])]);
+      expect(g.topologicalOrder(['a', 'b', 'c']).sort()).toEqual(['a', 'b', 'c']);
+    });
+
+    it('should report no cycle for an acyclic graph', () => {
+      expect(buildDependencyGraph(workspace).hasCycle()).toBe(false);
+    });
+  });
+});

--- a/packages/publish/src/stages/cargo-publish.ts
+++ b/packages/publish/src/stages/cargo-publish.ts
@@ -1,6 +1,6 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { debug, success, warn } from '@releasekit/core';
+import { buildDependencyGraph, debug, type GraphPackage, success, warn } from '@releasekit/core';
 import { createPublishError, PublishErrorCode } from '../errors/index.js';
 import type { PipelineContext, PublishResult } from '../types.js';
 import { hasCargoAuth } from '../utils/auth.js';
@@ -232,65 +232,22 @@ function orderCrates(crates: CrateInfo[], explicitOrder: string[]): CrateInfo[] 
 }
 
 function topologicalSort(crates: CrateInfo[]): CrateInfo[] {
-  const nameSet = new Set(crates.map((c) => c.name));
-  const graph = new Map<string, string[]>();
-  const crateMap = new Map(crates.map((c) => [c.name, c]));
+  const byName = new Map(crates.map((c) => [c.name, c]));
+  // Map each crate's directory to its name so `path:` deps (which are paths) resolve to crate names.
+  const nameByDir = new Map(crates.map((c) => [path.resolve(c.dir), c.name]));
 
-  for (const crate of crates) {
-    graph.set(crate.name, []);
-  }
+  const graphPackages: GraphPackage[] = crates.map((c) => ({
+    name: c.name,
+    dir: c.dir,
+    ecosystem: 'cargo',
+    deps: c.pathDeps
+      .map((depPath) => nameByDir.get(path.resolve(c.dir, depPath)))
+      .filter((name): name is string => name !== undefined),
+  }));
 
-  // Build dependency edges from path deps
-  for (const crate of crates) {
-    for (const depPath of crate.pathDeps) {
-      const resolvedDir = path.resolve(crate.dir, depPath);
-      // Find which crate lives at that path
-      for (const other of crates) {
-        if (path.resolve(other.dir) === resolvedDir && nameSet.has(other.name)) {
-          graph.get(crate.name)?.push(other.name);
-        }
-      }
-    }
-  }
-
-  // Kahn's algorithm
-  const inDegree = new Map<string, number>();
-  for (const name of nameSet) {
-    inDegree.set(name, 0);
-  }
-  for (const deps of graph.values()) {
-    for (const dep of deps) {
-      inDegree.set(dep, (inDegree.get(dep) ?? 0) + 1);
-    }
-  }
-
-  const queue: string[] = [];
-  for (const [name, degree] of inDegree) {
-    if (degree === 0) {
-      queue.push(name);
-    }
-  }
-
-  const result: CrateInfo[] = [];
-  while (queue.length > 0) {
-    const name = queue.shift();
-    if (!name) break;
-    const crate = crateMap.get(name);
-    if (crate) {
-      result.push(crate);
-    }
-
-    for (const dep of graph.get(name) ?? []) {
-      const newDegree = (inDegree.get(dep) ?? 1) - 1;
-      inDegree.set(dep, newDegree);
-      if (newDegree === 0) {
-        queue.push(dep);
-      }
-    }
-  }
-
-  // Reverse so dependencies come first
-  result.reverse();
-
-  return result;
+  const graph = buildDependencyGraph(graphPackages);
+  return graph
+    .topologicalOrder(crates.map((c) => c.name))
+    .map((name) => byName.get(name))
+    .filter((crate): crate is CrateInfo => crate !== undefined);
 }

--- a/packages/publish/src/stages/npm-publish.ts
+++ b/packages/publish/src/stages/npm-publish.ts
@@ -1,6 +1,6 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { debug, info, success, warn } from '@releasekit/core';
+import { buildDependencyGraph, debug, type GraphPackage, info, success, warn } from '@releasekit/core';
 import { createPublishError, PublishErrorCode } from '../errors/index.js';
 import type { PipelineContext, PublishResult } from '../types.js';
 import { detectNpmAuth } from '../utils/auth.js';
@@ -14,6 +14,55 @@ const ALREADY_PUBLISHED_PATTERN = /EPUBLISHCONFLICT|cannot publish over (?:the )
 
 /** Bounded auto-retry for transient registry blips: initial attempt + 2 retries. */
 const PUBLISH_RETRY = { maxAttempts: 3, initialDelay: 1000 } as const;
+
+/** Workspace deps an npm package declares (dependencies + peerDependencies; devDependencies excluded). */
+function readNpmWorkspaceDeps(pkgJsonPath: string): string[] {
+  try {
+    const json = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf-8'));
+    return [...Object.keys(json.dependencies ?? {}), ...Object.keys(json.peerDependencies ?? {})];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Order npm updates so a dependency publishes before any package that depends on it, closing the
+ * window where a just-published package references a not-yet-published version. An explicit
+ * `publishOrder` wins (matching cargo); otherwise the workspace graph topo-sorts dependencies first.
+ * Non-npm updates keep their position — the stage skips them anyway.
+ */
+export function orderNpmUpdates<T extends { packageName: string; filePath: string }>(
+  updates: T[],
+  explicitOrder: string[],
+  cwd: string,
+): T[] {
+  const npm = updates.filter((u) => u.filePath.endsWith('package.json'));
+  if (npm.length <= 1) return updates;
+  const other = updates.filter((u) => !u.filePath.endsWith('package.json'));
+  const byName = new Map(npm.map((u) => [u.packageName, u]));
+
+  let orderedNames: string[];
+  if (explicitOrder.length > 0) {
+    const remaining = new Set(npm.map((u) => u.packageName));
+    orderedNames = explicitOrder.filter((n) => remaining.has(n));
+    for (const n of orderedNames) remaining.delete(n);
+    for (const u of npm) if (remaining.has(u.packageName)) orderedNames.push(u.packageName);
+  } else {
+    const graphPackages: GraphPackage[] = npm.map((u) => {
+      const pkgJsonPath = path.resolve(cwd, u.filePath);
+      return {
+        name: u.packageName,
+        dir: path.dirname(pkgJsonPath),
+        ecosystem: 'npm',
+        deps: readNpmWorkspaceDeps(pkgJsonPath),
+      };
+    });
+    orderedNames = buildDependencyGraph(graphPackages).topologicalOrder(npm.map((u) => u.packageName));
+  }
+
+  const orderedNpm = orderedNames.map((n) => byName.get(n)).filter((u): u is T => u !== undefined);
+  return [...orderedNpm, ...other];
+}
 
 /** Error strategy: FAIL-FAST. First publish failure aborts the stage. */
 export async function runNpmPublishStage(ctx: PipelineContext): Promise<void> {
@@ -41,7 +90,8 @@ export async function runNpmPublishStage(ctx: PipelineContext): Promise<void> {
   });
 
   try {
-    for (const update of input.updates) {
+    const orderedUpdates = orderNpmUpdates(input.updates, config.npm.publishOrder, cwd);
+    for (const update of orderedUpdates) {
       const result: PublishResult = {
         packageName: update.packageName,
         version: update.newVersion,

--- a/packages/publish/src/stages/npm-publish.ts
+++ b/packages/publish/src/stages/npm-publish.ts
@@ -20,7 +20,10 @@ function readNpmWorkspaceDeps(pkgJsonPath: string): string[] {
   try {
     const json = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf-8'));
     return [...Object.keys(json.dependencies ?? {}), ...Object.keys(json.peerDependencies ?? {})];
-  } catch {
+  } catch (error) {
+    // A package whose deps can't be read looks dependency-free to the graph and could be ordered
+    // ahead of packages it actually depends on — surface it rather than silently mis-ordering.
+    debug(`Failed to read workspace deps from ${pkgJsonPath}: ${error}`);
     return [];
   }
 }
@@ -29,7 +32,7 @@ function readNpmWorkspaceDeps(pkgJsonPath: string): string[] {
  * Order npm updates so a dependency publishes before any package that depends on it, closing the
  * window where a just-published package references a not-yet-published version. An explicit
  * `publishOrder` wins (matching cargo); otherwise the workspace graph topo-sorts dependencies first.
- * Non-npm updates keep their position — the stage skips them anyway.
+ * Non-npm updates are moved to the end — the stage skips them anyway, so publish order is unaffected.
  */
 export function orderNpmUpdates<T extends { packageName: string; filePath: string }>(
   updates: T[],

--- a/packages/publish/src/types.ts
+++ b/packages/publish/src/types.ts
@@ -10,6 +10,7 @@ export interface NpmConfig {
   registry: string;
   copyFiles: string[];
   tag: string;
+  publishOrder: string[];
 }
 
 export interface CargoConfig {
@@ -161,6 +162,7 @@ export function getDefaultConfig(): PublishConfig {
       registry: 'https://registry.npmjs.org',
       copyFiles: ['LICENSE'],
       tag: 'latest',
+      publishOrder: [],
     },
     cargo: {
       enabled: false,
@@ -227,6 +229,7 @@ export function toPublishConfig(config: BasePublishConfig | undefined): PublishC
       registry: config.npm?.registry ?? defaults.npm.registry,
       copyFiles: config.npm?.copyFiles ?? defaults.npm.copyFiles,
       tag: config.npm?.tag ?? defaults.npm.tag,
+      publishOrder: config.npm?.publishOrder ?? defaults.npm.publishOrder,
     },
     cargo: {
       enabled: config.cargo?.enabled ?? defaults.cargo.enabled,

--- a/packages/publish/test/unit/stages/npm-publish-order.spec.ts
+++ b/packages/publish/test/unit/stages/npm-publish-order.spec.ts
@@ -1,0 +1,62 @@
+import * as fs from 'node:fs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { orderNpmUpdates } from '../../../src/stages/npm-publish.js';
+
+vi.mock('node:fs');
+
+// core <- utils, {core,utils} <- app. Manifest dep keys match packageName so they're internal edges.
+const manifests: Record<string, unknown> = {
+  '/ws/packages/core/package.json': { name: 'core' },
+  '/ws/packages/utils/package.json': { name: 'utils', dependencies: { core: '^1.0.0' } },
+  '/ws/packages/app/package.json': { name: 'app', dependencies: { utils: '^1.0.0', core: '^1.0.0' } },
+};
+
+function update(packageName: string, filePath: string) {
+  return { packageName, newVersion: '1.0.0', filePath };
+}
+
+// Deliberately not in dependency order.
+const npmUpdates = [
+  update('app', 'packages/app/package.json'),
+  update('utils', 'packages/utils/package.json'),
+  update('core', 'packages/core/package.json'),
+];
+
+describe('orderNpmUpdates', () => {
+  beforeEach(() => {
+    vi.mocked(fs.readFileSync).mockImplementation((p: fs.PathOrFileDescriptor) => {
+      const manifest = manifests[String(p)];
+      if (!manifest) throw new Error(`no manifest for ${String(p)}`);
+      return JSON.stringify(manifest);
+    });
+  });
+
+  it('should order npm updates dependencies-first by default', () => {
+    const ordered = orderNpmUpdates(npmUpdates, [], '/ws').map((u) => u.packageName);
+    expect(ordered).toEqual(['core', 'utils', 'app']);
+  });
+
+  it('should honour an explicit publishOrder over the topological sort', () => {
+    const ordered = orderNpmUpdates(npmUpdates, ['app', 'core', 'utils'], '/ws').map((u) => u.packageName);
+    expect(ordered).toEqual(['app', 'core', 'utils']);
+  });
+
+  it('should append npm packages missing from an explicit publishOrder', () => {
+    const ordered = orderNpmUpdates(npmUpdates, ['core'], '/ws').map((u) => u.packageName);
+    expect(ordered[0]).toBe('core');
+    expect(ordered).toContain('utils');
+    expect(ordered).toContain('app');
+    expect(ordered).toHaveLength(3);
+  });
+
+  it('should keep non-npm updates and not read them as package.json', () => {
+    const withCargo = [...npmUpdates, update('crate', 'crates/crate/Cargo.toml')];
+    const ordered = orderNpmUpdates(withCargo, [], '/ws').map((u) => u.packageName);
+    expect(ordered).toEqual(['core', 'utils', 'app', 'crate']);
+  });
+
+  it('should return a single-package list unchanged without touching git or fs ordering', () => {
+    const single = [update('core', 'packages/core/package.json')];
+    expect(orderNpmUpdates(single, [], '/ws')).toEqual(single);
+  });
+});

--- a/releasekit.schema.json
+++ b/releasekit.schema.json
@@ -388,6 +388,14 @@
               "type": "string",
               "default": "latest",
               "description": "NPM dist tag"
+            },
+            "publishOrder": {
+              "type": "array",
+              "default": [],
+              "items": {
+                "type": "string"
+              },
+              "description": "Explicit publish order for npm packages; empty auto-sorts dependencies first"
             }
           },
           "description": "NPM publishing configuration"


### PR DESCRIPTION
## What

Phase 1 (+1b) of the grouped/prerequisite-releases plan: a shared workspace dependency graph, plus its first consumers on the publish side. No versioning behaviour change.

### `@releasekit/core` — `dependencyGraph`
`buildDependencyGraph(packages)` returns a `WorkspaceDependencyGraph`:
- `getInternalDependencies` / `getInternalDependents`
- `transitiveDependencies` (closure, excludes self)
- `topologicalOrder(names)` — dependencies-first, cycle-safe (cycle members appended, never dropped)
- `hasCycle()`

Ecosystem-agnostic: callers resolve each ecosystem's edges to workspace names (npm `dependencies` + `peerDependencies` ∩ workspace, `devDependencies` excluded; cargo `path:` deps resolved to crate names). Generalises the Kahn's topological sort that lived inline in `cargo-publish`.

### cargo-publish
Now consumes the shared `topologicalOrder` instead of its own Kahn's implementation. Same deps-first result — except cyclic crates are now appended rather than silently dropped.

### npm-publish ordering (Phase 1b)
npm packages were published in `input.updates` order, so a dependent could publish before its dependency (a brief window where a published package references a not-yet-published version). They are now ordered dependencies-first via the graph, mirroring cargo. New `publish.npm.publishOrder` gives an explicit override (empty → topo-sort), matching `publish.cargo.publishOrder` / `publish.pub.publishOrder`. Schema + config docs regenerated.

## Test

- `core/test/unit/dependencyGraph.spec.ts` — 11 tests: npm + cargo edges, non-workspace/self filtering, transitive closure, deps-first order, subset-only edges, cycle handling.
- `publish/test/unit/stages/npm-publish-order.spec.ts` — deps-first ordering, explicit `publishOrder` override, missing-from-override append, non-npm preservation, single-package passthrough.
- Full gate green: `pnpm turbo run lint typecheck test` (24 tasks); `pnpm schema:check` up to date.

Closes #362.

## Notes

This is the Wave A sibling of #356 (`BaselineResolver`, PR #371) and is independent of it — branched off `main`. It's the foundation the prerequisite-resolution phases (#365) and `version.groups: independent` work build on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces a shared `WorkspaceDependencyGraph` in `@releasekit/core` and uses it to enforce dependencies-first publish ordering for both npm and cargo ecosystems. The npm publish stage previously iterated `input.updates` in arrival order; it now topo-sorts them first (or respects an explicit `publishOrder` override), matching the existing cargo behaviour and closing the window where a just-published package could reference a not-yet-published dependency.

- **`core/dependencyGraph.ts`**: New ecosystem-agnostic graph with Kahn's algorithm. Replaces the inline Kahn's in `cargo-publish`, and is the new backend for npm ordering. Cycle members are now appended instead of silently dropped.
- **`publish/npm-publish.ts`**: New `orderNpmUpdates` helper (exported for testing) reads `dependencies + peerDependencies` from each package's manifest, builds the graph, and returns updates in topo order. A new `publish.npm.publishOrder` config key provides an explicit override.
- **Schema + config docs**: `publishOrder` added to `NpmConfigSchema`, `NpmConfig` interface, defaults, coercion, JSON schema, and `configuration.md`.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge. The graph logic is correct, the Kahn's implementation handles cycles gracefully, and the npm ordering is consistent with the existing cargo behaviour.

The core graph algorithm is sound: indegree is correctly tracked as 'number of unemitted workspace dependencies', the subset-only edge filtering in topologicalOrder is applied consistently, memoisation in hasCycle is safe on an immutable graph, and the cycle-member append is a clear improvement over the old silent drop. Schema, types, defaults, and docs are all updated in sync. Test coverage is thorough across both new modules.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/core/src/dependencyGraph.ts | New ecosystem-agnostic workspace dependency graph. Kahn's algorithm is correctly implemented for both subset topological ordering and cycle detection. Indegree semantics are 'number of unemitted dependencies', which is correct for deps-first ordering. Memoised hasCycle is safe because the graph is immutable after construction. |
| packages/publish/src/stages/npm-publish.ts | Adds orderNpmUpdates (exported) and wires it into runNpmPublishStage. Graph is built only from the npm subset of updates; non-npm updates are appended at the end. Error path in readNpmWorkspaceDeps now emits a debug log instead of silently returning []. |
| packages/publish/src/stages/cargo-publish.ts | Replaces the inline 55-line Kahn's implementation with a 15-line delegation to the shared graph. Path-to-name resolution via nameByDir is semantically equivalent to the old O(n²) loop. Behaviour change: cycle members are now appended rather than silently dropped. |
| packages/core/test/unit/dependencyGraph.spec.ts | 11 well-structured tests covering direct deps/dependents, non-workspace filtering, self-dep filtering, transitive closure, deps-first order, subset-only edges, unknown-name dropping, mixed-ecosystem ordering, and cycle detection plus cycle-member append. |
| packages/publish/test/unit/stages/npm-publish-order.spec.ts | 5 tests for orderNpmUpdates: topo-sort default, explicit override, partial override (append missing), non-npm preservation, and single-package passthrough. |
| packages/config/src/schema.ts | Adds publishOrder: z.array(z.string()).default([]) to NpmConfigSchema and its default object. Consistent with the existing CargoPublishConfigSchema.publishOrder pattern. |
| packages/publish/src/types.ts | Adds publishOrder: string[] to the NpmConfig interface, getDefaultConfig, and toPublishConfig. All three sites are updated consistently. |
| packages/core/src/index.ts | Re-exports buildDependencyGraph, Ecosystem, GraphPackage, and WorkspaceDependencyGraph from the new module. |
| releasekit.schema.json | Generated schema updated to include publishOrder under publish.npm. Field definition matches the Zod schema. |
| docs/configuration.md | One-line doc addition for publishOrder in the publish.npm table. Description accurately reflects empty=auto-sort behaviour. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Stage as runNpmPublishStage
    participant Order as orderNpmUpdates
    participant Reader as readNpmWorkspaceDeps
    participant Graph as buildDependencyGraph
    participant FS as node:fs

    Stage->>Order: updates, config.npm.publishOrder, cwd
    Order->>Order: split npm vs other updates
    alt explicitOrder provided
        Order->>Order: filter by publishOrder, append remaining
    else topo-sort path
        loop each npm update
            Order->>Reader: pkgJsonPath
            Reader->>FS: readFileSync
            FS-->>Reader: raw JSON
            Reader-->>Order: dep keys
        end
        Order->>Graph: buildDependencyGraph(graphPackages)
        Graph-->>Order: WorkspaceDependencyGraph
        Order->>Graph: topologicalOrder(names)
        Note over Graph: Kahns on subset, cycle members appended
        Graph-->>Order: ordered names
    end
    Order-->>Stage: orderedNpm then other
    loop each update in order
        Stage->>Stage: skip non-package.json
        Stage->>Stage: check private and already-published
        Stage->>Stage: execCommand publish
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Stage as runNpmPublishStage
    participant Order as orderNpmUpdates
    participant Reader as readNpmWorkspaceDeps
    participant Graph as buildDependencyGraph
    participant FS as node:fs

    Stage->>Order: updates, config.npm.publishOrder, cwd
    Order->>Order: split npm vs other updates
    alt explicitOrder provided
        Order->>Order: filter by publishOrder, append remaining
    else topo-sort path
        loop each npm update
            Order->>Reader: pkgJsonPath
            Reader->>FS: readFileSync
            FS-->>Reader: raw JSON
            Reader-->>Order: dep keys
        end
        Order->>Graph: buildDependencyGraph(graphPackages)
        Graph-->>Order: WorkspaceDependencyGraph
        Order->>Graph: topologicalOrder(names)
        Note over Graph: Kahns on subset, cycle members appended
        Graph-->>Order: ordered names
    end
    Order-->>Stage: orderedNpm then other
    loop each update in order
        Stage->>Stage: skip non-package.json
        Stage->>Stage: check private and already-published
        Stage->>Stage: execCommand publish
    end
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["refactor(publish): log unreadable manife..."](https://github.com/goosewobbler/releasekit/commit/22b37ab5104ffcf2ac920e9cd2e8ac6c09c486a7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38891490)</sub>

<!-- /greptile_comment -->