### PR TITLE
feat(core): prerequisite resolution (core) — resolvePrerequisites

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -32,6 +32,7 @@ export {
   shouldMatchPackageTargets,
   shouldProcessPackage,
 } from './packageUtils.js';
+export { type PrerequisiteResolution, resolvePrerequisites } from './prerequisites.js';
 export type {
   VersionChangelogEntry,
   VersionOutput,

--- a/packages/core/src/prerequisites.ts
+++ b/packages/core/src/prerequisites.ts
@@ -49,5 +49,6 @@ export function resolvePrerequisites(
   // alone would miss that cross-boundary edge (the target isn't in the slice).
   const prerequisites = graph.topologicalOrder([...targetSet]).filter((name) => prereqSet.has(name));
 
-  return { targets: explicitTargets, prerequisites, targetSet };
+  // Return a copy of the targets, not the caller's array, so all three fields are freshly owned.
+  return { targets: [...explicitTargets], prerequisites, targetSet };
 }

--- a/packages/core/src/prerequisites.ts
+++ b/packages/core/src/prerequisites.ts
@@ -2,8 +2,9 @@
  * Prerequisite resolution — given a set of explicit release targets, derive the *prerequisite*
  * releases: the transitive internal dependencies of those targets that ALSO have a releasable
  * change. Prerequisites are pulled in only if they changed (an unchanged dependency needs no
- * release), are dependency-ordered so a dependency precedes its dependents, and keep their own
- * commit-driven bump (the override applies to the explicit targets, not their prerequisites).
+ * release), are listed in the workspace's dependency order (the full release set is published
+ * deps-first), and keep their own commit-driven bump (the override applies to the explicit targets,
+ * not their prerequisites).
  *
  * Group expansion of the explicit targets is the caller's concern — this operates on whatever
  * target list it is given.
@@ -16,7 +17,10 @@ export interface PrerequisiteResolution {
   targets: string[];
   /**
    * Derived prerequisites: transitive internal dependencies of the targets that also changed,
-   * dependency-ordered, excluding the targets themselves. Each keeps its own commit-driven bump.
+   * excluding the targets themselves, each keeping its own commit-driven bump. Listed in the
+   * workspace's dependency order — consistent with the full release set, not just among themselves.
+   * The authoritative publish order is `topologicalOrder([...targetSet])`; prerequisites are NOT a
+   * standalone "publish these before the targets" list.
    */
   prerequisites: string[];
   /** Everything that will release: targets ∪ prerequisites. */
@@ -38,10 +42,12 @@ export function resolvePrerequisites(
       if (changed.has(dep) && !targetSet.has(dep)) prereqSet.add(dep);
     }
   }
+  for (const name of prereqSet) targetSet.add(name);
 
-  // Dependency-ordered so the publish stage sees prerequisites before their dependents.
-  const prerequisites = graph.topologicalOrder([...prereqSet]);
-  for (const name of prerequisites) targetSet.add(name);
+  // Order by the FULL release set's dependency order, then filter to the derived subset — so a
+  // prerequisite that depends on an explicit target sorts after it. Ordering the prerequisite slice
+  // alone would miss that cross-boundary edge (the target isn't in the slice).
+  const prerequisites = graph.topologicalOrder([...targetSet]).filter((name) => prereqSet.has(name));
 
   return { targets: explicitTargets, prerequisites, targetSet };
 }

--- a/packages/core/src/prerequisites.ts
+++ b/packages/core/src/prerequisites.ts
@@ -1,0 +1,47 @@
+/**
+ * Prerequisite resolution — given a set of explicit release targets, derive the *prerequisite*
+ * releases: the transitive internal dependencies of those targets that ALSO have a releasable
+ * change. Prerequisites are pulled in only if they changed (an unchanged dependency needs no
+ * release), are dependency-ordered so a dependency precedes its dependents, and keep their own
+ * commit-driven bump (the override applies to the explicit targets, not their prerequisites).
+ *
+ * Group expansion of the explicit targets is the caller's concern — this operates on whatever
+ * target list it is given.
+ */
+
+import type { WorkspaceDependencyGraph } from './dependencyGraph.js';
+
+export interface PrerequisiteResolution {
+  /** The explicit release targets, verbatim — they receive any bump/prerelease/stable override. */
+  targets: string[];
+  /**
+   * Derived prerequisites: transitive internal dependencies of the targets that also changed,
+   * dependency-ordered, excluding the targets themselves. Each keeps its own commit-driven bump.
+   */
+  prerequisites: string[];
+  /** Everything that will release: targets ∪ prerequisites. */
+  targetSet: Set<string>;
+}
+
+export function resolvePrerequisites(
+  graph: WorkspaceDependencyGraph,
+  explicitTargets: string[],
+  changedPackages: Iterable<string>,
+): PrerequisiteResolution {
+  const changed = new Set(changedPackages);
+  const targetSet = new Set(explicitTargets);
+  const prereqSet = new Set<string>();
+
+  for (const target of explicitTargets) {
+    for (const dep of graph.transitiveDependencies(target)) {
+      // A dependency is a prerequisite only when it actually changed and isn't itself a target.
+      if (changed.has(dep) && !targetSet.has(dep)) prereqSet.add(dep);
+    }
+  }
+
+  // Dependency-ordered so the publish stage sees prerequisites before their dependents.
+  const prerequisites = graph.topologicalOrder([...prereqSet]);
+  for (const name of prerequisites) targetSet.add(name);
+
+  return { targets: explicitTargets, prerequisites, targetSet };
+}

