### PR TITLE
feat(version): scope the forced bump/prerelease/stable override per-package

### DIFF
--- a/packages/version/src/core/versionCalculator.ts
+++ b/packages/version/src/core/versionCalculator.ts
@@ -3,7 +3,7 @@
  */
 
 import { cwd } from 'node:process';
-import { sanitizePackageName } from '@releasekit/core';
+import { sanitizePackageName, shouldMatchPackageTargets } from '@releasekit/core';
 import { Bumper } from 'conventional-recommended-bump';
 import type { ReleaseType } from 'semver';
 import semver from 'semver';
@@ -22,9 +22,33 @@ import {
 } from '../utils/versionUtils.js';
 
 /**
+ * Strip the forced `bump` / `prerelease` / `stable` override for a package outside `overrideScope`,
+ * so it falls through to commit-driven calculation. Returns the (possibly scoped) config + options.
+ * Scoping changes *who* the override applies to, never the composed-bump formula.
+ */
+export function applyOverrideScope(
+  config: Config,
+  options: VersionOptions,
+): { config: Config; options: VersionOptions } {
+  const { overrideScope } = config;
+  if (overrideScope?.length && options.name && !shouldMatchPackageTargets(options.name, overrideScope)) {
+    return {
+      config: { ...config, type: undefined, isPrerelease: false, stableOnly: false },
+      options: { ...options, type: undefined },
+    };
+  }
+  return { config, options };
+}
+
+/**
  * Calculates the next version number based on the current version and options
  */
 export async function calculateVersion(config: Config, options: VersionOptions): Promise<string> {
+  const scoped = applyOverrideScope(config, options);
+  return calculateVersionInner(scoped.config, scoped.options);
+}
+
+async function calculateVersionInner(config: Config, options: VersionOptions): Promise<string> {
   log(`Starting version calculation for ${options.name || 'project'}`, 'debug');
 
   const {

--- a/packages/version/src/core/versionCalculator.ts
+++ b/packages/version/src/core/versionCalculator.ts
@@ -31,9 +31,14 @@ export function applyOverrideScope(
   options: VersionOptions,
 ): { config: Config; options: VersionOptions } {
   const { overrideScope } = config;
+  // `type` / `isPrerelease` / `stableOnly` are the engine's runtime override fields (folded from
+  // runOptions bump/prerelease/stable) — none is a static config-file setting, so clearing them to
+  // their "not specified" sentinel reverts an out-of-scope package to commit-driven calculation.
+  // When `options.name` is absent (a single-package repo) there's nothing to match against, so the
+  // override applies — scoping is only meaningful across multiple packages.
   if (overrideScope?.length && options.name && !shouldMatchPackageTargets(options.name, overrideScope)) {
     return {
-      config: { ...config, type: undefined, isPrerelease: false, stableOnly: false },
+      config: { ...config, type: undefined, isPrerelease: undefined, stableOnly: undefined },
       options: { ...options, type: undefined },
     };
   }

--- a/packages/version/src/core/versionEngine.ts
+++ b/packages/version/src/core/versionEngine.ts
@@ -49,6 +49,7 @@ export class VersionEngine {
       if (runOptions.stable) effective.stableOnly = true;
       if (runOptions.targets?.length) this.runtimeTargets = runOptions.targets;
       if (runOptions.baseRef) effective.baseRef = runOptions.baseRef;
+      if (runOptions.overrideScope) effective.overrideScope = runOptions.overrideScope;
     }
 
     // Default values for required properties

--- a/packages/version/src/types.ts
+++ b/packages/version/src/types.ts
@@ -33,6 +33,12 @@ export interface VersionRunOptions {
    * Useful for preview mode where only a PR's own commits should be analysed.
    */
   baseRef?: string;
+  /**
+   * Package name patterns the `bump` / `prerelease` / `stable` override applies to. When set, only
+   * matching packages receive the override; the rest fall through to commit-driven calculation.
+   * `undefined` (the default) applies the override to every package.
+   */
+  overrideScope?: string[];
 }
 
 export interface GitInfo {
@@ -87,6 +93,9 @@ export interface Config extends VersionConfigBase {
   /** Runtime override: when set, use this commit SHA as the start of the revision range
    *  for both bump calculation and changelog extraction. See VersionRunOptions.baseRef. */
   baseRef?: string;
+  /** Runtime override: package patterns the forced bump/prerelease/stable applies to. When set,
+   *  non-matching packages ignore the override and compute commit-driven. See VersionRunOptions.overrideScope. */
+  overrideScope?: string[];
   mismatchStrategy?: 'error' | 'warn' | 'ignore' | 'prefer-package' | 'prefer-git';
   strictReachable?: boolean;
   /** Pre-1.0 inferred-breaking bump policy ('spec' | 'strict'). See docs/configuration.md#versionzeromajor. */

--- a/packages/version/test/unit/core/applyOverrideScope.spec.ts
+++ b/packages/version/test/unit/core/applyOverrideScope.spec.ts
@@ -39,9 +39,20 @@ describe('applyOverrideScope', () => {
   it('should strip the override for a package outside overrideScope so it computes commit-driven', () => {
     const { config, options } = applyOverrideScope(cfg(['@scope/a']), opts('@other/b'));
     expect(config.type).toBeUndefined();
-    expect(config.isPrerelease).toBe(false);
-    expect(config.stableOnly).toBe(false);
+    expect(config.isPrerelease).toBeUndefined();
+    expect(config.stableOnly).toBeUndefined();
     expect(options.type).toBeUndefined();
+  });
+
+  it('should apply the override when the package has no name (single-package repo)', () => {
+    const { config, options } = applyOverrideScope(cfg(['@scope/a']), {
+      latestTag: 'v1.0.0',
+      versionPrefix: 'v',
+      type: 'major',
+    });
+    expect(config.type).toBe('major');
+    expect(config.isPrerelease).toBe(true);
+    expect(options.type).toBe('major');
   });
 
   it('should not mutate the input config (returns a scoped copy)', () => {

--- a/packages/version/test/unit/core/applyOverrideScope.spec.ts
+++ b/packages/version/test/unit/core/applyOverrideScope.spec.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { applyOverrideScope } from '../../../src/core/versionCalculator.js';
+import type { Config, VersionOptions } from '../../../src/types.js';
+
+// A config carrying a forced override (bump major + prerelease + stable), optionally scoped.
+const cfg = (overrideScope?: string[]): Config =>
+  ({
+    tagTemplate: '${prefix}${version}',
+    preset: 'conventional',
+    sync: false,
+    packages: [],
+    updateInternalDependencies: 'minor',
+    versionPrefix: 'v',
+    type: 'major',
+    isPrerelease: true,
+    stableOnly: true,
+    overrideScope,
+  }) as Config;
+
+const opts = (name: string): VersionOptions => ({ latestTag: 'v1.0.0', name, versionPrefix: 'v', type: 'major' });
+
+describe('applyOverrideScope', () => {
+  it('should apply the override to every package when overrideScope is undefined', () => {
+    const { config, options } = applyOverrideScope(cfg(undefined), opts('@scope/a'));
+    expect(config.type).toBe('major');
+    expect(config.isPrerelease).toBe(true);
+    expect(config.stableOnly).toBe(true);
+    expect(options.type).toBe('major');
+  });
+
+  it('should keep the override for a package that matches overrideScope', () => {
+    const { config, options } = applyOverrideScope(cfg(['@scope/*']), opts('@scope/a'));
+    expect(config.type).toBe('major');
+    expect(config.isPrerelease).toBe(true);
+    expect(config.stableOnly).toBe(true);
+    expect(options.type).toBe('major');
+  });
+
+  it('should strip the override for a package outside overrideScope so it computes commit-driven', () => {
+    const { config, options } = applyOverrideScope(cfg(['@scope/a']), opts('@other/b'));
+    expect(config.type).toBeUndefined();
+    expect(config.isPrerelease).toBe(false);
+    expect(config.stableOnly).toBe(false);
+    expect(options.type).toBeUndefined();
+  });
+
+  it('should not mutate the input config (returns a scoped copy)', () => {
+    const input = cfg(['@scope/a']);
+    applyOverrideScope(input, opts('@other/b'));
+    expect(input.type).toBe('major');
+    expect(input.isPrerelease).toBe(true);
+  });
+
+  it('should treat an empty overrideScope as "all packages"', () => {
+    const { config } = applyOverrideScope(cfg([]), opts('@other/b'));
+    expect(config.type).toBe('major');
+  });
+});


### PR DESCRIPTION
## What

Adds `VersionRunOptions.overrideScope?: string[]` — the package patterns a forced `bump` / `prerelease` / `stable` override applies to. `undefined` (today's behaviour) applies the override to every package; when set, only matching packages receive it and the rest fall through to commit-driven calculation.

This is the containment primitive **#365** (prerequisite resolution) builds on: it lets an explicit target set take, say, a `prerelease` override while *derived* prerequisites keep their own commit-driven bumps.

Closes #364.

## How

`calculateVersion` is the single per-package chokepoint — every strategy (sync / single / async / group) calls it with `options.name`. A new pure `applyOverrideScope(config, options)` strips the forced `type` / `isPrerelease` / `stableOnly` for a package outside `overrideScope`, returning a **scoped copy** (input config untouched); `calculateVersion` delegates to the unchanged body. The composed-bump SSOT is untouched — scoping changes *who* the override hits, never the formula. The engine folds `runOptions.overrideScope` into the effective config like the other overrides.

## Test

- `applyOverrideScope.spec` — `undefined` = all packages; a matched package keeps the override; an unmatched package has it stripped (commit-driven); empty array = all; the input config is not mutated.
- Full gate green: `pnpm turbo run lint typecheck test` (24 tasks).

## Notes

Wave B (Plan Phase 3). Branched off `main` — independent of #363 (which touches the group engine; this touches the calculator), so no stacking. Next: **#365** (prerequisite resolution), combining this with the dependency graph (#362) and group expansion (#363).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces `VersionRunOptions.overrideScope?: string[]`, a per-package filter that constrains which packages receive a forced `bump` / `prerelease` / `stable` override; packages outside the scope fall back to commit-driven calculation. The implementation is a pure, well-contained addition: a single exported `applyOverrideScope` helper wraps the existing `calculateVersion` body, and `VersionEngine` folds the new field into the effective config exactly like the other runtime overrides.

- **`applyOverrideScope`** (versionCalculator.ts) — returns a scoped copy of `config` + `options` with `type`, `isPrerelease`, and `stableOnly` cleared to `undefined` for non-matching packages; input config is never mutated. Single-package repos (no `options.name`) always receive the override, which is documented and tested.
- **`VersionRunOptions` / `Config`** (types.ts) — `overrideScope` is a runtime-only field; `toVersionConfig` correctly omits it so it cannot leak into static config.
- **Tests** (applyOverrideScope.spec.ts) — five cases covering all documented edge cases: undefined scope, matched package, unmatched package, unnamed-package bypass, and immutability.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a well-scoped addition with no mutations to existing code paths and full test coverage of the documented edge cases.

The `applyOverrideScope` function is purely additive: it wraps an existing body without modifying it, returns spread copies to preserve immutability, and the engine folds the new field identically to the other runtime overrides. No pre-existing behavior is altered for callers that don't set `overrideScope`.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/version/src/core/versionCalculator.ts | Adds exported `applyOverrideScope` + private `calculateVersionInner`; `calculateVersion` is now a thin wrapper that scopes overrides before delegating. Logic is clean and the input-config immutability contract is maintained. |
| packages/version/src/core/versionEngine.ts | Folds `runOptions.overrideScope` into the effective config alongside the other runtime overrides; one-line addition, consistent with the existing pattern. |
| packages/version/src/types.ts | Adds `overrideScope?: string[]` to both `VersionRunOptions` and `Config` with matching JSDoc; `toVersionConfig` intentionally omits `overrideScope` (runtime-only field), which is correct. |
| packages/version/test/unit/core/applyOverrideScope.spec.ts | Five targeted tests cover: undefined scope (all packages), matched package, unmatched package, unnamed package (single-repo bypass), and immutability; all documented edge cases are covered. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["calculateVersion(config, options)"] --> B["applyOverrideScope(config, options)"]
    B --> C{"overrideScope set AND non-empty?"}
    C -- No --> D["Return original config + options"]
    C -- Yes --> E{"options.name present?"}
    E -- "No - single-package repo" --> D
    E -- Yes --> F{"shouldMatchPackageTargets(name, overrideScope)?"}
    F -- Match --> D
    F -- "No match" --> G["Return scoped copy: type=undefined, isPrerelease=undefined, stableOnly=undefined"]
    D --> H["calculateVersionInner(config, options)"]
    G --> H
    H --> I{"type set?"}
    I -- Yes --> J["Forced bump logic"]
    I -- No --> K["Commit-driven conventional-commits"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["calculateVersion(config, options)"] --> B["applyOverrideScope(config, options)"]
    B --> C{"overrideScope set AND non-empty?"}
    C -- No --> D["Return original config + options"]
    C -- Yes --> E{"options.name present?"}
    E -- "No - single-package repo" --> D
    E -- Yes --> F{"shouldMatchPackageTargets(name, overrideScope)?"}
    F -- Match --> D
    F -- "No match" --> G["Return scoped copy: type=undefined, isPrerelease=undefined, stableOnly=undefined"]
    D --> H["calculateVersionInner(config, options)"]
    G --> H
    H --> I{"type set?"}
    I -- Yes --> J["Forced bump logic"]
    I -- No --> K["Commit-driven conventional-commits"]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["refactor(version): clarify override-scop..."](https://github.com/goosewobbler/releasekit/commit/8e2c23287037c1621149d71fdc2a3b27605ad228) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39001103)</sub>

<!-- /greptile_comment -->