### PR TITLE
feat(version): add version.groups 'independent' sync mode

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -114,6 +114,11 @@ of the monorepo versions independently. Each entry under `groups` is a group nam
   group of every package — there is one mechanism, not two.
 - **`linked`** — only members with a releasable change release, but every releasing member
   shares the same computed version. Unchanged members are left untouched (no empty re-release).
+- **`independent`** — only members with a releasable change release, each on its **own**
+  commit-driven version line (no shared group version). The set is still atomic: targeting any
+  member pulls in the whole group, and dropping a changed member (via `config.skip`) warns. Use
+  this for packages coupled by a contract but versioned separately (e.g. a wire protocol across
+  an npm package and a Rust crate on different version lines).
 
 **Group baseline** is the highest member version found in tags / manifests; the group bumps
 from there.
@@ -123,9 +128,9 @@ from there.
 > releases at `2.4.0`, skipping its own `1.x` line), overriding the per-package "initial version
 > from `package.json`" rule. The version step warns when the jump skips versions.
 
-**`--target` and fixed groups.** Targeting a strict subset of a `fixed` group expands to the
-whole group (a fixed group never silently splits). `linked` groups and ungrouped packages honor
-targets as-is.
+**`--target` and atomic groups.** Targeting a strict subset of an atomic group (`fixed` or
+`independent`) expands to the whole group, so it never silently splits. `linked` groups and
+ungrouped packages honor targets as-is.
 
 **Workspace pins.** Intra-group `workspace:*` dependencies resolve to the group version within a
 run, so a fixed group publishes internally consistent.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -106,7 +106,7 @@ of the monorepo versions independently. Each entry under `groups` is a group nam
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `packages` | `string[]` | — | Package patterns (exact names, @scope/*, or globs) whose matched packages form this group. Same matching rules as version.packages. |
-| `sync` | `"fixed"` \| `"linked"` | — | fixed: all members release together at the shared group version. linked: only changed members release, all at the same computed version. |
+| `sync` | `"fixed"` \| `"linked"` \| `"independent"` | — | fixed: all members release together at the shared group version. linked: only changed members release, all at the same computed version. independent: only changed members release, each on its own commit-driven version line (no shared version), but the set ships atomically. |
 
 - **`fixed`** — any releasable change in *any* member releases **all** members at the shared
   group version, computed as `bump(max(member baselines))`. This is the changesets `fixed`

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -53,9 +53,9 @@ export const VersionGroupSchema = z.object({
       'Package patterns (exact names, @scope/*, or globs) whose matched packages form this group. Same matching rules as version.packages.',
     ),
   sync: z
-    .enum(['fixed', 'linked'])
+    .enum(['fixed', 'linked', 'independent'])
     .describe(
-      'fixed: all members release together at the shared group version. linked: only changed members release, all at the same computed version.',
+      'fixed: all members release together at the shared group version. linked: only changed members release, all at the same computed version. independent: only changed members release, each on its own commit-driven version line (no shared version), but the set ships atomically.',
     ),
 });
 
@@ -90,7 +90,7 @@ export const VersionConfigSchema = z.object({
     .record(z.string(), VersionGroupSchema)
     .optional()
     .describe(
-      'Named version groups. Each group binds a set of package patterns to a fixed or linked sync mode. fixed: any releasable change in any member releases ALL members at the shared group version (bump(max(member baselines))). linked: only members with releasable changes release, but every releasing member shares the same computed version. Packages not matched by any group version independently. A package may belong to at most one group. Set version.sync to false when using groups.',
+      'Named version groups. Each group binds a set of package patterns to a fixed, linked, or independent sync mode. fixed: any releasable change in any member releases ALL members at the shared group version (bump(max(member baselines))). linked: only members with releasable changes release, but every releasing member shares the same computed version. independent: only members with releasable changes release, each on its own commit-driven version line (no shared version), but the set is atomic — targeting any member pulls in the whole group. Packages not matched by any group version independently. A package may belong to at most one group. Set version.sync to false when using groups.',
     ),
   packages: z.array(z.string()).default([]).describe('Packages to include in versioning'),
   mainPackage: z.string().optional().describe('Package to use for version determination'),

--- a/packages/config/test/unit/schema.spec.ts
+++ b/packages/config/test/unit/schema.spec.ts
@@ -167,9 +167,17 @@ describe('VersionConfigSchema', () => {
   it('should reject a group with an invalid sync mode', () => {
     expect(() =>
       VersionConfigSchema.parse({
-        groups: { native: { packages: ['@wdio/native-*'], sync: 'independent' } },
+        groups: { native: { packages: ['@wdio/native-*'], sync: 'frozen' } },
       }),
     ).toThrow();
+  });
+
+  it('should accept an independent group', () => {
+    const result = VersionConfigSchema.parse({
+      sync: false,
+      groups: { native: { packages: ['@wdio/native-*'], sync: 'independent' } },
+    });
+    expect(result.groups?.native.sync).toBe('independent');
   });
 
   it('should leave groups undefined when not specified', () => {

--- a/packages/version/src/core/groupResolution.ts
+++ b/packages/version/src/core/groupResolution.ts
@@ -1,11 +1,14 @@
 /**
  * Version-group resolution.
  *
- * A "version group" binds a set of packages to a shared sync mode:
+ * A "version group" binds a set of packages to a sync mode:
  *  - `fixed`:  any releasable change in any member releases ALL members at the shared group version
  *              (`bump(max(member baselines))`).
  *  - `linked`: only members with releasable changes release, but every releasing member shares the
  *              same computed version.
+ *  - `independent`: only members with releasable changes release, each on its own commit-driven
+ *              version line (no shared version), but the set is atomic — targeting any member pulls
+ *              in the whole group so it never ships a partial subset.
  *
  * The global `version.sync: true` flag is **sugar** for a single implicit `fixed` group containing
  * every workspace package — there is exactly one mechanism, normalized here, not two. This keeps
@@ -25,7 +28,7 @@ export const IMPLICIT_SYNC_GROUP = '__sync__';
 export interface ResolvedGroup {
   /** Config key (or {@link IMPLICIT_SYNC_GROUP} for the desugared `sync: true` group). */
   name: string;
-  sync: 'fixed' | 'linked';
+  sync: 'fixed' | 'linked' | 'independent';
   /** Raw patterns from config. */
   patterns: string[];
   /** Workspace packages that matched this group's patterns. */
@@ -166,15 +169,16 @@ export function hasGroups(config: Config): boolean {
 }
 
 /**
- * Expand a set of `--target` patterns so that targeting any member of a **fixed** group pulls in
- * the whole group. Silently splitting a fixed group would break its invariant (all members release
- * together at the same version), so we expand rather than error.
+ * Expand a set of `--target` patterns so that targeting any member of an **atomic** group (`fixed`
+ * or `independent`) pulls in the whole group. Silently splitting an atomic group breaks its
+ * invariant — fixed members all release at the same version; an independent group's changed members
+ * all release together — so we expand rather than error.
  *
- * Returns the expanded target patterns plus a record of which fixed groups were expanded (for
- * logging). `linked` groups are left untouched — partial targeting of a linked group is well
- * defined (only changed, targeted members release).
+ * Returns the expanded target patterns plus a record of which groups were expanded (for logging).
+ * `linked` groups are left untouched — partial targeting of a linked group is well defined (only
+ * changed, targeted members release).
  */
-export function expandTargetsForFixedGroups(
+export function expandTargetsForAtomicGroups(
   resolution: GroupResolution,
   targets: string[],
 ): { targets: string[]; expandedGroups: string[] } {
@@ -184,7 +188,7 @@ export function expandTargetsForFixedGroups(
   const expandedGroups: string[] = [];
 
   for (const group of resolution.groups) {
-    if (group.sync !== 'fixed') continue;
+    if (group.sync === 'linked') continue;
 
     const someTargeted = group.members.some((m) => shouldMatchPackageTargets(m.packageJson.name, targets));
     const allTargeted = group.members.every((m) => shouldMatchPackageTargets(m.packageJson.name, targets));
@@ -195,7 +199,7 @@ export function expandTargetsForFixedGroups(
       }
       expandedGroups.push(group.name);
       log(
-        `--target hit a strict subset of fixed group "${group.name}"; expanding to all ${group.members.length} ` +
+        `--target hit a strict subset of ${group.sync} group "${group.name}"; expanding to all ${group.members.length} ` +
           `members so the group releases atomically: ${group.members.map((m) => m.packageJson.name).join(', ')}.`,
         'warning',
       );

--- a/packages/version/src/core/groupStrategy.ts
+++ b/packages/version/src/core/groupStrategy.ts
@@ -397,17 +397,26 @@ export function createGroupStrategy(config: Config): (packages: PackagesWithRoot
           continue;
         }
 
-        // `config.skip` and the target filter both remove members from `members`, so an atomic
-        // (fixed/independent) group can release with a subset of its declared members — breaking its
-        // atomicity. Warn so the partial release is intentional, not a surprise. Only relevant once
-        // the group is actually releasing (past the no-change guard above). Linked groups are exempt:
-        // partial release is their defined behaviour.
+        // `config.skip` and the target filter remove members from `members`, so an atomic group can
+        // ship a partial set. fixed loses lockstep if ANY declared member is missing; independent only
+        // breaks if a *changed* member is missing — an unchanged skipped member would not release
+        // anyway, so we plan the excluded members to avoid a false alarm. Linked groups release
+        // partially by design, so they're exempt.
         if (group.sync !== 'linked') {
           const inRelease = new Set(members.map((m) => m.packageJson.name));
-          const excluded = group.members.map((m) => m.packageJson.name).filter((name) => !inRelease.has(name));
-          if (excluded.length > 0) {
+          const excludedMembers = group.members.filter((m) => !inRelease.has(m.packageJson.name));
+          let droppedNames: string[];
+          if (group.sync === 'fixed') {
+            droppedNames = excludedMembers.map((m) => m.packageJson.name);
+          } else {
+            const excludedPlans = await Promise.all(
+              excludedMembers.map((m) => planMember(config, m, formattedPrefix, globalTag)),
+            );
+            droppedNames = excludedPlans.filter((p) => p.changed).map((p) => p.pkg.packageJson.name);
+          }
+          if (droppedNames.length > 0) {
             log(
-              `Group "${group.name}" (${group.sync}) will release without: ${excluded.join(', ')}. ` +
+              `Group "${group.name}" (${group.sync}) will release without: ${droppedNames.join(', ')}. ` +
                 'They were excluded by config.skip or --target, so the group will not ship as a single atomic unit. ' +
                 'Include them (remove from config.skip or add via --target) to keep the group atomic.',
               'warning',

--- a/packages/version/src/core/groupStrategy.ts
+++ b/packages/version/src/core/groupStrategy.ts
@@ -39,7 +39,7 @@ import {
 } from '../utils/jsonOutput.js';
 import { log } from '../utils/logging.js';
 import { BaselineResolver } from './baselineResolver.js';
-import { expandTargetsForFixedGroups, type ResolvedGroup, resolveGroups } from './groupResolution.js';
+import { expandTargetsForAtomicGroups, type ResolvedGroup, resolveGroups } from './groupResolution.js';
 import { calculateVersion } from './versionCalculator.js';
 import type { PackagesWithRoot } from './versionEngine.js';
 
@@ -141,9 +141,10 @@ function memberBumpRank(plan: MemberPlan): number {
 }
 
 interface GroupComputation {
-  /** The shared version every releasing member is written to. */
+  /** The shared version every releasing member is written to. Empty for `independent` groups, whose
+   *  members each release at their own `MemberPlan.ownNext`. */
   groupVersion: string;
-  /** Members that will be released (all members for fixed, changed members for linked). */
+  /** Members that will be released (all members for fixed; changed members for linked/independent). */
   releasing: MemberPlan[];
   /** Whether the group has any releasable change at all. */
   hasChange: boolean;
@@ -156,6 +157,13 @@ function computeGroup(group: ResolvedGroup, plans: MemberPlan[], config: Config)
   const changedPlans = plans.filter((p) => p.changed);
   if (changedPlans.length === 0) {
     return { groupVersion: '', releasing: [], hasChange: false };
+  }
+
+  // Independent groups have no shared version — each changed member releases on its own
+  // commit-driven line. Only changed members release; atomicity is enforced by target expansion
+  // (the whole group is pulled in) and the partial-subset warning in the caller.
+  if (group.sync === 'independent') {
+    return { groupVersion: '', releasing: changedPlans, hasChange: true };
   }
 
   const maxBaseline = plans.map((p) => p.baseline).sort(semver.rcompare)[0];
@@ -254,39 +262,43 @@ async function releaseGroup(
   computation: GroupComputation,
   config: Config,
   baselineResolver: BaselineResolver,
-): Promise<string[]> {
+): Promise<Array<{ name: string; version: string }>> {
   const { groupVersion, releasing } = computation;
   const formattedPrefix = formatVersionPrefix(config.versionPrefix || 'v');
-  const released: string[] = [];
+  const released: Array<{ name: string; version: string }> = [];
 
   for (const plan of releasing) {
     const pkg = plan.pkg;
     const name = pkg.packageJson.name;
     if (!shouldProcess(pkg, config)) continue;
 
-    // Adoption: a member below the group version jumps to it. Warn loudly when the jump skips
-    // versions — i.e. the group version is strictly beyond what a single major bump of this member
-    // would have produced — so adopters time the migration to a real breaking change. An unchanged
-    // member that is nonetheless released (fixed group) is the routine lockstep case: just log it at
-    // info level, since it doesn't skip any versions for that member.
-    if (semver.valid(plan.baseline) && semver.lt(plan.baseline, groupVersion)) {
+    // Independent members release on their own commit-driven line; fixed/linked members adopt the
+    // shared group version.
+    const version = group.sync === 'independent' ? plan.ownNext : groupVersion;
+
+    // Adoption (fixed/linked only): a member below the shared group version jumps to it. Warn loudly
+    // when the jump skips versions — i.e. the group version is strictly beyond what a single major
+    // bump of this member would have produced — so adopters time the migration to a real breaking
+    // change. An unchanged member that is nonetheless released (fixed group) is the routine lockstep
+    // case: just log it at info level, since it doesn't skip any versions for that member.
+    if (group.sync !== 'independent' && semver.valid(plan.baseline) && semver.lt(plan.baseline, version)) {
       const singleMajorBump = semver.inc(plan.baseline, 'major') ?? plan.baseline;
-      const jumpsMoreThanOneBump = semver.gt(groupVersion, singleMajorBump);
+      const jumpsMoreThanOneBump = semver.gt(version, singleMajorBump);
       if (jumpsMoreThanOneBump) {
         log(
-          `Group "${group.name}": ${name} adopts group version ${groupVersion} (was ${plan.baseline}). ` +
+          `Group "${group.name}": ${name} adopts group version ${version} (was ${plan.baseline}). ` +
             'This skips intermediate versions with no semver event behind the jump — time group ' +
             'migrations to a real breaking change in the family.',
           'warning',
         );
       } else if (!plan.changed) {
-        log(`Group "${group.name}": ${name} rides along to ${groupVersion} (was ${plan.baseline}).`, 'info');
+        log(`Group "${group.name}": ${name} rides along to ${version} (was ${plan.baseline}).`, 'info');
       }
     }
 
     const packageJsonPath = path.join(pkg.dir, 'package.json');
     if (fs.existsSync(packageJsonPath)) {
-      updatePackageVersion(packageJsonPath, groupVersion, config.dryRun);
+      updatePackageVersion(packageJsonPath, version, config.dryRun);
     } else {
       log(`Skipping package.json update for ${name} - no package.json found (Rust-only package)`, 'debug');
     }
@@ -295,13 +307,13 @@ async function releaseGroup(
     // to single/async; group members are package-keyed).
     const cargoTomlPath = path.join(pkg.dir, 'Cargo.toml');
     if (config.cargo?.enabled !== false && fs.existsSync(cargoTomlPath)) {
-      updatePackageVersion(cargoTomlPath, groupVersion, config.dryRun);
+      updatePackageVersion(cargoTomlPath, version, config.dryRun);
     }
 
     // Per-package tag + changelog. Group members always get package-specific tags so each
     // member's release is individually addressable (the group acts atomically at the version level,
     // not the tag level).
-    const tag = formatTag(groupVersion, formattedPrefix, name, config.tagTemplate, true);
+    const tag = formatTag(version, formattedPrefix, name, config.tagTemplate, true);
     addTag(tag);
     setPackageUpdateTag(name, tag);
     setPackageUpdateGroup(name, group.name);
@@ -312,14 +324,14 @@ async function releaseGroup(
       latestTag: plan.latestTag,
       hasRealTag: plan.latestTag !== '',
       usedPackageSpecificTag: plan.usedPackageSpecificTag,
-      nextVersion: groupVersion,
+      nextVersion: version,
       graduationName: name,
       baselineTagPrefix,
       formattedPrefix,
     });
     addChangelogData({
       packageName: name,
-      version: groupVersion,
+      version,
       previousVersion,
       revisionRange,
       repoUrl: readRepoUrl(pkg.dir),
@@ -327,14 +339,14 @@ async function releaseGroup(
     });
 
     if (config.baselineTagTemplate) {
-      addBaselineTag(formatTag(groupVersion, formattedPrefix, name, config.baselineTagTemplate, false));
+      addBaselineTag(formatTag(version, formattedPrefix, name, config.baselineTagTemplate, false));
     }
 
-    released.push(name);
+    released.push({ name, version });
     log(
       config.dryRun
-        ? `[DRY RUN] Group "${group.name}": would release ${name} at ${groupVersion} (tag: ${tag})`
-        : `Group "${group.name}": ${name} prepared at ${groupVersion} (tag: ${tag})`,
+        ? `[DRY RUN] Group "${group.name}": would release ${name} at ${version} (tag: ${tag})`
+        : `Group "${group.name}": ${name} prepared at ${version} (tag: ${tag})`,
       config.dryRun ? 'info' : 'success',
     );
   }
@@ -362,9 +374,10 @@ export function createGroupStrategy(config: Config): (packages: PackagesWithRoot
 
       const resolution = resolveGroups(config, packages.packages);
 
-      // --target on a strict subset of a fixed group expands to the whole group so the group's
-      // atomic-release invariant holds. Linked groups and ungrouped packages keep their raw targets.
-      const { targets } = expandTargetsForFixedGroups(resolution, runtimeTargets);
+      // --target on a strict subset of an atomic group (fixed or independent) expands to the whole
+      // group so its atomic-release invariant holds. Linked groups and ungrouped packages keep their
+      // raw targets.
+      const { targets } = expandTargetsForAtomicGroups(resolution, runtimeTargets);
 
       const targetFilter = (pkg: Package): boolean =>
         targets.length === 0 || shouldMatchPackageTargets(pkg.packageJson.name, targets);
@@ -384,32 +397,34 @@ export function createGroupStrategy(config: Config): (packages: PackagesWithRoot
           continue;
         }
 
-        // `config.skip` and the target filter both remove members from `members`, so a fixed group
-        // can release with a subset of its declared members — leaving the group at divergent
-        // versions. Warn so the divergence is intentional, not a surprise. Only relevant once the
-        // group is actually releasing (past the no-change guard above).
-        if (group.sync === 'fixed') {
-          const released = new Set(members.map((m) => m.packageJson.name));
-          const notInRelease = group.members.map((m) => m.packageJson.name).filter((name) => !released.has(name));
-          if (notInRelease.length > 0) {
+        // `config.skip` and the target filter both remove members from `members`, so an atomic
+        // (fixed/independent) group can release with a subset of its declared members — breaking its
+        // atomicity. Warn so the partial release is intentional, not a surprise. Only relevant once
+        // the group is actually releasing (past the no-change guard above). Linked groups are exempt:
+        // partial release is their defined behaviour.
+        if (group.sync !== 'linked') {
+          const inRelease = new Set(members.map((m) => m.packageJson.name));
+          const excluded = group.members.map((m) => m.packageJson.name).filter((name) => !inRelease.has(name));
+          if (excluded.length > 0) {
             log(
-              `Group "${group.name}" is fixed but will release without: ${notInRelease.join(', ')}. ` +
-                'They were excluded by config.skip or --target, so the group will end up at divergent versions. ' +
-                'Remove the package from config.skip (or include it via --target) to keep the group atomic.',
+              `Group "${group.name}" (${group.sync}) will release without: ${excluded.join(', ')}. ` +
+                'They were excluded by config.skip or --target, so the group will not ship as a single atomic unit. ' +
+                'Include them (remove from config.skip or add via --target) to keep the group atomic.',
               'warning',
             );
           }
         }
 
         log(
-          `Group "${group.name}" (${group.sync}): releasing ${computation.releasing.length} member(s) at ` +
-            `${computation.groupVersion}.`,
+          group.sync === 'independent'
+            ? `Group "${group.name}" (independent): releasing ${computation.releasing.length} member(s) on their own version lines.`
+            : `Group "${group.name}" (${group.sync}): releasing ${computation.releasing.length} member(s) at ${computation.groupVersion}.`,
           'info',
         );
         const released = await releaseGroup(group, computation, config, baselineResolver);
-        for (const name of released) {
+        for (const { name, version } of released) {
           allReleased.push(name);
-          allVersions.set(name, computation.groupVersion);
+          allVersions.set(name, version);
         }
       }
 

--- a/packages/version/test/unit/core/groupResolution.spec.ts
+++ b/packages/version/test/unit/core/groupResolution.spec.ts
@@ -139,7 +139,7 @@ describe('groupResolution', () => {
     });
   });
 
-  describe('expandTargetsForAtomicGroups (--target on a subset of a fixed group)', () => {
+  describe('expandTargetsForAtomicGroups (--target on a subset of an atomic group)', () => {
     const packages = [pkg('@wdio/native-core'), pkg('@wdio/native-utils'), pkg('@wdio/native-spy')];
 
     it('should expand a strict subset of a fixed group to the whole group', () => {

--- a/packages/version/test/unit/core/groupResolution.spec.ts
+++ b/packages/version/test/unit/core/groupResolution.spec.ts
@@ -1,7 +1,7 @@
 import type { Package } from '@manypkg/get-packages';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
-  expandTargetsForFixedGroups,
+  expandTargetsForAtomicGroups,
   hasExplicitGroups,
   hasGroups,
   IMPLICIT_SYNC_GROUP,
@@ -139,7 +139,7 @@ describe('groupResolution', () => {
     });
   });
 
-  describe('expandTargetsForFixedGroups (--target on a subset of a fixed group)', () => {
+  describe('expandTargetsForAtomicGroups (--target on a subset of a fixed group)', () => {
     const packages = [pkg('@wdio/native-core'), pkg('@wdio/native-utils'), pkg('@wdio/native-spy')];
 
     it('should expand a strict subset of a fixed group to the whole group', () => {
@@ -147,7 +147,7 @@ describe('groupResolution', () => {
         base({ groups: { native: { packages: ['@wdio/native-*'], sync: 'fixed' } } }),
         packages,
       );
-      const { targets, expandedGroups } = expandTargetsForFixedGroups(res, ['@wdio/native-core']);
+      const { targets, expandedGroups } = expandTargetsForAtomicGroups(res, ['@wdio/native-core']);
       expect(new Set(targets)).toEqual(new Set(['@wdio/native-core', '@wdio/native-utils', '@wdio/native-spy']));
       expect(expandedGroups).toEqual(['native']);
     });
@@ -157,8 +157,18 @@ describe('groupResolution', () => {
         base({ groups: { native: { packages: ['@wdio/native-*'], sync: 'fixed' } } }),
         packages,
       );
-      const { expandedGroups } = expandTargetsForFixedGroups(res, ['@wdio/native-*']);
+      const { expandedGroups } = expandTargetsForAtomicGroups(res, ['@wdio/native-*']);
       expect(expandedGroups).toEqual([]);
+    });
+
+    it('should expand a strict subset of an independent group to the whole group', () => {
+      const res = resolveGroups(
+        base({ groups: { native: { packages: ['@wdio/native-*'], sync: 'independent' } } }),
+        packages,
+      );
+      const { targets, expandedGroups } = expandTargetsForAtomicGroups(res, ['@wdio/native-core']);
+      expect(new Set(targets)).toEqual(new Set(['@wdio/native-core', '@wdio/native-utils', '@wdio/native-spy']));
+      expect(expandedGroups).toEqual(['native']);
     });
 
     it('should NOT expand a linked group (partial targeting is well defined there)', () => {
@@ -166,7 +176,7 @@ describe('groupResolution', () => {
         base({ groups: { native: { packages: ['@wdio/native-*'], sync: 'linked' } } }),
         packages,
       );
-      const { targets, expandedGroups } = expandTargetsForFixedGroups(res, ['@wdio/native-core']);
+      const { targets, expandedGroups } = expandTargetsForAtomicGroups(res, ['@wdio/native-core']);
       expect(targets).toEqual(['@wdio/native-core']);
       expect(expandedGroups).toEqual([]);
     });
@@ -176,7 +186,7 @@ describe('groupResolution', () => {
         base({ groups: { native: { packages: ['@wdio/native-*'], sync: 'fixed' } } }),
         packages,
       );
-      expect(expandTargetsForFixedGroups(res, [])).toEqual({ targets: [], expandedGroups: [] });
+      expect(expandTargetsForAtomicGroups(res, [])).toEqual({ targets: [], expandedGroups: [] });
     });
   });
 });

--- a/packages/version/test/unit/core/groupStrategy.spec.ts
+++ b/packages/version/test/unit/core/groupStrategy.spec.ts
@@ -482,14 +482,15 @@ describe('createGroupStrategy', () => {
       expect(jsonOutput.setPackageUpdateGroup).not.toHaveBeenCalledWith('@wdio/native-utils', 'native');
     });
 
-    it('should warn when an independent group ships without an excluded member', async () => {
+    it('should warn when an independent group ships without an excluded CHANGED member', async () => {
       const core = mkPackage('@wdio/native-core', '2.3.0');
       const utils = mkPackage('@wdio/native-utils', '2.3.0');
       const spy = mkPackage('@wdio/native-spy', '2.3.0');
 
-      // core changes; spy is excluded via config.skip, so the atomic set ships partially.
+      // core and spy both changed, but spy is in config.skip — dropping a changed member breaks the
+      // atomic set, so it must warn.
       vi.mocked(calculator.calculateVersion).mockImplementation(async (_cfg, opts) =>
-        opts.name === '@wdio/native-core' ? '2.4.0' : '',
+        opts.name === '@wdio/native-core' || opts.name === '@wdio/native-spy' ? '2.4.0' : '',
       );
 
       const strategy = createGroupStrategy(
@@ -504,6 +505,27 @@ describe('createGroupStrategy', () => {
         expect.stringContaining('will release without: @wdio/native-spy'),
         'warning',
       );
+    });
+
+    it('should NOT warn when an independent group skips an unchanged member', async () => {
+      const core = mkPackage('@wdio/native-core', '2.3.0');
+      const spy = mkPackage('@wdio/native-spy', '2.3.0');
+
+      // Only core changed; spy is skipped but had no releasable change, so the set still ships
+      // atomically — warning here would be a false alarm.
+      vi.mocked(calculator.calculateVersion).mockImplementation(async (_cfg, opts) =>
+        opts.name === '@wdio/native-core' ? '2.4.0' : '',
+      );
+
+      const strategy = createGroupStrategy(
+        baseConfig({
+          skip: ['@wdio/native-spy'],
+          groups: { native: { packages: ['@wdio/native-*'], sync: 'independent' } },
+        }),
+      );
+      await strategy(workspace([core, spy]));
+
+      expect(logging.log).not.toHaveBeenCalledWith(expect.stringContaining('will release without'), 'warning');
     });
   });
 });

--- a/packages/version/test/unit/core/groupStrategy.spec.ts
+++ b/packages/version/test/unit/core/groupStrategy.spec.ts
@@ -421,4 +421,89 @@ describe('createGroupStrategy', () => {
       await expect(strategy(workspace([core]))).rejects.toThrow(/more than one version group/);
     });
   });
+
+  describe('independent groups', () => {
+    it('should release each changed member on its own version line (no shared version)', async () => {
+      const core = mkPackage('@wdio/native-core', '2.3.0');
+      const utils = mkPackage('@wdio/native-utils', '2.3.0');
+
+      // core earns a minor, utils a patch — independent means each keeps its own commit-driven bump
+      // (a fixed/linked group would write the shared 2.4.0 to both).
+      vi.mocked(calculator.calculateVersion).mockImplementation(async (_cfg, opts) => {
+        if (opts.name === '@wdio/native-core') return '2.4.0';
+        if (opts.name === '@wdio/native-utils') return '2.3.1';
+        return '';
+      });
+
+      const strategy = createGroupStrategy(
+        baseConfig({ groups: { native: { packages: ['@wdio/native-*'], sync: 'independent' } } }),
+      );
+      await strategy(workspace([core, utils]));
+
+      expect(packageManagement.updatePackageVersion).toHaveBeenCalledWith(
+        '/ws/packages/wdio-native-core/package.json',
+        '2.4.0',
+        undefined,
+      );
+      expect(packageManagement.updatePackageVersion).toHaveBeenCalledWith(
+        '/ws/packages/wdio-native-utils/package.json',
+        '2.3.1',
+        undefined,
+      );
+      // Still tagged with the group name so CI surfaces treat the set as a unit.
+      expect(jsonOutput.setPackageUpdateGroup).toHaveBeenCalledWith('@wdio/native-core', 'native');
+      expect(jsonOutput.setPackageUpdateGroup).toHaveBeenCalledWith('@wdio/native-utils', 'native');
+    });
+
+    it('should skip unchanged members', async () => {
+      const core = mkPackage('@wdio/native-core', '2.3.0');
+      const utils = mkPackage('@wdio/native-utils', '2.3.0');
+
+      // Only core changed.
+      vi.mocked(calculator.calculateVersion).mockImplementation(async (_cfg, opts) =>
+        opts.name === '@wdio/native-core' ? '2.4.0' : '',
+      );
+
+      const strategy = createGroupStrategy(
+        baseConfig({ groups: { native: { packages: ['@wdio/native-*'], sync: 'independent' } } }),
+      );
+      await strategy(workspace([core, utils]));
+
+      expect(packageManagement.updatePackageVersion).toHaveBeenCalledWith(
+        '/ws/packages/wdio-native-core/package.json',
+        '2.4.0',
+        undefined,
+      );
+      expect(packageManagement.updatePackageVersion).not.toHaveBeenCalledWith(
+        '/ws/packages/wdio-native-utils/package.json',
+        expect.anything(),
+        undefined,
+      );
+      expect(jsonOutput.setPackageUpdateGroup).not.toHaveBeenCalledWith('@wdio/native-utils', 'native');
+    });
+
+    it('should warn when an independent group ships without an excluded member', async () => {
+      const core = mkPackage('@wdio/native-core', '2.3.0');
+      const utils = mkPackage('@wdio/native-utils', '2.3.0');
+      const spy = mkPackage('@wdio/native-spy', '2.3.0');
+
+      // core changes; spy is excluded via config.skip, so the atomic set ships partially.
+      vi.mocked(calculator.calculateVersion).mockImplementation(async (_cfg, opts) =>
+        opts.name === '@wdio/native-core' ? '2.4.0' : '',
+      );
+
+      const strategy = createGroupStrategy(
+        baseConfig({
+          skip: ['@wdio/native-spy'],
+          groups: { native: { packages: ['@wdio/native-*'], sync: 'independent' } },
+        }),
+      );
+      await strategy(workspace([core, utils, spy]));
+
+      expect(logging.log).toHaveBeenCalledWith(
+        expect.stringContaining('will release without: @wdio/native-spy'),
+        'warning',
+      );
+    });
+  });
 });

--- a/releasekit.schema.json
+++ b/releasekit.schema.json
@@ -123,9 +123,10 @@
                 "type": "string",
                 "enum": [
                   "fixed",
-                  "linked"
+                  "linked",
+                  "independent"
                 ],
-                "description": "fixed: all members release together at the shared group version. linked: only changed members release, all at the same computed version."
+                "description": "fixed: all members release together at the shared group version. linked: only changed members release, all at the same computed version. independent: only changed members release, each on its own commit-driven version line (no shared version), but the set ships atomically."
               }
             },
             "required": [
@@ -133,7 +134,7 @@
               "sync"
             ]
           },
-          "description": "Named version groups. Each group binds a set of package patterns to a fixed or linked sync mode. fixed: any releasable change in any member releases ALL members at the shared group version (bump(max(member baselines))). linked: only members with releasable changes release, but every releasing member shares the same computed version. Packages not matched by any group version independently. A package may belong to at most one group. Set version.sync to false when using groups.",
+          "description": "Named version groups. Each group binds a set of package patterns to a fixed, linked, or independent sync mode. fixed: any releasable change in any member releases ALL members at the shared group version (bump(max(member baselines))). linked: only members with releasable changes release, but every releasing member shares the same computed version. independent: only members with releasable changes release, each on its own commit-driven version line (no shared version), but the set is atomic — targeting any member pulls in the whole group. Packages not matched by any group version independently. A package may belong to at most one group. Set version.sync to false when using groups.",
           "propertyNames": {
             "type": "string"
           }

--- a/scripts/generate-config-docs.ts
+++ b/scripts/generate-config-docs.ts
@@ -187,6 +187,11 @@ function renderVersion(prop: SchemaProperty): void {
       '  group of every package — there is one mechanism, not two.',
       '- **`linked`** — only members with a releasable change release, but every releasing member',
       '  shares the same computed version. Unchanged members are left untouched (no empty re-release).',
+      '- **`independent`** — only members with a releasable change release, each on its **own**',
+      '  commit-driven version line (no shared group version). The set is still atomic: targeting any',
+      '  member pulls in the whole group, and dropping a changed member (via `config.skip`) warns. Use',
+      '  this for packages coupled by a contract but versioned separately (e.g. a wire protocol across',
+      '  an npm package and a Rust crate on different version lines).',
       '',
     );
     emit(
@@ -202,9 +207,9 @@ function renderVersion(prop: SchemaProperty): void {
       '',
     );
     emit(
-      '**`--target` and fixed groups.** Targeting a strict subset of a `fixed` group expands to the',
-      'whole group (a fixed group never silently splits). `linked` groups and ungrouped packages honor',
-      'targets as-is.',
+      '**`--target` and atomic groups.** Targeting a strict subset of an atomic group (`fixed` or',
+      '`independent`) expands to the whole group, so it never silently splits. `linked` groups and',
+      'ungrouped packages honor targets as-is.',
       '',
     );
     emit(


### PR DESCRIPTION
## What

Adds a third `version.groups` sync mode — **`independent`** — completing the taxonomy alongside `fixed` and `linked`.

| mode | members release | version line |
|---|---|---|
| `fixed` | all (on any member's change) | shared |
| `linked` | changed only | shared |
| **`independent`** | **changed only** | **own commit-driven line each** |

An `independent` group's members each version on their own line (no shared group version), but the set is **atomic**: targeting any member expands to the whole group, and shipping a partial subset (via `config.skip` / `--target`) warns. This is the mode for wire-protocol-coupled packages that live on different version lines — e.g. zubridge's `@zubridge/tauri` (npm, `1.1.x`) + `tauri-plugin-zubridge` (cargo, `0.1.x`).

Closes #363.

## Changes

- **config**: `'independent'` enum value on `version.groups.*.sync` + updated descriptions; `releasekit.schema.json` + `docs/configuration.md` regenerated (`schema:check` green).
- **groupResolution**: `ResolvedGroup.sync` gains `'independent'`; `expandTargetsForFixedGroups` → `expandTargetsForAtomicGroups` (now expands `fixed` *and* `independent`; `linked` left untouched).
- **groupStrategy**: `computeGroup` short-circuits `independent` (no shared version, changed-only `releasing`); `releaseGroup` writes each member's own `ownNext` and returns per-member versions; the partial-release warning generalises to all atomic groups.

## Test

- `groupStrategy.spec` — each changed member on its own line (no shared version), skip-unchanged, partial-atomic warning.
- `groupResolution.spec` — `--target` on a subset of an `independent` group expands to the whole group.
- `schema.spec` — `independent` accepted; a genuinely-invalid mode still rejected.
- Full gate green: `pnpm turbo run lint typecheck test` (24 tasks).

## Notes

Wave B, first item (now that #356 / #362 are merged). Self-contained — no dependency graph needed. Next: #364 (`overrideScope`) → #365 (prerequisite resolution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces `independent` as a third `version.groups` sync mode, completing the trio alongside `fixed` and `linked`. Members of an `independent` group each release on their own commit-driven version line with no shared group version, but the set remains atomic — targeting any member expands to the whole group, and dropping a changed member via `config.skip` triggers a warning.

- **Schema & config**: `'independent'` added to the `sync` enum in `schema.ts`, `releasekit.schema.json` regenerated, and `docs/configuration.md` / `generate-config-docs.ts` updated with prose, table entry, and revised `--target and atomic groups` subsection.
- **groupResolution**: `expandTargetsForFixedGroups` renamed to `expandTargetsForAtomicGroups`; the guard flips from `!== 'fixed'` to `=== 'linked'` so both `fixed` and `independent` groups expand on a strict-subset target.
- **groupStrategy**: `computeGroup` short-circuits `independent` groups with an empty `groupVersion` and `releasing = changedPlans`; `releaseGroup` uses `plan.ownNext` per member; the partial-release warning now plans excluded members for `independent` groups and only fires when a dropped member actually had changes, correctly avoiding the false-positive case flagged in the prior review.
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge — the logic is well-contained, all three sync modes are correctly branched, and the prior false-positive warning concern has been resolved.

All changed files are internally consistent. The independent path through `computeGroup` and `releaseGroup` is cleanly isolated behind `group.sync === 'independent'` guards, `plan.ownNext` is always non-empty for members that reach the release loop (guarded by `changed: !!ownNext`), and the partial-warning logic correctly excludes unchanged dropped members for independent groups. Test coverage is thorough across schema acceptance/rejection, target expansion, per-member version lines, skip-unchanged, warn-on-dropped-changed, and no-false-positive-on-dropped-unchanged scenarios.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/version/src/core/groupStrategy.ts | Independent path short-circuits `computeGroup` with no shared version; `releaseGroup` uses `plan.ownNext` per member; partial-release warning correctly plans excluded members and only fires for changed ones. |
| packages/version/src/core/groupResolution.ts | Rename `expandTargetsForFixedGroups` → `expandTargetsForAtomicGroups`; the `linked`-skip guard cleanly replaces the old `fixed`-only guard; `ResolvedGroup.sync` union updated correctly. |
| packages/version/test/unit/core/groupStrategy.spec.ts | Four new `independent` group specs cover: per-member version lines, skip-unchanged, warn-on-dropped-changed, and no-false-positive-on-dropped-unchanged. |
| packages/version/test/unit/core/groupResolution.spec.ts | Describe block label updated; new test verifies independent-group subset expansion; existing fixed/linked tests updated to use the renamed export. |
| packages/config/src/schema.ts | Adds `'independent'` to the `sync` enum and updates descriptions across both the group schema and the groups description string. |
| packages/config/test/unit/schema.spec.ts | Previous rejection test updated from `'independent'` to `'frozen'`; new acceptance test for `independent` added; both correct. |
| docs/configuration.md | Table row, prose bullet, and `--target` subsection all updated to reflect the new `independent` mode and the atomic-group concept. |
| releasekit.schema.json | Generated JSON schema regenerated; `independent` added to the `sync` enum and descriptions updated consistently. |
| scripts/generate-config-docs.ts | Doc-generator updated with the new `independent` bullet and the updated `--target and atomic groups` paragraph. |

</details>


</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `docs/configuration.md`, line 111-128 ([link](https://github.com/goosewobbler/releasekit/blob/12c05a4fa97dfa7165a09ec1516f490ff1501859/docs/configuration.md#L111-L128)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Missing `independent` prose section and stale `--target` docs**

   The table row for `sync` was updated to include `independent`, but the hand-written prose below the table only has bullet explanations for `fixed` and `linked` — `independent` has no comparable entry. Readers who scan past the table will see no descriptive paragraph for the new mode.

   Additionally, the `--target and fixed groups` subsection (line 126) is now stale: `independent` groups are also atomic and also expand on a strict-subset target, but the section title and body still name only `fixed`. A user with an `independent` group who reads that section will incorrectly believe only `fixed` groups expand.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20docs%2Fconfiguration.md%0ALine%3A%20111-128%0A%0AComment%3A%0A**Missing%20%60independent%60%20prose%20section%20and%20stale%20%60--target%60%20docs**%0A%0AThe%20table%20row%20for%20%60sync%60%20was%20updated%20to%20include%20%60independent%60%2C%20but%20the%20hand-written%20prose%20below%20the%20table%20only%20has%20bullet%20explanations%20for%20%60fixed%60%20and%20%60linked%60%20%E2%80%94%20%60independent%60%20has%20no%20comparable%20entry.%20Readers%20who%20scan%20past%20the%20table%20will%20see%20no%20descriptive%20paragraph%20for%20the%20new%20mode.%0A%0AAdditionally%2C%20the%20%60--target%20and%20fixed%20groups%60%20subsection%20%28line%20126%29%20is%20now%20stale%3A%20%60independent%60%20groups%20are%20also%20atomic%20and%20also%20expand%20on%20a%20strict-subset%20target%2C%20but%20the%20section%20title%20and%20body%20still%20name%20only%20%60fixed%60.%20A%20user%20with%20an%20%60independent%60%20group%20who%20reads%20that%20section%20will%20incorrectly%20believe%20only%20%60fixed%60%20groups%20expand.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=goosewobbler%2Freleasekit&pr=382&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20docs%2Fconfiguration.md%0ALine%3A%20111-128%0A%0AComment%3A%0A**Missing%20%60independent%60%20prose%20section%20and%20stale%20%60--target%60%20docs**%0A%0AThe%20table%20row%20for%20%60sync%60%20was%20updated%20to%20include%20%60independent%60%2C%20but%20the%20hand-written%20prose%20below%20the%20table%20only%20has%20bullet%20explanations%20for%20%60fixed%60%20and%20%60linked%60%20%E2%80%94%20%60independent%60%20has%20no%20comparable%20entry.%20Readers%20who%20scan%20past%20the%20table%20will%20see%20no%20descriptive%20paragraph%20for%20the%20new%20mode.%0A%0AAdditionally%2C%20the%20%60--target%20and%20fixed%20groups%60%20subsection%20%28line%20126%29%20is%20now%20stale%3A%20%60independent%60%20groups%20are%20also%20atomic%20and%20also%20expand%20on%20a%20strict-subset%20target%2C%20but%20the%20section%20title%20and%20body%20still%20name%20only%20%60fixed%60.%20A%20user%20with%20an%20%60independent%60%20group%20who%20reads%20that%20section%20will%20incorrectly%20believe%20only%20%60fixed%60%20groups%20expand.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=382&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix(version): only warn on a dropped \*ch..."](https://github.com/goosewobbler/releasekit/commit/e187fd9249ffeff45aed12567c4270ac9d1d81f2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38997988)</sub>

<!-- /greptile_comment -->