### PR TITLE
feat: release prerequisites for targeted versioning (--include-prerequisites)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -52,6 +52,7 @@ Run the full release pipeline: version, changelog, publish, git, and GitHub Rele
 | `--stable` | boolean | `false` | Graduate prerelease packages to stable without bumping |
 | `-s, --sync` | boolean | `false` | Use synchronized versioning across all packages |
 | `-t, --target <packages>` | string | all | Target specific packages (comma-separated) |
+| `--include-prerequisites` | boolean | `false` | Also release the changed internal dependencies of `--target` packages (and the rest of their groups) |
 | `--scope <name>` | string | - | Resolve scope name to target packages from `ci.scopeLabels` config |
 | `--branch <name>` | string | current | Override the git branch used for push |
 | `--npm-auth <method>` | `auto` \| `oidc` \| `token` | `auto` | NPM auth method |
@@ -92,6 +93,8 @@ Calculate versions, commit to the release branch, and create/update the standing
 
 | Flag | Type | Default | Description |
 |---|---|---|---|
+| `-t, --target <packages>` | string | labels | Ad-hoc override: release only these packages (comma-separated). Wins over label-derived targets |
+| `--include-prerequisites` | boolean | `false` | With `--target`, also release the changed internal dependencies (and group members) of the targets |
 | `--reconcile` | boolean | `false` | Bypass the skip-pattern guard so a post-release reconcile run still updates the standing PR (HEAD is a release commit at that point) |
 
 ```bash
@@ -182,6 +185,7 @@ Version a package or packages based on configuration and conventional commits. A
 | `-s, --sync` | boolean | config | Use synchronized versioning across all packages |
 | `-j, --json` | boolean | `false` | Output results as JSON |
 | `-t, --target <packages>` | string | all | Comma-delimited list of package names to target |
+| `--include-prerequisites` | boolean | `false` | Also release the changed internal dependencies of `--target` packages (and the rest of their groups) |
 | `--project-dir <path>` | string | `cwd` | Project directory to run commands in |
 
 `--stable` and `--prerelease` are mutually exclusive. `--target` is ignored for single-package repos.

--- a/packages/release/src/commands/release-command.ts
+++ b/packages/release/src/commands/release-command.ts
@@ -13,6 +13,11 @@ export function createReleaseCommand(): Command {
     .option('--stable', 'Graduate prerelease packages to stable without bumping', false)
     .option('-s, --sync', 'Use synchronized versioning across all packages', false)
     .option('-t, --target <packages>', 'Target specific packages (comma-separated)')
+    .option(
+      '--include-prerequisites',
+      'Also release the changed internal dependencies of --target packages (and the rest of their groups)',
+      false,
+    )
     .option('--scope <name>', 'Resolve scope name to target packages from ci.scopeLabels config')
     .option('--branch <name>', 'Override the git branch used for push')
     .addOption(new Option('--npm-auth <method>', 'NPM auth method').choices(['auto', 'oidc', 'token']).default('auto'))
@@ -39,6 +44,7 @@ export function createReleaseCommand(): Command {
         stable: opts.stable,
         sync: opts.sync,
         target: opts.target,
+        includePrerequisites: opts.includePrerequisites,
         scope: opts.scope,
         branch: opts.branch,
         npmAuth: opts.npmAuth,

--- a/packages/release/src/commands/standing-pr-command.ts
+++ b/packages/release/src/commands/standing-pr-command.ts
@@ -21,6 +21,12 @@ export function createStandingPRCommand(): Command {
     cmd
       .command('update')
       .description('Calculate versions, commit to release branch, and create/update the standing PR')
+      .option('-t, --target <packages>', 'Ad-hoc override: release only these packages (comma-separated)')
+      .option(
+        '--include-prerequisites',
+        'With --target, also release the changed internal dependencies (and group members) of the targets',
+        false,
+      )
       .option(
         '--reconcile',
         'Bypass the skip-pattern guard so a post-release reconcile run still updates the standing PR (HEAD is a release commit at that point)',
@@ -35,6 +41,8 @@ export function createStandingPRCommand(): Command {
       verbose: opts.verbose,
       quiet: opts.quiet,
       reconcile: opts.reconcile,
+      target: opts.target,
+      includePrerequisites: opts.includePrerequisites,
     };
 
     try {

--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -38,6 +38,10 @@ export interface StandingPROptions {
    * intend an update, so they opt out via this flag. All other guards/behaviour are unchanged.
    */
   reconcile?: boolean;
+  /** Ad-hoc CLI override: release only these comma-split package patterns (supplements label overrides). */
+  target?: string;
+  /** Ad-hoc CLI override: also release the changed prerequisites (and group members) of the targets. */
+  includePrerequisites?: boolean;
 }
 
 export interface StandingPRResult {
@@ -679,6 +683,7 @@ interface BuildOptionsExtras {
   target?: string;
   stable?: boolean;
   prerelease?: boolean;
+  includePrerequisites?: boolean;
 }
 
 function buildBaseReleaseOptions(
@@ -692,6 +697,7 @@ function buildBaseReleaseOptions(
     sync: extras?.sync ?? false,
     bump: extras?.bump,
     target: extras?.target,
+    includePrerequisites: extras?.includePrerequisites,
     stable: extras?.stable,
     prerelease: extras?.prerelease ? true : undefined,
     skipNotes: true,
@@ -772,14 +778,18 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
   const sync = releaseKitConfig.version?.sync ?? false;
   // When labels conflict, drop the override (fall back to commit-driven) but keep the
   // conflict descriptions for the final status check.
+  // CLI --target (ad-hoc override) wins over the label-derived target; --include-prerequisites opts
+  // the targeted set's changed dependencies into the release either way.
+  const cliTarget = options.target ?? overrides.target;
   const buildExtras: BuildOptionsExtras = overrides.conflicts.length
-    ? { sync, target: overrides.target }
+    ? { sync, target: cliTarget, includePrerequisites: options.includePrerequisites }
     : {
         sync,
         bump: overrides.bump,
-        target: overrides.target,
+        target: cliTarget,
         stable: overrides.stable,
         prerelease: overrides.prerelease,
+        includePrerequisites: options.includePrerequisites,
       };
 
   // Dry-run version analysis to compute bumps without writing

--- a/packages/release/src/steps.ts
+++ b/packages/release/src/steps.ts
@@ -24,6 +24,7 @@ export async function runVersionStep(options: ReleaseOptions): Promise<VersionOu
     sync: options.sync,
     targets,
     baseRef: options.baseRef,
+    includePrerequisites: options.includePrerequisites,
   };
 
   const engine = new VersionEngine(config, runOptions);

--- a/packages/release/src/types.ts
+++ b/packages/release/src/types.ts
@@ -9,6 +9,8 @@ export interface ReleaseOptions {
   stable?: boolean;
   sync: boolean;
   target?: string;
+  /** Also release the changed internal dependencies of `target` packages (and the rest of their groups). */
+  includePrerequisites?: boolean;
   scope?: string;
   branch?: string;
   skipNotes: boolean;

--- a/packages/version/src/command.ts
+++ b/packages/version/src/command.ts
@@ -17,6 +17,11 @@ export function createVersionCommand(): Command {
     .option('-s, --sync', 'Use synchronized versioning across all packages')
     .option('-j, --json', 'Output results as JSON', false)
     .option('-t, --target <packages>', 'Comma-delimited list of package names to target')
+    .option(
+      '--include-prerequisites',
+      'Also release the changed internal dependencies of --target packages (and the rest of their groups)',
+      false,
+    )
     .option('--project-dir <path>', 'Project directory to run commands in', process.cwd())
     .action(async (options) => {
       if (options.stable && options.prerelease) {
@@ -57,6 +62,7 @@ export function createVersionCommand(): Command {
           dryRun: options.dryRun,
           sync: options.sync,
           targets: cliTargets.length > 0 ? cliTargets : undefined,
+          includePrerequisites: options.includePrerequisites,
         };
 
         const engine = new VersionEngine(config, runOptions);

--- a/packages/version/src/core/prerequisiteScope.ts
+++ b/packages/version/src/core/prerequisiteScope.ts
@@ -1,0 +1,55 @@
+/**
+ * Compose the prerequisite-release target set and override scope for a `--include-prerequisites`
+ * run, bridging the discovered workspace to the core `resolvePrerequisites`.
+ *
+ *  - Explicit targets are expanded to their whole group (any mode) — the bump/prerelease/stable
+ *    override applies to the declared coordination set, not just the one package named.
+ *  - Their transitive internal dependencies that *also changed* are pulled in as derived
+ *    prerequisites, which keep their own commit-driven bump (excluded from the override scope).
+ *
+ * The graph and changed-detection are injected so this stays a pure, unit-testable composition.
+ */
+
+import type { Package } from '@manypkg/get-packages';
+import { resolvePrerequisites, shouldMatchPackageTargets, type WorkspaceDependencyGraph } from '@releasekit/core';
+import type { Config } from '../types.js';
+import { resolveGroups } from './groupResolution.js';
+
+export interface PrerequisiteTargets {
+  /** Every package that will release: group-expanded explicit targets ∪ derived prerequisites. */
+  targets: string[];
+  /** The packages the bump/prerelease/stable override applies to (the group-expanded explicit set). */
+  overrideScope: string[];
+}
+
+export function resolvePrerequisiteTargets(
+  graph: WorkspaceDependencyGraph,
+  packages: Package[],
+  config: Config,
+  explicitTargets: string[],
+  isChanged: (name: string) => boolean,
+): PrerequisiteTargets {
+  const explicitNames = packages
+    .map((p) => p.packageJson.name)
+    .filter((name) => shouldMatchPackageTargets(name, explicitTargets));
+
+  // Expand each explicit target to its whole group, regardless of sync mode — the override is
+  // meant for the declared coordination set, and prerequisite derivation starts from that set.
+  const resolution = resolveGroups(config, packages);
+  const overrideSet = new Set(explicitNames);
+  for (const name of explicitNames) {
+    const group = resolution.groupOf(name);
+    if (group) for (const member of group.members) overrideSet.add(member.packageJson.name);
+  }
+
+  // Detect which transitive dependencies of the expanded targets actually changed — only those
+  // become prerequisites (an unchanged dependency needs no release).
+  const candidateDeps = new Set<string>();
+  for (const name of overrideSet) {
+    for (const dep of graph.transitiveDependencies(name)) candidateDeps.add(dep);
+  }
+  const changed = [...candidateDeps].filter((name) => isChanged(name));
+
+  const { targetSet } = resolvePrerequisites(graph, [...overrideSet], changed);
+  return { targets: [...targetSet], overrideScope: [...overrideSet] };
+}

--- a/packages/version/src/core/versionEngine.ts
+++ b/packages/version/src/core/versionEngine.ts
@@ -8,9 +8,13 @@ import { minimatch } from 'minimatch';
 import * as yaml from 'yaml';
 import { GitError } from '../errors/gitError.js';
 import { createVersionError, VersionError, VersionErrorCode } from '../errors/versionError.js';
+import { getCommitsLength, getLatestTag, getLatestTagForPackage } from '../git/tagsAndBranches.js';
 import type { Config, VersionRunOptions } from '../types.js';
+import { formatVersionPrefix } from '../utils/formatting.js';
 import { log } from '../utils/logging.js';
+import { resolvePrerequisiteTargets } from './prerequisiteScope.js';
 import { createStrategy, createStrategyMap, type StrategyFunction, type StrategyType } from './versionStrategies.js';
+import { buildWorkspaceGraph } from './workspaceGraph.js';
 
 // Define extended type that includes root property
 export interface PackagesWithRoot extends Packages {
@@ -26,6 +30,7 @@ export class VersionEngine {
   private strategies: Record<StrategyType, StrategyFunction>;
   private currentStrategy: StrategyFunction;
   private runtimeTargets: string[] = [];
+  private includePrerequisites = false;
 
   constructor(config: Config, runOptions?: VersionRunOptions) {
     // Validate required configuration
@@ -50,6 +55,7 @@ export class VersionEngine {
       if (runOptions.targets?.length) this.runtimeTargets = runOptions.targets;
       if (runOptions.baseRef) effective.baseRef = runOptions.baseRef;
       if (runOptions.overrideScope) effective.overrideScope = runOptions.overrideScope;
+      if (runOptions.includePrerequisites) this.includePrerequisites = true;
     }
 
     // Default values for required properties
@@ -341,6 +347,30 @@ export class VersionEngine {
   /**
    * Get workspace packages information - with caching for performance
    */
+  /**
+   * Lightweight changed-detection for prerequisite resolution: a package is "changed" when it has
+   * commits since its last release tag. Over-inclusive by design — a pulled-in prerequisite with no
+   * *releasable* change is still skipped by the per-package bump calc downstream.
+   */
+  private async detectChangedPackages(packages: Package[]): Promise<Set<string>> {
+    const formattedPrefix = formatVersionPrefix(this.config.versionPrefix || 'v');
+    const changed = new Set<string>();
+    for (const pkg of packages) {
+      let tag = '';
+      try {
+        tag = await getLatestTagForPackage(pkg.packageJson.name, formattedPrefix, {
+          tagTemplate: this.config.tagTemplate,
+          packageSpecificTags: this.config.packageSpecificTags,
+        });
+        if (!tag) tag = await getLatestTag(formattedPrefix);
+      } catch {
+        // No tag resolvable — getCommitsLength falls back to git describe / full history.
+      }
+      if (getCommitsLength(pkg.dir, tag) > 0) changed.add(pkg.packageJson.name);
+    }
+    return changed;
+  }
+
   public async getWorkspacePackages(): Promise<PackagesWithRoot> {
     try {
       // Return cached result if available for better performance
@@ -376,6 +406,31 @@ export class VersionEngine {
       if (!mergedPackages.root) {
         log('Root path is undefined in packages result, setting to current working directory', 'warning');
         mergedPackages.root = workspaceRoot;
+      }
+
+      // --include-prerequisites: expand the explicit targets to the full release set (their changed
+      // transitive dependencies + the rest of any group they belong to) and scope the bump/prerelease/
+      // stable override to just the explicit, group-expanded targets. Runs on the full discovered set,
+      // before the target pre-filter below, so prerequisites aren't pruned away.
+      if (this.includePrerequisites && this.runtimeTargets.length > 0) {
+        const graph = buildWorkspaceGraph(mergedPackages.packages);
+        const changed = await this.detectChangedPackages(mergedPackages.packages);
+        const { targets, overrideScope } = resolvePrerequisiteTargets(
+          graph,
+          mergedPackages.packages,
+          this.config,
+          this.runtimeTargets,
+          (name) => changed.has(name),
+        );
+        log(
+          `Prerequisites: releasing ${targets.length} package(s); override scoped to [${overrideScope.join(', ')}].`,
+          'info',
+        );
+        this.runtimeTargets = targets;
+        this.config.overrideScope = overrideScope;
+        // Rebuild strategies so they pick up the override scope derived from the workspace graph.
+        this.strategies = createStrategyMap(this.config);
+        this.currentStrategy = createStrategy(this.config);
       }
 
       // When explicit version groups are configured, do NOT pre-filter by runtime targets here.

--- a/packages/version/src/core/versionEngine.ts
+++ b/packages/version/src/core/versionEngine.ts
@@ -345,32 +345,34 @@ export class VersionEngine {
   }
 
   /**
-   * Get workspace packages information - with caching for performance
-   */
-  /**
    * Lightweight changed-detection for prerequisite resolution: a package is "changed" when it has
    * commits since its last release tag. Over-inclusive by design — a pulled-in prerequisite with no
-   * *releasable* change is still skipped by the per-package bump calc downstream.
+   * *releasable* change is still skipped by the per-package bump calc downstream. Tag lookups are
+   * independent per package, so they run in parallel.
    */
   private async detectChangedPackages(packages: Package[]): Promise<Set<string>> {
     const formattedPrefix = formatVersionPrefix(this.config.versionPrefix || 'v');
-    const changed = new Set<string>();
-    for (const pkg of packages) {
-      let tag = '';
-      try {
-        tag = await getLatestTagForPackage(pkg.packageJson.name, formattedPrefix, {
-          tagTemplate: this.config.tagTemplate,
-          packageSpecificTags: this.config.packageSpecificTags,
-        });
-        if (!tag) tag = await getLatestTag(formattedPrefix);
-      } catch {
-        // No tag resolvable — getCommitsLength falls back to git describe / full history.
-      }
-      if (getCommitsLength(pkg.dir, tag) > 0) changed.add(pkg.packageJson.name);
-    }
-    return changed;
+    const results = await Promise.all(
+      packages.map(async (pkg) => {
+        let tag = '';
+        try {
+          tag = await getLatestTagForPackage(pkg.packageJson.name, formattedPrefix, {
+            tagTemplate: this.config.tagTemplate,
+            packageSpecificTags: this.config.packageSpecificTags,
+          });
+          if (!tag) tag = await getLatestTag(formattedPrefix);
+        } catch {
+          // No tag resolvable — getCommitsLength falls back to git describe / full history.
+        }
+        return getCommitsLength(pkg.dir, tag) > 0 ? pkg.packageJson.name : null;
+      }),
+    );
+    return new Set(results.filter((name): name is string => name !== null));
   }
 
+  /**
+   * Get workspace packages information - with caching for performance
+   */
   public async getWorkspacePackages(): Promise<PackagesWithRoot> {
     try {
       // Return cached result if available for better performance

--- a/packages/version/src/core/workspaceGraph.ts
+++ b/packages/version/src/core/workspaceGraph.ts
@@ -1,0 +1,62 @@
+/**
+ * Build the internal dependency graph for a discovered workspace, bridging the version engine's
+ * package list to the ecosystem-agnostic graph in `@releasekit/core`. Edge extraction is per
+ * ecosystem; the core graph then filters each package's declared deps to workspace members.
+ *
+ *  - npm:   `dependencies` + `peerDependencies` keys (devDependencies excluded).
+ *  - cargo: `path:` dependencies, resolved from their directory to the crate name.
+ *  - pub:   not yet wired (no edges) — deferred.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { Package } from '@manypkg/get-packages';
+import { parseCargoToml } from '@releasekit/config';
+import { buildDependencyGraph, type GraphPackage, type WorkspaceDependencyGraph } from '@releasekit/core';
+
+function npmDeps(pkg: Package): string[] {
+  const json = pkg.packageJson as { dependencies?: Record<string, string>; peerDependencies?: Record<string, string> };
+  return [...Object.keys(json.dependencies ?? {}), ...Object.keys(json.peerDependencies ?? {})];
+}
+
+function cargoDeps(cargoTomlPath: string, pkgDir: string, nameByDir: Map<string, string>): string[] {
+  try {
+    const cargo = parseCargoToml(cargoTomlPath);
+    const deps: string[] = [];
+    for (const dep of Object.values(cargo.dependencies ?? {})) {
+      if (dep && typeof dep === 'object' && 'path' in dep) {
+        const resolved = nameByDir.get(path.resolve(pkgDir, (dep as { path: string }).path));
+        if (resolved) deps.push(resolved);
+      }
+    }
+    return deps;
+  } catch {
+    // Unparseable Cargo.toml — treat as having no internal edges rather than aborting the run.
+    return [];
+  }
+}
+
+export function buildWorkspaceGraph(packages: Package[]): WorkspaceDependencyGraph {
+  // Resolve cargo `path:` deps (which point at directories) back to crate names.
+  const nameByDir = new Map(packages.map((p) => [path.resolve(p.dir), p.packageJson.name]));
+
+  const graphPackages: GraphPackage[] = packages.map((p) => {
+    const hasPackageJson = fs.existsSync(path.join(p.dir, 'package.json'));
+    const cargoTomlPath = path.join(p.dir, 'Cargo.toml');
+
+    if (hasPackageJson) {
+      return { name: p.packageJson.name, dir: p.dir, ecosystem: 'npm', deps: npmDeps(p) };
+    }
+    if (fs.existsSync(cargoTomlPath)) {
+      return {
+        name: p.packageJson.name,
+        dir: p.dir,
+        ecosystem: 'cargo',
+        deps: cargoDeps(cargoTomlPath, p.dir, nameByDir),
+      };
+    }
+    return { name: p.packageJson.name, dir: p.dir, ecosystem: 'pub', deps: [] };
+  });
+
+  return buildDependencyGraph(graphPackages);
+}

--- a/packages/version/src/types.ts
+++ b/packages/version/src/types.ts
@@ -39,6 +39,13 @@ export interface VersionRunOptions {
    * `undefined` (the default) applies the override to every package.
    */
   overrideScope?: string[];
+  /**
+   * Expand the explicit `targets` to also release their changed transitive dependencies
+   * (prerequisites) plus the rest of any group a target belongs to. The override (bump/prerelease/
+   * stable) stays scoped to the explicit, group-expanded targets; prerequisites keep their own
+   * commit-driven bump.
+   */
+  includePrerequisites?: boolean;
 }
 
 export interface GitInfo {

--- a/packages/version/test/unit/core/prerequisiteScope.spec.ts
+++ b/packages/version/test/unit/core/prerequisiteScope.spec.ts
@@ -1,0 +1,60 @@
+import type { Package } from '@manypkg/get-packages';
+import { buildDependencyGraph, type GraphPackage } from '@releasekit/core';
+import { describe, expect, it } from 'vitest';
+import { resolvePrerequisiteTargets } from '../../../src/core/prerequisiteScope.js';
+import type { Config } from '../../../src/types.js';
+
+function pkg(name: string): Package {
+  return { dir: `/ws/${name}`, relativeDir: name, packageJson: { name, version: '1.0.0' } } as unknown as Package;
+}
+function gpkg(name: string, deps: string[]): GraphPackage {
+  return { name, dir: `/ws/${name}`, ecosystem: 'npm', deps };
+}
+const baseConfig = (overrides: Partial<Config> = {}): Config =>
+  ({
+    sync: false,
+    preset: 'conventional',
+    packages: [],
+    tagTemplate: '',
+    updateInternalDependencies: 'minor',
+    versionPrefix: '',
+    ...overrides,
+  }) as Config;
+
+// core <- utils, core <- types, {utils,types} <- app
+const packages = [pkg('core'), pkg('utils'), pkg('types'), pkg('app')];
+const graph = buildDependencyGraph([
+  gpkg('core', []),
+  gpkg('utils', ['core']),
+  gpkg('types', ['core']),
+  gpkg('app', ['utils', 'types']),
+]);
+
+describe('resolvePrerequisiteTargets', () => {
+  it('should pull changed transitive deps in as targets while scoping the override to the explicit target', () => {
+    const result = resolvePrerequisiteTargets(graph, packages, baseConfig(), ['app'], () => true);
+    expect(new Set(result.targets)).toEqual(new Set(['app', 'utils', 'types', 'core']));
+    expect(result.overrideScope).toEqual(['app']);
+  });
+
+  it('should not pull in unchanged dependencies', () => {
+    const result = resolvePrerequisiteTargets(graph, packages, baseConfig(), ['app'], (n) => n === 'utils');
+    expect(new Set(result.targets)).toEqual(new Set(['app', 'utils']));
+    expect(result.overrideScope).toEqual(['app']);
+  });
+
+  it('should expand an explicit target to its whole group for the override scope', () => {
+    const config = baseConfig({ groups: { g: { packages: ['app', 'utils'], sync: 'fixed' } } });
+    const result = resolvePrerequisiteTargets(graph, packages, config, ['app'], () => false);
+    expect(new Set(result.overrideScope)).toEqual(new Set(['app', 'utils']));
+    expect(new Set(result.targets)).toEqual(new Set(['app', 'utils']));
+  });
+
+  it('should derive prerequisites from the group-expanded target set', () => {
+    const config = baseConfig({ groups: { g: { packages: ['app', 'utils'], sync: 'fixed' } } });
+    const result = resolvePrerequisiteTargets(graph, packages, config, ['app'], (n) => n === 'core');
+    expect(new Set(result.targets)).toEqual(new Set(['app', 'utils', 'core']));
+    expect(new Set(result.overrideScope)).toEqual(new Set(['app', 'utils']));
+    expect(result.targets).not.toContain('types');
+  });
+});

--- a/packages/version/test/unit/core/workspaceGraph.spec.ts
+++ b/packages/version/test/unit/core/workspaceGraph.spec.ts
@@ -1,0 +1,42 @@
+import * as fs from 'node:fs';
+import type { Package } from '@manypkg/get-packages';
+import { parseCargoToml } from '@releasekit/config';
+import { describe, expect, it, vi } from 'vitest';
+import { buildWorkspaceGraph } from '../../../src/core/workspaceGraph.js';
+
+vi.mock('node:fs');
+vi.mock('@releasekit/config', () => ({ parseCargoToml: vi.fn() }));
+
+function pkg(name: string, dir: string, packageJson: Record<string, unknown> = {}): Package {
+  return { dir, relativeDir: dir, packageJson: { name, version: '1.0.0', ...packageJson } } as unknown as Package;
+}
+
+describe('buildWorkspaceGraph', () => {
+  it('should build npm edges from dependencies + peerDependencies, excluding devDeps and externals', () => {
+    vi.mocked(fs.existsSync).mockImplementation((p) => String(p).endsWith('package.json'));
+    const packages = [
+      pkg('core', '/ws/core'),
+      pkg('types', '/ws/types'),
+      pkg('app', '/ws/app', {
+        dependencies: { core: '1.0.0', react: '^18' },
+        peerDependencies: { types: '1.0.0' },
+        devDependencies: { vitest: '1' },
+      }),
+    ];
+    const graph = buildWorkspaceGraph(packages);
+    // react is external (filtered by the core graph); vitest is a devDep (never collected).
+    expect([...graph.getInternalDependencies('app')].sort()).toEqual(['core', 'types']);
+  });
+
+  it('should build cargo edges by resolving path deps to crate names', () => {
+    // No package.json anywhere → cargo branch.
+    vi.mocked(fs.existsSync).mockImplementation((p) => String(p).endsWith('Cargo.toml'));
+    vi.mocked(parseCargoToml).mockImplementation((p) =>
+      String(p).includes('plugin') ? ({ dependencies: { 'core-rs': { path: '../core-rs' } } } as never) : ({} as never),
+    );
+    const packages = [pkg('core-rs', '/ws/core-rs'), pkg('plugin', '/ws/plugin')];
+    const graph = buildWorkspaceGraph(packages);
+    expect([...graph.getInternalDependencies('plugin')]).toEqual(['core-rs']);
+    expect([...graph.getInternalDependents('core-rs')]).toEqual(['plugin']);
+  });
+});


### PR DESCRIPTION
## What

Wires the core `resolvePrerequisites` (#384, merged) into the version engine and CLI — the end-to-end **`--include-prerequisites`** behaviour. Completes **#365**.

Targeting a package with `--include-prerequisites` now also releases its **changed internal dependencies** (prerequisites) and the rest of any **group** it belongs to, while the bump/prerelease/stable override stays scoped to the explicit targets — prerequisites keep their own commit-driven bump.

```
releasekit version --target @scope/app --include-prerequisites --prerelease --dry-run
# → @scope/app at its prerelease; each changed internal dep at its own commit-driven bump;
#   unchanged deps absent.
```

## How

- **`buildWorkspaceGraph`** (`version/src/core/workspaceGraph.ts`) — builds the `@releasekit/core` dependency graph from the discovered workspace: npm `dependencies` + `peerDependencies` (devDeps excluded), cargo `path:` deps resolved to crate names.
- **`resolvePrerequisiteTargets`** (`version/src/core/prerequisiteScope.ts`) — group-expands the explicit targets (any mode), derives their changed transitive deps via `resolvePrerequisites`, and returns `{ targets, overrideScope }`.
- **`VersionEngine`** — new `includePrerequisites` run option runs the resolution on the **full discovered set before the target pre-filter** (so prerequisites aren't pruned), expands the runtime target set, and sets `overrideScope` (#383) to the explicit, group-expanded targets. Lightweight commits-since-tag changed-detection (over-inclusive by design — a non-releasable prerequisite is still skipped by the per-package bump calc).
- **CLI** — `--include-prerequisites` on `version` and `release`; `--target` (+ `--include-prerequisites`) on `standing-pr update` as an ad-hoc override that wins over label-derived targets. `docs/cli.md` updated.

## Test

- `prerequisiteScope.spec` — changed deps pulled in / unchanged skipped; group expansion of the override scope; prerequisites derived from the group-expanded set.
- `workspaceGraph.spec` — npm edges (peerDeps in, devDeps/externals out); cargo path-dep → crate-name resolution.
- Full gate green: `pnpm turbo run lint typecheck test` (24 tasks).

## Builds on

#384 (core `resolvePrerequisites`), #382 (group expansion `expandTargetsForAtomicGroups`), #383 (`overrideScope`) — all merged.

## Follow-up (manual)

The plan's dry-run validation against `wdio-desktop-mobile` / `zubridge` (real polyglot consumers) is best run by hand once this lands — not reproducible in CI here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR wires the previously-merged `resolvePrerequisites` core into the version engine and CLI, delivering end-to-end `--include-prerequisites` behaviour: targeting a package also releases its changed transitive internal dependencies and the rest of any atomic group it belongs to, while bump/prerelease/stable overrides stay scoped to the explicit (group-expanded) targets.

- **`buildWorkspaceGraph`** bridges `@manypkg` package discovery to the `@releasekit/core` graph: npm uses `dependencies` + `peerDependencies` (devDeps excluded), cargo resolves `path:` deps to crate names, pub is deferred with no edges.
- **`resolvePrerequisiteTargets`** group-expands explicit targets, filters their transitive deps to changed-only via `detectChangedPackages` (parallelised tag-lookup + commit-count), and returns `{ targets, overrideScope }` — injected as functions so the layer stays unit-testable.
- **CLI** surfaces `--include-prerequisites` on `release` and `version`, and adds both `--target` and `--include-prerequisites` to `standing-pr update` as ad-hoc overrides that win over label-derived targets.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the new feature is well-guarded (no-op when runtimeTargets is empty), parallelised git I/O is correct (getCommitsLength is synchronous), state mutations inside getWorkspacePackages() are isolated to the shallow-copied config, and the cache prevents double-execution.

The three new modules (workspaceGraph, prerequisiteScope, detectChangedPackages) are each unit-tested. The expansion block in getWorkspacePackages() runs before the target pre-filter and rebuilds strategies correctly. No cross-cutting issues were found with the existing caching, group-resolution, or override-scope logic.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/version/src/core/versionEngine.ts | Adds detectChangedPackages (parallelised tag-lookup + commit-count) and the --include-prerequisites expansion block inside getWorkspacePackages(). The strategy rebuild after scope derivation and the caching interaction both look correct. |
| packages/version/src/core/prerequisiteScope.ts | New file: pure composition layer that group-expands explicit targets, derives changed transitive deps via resolvePrerequisites, and returns { targets, overrideScope }. Clean and unit-testable by design. |
| packages/version/src/core/workspaceGraph.ts | New file: builds the WorkspaceDependencyGraph from the version engine's package list; correctly handles npm, cargo (path-dep → crate-name resolution), and pub (no edges, deferred). External npm deps are filtered downstream by buildDependencyGraph. |
| packages/release/src/standing-pr/standing-pr.ts | Wires --target and --include-prerequisites into the standing-PR flow; CLI target wins over label target via options.target ?? overrides.target; both conflict and non-conflict branches correctly propagate includePrerequisites. |
| packages/version/test/unit/core/prerequisiteScope.spec.ts | Good coverage: changed deps pulled in, unchanged skipped, group expansion of override scope, prerequisites derived from group-expanded set. |
| packages/version/test/unit/core/workspaceGraph.spec.ts | Covers npm edges (devDeps excluded, externals filtered) and cargo path-dep → crate-name resolution via mocked fs and parseCargoToml. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant CLI as CLI (version/release/standing-pr)
    participant VE as VersionEngine
    participant WG as buildWorkspaceGraph
    participant DC as detectChangedPackages
    participant PS as resolvePrerequisiteTargets
    participant RC as resolvePrerequisites (core)

    CLI->>VE: "new VersionEngine(config, { targets, includePrerequisites })"
    VE->>VE: getWorkspacePackages()
    VE->>WG: buildWorkspaceGraph(allPackages)
    WG-->>VE: WorkspaceDependencyGraph
    VE->>DC: detectChangedPackages(allPackages)
    DC->>DC: getLatestTagForPackage / getLatestTag (parallel)
    DC->>DC: getCommitsLength per package
    DC-->>VE: Set of changedPackageNames
    VE->>PS: resolvePrerequisiteTargets(graph, packages, config, runtimeTargets, isChanged)
    PS->>PS: shouldMatchPackageTargets → explicitNames
    PS->>PS: resolveGroups → overrideSet (group-expanded)
    PS->>PS: graph.transitiveDependencies → candidateDeps
    PS->>RC: resolvePrerequisites(graph, overrideSet, changedDeps)
    RC-->>PS: "{ targetSet }"
    PS-->>VE: "{ targets, overrideScope }"
    VE->>VE: "runtimeTargets = targets"
    VE->>VE: "config.overrideScope = overrideScope"
    VE->>VE: rebuild strategies
    VE->>VE: run(packages, targets)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant CLI as CLI (version/release/standing-pr)
    participant VE as VersionEngine
    participant WG as buildWorkspaceGraph
    participant DC as detectChangedPackages
    participant PS as resolvePrerequisiteTargets
    participant RC as resolvePrerequisites (core)

    CLI->>VE: "new VersionEngine(config, { targets, includePrerequisites })"
    VE->>VE: getWorkspacePackages()
    VE->>WG: buildWorkspaceGraph(allPackages)
    WG-->>VE: WorkspaceDependencyGraph
    VE->>DC: detectChangedPackages(allPackages)
    DC->>DC: getLatestTagForPackage / getLatestTag (parallel)
    DC->>DC: getCommitsLength per package
    DC-->>VE: Set of changedPackageNames
    VE->>PS: resolvePrerequisiteTargets(graph, packages, config, runtimeTargets, isChanged)
    PS->>PS: shouldMatchPackageTargets → explicitNames
    PS->>PS: resolveGroups → overrideSet (group-expanded)
    PS->>PS: graph.transitiveDependencies → candidateDeps
    PS->>RC: resolvePrerequisites(graph, overrideSet, changedDeps)
    RC-->>PS: "{ targetSet }"
    PS-->>VE: "{ targets, overrideScope }"
    VE->>VE: "runtimeTargets = targets"
    VE->>VE: "config.overrideScope = overrideScope"
    VE->>VE: rebuild strategies
    VE->>VE: run(packages, targets)
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["refactor(version): parallelize prerequis..."](https://github.com/goosewobbler/releasekit/commit/c53833cdc45917f4d5a2dbab6258f6181e9bac97) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39008416)</sub>

<!-- /greptile_comment -->