--- a/packages/core/test/unit/prerequisites.spec.ts
+++ b/packages/core/test/unit/prerequisites.spec.ts
@@ -47,6 +47,22 @@ describe('resolvePrerequisites', () => {
     expect(prerequisites).not.toContain('utils');
   });
 
+  it('should order prerequisites by the full release graph when a prereq depends on a target', () => {
+    // utils (a prerequisite) depends on core (an explicit target). The complete release order must
+    // place core before utils — prerequisites must not be treated as "publish before the targets".
+    const { targets, prerequisites, targetSet } = resolvePrerequisites(
+      graph,
+      ['core', 'app'],
+      ['app', 'utils', 'core'],
+    );
+    expect(targets).toEqual(['core', 'app']);
+    expect(prerequisites).toEqual(['utils']); // core is a target, so only utils is a derived prereq
+    expect(targetSet).toEqual(new Set(['core', 'app', 'utils']));
+    // The authoritative publish order is the topo-sort of the full release set: core before utils.
+    const order = graph.topologicalOrder([...targetSet]);
+    expect(order.indexOf('core')).toBeLessThan(order.indexOf('utils'));
+  });
+
   it('should dedupe a prerequisite shared by multiple targets', () => {
     const { prerequisites } = resolvePrerequisites(graph, ['utils', 'types'], ['utils', 'types', 'core']);
     expect(prerequisites).toEqual(['core']);

--- a/packages/core/test/unit/prerequisites.spec.ts
+++ b/packages/core/test/unit/prerequisites.spec.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { buildDependencyGraph, type GraphPackage } from '../../src/dependencyGraph.js';
+import { resolvePrerequisites } from '../../src/prerequisites.js';
+
+function pkg(name: string, deps: string[]): GraphPackage {
+  return { name, dir: `/ws/${name}`, ecosystem: 'npm', deps };
+}
+
+// core <- utils, core <- types, {utils,types} <- app
+const graph = buildDependencyGraph([
+  pkg('core', []),
+  pkg('utils', ['core']),
+  pkg('types', ['core']),
+  pkg('app', ['utils', 'types']),
+]);
+
+describe('resolvePrerequisites', () => {
+  it('should derive changed transitive deps as prerequisites, dependency-ordered', () => {
+    const { targets, prerequisites, targetSet } = resolvePrerequisites(
+      graph,
+      ['app'],
+      ['app', 'utils', 'types', 'core'],
+    );
+    expect(targets).toEqual(['app']);
+    expect(new Set(prerequisites)).toEqual(new Set(['core', 'utils', 'types']));
+    // core is depended on by utils + types, so it must come first.
+    expect(prerequisites.indexOf('core')).toBeLessThan(prerequisites.indexOf('utils'));
+    expect(prerequisites.indexOf('core')).toBeLessThan(prerequisites.indexOf('types'));
+    expect(targetSet).toEqual(new Set(['app', 'utils', 'types', 'core']));
+  });
+
+  it('should skip dependencies that did not change', () => {
+    const { prerequisites, targetSet } = resolvePrerequisites(graph, ['app'], ['app', 'utils']);
+    expect(prerequisites).toEqual(['utils']);
+    expect(targetSet).toEqual(new Set(['app', 'utils']));
+  });
+
+  it('should return no prerequisites when the target has no changed dependencies', () => {
+    const { prerequisites, targetSet } = resolvePrerequisites(graph, ['app'], ['app']);
+    expect(prerequisites).toEqual([]);
+    expect(targetSet).toEqual(new Set(['app']));
+  });
+
+  it('should never count an explicit target as its own prerequisite', () => {
+    const { prerequisites } = resolvePrerequisites(graph, ['app', 'utils'], ['app', 'utils', 'core']);
+    expect(prerequisites).toEqual(['core']);
+    expect(prerequisites).not.toContain('utils');
+  });
+
+  it('should dedupe a prerequisite shared by multiple targets', () => {
+    const { prerequisites } = resolvePrerequisites(graph, ['utils', 'types'], ['utils', 'types', 'core']);
+    expect(prerequisites).toEqual(['core']);
+  });
+
+  it('should not throw and derive nothing for a target outside the graph', () => {
+    const { targets, prerequisites } = resolvePrerequisites(graph, ['ghost'], ['ghost', 'core']);
+    expect(targets).toEqual(['ghost']);
+    expect(prerequisites).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What

The **core of prerequisite resolution** (first half of #365): a pure `resolvePrerequisites` in `@releasekit/core`.

```ts
resolvePrerequisites(graph, explicitTargets, changedPackages)
  → { targets, prerequisites, targetSet }
```

Given explicit release targets, it derives the **prerequisites**: the transitive internal dependencies of the targets that *also* have a releasable change — dependency-ordered, excluding the targets themselves. Unchanged dependencies are not pulled in (nothing to release); prerequisites keep their own commit-driven bump (the override applies to the explicit targets, not their prerequisites). Built directly on the dependency graph from #362.

## Why split

#365 combines three foundations — the dependency graph (#362, **merged**), group-aware target expansion (#363, PR #382), and `overrideScope` (#364, PR #383). The graph-only core has no dependency on the latter two, so it lands cleanly off `main` now. The **engine wiring** (run `resolvePrerequisites` before the discovery pre-filter via a defer flag; expand explicit targets to their group; set `overrideScope` = expanded targets; exclude derived prerequisites) and the **CLI** (`--include-prerequisites`, `standing-pr update --target`) follow in a second PR once #382 and #383 merge.

## Test

`prerequisites.spec` — deps-ordered closure; unchanged deps skipped; no-prereq case; a target is never its own prerequisite; shared prereq deduped; unknown target is a safe no-op. Full gate green (24 tasks).

## Notes

Part of #365 (does not close it). Wave B, Plan Phase 4 (core).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces `resolvePrerequisites` in `@releasekit/core` — a pure function that, given explicit release targets and the set of changed packages, derives the transitive internal dependencies that also need to be released (prerequisites), keeping them in correct workspace dependency order. The previous review's concern about cross-boundary ordering (a prerequisite that depends on an explicit target) has been addressed by running `topologicalOrder` over the full release set (`targets ∪ prereqs`) and then filtering, rather than ordering the prerequisite slice in isolation.

- **`prerequisites.ts`**: Clean, well-documented implementation. The key invariant — using `topologicalOrder([...targetSet])` on the combined set before filtering — correctly resolves ordering across the target/prerequisite boundary without extra complexity.
- **`prerequisites.spec.ts`**: Seven focused tests covering the full behaviour surface, including the newly added cross-boundary ordering test that locks in the corrected contract raised in the prior review.
- **`index.ts`**: Minimal export addition; no concerns.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the implementation is a pure, self-contained function with no side effects, and the prior ordering bug is demonstrably fixed and test-covered.

The cross-boundary ordering issue flagged in the previous review is now correctly handled by computing topologicalOrder over the full release set (targets + prerequisites) before filtering, and a dedicated test validates this contract. All other edge cases (unchanged deps skipped, no self-prerequisite, dedup, unknown target) are covered. No new logic issues found.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/core/src/prerequisites.ts | New pure function resolvePrerequisites correctly derives prerequisite releases using the full-release-set topological order to avoid cross-boundary ordering errors; previous review concern about ordering is now addressed. |
| packages/core/test/unit/prerequisites.spec.ts | Seven test cases cover: deps-ordered closure, unchanged-dep skipping, no-prereq case, no self-prerequisite, cross-boundary ordering (prereq depends on a target), shared-prereq dedup, and unknown target no-op. The new cross-boundary test directly addresses the prior review concern. |
| packages/core/src/index.ts | Adds public export of PrerequisiteResolution type and resolvePrerequisites function; no issues. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["resolvePrerequisites(graph, explicitTargets, changedPackages)"] --> B["Build changed Set\nBuild targetSet from explicitTargets\nInit empty prereqSet"]
    B --> C["For each explicit target:\n  walk transitiveDependencies(target)"]
    C --> D{"dep in changed?\nAND dep not in targetSet?"}
    D -- Yes --> E["prereqSet.add(dep)"]
    D -- No --> C
    E --> C
    C --> F["Add all prereqSet names into targetSet\n(targets ∪ prereqs)"]
    F --> G["topologicalOrder([...targetSet])\n(full release set — cross-boundary edges included)"]
    G --> H["Filter result to prereqSet only\n→ prerequisites in correct dep order"]
    H --> I["Return { targets: copy, prerequisites, targetSet }"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["resolvePrerequisites(graph, explicitTargets, changedPackages)"] --> B["Build changed Set\nBuild targetSet from explicitTargets\nInit empty prereqSet"]
    B --> C["For each explicit target:\n  walk transitiveDependencies(target)"]
    C --> D{"dep in changed?\nAND dep not in targetSet?"}
    D -- Yes --> E["prereqSet.add(dep)"]
    D -- No --> C
    E --> C
    C --> F["Add all prereqSet names into targetSet\n(targets ∪ prereqs)"]
    F --> G["topologicalOrder([...targetSet])\n(full release set — cross-boundary edges included)"]
    G --> H["Filter result to prereqSet only\n→ prerequisites in correct dep order"]
    H --> I["Return { targets: copy, prerequisites, targetSet }"]
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["refactor(core): return a copy of targets..."](https://github.com/goosewobbler/releasekit/commit/6f18cf096cc70975af488efc11508d7541a26cf2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39003207)</sub>

<!-- /greptile_comment -->