### PR TITLE
refactor(forge): route all GitHub access through one Forge seam (#358)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@ This repo **dogfoods itself**: releases run in standing-PR mode with sync versio
 packages/
 ├── core/      # Shared types (VersionOutput contract) + logging
 ├── config/    # Config loading, Zod schemas, JSONC parsing
+├── forge/     # Forge (GitHub) collaboration API behind one Forge interface + in-memory fake
 ├── version/   # Version calculation, bump strategies (sync/single/async)
 ├── notes/     # Changelog + release notes, LLM enhancement, templates
 ├── publish/   # Multi-registry publish pipeline, git tags, GitHub Releases

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -23,3 +23,8 @@ Conflating these is the historical source of the `fix(version)` bug cluster (#33
 - **Explicit group** — a declared coordination invariant over related packages: `fixed` (shared version, all move) · `linked` (shared version, changed-only) · `independent` (own version lines, changed-only, atomic).
 - **Prerequisite** — *derived* from the dependency graph at release time; keeps its own commit-driven bump; pulled in only if changed; dependency-ordered.
 - **Selection** — orthogonal *"what to act on now"* (scope labels / checkboxes / CLI). Under this taxonomy, scope labels revert to pure selection — they are not the home for co-release coupling.
+
+## Forge — the hosting platform, distinct from git
+
+- **Forge** — the *remote* hosting platform's collaboration API: pull requests, marker comments, labels, commit statuses, releases. GitHub is the only forge today; GitLab/Bitbucket would be additional **adapters** behind the same `Forge` interface (`@releasekit/forge`: `Forge` interface + `GitHubForge` octokit adapter + in-memory fake). Returns plain data — never leaks Octokit types — so a second forge is a new adapter with zero caller changes.
+- **Not** the **git** layer — `git` is the *local* CLI (tags, log, commit, push, status; no token, no PR concept); a forge is the *server-side API* over HTTP with a token. A release run uses both at once.

--- a/packages/forge/package.json
+++ b/packages/forge/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@releasekit/forge",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Forge (GitHub/GitLab/Bitbucket) platform access for releasekit",
+  "type": "module",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
+  },
+  "scripts": {
+    "build": "tsup src/index.ts --format esm --dts",
+    "dev": "tsup src/index.ts --format esm --watch --dts",
+    "clean": "rm -rf dist coverage .turbo",
+    "lint": "biome check .",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:unit": "vitest run --dir test/unit",
+    "test:coverage": "vitest run --coverage"
+  },
+  "dependencies": {
+    "@octokit/rest": "catalog:"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "catalog:",
+    "@types/node": "catalog:",
+    "@vitest/coverage-v8": "catalog:",
+    "tsup": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "engines": {
+    "node": ">=22"
+  }
+}

--- a/packages/forge/src/errors.ts
+++ b/packages/forge/src/errors.ts
@@ -1,0 +1,13 @@
+/**
+ * The HTTP status carried by a forge error, if any, without depending on a concrete adapter's error
+ * type. Octokit's `RequestError` exposes `.status`; a GitLab/Bitbucket adapter would surface the same
+ * field. Callers branch on the number so status-specific handling (401/403/404, …) survives swapping
+ * the forge — instead of `instanceof RequestError`, which only ever matches the GitHub adapter.
+ */
+export function forgeErrorStatus(error: unknown): number | undefined {
+  if (error && typeof error === 'object' && 'status' in error) {
+    const { status } = error as { status?: unknown };
+    if (typeof status === 'number') return status;
+  }
+  return undefined;
+}

--- a/packages/forge/src/fake.ts
+++ b/packages/forge/src/fake.ts
@@ -20,6 +20,12 @@ import type {
 interface FakeComment {
   id: number;
   body: string;
+  /**
+   * The PR the comment lives on. `createComment` tags it; a seeded comment may set it to scope the
+   * comment to one PR. Left undefined, a seeded comment is "ambient" — visible from any PR's
+   * `findComment` (a convenience for the common single-PR test).
+   */
+  prNumber?: number;
 }
 
 /** Seed state for a {@link FakeForge}. Everything is optional; unseeded reads return empty/null. */
@@ -116,13 +122,16 @@ export class FakeForge implements Forge {
     this.mergedPullRequests.push({ prNumber, method });
   }
 
-  async findComment(_prNumber: number, marker: string): Promise<FakeComment | null> {
-    return this.comments.find((c) => c.body.startsWith(marker)) ?? null;
+  async findComment(prNumber: number, marker: string): Promise<FakeComment | null> {
+    return (
+      this.comments.find((c) => c.body.startsWith(marker) && (c.prNumber === undefined || c.prNumber === prNumber)) ??
+      null
+    );
   }
 
   async createComment(prNumber: number, body: string): Promise<void> {
     this.createdComments.push({ prNumber, body });
-    this.comments.push({ id: this.nextCommentId++, body });
+    this.comments.push({ id: this.nextCommentId++, body, prNumber });
   }
 
   async updateComment(commentId: number, body: string): Promise<void> {

--- a/packages/forge/src/fake.ts
+++ b/packages/forge/src/fake.ts
@@ -86,12 +86,12 @@ export class FakeForge implements Forge {
     return this.pullRequestsForCommit[commitSha] ?? [];
   }
 
-  async findStandingPR(): Promise<StandingPullRequest | null> {
+  async findStandingPR(_branch: string): Promise<StandingPullRequest | null> {
     return this.standingPR;
   }
 
-  async listRecentlyClosedPullRequests(): Promise<AssociatedPullRequest[]> {
-    return this.recentlyClosedPRs;
+  async listRecentlyClosedPullRequests(_branch: string, limit: number): Promise<AssociatedPullRequest[]> {
+    return this.recentlyClosedPRs.slice(0, limit);
   }
 
   async getIssue(issueNumber: number): Promise<IssueDetails> {

--- a/packages/forge/src/fake.ts
+++ b/packages/forge/src/fake.ts
@@ -1,0 +1,186 @@
+import type {
+  AssociatedPullRequest,
+  CommitStatus,
+  CreateLabelResult,
+  Forge,
+  IssueDetails,
+  MergeMethod,
+  NewLabel,
+  NewPullRequest,
+  NewRelease,
+  PullRequestChanges,
+  PullRequestDetails,
+  PullRequestRef,
+  ReleaseChanges,
+  ReleaseRef,
+  ReleaseSummary,
+  StandingPullRequest,
+} from './types.js';
+
+interface FakeComment {
+  id: number;
+  body: string;
+}
+
+/** Seed state for a {@link FakeForge}. Everything is optional; unseeded reads return empty/null. */
+export interface FakeForgeSeed {
+  standingPR?: StandingPullRequest | null;
+  recentlyClosedPRs?: AssociatedPullRequest[];
+  pullRequestsForCommit?: Record<string, AssociatedPullRequest[]>;
+  issues?: Record<number, IssueDetails>;
+  pullRequests?: Record<number, PullRequestDetails>;
+  comments?: FakeComment[];
+  labelNames?: string[];
+  releases?: ReleaseSummary[];
+  releasesByTag?: Record<string, ReleaseRef>;
+}
+
+/**
+ * In-memory {@link Forge} for tests — the second adapter that justifies the seam. Reads return seeded
+ * data; writes mutate in-memory state and are recorded on public arrays for assertions. Comment and
+ * label operations behave realistically (marker upsert finds/updates a seeded comment; createLabel is
+ * idempotent) so callers can be exercised end-to-end without an Octokit mock.
+ */
+export class FakeForge implements Forge {
+  standingPR: StandingPullRequest | null;
+  private readonly recentlyClosedPRs: AssociatedPullRequest[];
+  private readonly pullRequestsForCommit: Record<string, AssociatedPullRequest[]>;
+  private readonly issues: Record<number, IssueDetails>;
+  private readonly pullRequestDetails: Record<number, PullRequestDetails>;
+  comments: FakeComment[];
+  labelNames: string[];
+  private readonly releases: ReleaseSummary[];
+  private readonly releasesByTag: Record<string, ReleaseRef>;
+
+  // Recorded writes, for assertions.
+  readonly createdComments: Array<{ prNumber: number; body: string }> = [];
+  readonly updatedComments: Array<{ commentId: number; body: string }> = [];
+  readonly upsertedComments: Array<{ prNumber: number; marker: string; body: string }> = [];
+  readonly createdPullRequests: NewPullRequest[] = [];
+  readonly updatedPullRequests: Array<{ prNumber: number; changes: PullRequestChanges }> = [];
+  readonly mergedPullRequests: Array<{ prNumber: number; method: MergeMethod }> = [];
+  readonly createdLabels: NewLabel[] = [];
+  readonly setLabelsCalls: Array<{ issueNumber: number; labels: string[] }> = [];
+  readonly commitStatuses: CommitStatus[] = [];
+  readonly createdReleases: NewRelease[] = [];
+  readonly updatedReleases: Array<{ releaseId: number; release: ReleaseChanges }> = [];
+
+  private nextCommentId: number;
+  private nextPrNumber = 42;
+  private nextReleaseId = 1;
+
+  constructor(seed: FakeForgeSeed = {}) {
+    this.standingPR = seed.standingPR ?? null;
+    this.recentlyClosedPRs = seed.recentlyClosedPRs ?? [];
+    this.pullRequestsForCommit = seed.pullRequestsForCommit ?? {};
+    this.issues = seed.issues ?? {};
+    this.pullRequestDetails = seed.pullRequests ?? {};
+    this.comments = [...(seed.comments ?? [])];
+    this.labelNames = [...(seed.labelNames ?? [])];
+    this.releases = seed.releases ?? [];
+    this.releasesByTag = seed.releasesByTag ?? {};
+    this.nextCommentId = Math.max(0, ...this.comments.map((c) => c.id)) + 1;
+  }
+
+  async listPullRequestsForCommit(commitSha: string): Promise<AssociatedPullRequest[]> {
+    return this.pullRequestsForCommit[commitSha] ?? [];
+  }
+
+  async findStandingPR(): Promise<StandingPullRequest | null> {
+    return this.standingPR;
+  }
+
+  async listRecentlyClosedPullRequests(): Promise<AssociatedPullRequest[]> {
+    return this.recentlyClosedPRs;
+  }
+
+  async getIssue(issueNumber: number): Promise<IssueDetails> {
+    return this.issues[issueNumber] ?? { body: '', title: '', labels: [], isPullRequest: true };
+  }
+
+  async getPullRequest(prNumber: number): Promise<PullRequestDetails> {
+    return this.pullRequestDetails[prNumber] ?? { body: '', labels: [] };
+  }
+
+  async createPullRequest(pr: NewPullRequest): Promise<PullRequestRef> {
+    this.createdPullRequests.push(pr);
+    const number = this.nextPrNumber++;
+    return { number, url: `https://github.com/fake/fake/pull/${number}` };
+  }
+
+  async updatePullRequest(prNumber: number, changes: PullRequestChanges): Promise<void> {
+    this.updatedPullRequests.push({ prNumber, changes });
+  }
+
+  async mergePullRequest(prNumber: number, method: MergeMethod): Promise<void> {
+    this.mergedPullRequests.push({ prNumber, method });
+  }
+
+  async findComment(_prNumber: number, marker: string): Promise<FakeComment | null> {
+    return this.comments.find((c) => c.body.startsWith(marker)) ?? null;
+  }
+
+  async createComment(prNumber: number, body: string): Promise<void> {
+    this.createdComments.push({ prNumber, body });
+    this.comments.push({ id: this.nextCommentId++, body });
+  }
+
+  async updateComment(commentId: number, body: string): Promise<void> {
+    this.updatedComments.push({ commentId, body });
+    const comment = this.comments.find((c) => c.id === commentId);
+    if (comment) comment.body = body;
+  }
+
+  async upsertMarkerComment(prNumber: number, marker: string, body: string): Promise<void> {
+    this.upsertedComments.push({ prNumber, marker, body });
+    const existing = await this.findComment(prNumber, marker);
+    if (existing) {
+      await this.updateComment(existing.id, body);
+    } else {
+      await this.createComment(prNumber, body);
+    }
+  }
+
+  async listLabelNames(): Promise<string[]> {
+    return [...this.labelNames];
+  }
+
+  async createLabel(label: NewLabel): Promise<CreateLabelResult> {
+    this.createdLabels.push(label);
+    if (this.labelNames.includes(label.name)) return 'exists';
+    this.labelNames.push(label.name);
+    return 'created';
+  }
+
+  async setLabels(issueNumber: number, labels: string[]): Promise<void> {
+    this.setLabelsCalls.push({ issueNumber, labels });
+  }
+
+  async setCommitStatus(status: CommitStatus): Promise<void> {
+    this.commitStatuses.push(status);
+  }
+
+  async listReleases(): Promise<ReleaseSummary[]> {
+    return this.releases;
+  }
+
+  async createRelease(release: NewRelease): Promise<ReleaseRef> {
+    this.createdReleases.push(release);
+    const id = this.nextReleaseId++;
+    return { id, url: `https://github.com/fake/fake/releases/${id}`, tagName: release.tagName };
+  }
+
+  async updateRelease(releaseId: number, release: ReleaseChanges): Promise<ReleaseRef> {
+    this.updatedReleases.push({ releaseId, release });
+    return { id: releaseId, url: `https://github.com/fake/fake/releases/${releaseId}`, tagName: release.tagName };
+  }
+
+  async getReleaseByTag(tag: string): Promise<ReleaseRef | null> {
+    return this.releasesByTag[tag] ?? null;
+  }
+}
+
+/** Convenience factory mirroring {@link createGitHubForge}. */
+export function createFakeForge(seed: FakeForgeSeed = {}): FakeForge {
+  return new FakeForge(seed);
+}

--- a/packages/forge/src/github.ts
+++ b/packages/forge/src/github.ts
@@ -1,0 +1,228 @@
+import { Octokit } from '@octokit/rest';
+import type {
+  AssociatedPullRequest,
+  CommitStatus,
+  CreateLabelResult,
+  Forge,
+  ForgeComment,
+  IssueDetails,
+  MergeMethod,
+  NewLabel,
+  NewPullRequest,
+  NewRelease,
+  PullRequestChanges,
+  PullRequestDetails,
+  PullRequestRef,
+  ReleaseChanges,
+  ReleaseRef,
+  ReleaseSummary,
+  StandingPullRequest,
+} from './types.js';
+
+/** Releases are listed at most this many pages deep (100/page) — bounds the examples fetch. */
+const MAX_RELEASE_PAGES = 3;
+
+type LabelLike = string | { name?: string | null };
+
+function labelNames(labels: LabelLike[] | undefined): string[] {
+  return (labels ?? []).map((label) => (typeof label === 'string' ? label : (label.name ?? '')));
+}
+
+/** Whether a createLabel error is GitHub's idempotent "label already exists" 422. */
+function isAlreadyExistsError(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null) return false;
+  if ((error as { status?: number }).status !== 422) return false;
+  // A 422 for "already exists" carries an errors[].code === 'already_exists'. Other 422s (name too
+  // long, disallowed characters, …) are real validation failures and must surface to the caller.
+  const errors = (error as { response?: { data?: { errors?: Array<{ code?: string }> } } }).response?.data?.errors;
+  return Array.isArray(errors) && errors.some((e) => e?.code === 'already_exists');
+}
+
+/**
+ * Octokit-backed {@link Forge}. `owner`/`repo` are bound at construction so callers speak only in
+ * domain terms. Methods map Octokit responses to the plain types in `./types.ts` and otherwise let
+ * Octokit errors propagate — callers keep whatever status-specific handling they already had.
+ */
+export class GitHubForge implements Forge {
+  constructor(
+    private readonly octokit: Octokit,
+    private readonly owner: string,
+    private readonly repo: string,
+  ) {}
+
+  private get base() {
+    return { owner: this.owner, repo: this.repo };
+  }
+
+  async listPullRequestsForCommit(commitSha: string): Promise<AssociatedPullRequest[]> {
+    const { data } = await this.octokit.rest.repos.listPullRequestsAssociatedWithCommit({
+      ...this.base,
+      commit_sha: commitSha,
+    });
+    return data.map((pr) => ({ number: pr.number, mergedAt: pr.merged_at }));
+  }
+
+  async findStandingPR(branch: string): Promise<StandingPullRequest | null> {
+    const { data } = await this.octokit.rest.pulls.list({
+      ...this.base,
+      head: `${this.owner}:${branch}`,
+      state: 'open',
+      per_page: 1,
+    });
+    const pr = data[0];
+    return pr ? { number: pr.number, url: pr.html_url, labels: labelNames(pr.labels).filter(Boolean) } : null;
+  }
+
+  async listRecentlyClosedPullRequests(branch: string, limit: number): Promise<AssociatedPullRequest[]> {
+    const { data } = await this.octokit.rest.pulls.list({
+      ...this.base,
+      head: `${this.owner}:${branch}`,
+      state: 'closed',
+      sort: 'updated',
+      direction: 'desc',
+      per_page: limit,
+    });
+    return data.map((pr) => ({ number: pr.number, mergedAt: pr.merged_at }));
+  }
+
+  async getIssue(issueNumber: number): Promise<IssueDetails> {
+    const { data } = await this.octokit.rest.issues.get({ ...this.base, issue_number: issueNumber });
+    return {
+      body: data.body ?? '',
+      title: data.title,
+      labels: labelNames(data.labels),
+      isPullRequest: Boolean(data.pull_request),
+    };
+  }
+
+  async getPullRequest(prNumber: number): Promise<PullRequestDetails> {
+    const { data } = await this.octokit.rest.pulls.get({ ...this.base, pull_number: prNumber });
+    return { body: data.body ?? '', labels: labelNames(data.labels) };
+  }
+
+  async createPullRequest(pr: NewPullRequest): Promise<PullRequestRef> {
+    const { data } = await this.octokit.rest.pulls.create({ ...this.base, ...pr });
+    return { number: data.number, url: data.html_url };
+  }
+
+  async updatePullRequest(prNumber: number, changes: PullRequestChanges): Promise<void> {
+    await this.octokit.rest.pulls.update({ ...this.base, pull_number: prNumber, ...changes });
+  }
+
+  async mergePullRequest(prNumber: number, method: MergeMethod): Promise<void> {
+    await this.octokit.rest.pulls.merge({ ...this.base, pull_number: prNumber, merge_method: method });
+  }
+
+  async findComment(prNumber: number, marker: string): Promise<ForgeComment | null> {
+    const iterator = this.octokit.paginate.iterator(this.octokit.rest.issues.listComments, {
+      ...this.base,
+      issue_number: prNumber,
+      per_page: 100,
+    });
+    for await (const response of iterator) {
+      for (const comment of response.data) {
+        if (comment.body?.startsWith(marker)) return { id: comment.id, body: comment.body };
+      }
+    }
+    return null;
+  }
+
+  async createComment(prNumber: number, body: string): Promise<void> {
+    await this.octokit.rest.issues.createComment({ ...this.base, issue_number: prNumber, body });
+  }
+
+  async updateComment(commentId: number, body: string): Promise<void> {
+    await this.octokit.rest.issues.updateComment({ ...this.base, comment_id: commentId, body });
+  }
+
+  async upsertMarkerComment(prNumber: number, marker: string, body: string): Promise<void> {
+    const existing = await this.findComment(prNumber, marker);
+    if (existing) {
+      await this.updateComment(existing.id, body);
+    } else {
+      await this.createComment(prNumber, body);
+    }
+  }
+
+  async listLabelNames(): Promise<string[]> {
+    const names: string[] = [];
+    const iterator = this.octokit.paginate.iterator(this.octokit.rest.issues.listLabelsForRepo, {
+      ...this.base,
+      per_page: 100,
+    });
+    for await (const response of iterator) {
+      for (const label of response.data) names.push(label.name);
+    }
+    return names;
+  }
+
+  async createLabel(label: NewLabel): Promise<CreateLabelResult> {
+    try {
+      await this.octokit.rest.issues.createLabel({ ...this.base, ...label });
+      return 'created';
+    } catch (error) {
+      if (isAlreadyExistsError(error)) return 'exists';
+      throw error;
+    }
+  }
+
+  async setLabels(issueNumber: number, labels: string[]): Promise<void> {
+    await this.octokit.rest.issues.setLabels({ ...this.base, issue_number: issueNumber, labels });
+  }
+
+  async setCommitStatus(status: CommitStatus): Promise<void> {
+    await this.octokit.rest.repos.createCommitStatus({ ...this.base, ...status });
+  }
+
+  async listReleases(): Promise<ReleaseSummary[]> {
+    const releases: ReleaseSummary[] = [];
+    for (let page = 1; page <= MAX_RELEASE_PAGES; page++) {
+      const { data } = await this.octokit.rest.repos.listReleases({ ...this.base, per_page: 100, page });
+      for (const r of data) {
+        releases.push({ tagName: r.tag_name, draft: r.draft, prerelease: r.prerelease, body: r.body ?? '' });
+      }
+      if (data.length < 100) break;
+    }
+    return releases;
+  }
+
+  async createRelease(release: NewRelease): Promise<ReleaseRef> {
+    const { data } = await this.octokit.rest.repos.createRelease({
+      ...this.base,
+      tag_name: release.tagName,
+      name: release.name,
+      body: release.body,
+      draft: release.draft,
+      prerelease: release.prerelease,
+      generate_release_notes: release.generateReleaseNotes ?? false,
+    });
+    return { id: data.id, url: data.html_url, tagName: data.tag_name };
+  }
+
+  async updateRelease(releaseId: number, release: ReleaseChanges): Promise<ReleaseRef> {
+    const { data } = await this.octokit.rest.repos.updateRelease({
+      ...this.base,
+      release_id: releaseId,
+      tag_name: release.tagName,
+      name: release.name,
+      body: release.body,
+      draft: release.draft,
+      prerelease: release.prerelease,
+    });
+    return { id: data.id, url: data.html_url, tagName: data.tag_name };
+  }
+
+  async getReleaseByTag(tag: string): Promise<ReleaseRef | null> {
+    try {
+      const { data } = await this.octokit.rest.repos.getReleaseByTag({ ...this.base, tag });
+      return { id: data.id, url: data.html_url, tagName: data.tag_name };
+    } catch {
+      return null;
+    }
+  }
+}
+
+/** Construct a GitHub-backed {@link Forge} for `owner`/`repo`, authenticated with `token`. */
+export function createGitHubForge({ token, owner, repo }: { token: string; owner: string; repo: string }): Forge {
+  return new GitHubForge(new Octokit({ auth: token }), owner, repo);
+}

--- a/packages/forge/src/index.ts
+++ b/packages/forge/src/index.ts
@@ -1,0 +1,23 @@
+export { createFakeForge, FakeForge, type FakeForgeSeed } from './fake.js';
+export { createGitHubForge, GitHubForge } from './github.js';
+export type {
+  AssociatedPullRequest,
+  CommitStatus,
+  CommitStatusState,
+  CreateLabelResult,
+  Forge,
+  ForgeComment,
+  IssueDetails,
+  MergeMethod,
+  NewLabel,
+  NewPullRequest,
+  NewRelease,
+  PullRequestChanges,
+  PullRequestDetails,
+  PullRequestRef,
+  PullRequestState,
+  ReleaseChanges,
+  ReleaseRef,
+  ReleaseSummary,
+  StandingPullRequest,
+} from './types.js';

--- a/packages/forge/src/index.ts
+++ b/packages/forge/src/index.ts
@@ -1,3 +1,4 @@
+export { forgeErrorStatus } from './errors.js';
 export { createFakeForge, FakeForge, type FakeForgeSeed } from './fake.js';
 export { createGitHubForge, GitHubForge } from './github.js';
 export type {

--- a/packages/forge/src/types.ts
+++ b/packages/forge/src/types.ts
@@ -1,0 +1,151 @@
+/**
+ * `Forge` — the remote hosting platform's collaboration API (pull requests, marker comments,
+ * labels, commit statuses, releases), behind one vendor-neutral interface.
+ *
+ * GitHub is the only forge today (`GitHubForge`); a GitLab/Bitbucket adapter would implement the
+ * same interface with zero changes to callers. Methods take/return plain data — they never leak
+ * Octokit request or response types — so the seam stays swappable and the in-memory fake can stand
+ * in for the real platform in tests. `owner`/`repo`/auth are bound when an adapter is constructed,
+ * so callers speak only in domain terms (branch, PR number, tag).
+ */
+
+export type CommitStatusState = 'error' | 'failure' | 'pending' | 'success';
+export type PullRequestState = 'open' | 'closed';
+export type MergeMethod = 'merge' | 'squash' | 'rebase';
+
+export interface PullRequestRef {
+  number: number;
+  url: string;
+}
+
+/** An open standing-release PR, including its current label set. */
+export interface StandingPullRequest extends PullRequestRef {
+  labels: string[];
+}
+
+/** A PR associated with a commit / closed window; `mergedAt` is null when it was closed unmerged. */
+export interface AssociatedPullRequest {
+  number: number;
+  mergedAt: string | null;
+}
+
+/** An issue as returned by the issues endpoint (a PR is also an issue). */
+export interface IssueDetails {
+  body: string;
+  title: string;
+  labels: string[];
+  /** True when the issue is really a pull request (the API returns a `pull_request` field). */
+  isPullRequest: boolean;
+}
+
+export interface PullRequestDetails {
+  body: string;
+  labels: string[];
+}
+
+/** A located issue/PR comment. */
+export interface ForgeComment {
+  id: number;
+  body: string;
+}
+
+export interface NewPullRequest {
+  title: string;
+  body: string;
+  head: string;
+  base: string;
+}
+
+export interface PullRequestChanges {
+  title?: string;
+  body?: string;
+  state?: PullRequestState;
+}
+
+export interface NewLabel {
+  name: string;
+  color: string;
+  description: string;
+}
+
+/** Whether `createLabel` actually created the label or found it already present (idempotent). */
+export type CreateLabelResult = 'created' | 'exists';
+
+export interface CommitStatus {
+  sha: string;
+  state: CommitStatusState;
+  description: string;
+  context: string;
+}
+
+export interface ReleaseRef {
+  id: number;
+  url: string;
+  tagName: string;
+}
+
+export interface ReleaseSummary {
+  tagName: string;
+  draft: boolean;
+  prerelease: boolean;
+  body: string;
+}
+
+export interface NewRelease {
+  tagName: string;
+  name: string;
+  body: string;
+  draft: boolean;
+  prerelease: boolean;
+  generateReleaseNotes?: boolean;
+}
+
+export interface ReleaseChanges {
+  tagName: string;
+  name: string;
+  body: string;
+  draft: boolean;
+  prerelease: boolean;
+}
+
+export interface Forge {
+  // — Pull requests —
+  /** PRs associated with a commit (used to map merge commits back to their PRs). */
+  listPullRequestsForCommit(commitSha: string): Promise<AssociatedPullRequest[]>;
+  /** The open standing-release PR whose head is `branch`, with its labels, or null. */
+  findStandingPR(branch: string): Promise<StandingPullRequest | null>;
+  /** Recently-closed PRs whose head is `branch`, most-recently-updated first. */
+  listRecentlyClosedPullRequests(branch: string, limit: number): Promise<AssociatedPullRequest[]>;
+  /** Issue view of a PR (body, title, labels, and whether it is a PR). */
+  getIssue(issueNumber: number): Promise<IssueDetails>;
+  /** PR view (body + labels). */
+  getPullRequest(prNumber: number): Promise<PullRequestDetails>;
+  createPullRequest(pr: NewPullRequest): Promise<PullRequestRef>;
+  updatePullRequest(prNumber: number, changes: PullRequestChanges): Promise<void>;
+  mergePullRequest(prNumber: number, method: MergeMethod): Promise<void>;
+
+  // — Marker comments —
+  /** The first comment whose body starts with `marker` (id + body), or null. */
+  findComment(prNumber: number, marker: string): Promise<ForgeComment | null>;
+  createComment(prNumber: number, body: string): Promise<void>;
+  updateComment(commentId: number, body: string): Promise<void>;
+  /** Create the marker comment, or update the existing one — never stack a second. */
+  upsertMarkerComment(prNumber: number, marker: string, body: string): Promise<void>;
+
+  // — Labels —
+  /** Every label name defined on the repository. */
+  listLabelNames(): Promise<string[]>;
+  /** Create a label; resolves to 'exists' (not an error) when it is already present. */
+  createLabel(label: NewLabel): Promise<CreateLabelResult>;
+  /** Replace the full label set on an issue/PR. */
+  setLabels(issueNumber: number, labels: string[]): Promise<void>;
+
+  // — Commit status —
+  setCommitStatus(status: CommitStatus): Promise<void>;
+
+  // — Releases —
+  listReleases(): Promise<ReleaseSummary[]>;
+  createRelease(release: NewRelease): Promise<ReleaseRef>;
+  updateRelease(releaseId: number, release: ReleaseChanges): Promise<ReleaseRef>;
+  getReleaseByTag(tag: string): Promise<ReleaseRef | null>;
+}

--- a/packages/forge/test/unit/fake.spec.ts
+++ b/packages/forge/test/unit/fake.spec.ts
@@ -43,6 +43,17 @@ describe('FakeForge', () => {
     expect(await forge.findComment(1, 'MARK')).toMatchObject({ body: 'MARK second' });
   });
 
+  it('should scope findComment to the requested PR (created comments) while ambient seeds are global', async () => {
+    const forge = createFakeForge({ comments: [{ id: 1, body: 'AMBIENT note' }] });
+    await forge.createComment(5, 'PR5 note');
+
+    // An unscoped seeded comment is visible from any PR.
+    expect(await forge.findComment(99, 'AMBIENT')).toMatchObject({ body: 'AMBIENT note' });
+    // A created comment is only found on its own PR.
+    expect(await forge.findComment(5, 'PR5')).toMatchObject({ body: 'PR5 note' });
+    expect(await forge.findComment(6, 'PR5')).toBeNull();
+  });
+
   it('should make createLabel idempotent against seeded labels', async () => {
     const forge = createFakeForge({ labelNames: ['existing'] });
 

--- a/packages/forge/test/unit/fake.spec.ts
+++ b/packages/forge/test/unit/fake.spec.ts
@@ -52,4 +52,58 @@ describe('FakeForge', () => {
     expect((await forge.listLabelNames()).sort()).toEqual(['existing', 'fresh']);
     expect(forge.createdLabels).toHaveLength(3);
   });
+
+  it('should bound listRecentlyClosedPullRequests by the limit argument', async () => {
+    const forge = createFakeForge({
+      recentlyClosedPRs: [
+        { number: 1, mergedAt: 'a' },
+        { number: 2, mergedAt: 'b' },
+        { number: 3, mergedAt: 'c' },
+      ],
+    });
+    expect(await forge.listRecentlyClosedPullRequests('release/next', 2)).toHaveLength(2);
+    expect(await forge.listRecentlyClosedPullRequests('release/next', 10)).toHaveLength(3);
+  });
+
+  it('should return seeded issue/PR details and sensible defaults', async () => {
+    const forge = createFakeForge({
+      issues: { 7: { body: 'ib', title: 'it', labels: ['l'], isPullRequest: true } },
+      pullRequests: { 7: { body: 'pb', labels: ['p'] } },
+    });
+    expect(await forge.getIssue(7)).toEqual({ body: 'ib', title: 'it', labels: ['l'], isPullRequest: true });
+    expect(await forge.getPullRequest(7)).toEqual({ body: 'pb', labels: ['p'] });
+    expect(await forge.getIssue(404)).toEqual({ body: '', title: '', labels: [], isPullRequest: true });
+    expect(await forge.getPullRequest(404)).toEqual({ body: '', labels: [] });
+  });
+
+  it('should record label and release writes and return release refs', async () => {
+    const forge = createFakeForge();
+    await forge.setLabels(7, ['a', 'b']);
+    const created = await forge.createRelease({
+      tagName: 'v1',
+      name: 'v1',
+      body: 'b',
+      draft: false,
+      prerelease: false,
+    });
+    const updated = await forge.updateRelease(created.id, {
+      tagName: 'v1',
+      name: 'v1',
+      body: 'b2',
+      draft: true,
+      prerelease: false,
+    });
+
+    expect(forge.setLabelsCalls).toEqual([{ issueNumber: 7, labels: ['a', 'b'] }]);
+    expect(created).toEqual({ id: 1, url: expect.stringContaining('1'), tagName: 'v1' });
+    expect(updated.id).toBe(1);
+    expect(forge.createdReleases).toHaveLength(1);
+    expect(forge.updatedReleases).toEqual([{ releaseId: 1, release: expect.objectContaining({ body: 'b2' }) }]);
+  });
+
+  it('should return seeded releases from listReleases', async () => {
+    const releases = [{ tagName: 'v1', draft: false, prerelease: false, body: 'b' }];
+    const forge = createFakeForge({ releases });
+    expect(await forge.listReleases()).toEqual(releases);
+  });
 });

--- a/packages/forge/test/unit/fake.spec.ts
+++ b/packages/forge/test/unit/fake.spec.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { createFakeForge } from '../../src/fake.js';
+
+describe('FakeForge', () => {
+  it('should return seeded reads and null for unseeded ones', async () => {
+    const forge = createFakeForge({
+      standingPR: { number: 3, url: 'u', labels: ['release'] },
+      pullRequestsForCommit: { abc: [{ number: 5, mergedAt: '2026-01-01' }] },
+      releasesByTag: { v1: { id: 9, url: 'r', tagName: 'v1' } },
+    });
+
+    expect(await forge.findStandingPR('release/next')).toEqual({ number: 3, url: 'u', labels: ['release'] });
+    expect(await forge.listPullRequestsForCommit('abc')).toEqual([{ number: 5, mergedAt: '2026-01-01' }]);
+    expect(await forge.listPullRequestsForCommit('missing')).toEqual([]);
+    expect(await forge.getReleaseByTag('v1')).toEqual({ id: 9, url: 'r', tagName: 'v1' });
+    expect(await forge.getReleaseByTag('absent')).toBeNull();
+  });
+
+  it('should record writes for assertions', async () => {
+    const forge = createFakeForge();
+    const ref = await forge.createPullRequest({ title: 't', body: 'b', head: 'h', base: 'm' });
+    await forge.updatePullRequest(ref.number, { state: 'closed' });
+    await forge.mergePullRequest(ref.number, 'squash');
+    await forge.setCommitStatus({ sha: 's', state: 'pending', description: 'd', context: 'c' });
+
+    expect(ref).toEqual({ number: 42, url: expect.stringContaining('42') });
+    expect(forge.createdPullRequests).toEqual([{ title: 't', body: 'b', head: 'h', base: 'm' }]);
+    expect(forge.updatedPullRequests).toEqual([{ prNumber: 42, changes: { state: 'closed' } }]);
+    expect(forge.mergedPullRequests).toEqual([{ prNumber: 42, method: 'squash' }]);
+    expect(forge.commitStatuses).toEqual([{ sha: 's', state: 'pending', description: 'd', context: 'c' }]);
+  });
+
+  it('should upsert a marker comment: create then update the same comment', async () => {
+    const forge = createFakeForge();
+
+    await forge.upsertMarkerComment(1, 'MARK', 'MARK first');
+    expect(forge.createdComments).toEqual([{ prNumber: 1, body: 'MARK first' }]);
+    expect(await forge.findComment(1, 'MARK')).toMatchObject({ body: 'MARK first' });
+
+    await forge.upsertMarkerComment(1, 'MARK', 'MARK second');
+    expect(forge.createdComments).toHaveLength(1); // not stacked
+    expect(forge.updatedComments).toHaveLength(1);
+    expect(await forge.findComment(1, 'MARK')).toMatchObject({ body: 'MARK second' });
+  });
+
+  it('should make createLabel idempotent against seeded labels', async () => {
+    const forge = createFakeForge({ labelNames: ['existing'] });
+
+    expect(await forge.createLabel({ name: 'existing', color: 'c', description: 'd' })).toBe('exists');
+    expect(await forge.createLabel({ name: 'fresh', color: 'c', description: 'd' })).toBe('created');
+    expect(await forge.createLabel({ name: 'fresh', color: 'c', description: 'd' })).toBe('exists'); // now present
+    expect((await forge.listLabelNames()).sort()).toEqual(['existing', 'fresh']);
+    expect(forge.createdLabels).toHaveLength(3);
+  });
+});

--- a/packages/forge/test/unit/github.spec.ts
+++ b/packages/forge/test/unit/github.spec.ts
@@ -1,6 +1,7 @@
 import type { Octokit } from '@octokit/rest';
 import { describe, expect, it, vi } from 'vitest';
-import { GitHubForge } from '../../src/github.js';
+import { forgeErrorStatus } from '../../src/errors.js';
+import { createGitHubForge, GitHubForge } from '../../src/github.js';
 
 /** A hand-built Octokit stand-in exposing only the surface GitHubForge touches. */
 function makeOctokit() {
@@ -247,5 +248,141 @@ describe('GitHubForge', () => {
       await new GitHubForge(octokit, 'o', 'r').listReleases();
       expect(fns.listReleases).toHaveBeenCalledTimes(3);
     });
+  });
+
+  describe('remaining read/write operations', () => {
+    it('should map PRs associated with a commit', async () => {
+      const { octokit, fns } = makeOctokit();
+      fns.listPullRequestsAssociatedWithCommit.mockResolvedValue({
+        data: [
+          { number: 1, merged_at: '2026-01-01' },
+          { number: 2, merged_at: null },
+        ],
+      });
+      expect(await new GitHubForge(octokit, 'o', 'r').listPullRequestsForCommit('sha')).toEqual([
+        { number: 1, mergedAt: '2026-01-01' },
+        { number: 2, mergedAt: null },
+      ]);
+      expect(fns.listPullRequestsAssociatedWithCommit).toHaveBeenCalledWith({
+        owner: 'o',
+        repo: 'r',
+        commit_sha: 'sha',
+      });
+    });
+
+    it('should list recently-closed PRs for the head branch, bounded by limit', async () => {
+      const { octokit, fns } = makeOctokit();
+      fns.pullsList.mockResolvedValue({ data: [{ number: 9, merged_at: '2026-01-02' }] });
+      expect(await new GitHubForge(octokit, 'o', 'r').listRecentlyClosedPullRequests('release/next', 10)).toEqual([
+        { number: 9, mergedAt: '2026-01-02' },
+      ]);
+      expect(fns.pullsList).toHaveBeenCalledWith(
+        expect.objectContaining({
+          head: 'o:release/next',
+          state: 'closed',
+          sort: 'updated',
+          direction: 'desc',
+          per_page: 10,
+        }),
+      );
+    });
+
+    it('should map a pull request to {body,labels}', async () => {
+      const { octokit, fns } = makeOctokit();
+      fns.pullsGet.mockResolvedValue({ data: { body: 'b', labels: [{ name: 'x' }] } });
+      expect(await new GitHubForge(octokit, 'o', 'r').getPullRequest(4)).toEqual({ body: 'b', labels: ['x'] });
+    });
+
+    it('should update a pull request with the given changes', async () => {
+      const { octokit, fns } = makeOctokit();
+      await new GitHubForge(octokit, 'o', 'r').updatePullRequest(4, { state: 'closed' });
+      expect(fns.pullsUpdate).toHaveBeenCalledWith({ owner: 'o', repo: 'r', pull_number: 4, state: 'closed' });
+    });
+
+    it('should create and update comments directly', async () => {
+      const { octokit, fns } = makeOctokit();
+      const forge = new GitHubForge(octokit, 'o', 'r');
+      await forge.createComment(4, 'hi');
+      await forge.updateComment(99, 'edited');
+      expect(fns.createComment).toHaveBeenCalledWith({ owner: 'o', repo: 'r', issue_number: 4, body: 'hi' });
+      expect(fns.updateComment).toHaveBeenCalledWith({ owner: 'o', repo: 'r', comment_id: 99, body: 'edited' });
+    });
+
+    it('should set labels and list label names', async () => {
+      const { octokit, fns } = makeOctokit();
+      const forge = new GitHubForge(octokit, 'o', 'r');
+      await forge.setLabels(4, ['a', 'b']);
+      expect(fns.setLabels).toHaveBeenCalledWith({ owner: 'o', repo: 'r', issue_number: 4, labels: ['a', 'b'] });
+
+      fns.iterator.mockReturnValue(pages([{ name: 'a' }, { name: 'b' }]));
+      expect(await forge.listLabelNames()).toEqual(['a', 'b']);
+    });
+
+    it('should set a commit status', async () => {
+      const { octokit, fns } = makeOctokit();
+      await new GitHubForge(octokit, 'o', 'r').setCommitStatus({
+        sha: 's',
+        state: 'success',
+        description: 'd',
+        context: 'c',
+      });
+      expect(fns.createCommitStatus).toHaveBeenCalledWith({
+        owner: 'o',
+        repo: 'r',
+        sha: 's',
+        state: 'success',
+        description: 'd',
+        context: 'c',
+      });
+    });
+
+    it('should create a release with generate_release_notes mapped from generateReleaseNotes', async () => {
+      const { octokit, fns } = makeOctokit();
+      fns.createRelease.mockResolvedValue({ data: { id: 3, html_url: 'u', tag_name: 'v1' } });
+      const ref = await new GitHubForge(octokit, 'o', 'r').createRelease({
+        tagName: 'v1',
+        name: 'v1',
+        body: 'b',
+        draft: false,
+        prerelease: false,
+        generateReleaseNotes: true,
+      });
+      expect(ref).toEqual({ id: 3, url: 'u', tagName: 'v1' });
+      expect(fns.createRelease).toHaveBeenCalledWith(
+        expect.objectContaining({ tag_name: 'v1', generate_release_notes: true }),
+      );
+    });
+
+    it('should update a release', async () => {
+      const { octokit, fns } = makeOctokit();
+      fns.updateRelease.mockResolvedValue({ data: { id: 3, html_url: 'u', tag_name: 'v1' } });
+      const ref = await new GitHubForge(octokit, 'o', 'r').updateRelease(3, {
+        tagName: 'v1',
+        name: 'v1',
+        body: 'b',
+        draft: true,
+        prerelease: false,
+      });
+      expect(ref).toEqual({ id: 3, url: 'u', tagName: 'v1' });
+      expect(fns.updateRelease).toHaveBeenCalledWith(expect.objectContaining({ release_id: 3, draft: true }));
+    });
+  });
+});
+
+describe('createGitHubForge', () => {
+  it('should build a GitHubForge bound to owner/repo', () => {
+    expect(createGitHubForge({ token: 't', owner: 'o', repo: 'r' })).toBeInstanceOf(GitHubForge);
+  });
+});
+
+describe('forgeErrorStatus', () => {
+  it('should read a numeric status off an error', () => {
+    expect(forgeErrorStatus(Object.assign(new Error('x'), { status: 404 }))).toBe(404);
+  });
+
+  it('should return undefined for errors without a numeric status', () => {
+    expect(forgeErrorStatus(new Error('plain'))).toBeUndefined();
+    expect(forgeErrorStatus({ status: 'nope' })).toBeUndefined();
+    expect(forgeErrorStatus(undefined)).toBeUndefined();
   });
 });

--- a/packages/forge/test/unit/github.spec.ts
+++ b/packages/forge/test/unit/github.spec.ts
@@ -1,0 +1,251 @@
+import type { Octokit } from '@octokit/rest';
+import { describe, expect, it, vi } from 'vitest';
+import { GitHubForge } from '../../src/github.js';
+
+/** A hand-built Octokit stand-in exposing only the surface GitHubForge touches. */
+function makeOctokit() {
+  const fns = {
+    listPullRequestsAssociatedWithCommit: vi.fn(),
+    createCommitStatus: vi.fn().mockResolvedValue({}),
+    listReleases: vi.fn(),
+    createRelease: vi.fn(),
+    updateRelease: vi.fn(),
+    getReleaseByTag: vi.fn(),
+    pullsList: vi.fn(),
+    pullsGet: vi.fn(),
+    pullsCreate: vi.fn(),
+    pullsUpdate: vi.fn().mockResolvedValue({}),
+    pullsMerge: vi.fn().mockResolvedValue({}),
+    issuesGet: vi.fn(),
+    createComment: vi.fn().mockResolvedValue({}),
+    updateComment: vi.fn().mockResolvedValue({}),
+    createLabel: vi.fn().mockResolvedValue({}),
+    setLabels: vi.fn().mockResolvedValue({}),
+    iterator: vi.fn(),
+  };
+  const octokit = {
+    rest: {
+      repos: {
+        listPullRequestsAssociatedWithCommit: fns.listPullRequestsAssociatedWithCommit,
+        createCommitStatus: fns.createCommitStatus,
+        listReleases: fns.listReleases,
+        createRelease: fns.createRelease,
+        updateRelease: fns.updateRelease,
+        getReleaseByTag: fns.getReleaseByTag,
+      },
+      pulls: {
+        list: fns.pullsList,
+        get: fns.pullsGet,
+        create: fns.pullsCreate,
+        update: fns.pullsUpdate,
+        merge: fns.pullsMerge,
+      },
+      issues: {
+        get: fns.issuesGet,
+        createComment: fns.createComment,
+        updateComment: fns.updateComment,
+        listComments: { __ref: 'listComments' },
+        listLabelsForRepo: { __ref: 'listLabelsForRepo' },
+        createLabel: fns.createLabel,
+        setLabels: fns.setLabels,
+      },
+    },
+    paginate: { iterator: fns.iterator },
+  } as unknown as Octokit;
+  return { octokit, fns };
+}
+
+/** Build an async-iterable matching octokit.paginate.iterator's contract over the given pages. */
+function pages<T>(...batches: T[][]) {
+  return {
+    async *[Symbol.asyncIterator]() {
+      for (const data of batches) yield { data };
+    },
+  };
+}
+
+const labelError = (code: string) =>
+  Object.assign(new Error('422'), { status: 422, response: { data: { errors: [{ code }] } } });
+
+describe('GitHubForge', () => {
+  describe('createLabel idempotency', () => {
+    it('should report a label as created on success', async () => {
+      const { octokit, fns } = makeOctokit();
+      fns.createLabel.mockResolvedValue({});
+      const forge = new GitHubForge(octokit, 'o', 'r');
+      expect(await forge.createLabel({ name: 'a', color: 'fff', description: 'd' })).toBe('created');
+      expect(fns.createLabel).toHaveBeenCalledWith({
+        owner: 'o',
+        repo: 'r',
+        name: 'a',
+        color: 'fff',
+        description: 'd',
+      });
+    });
+
+    it('should treat an already_exists 422 as exists, not an error', async () => {
+      const { octokit, fns } = makeOctokit();
+      fns.createLabel.mockRejectedValue(labelError('already_exists'));
+      const forge = new GitHubForge(octokit, 'o', 'r');
+      expect(await forge.createLabel({ name: 'a', color: 'fff', description: 'd' })).toBe('exists');
+    });
+
+    it('should rethrow a 422 that is not already_exists (validation failure)', async () => {
+      const { octokit, fns } = makeOctokit();
+      fns.createLabel.mockRejectedValue(labelError('invalid'));
+      const forge = new GitHubForge(octokit, 'o', 'r');
+      await expect(forge.createLabel({ name: 'a', color: 'fff', description: 'd' })).rejects.toThrow();
+    });
+
+    it('should rethrow a non-422 createLabel error (auth / rate limit)', async () => {
+      const { octokit, fns } = makeOctokit();
+      fns.createLabel.mockRejectedValue(Object.assign(new Error('403'), { status: 403 }));
+      const forge = new GitHubForge(octokit, 'o', 'r');
+      await expect(forge.createLabel({ name: 'a', color: 'fff', description: 'd' })).rejects.toThrow();
+    });
+  });
+
+  describe('getReleaseByTag', () => {
+    it('should map a found release', async () => {
+      const { octokit, fns } = makeOctokit();
+      fns.getReleaseByTag.mockResolvedValue({ data: { id: 7, html_url: 'u', tag_name: 'v1' } });
+      expect(await new GitHubForge(octokit, 'o', 'r').getReleaseByTag('v1')).toEqual({
+        id: 7,
+        url: 'u',
+        tagName: 'v1',
+      });
+    });
+
+    it('should return null when the release is not found (throws)', async () => {
+      const { octokit, fns } = makeOctokit();
+      fns.getReleaseByTag.mockRejectedValue(Object.assign(new Error('404'), { status: 404 }));
+      expect(await new GitHubForge(octokit, 'o', 'r').getReleaseByTag('v1')).toBeNull();
+    });
+  });
+
+  describe('findStandingPR', () => {
+    it('should map the open PR, drop empty label names, and query the head branch', async () => {
+      const { octokit, fns } = makeOctokit();
+      fns.pullsList.mockResolvedValue({
+        data: [{ number: 5, html_url: 'u', labels: ['a', { name: 'b' }, { name: '' }, { name: null }] }],
+      });
+      const forge = new GitHubForge(octokit, 'o', 'r');
+      expect(await forge.findStandingPR('release/next')).toEqual({ number: 5, url: 'u', labels: ['a', 'b'] });
+      expect(fns.pullsList).toHaveBeenCalledWith(
+        expect.objectContaining({ owner: 'o', repo: 'r', head: 'o:release/next', state: 'open', per_page: 1 }),
+      );
+    });
+
+    it('should return null when there is no open standing PR', async () => {
+      const { octokit, fns } = makeOctokit();
+      fns.pullsList.mockResolvedValue({ data: [] });
+      expect(await new GitHubForge(octokit, 'o', 'r').findStandingPR('b')).toBeNull();
+    });
+  });
+
+  describe('marker comments', () => {
+    it('should return the first comment whose body starts with the marker', async () => {
+      const { octokit, fns } = makeOctokit();
+      fns.iterator.mockReturnValue(
+        pages([
+          { id: 1, body: 'nope' },
+          { id: 2, body: 'MARK hello' },
+        ]),
+      );
+      expect(await new GitHubForge(octokit, 'o', 'r').findComment(9, 'MARK')).toEqual({ id: 2, body: 'MARK hello' });
+    });
+
+    it('should update the existing marker comment on upsert (never stack a second)', async () => {
+      const { octokit, fns } = makeOctokit();
+      fns.iterator.mockReturnValue(pages([{ id: 2, body: 'MARK old' }]));
+      await new GitHubForge(octokit, 'o', 'r').upsertMarkerComment(9, 'MARK', 'MARK new');
+      expect(fns.updateComment).toHaveBeenCalledWith({ owner: 'o', repo: 'r', comment_id: 2, body: 'MARK new' });
+      expect(fns.createComment).not.toHaveBeenCalled();
+    });
+
+    it('should create a new comment on upsert when none matches the marker', async () => {
+      const { octokit, fns } = makeOctokit();
+      fns.iterator.mockReturnValue(pages([{ id: 1, body: 'unrelated' }]));
+      await new GitHubForge(octokit, 'o', 'r').upsertMarkerComment(9, 'MARK', 'MARK new');
+      expect(fns.createComment).toHaveBeenCalledWith({ owner: 'o', repo: 'r', issue_number: 9, body: 'MARK new' });
+      expect(fns.updateComment).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getIssue', () => {
+    it('should map body/title/labels and detect a pull request', async () => {
+      const { octokit, fns } = makeOctokit();
+      fns.issuesGet.mockResolvedValue({
+        data: { body: 'b', title: 't', labels: ['x', { name: 'y' }], pull_request: {} },
+      });
+      expect(await new GitHubForge(octokit, 'o', 'r').getIssue(3)).toEqual({
+        body: 'b',
+        title: 't',
+        labels: ['x', 'y'],
+        isPullRequest: true,
+      });
+    });
+
+    it('should default a null body to empty and report a plain issue as not a PR', async () => {
+      const { octokit, fns } = makeOctokit();
+      fns.issuesGet.mockResolvedValue({ data: { body: null, title: 't', labels: [] } });
+      expect(await new GitHubForge(octokit, 'o', 'r').getIssue(3)).toEqual({
+        body: '',
+        title: 't',
+        labels: [],
+        isPullRequest: false,
+      });
+    });
+  });
+
+  describe('pull requests', () => {
+    it('should map a created PR to {number,url}', async () => {
+      const { octokit, fns } = makeOctokit();
+      fns.pullsCreate.mockResolvedValue({ data: { number: 11, html_url: 'pr-url' } });
+      const ref = await new GitHubForge(octokit, 'o', 'r').createPullRequest({
+        title: 't',
+        body: 'b',
+        head: 'h',
+        base: 'm',
+      });
+      expect(ref).toEqual({ number: 11, url: 'pr-url' });
+      expect(fns.pullsCreate).toHaveBeenCalledWith({
+        owner: 'o',
+        repo: 'r',
+        title: 't',
+        body: 'b',
+        head: 'h',
+        base: 'm',
+      });
+    });
+
+    it('should merge via the requested method', async () => {
+      const { octokit, fns } = makeOctokit();
+      await new GitHubForge(octokit, 'o', 'r').mergePullRequest(7, 'squash');
+      expect(fns.pullsMerge).toHaveBeenCalledWith({ owner: 'o', repo: 'r', pull_number: 7, merge_method: 'squash' });
+    });
+  });
+
+  describe('listReleases', () => {
+    const full = (tag: string) =>
+      Array.from({ length: 100 }, () => ({ tag_name: tag, draft: false, prerelease: false, body: 'b' }));
+
+    it('should paginate until a short page and map fields', async () => {
+      const { octokit, fns } = makeOctokit();
+      fns.listReleases
+        .mockResolvedValueOnce({ data: full('t') })
+        .mockResolvedValueOnce({ data: [{ tag_name: 'last', draft: true, prerelease: false, body: null }] });
+      const releases = await new GitHubForge(octokit, 'o', 'r').listReleases();
+      expect(fns.listReleases).toHaveBeenCalledTimes(2);
+      expect(releases).toHaveLength(101);
+      expect(releases[100]).toEqual({ tagName: 'last', draft: true, prerelease: false, body: '' });
+    });
+
+    it('should stop at the 3-page cap when every page is full', async () => {
+      const { octokit, fns } = makeOctokit();
+      fns.listReleases.mockResolvedValue({ data: full('t') });
+      await new GitHubForge(octokit, 'o', 'r').listReleases();
+      expect(fns.listReleases).toHaveBeenCalledTimes(3);
+    });
+  });
+});

--- a/packages/forge/tsconfig.json
+++ b/packages/forge/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/packages/forge/vitest.config.ts
+++ b/packages/forge/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig, mergeConfig } from 'vitest/config';
+import baseConfig from '../../vitest.config.base.js';
+
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    test: {
+      include: ['test/**/*.spec.ts'],
+    },
+  }),
+);

--- a/packages/notes/package.json
+++ b/packages/notes/package.json
@@ -58,6 +58,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.104.1",
+    "@octokit/rest": "catalog:",
     "chalk": "catalog:",
     "commander": "catalog:",
     "ejs": "^4.0.1",

--- a/packages/notes/package.json
+++ b/packages/notes/package.json
@@ -60,6 +60,7 @@
     "@anthropic-ai/sdk": "^0.104.1",
     "@octokit/request-error": "^7.1.0",
     "@octokit/rest": "^22.0.1",
+    "@releasekit/forge": "workspace:*",
     "chalk": "catalog:",
     "commander": "catalog:",
     "ejs": "^4.0.1",

--- a/packages/notes/package.json
+++ b/packages/notes/package.json
@@ -58,7 +58,6 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.104.1",
-    "@releasekit/forge": "workspace:*",
     "chalk": "catalog:",
     "commander": "catalog:",
     "ejs": "^4.0.1",
@@ -75,6 +74,7 @@
     "@biomejs/biome": "catalog:",
     "@releasekit/config": "workspace:*",
     "@releasekit/core": "workspace:*",
+    "@releasekit/forge": "workspace:*",
     "@types/ejs": "^3.1.5",
     "@types/node": "catalog:",
     "@vitest/coverage-v8": "catalog:",

--- a/packages/notes/package.json
+++ b/packages/notes/package.json
@@ -58,8 +58,6 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.104.1",
-    "@octokit/request-error": "^7.1.0",
-    "@octokit/rest": "^22.0.1",
     "@releasekit/forge": "workspace:*",
     "chalk": "catalog:",
     "commander": "catalog:",

--- a/packages/notes/src/llm/context/prFetcher.ts
+++ b/packages/notes/src/llm/context/prFetcher.ts
@@ -1,6 +1,5 @@
-import { RequestError } from '@octokit/request-error';
 import { debug, warn } from '@releasekit/core';
-import { createGitHubForge } from '@releasekit/forge';
+import { createGitHubForge, type Forge, forgeErrorStatus } from '@releasekit/forge';
 import type { PRContext } from '../../core/types.js';
 
 const BODY_CAP = 2048;
@@ -64,8 +63,8 @@ export async function fetchPullRequestContext(
   issueNumbers: number[],
   token: string,
   cache: Map<number, PRContext | null>,
+  forge: Forge = createGitHubForge({ token, owner, repo }),
 ): Promise<void> {
-  const forge = createGitHubForge({ token, owner, repo });
   const needed = issueNumbers.filter((n) => !cache.has(n));
 
   for (let i = 0; i < needed.length; i += FETCH_CONCURRENCY) {
@@ -81,14 +80,11 @@ export async function fetchPullRequestContext(
           const body = truncateBody(sanitiseBody(issue.body));
           cache.set(number, { number, title: issue.title, body });
         } catch (error) {
-          if (error instanceof RequestError) {
-            if (error.status === 401 || error.status === 403) {
-              warn(`GitHub API auth error fetching PR #${number} (${error.status}): check GITHUB_TOKEN permissions`);
-            } else if (error.status === 404) {
-              cache.set(number, null); // not found — avoid re-fetching
-            } else {
-              debug(`Failed to fetch PR #${number}: ${error.message}`);
-            }
+          const status = forgeErrorStatus(error);
+          if (status === 401 || status === 403) {
+            warn(`GitHub API auth error fetching PR #${number} (${status}): check GITHUB_TOKEN permissions`);
+          } else if (status === 404) {
+            cache.set(number, null); // not found — avoid re-fetching
           } else {
             debug(`Failed to fetch PR #${number}: ${error instanceof Error ? error.message : String(error)}`);
           }

--- a/packages/notes/src/llm/context/prFetcher.ts
+++ b/packages/notes/src/llm/context/prFetcher.ts
@@ -1,6 +1,6 @@
 import { RequestError } from '@octokit/request-error';
-import { Octokit } from '@octokit/rest';
 import { debug, warn } from '@releasekit/core';
+import { createGitHubForge } from '@releasekit/forge';
 import type { PRContext } from '../../core/types.js';
 
 const BODY_CAP = 2048;
@@ -65,7 +65,7 @@ export async function fetchPullRequestContext(
   token: string,
   cache: Map<number, PRContext | null>,
 ): Promise<void> {
-  const octokit = new Octokit({ auth: token });
+  const forge = createGitHubForge({ token, owner, repo });
   const needed = issueNumbers.filter((n) => !cache.has(n));
 
   for (let i = 0; i < needed.length; i += FETCH_CONCURRENCY) {
@@ -73,14 +73,13 @@ export async function fetchPullRequestContext(
     await Promise.all(
       batch.map(async (number) => {
         try {
-          const { data } = await octokit.rest.issues.get({ owner, repo, issue_number: number });
-          if (!data.pull_request) {
+          const issue = await forge.getIssue(number);
+          if (!issue.isPullRequest) {
             cache.set(number, null); // cache as "not a PR" to avoid re-fetching
             return;
           }
-          const raw = data.body ?? '';
-          const body = truncateBody(sanitiseBody(raw));
-          cache.set(number, { number, title: data.title, body });
+          const body = truncateBody(sanitiseBody(issue.body));
+          cache.set(number, { number, title: issue.title, body });
         } catch (error) {
           if (error instanceof RequestError) {
             if (error.status === 401 || error.status === 403) {

--- a/packages/notes/src/llm/examples/fetcher.ts
+++ b/packages/notes/src/llm/examples/fetcher.ts
@@ -2,9 +2,8 @@ import { createHash } from 'node:crypto';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { RequestError } from '@octokit/request-error';
 import { debug, warn } from '@releasekit/core';
-import { createGitHubForge } from '@releasekit/forge';
+import { createGitHubForge, type Forge, forgeErrorStatus } from '@releasekit/forge';
 import { parseReleaseBodyToExample } from './parser.js';
 import type { Example } from './types.js';
 
@@ -15,6 +14,8 @@ export interface FetchExamplesOptions {
   count: number;
   githubToken?: string;
   isMonorepo?: boolean;
+  /** Inject a forge (tests); defaults to a GitHub-backed forge built from the token. */
+  forge?: Forge;
 }
 
 // Parsed release body text is cached in /tmp keyed by the latest release tag.
@@ -77,7 +78,7 @@ export async function fetchExamples(options: FetchExamplesOptions): Promise<Exam
     return [];
   }
 
-  const forge = createGitHubForge({ token, owner, repo });
+  const forge = options.forge ?? createGitHubForge({ token, owner, repo });
 
   try {
     const allReleases = await forge.listReleases();
@@ -113,8 +114,9 @@ export async function fetchExamples(options: FetchExamplesOptions): Promise<Exam
     debug(`Fetched ${examples.length} examples for ${packageName}`);
     return examples;
   } catch (error) {
-    if (error instanceof RequestError && (error.status === 401 || error.status === 403)) {
-      warn(`GitHub API auth error (${error.status}) — skipping examples fetch; check GITHUB_TOKEN permissions`);
+    const status = forgeErrorStatus(error);
+    if (status === 401 || status === 403) {
+      warn(`GitHub API auth error (${status}) — skipping examples fetch; check GITHUB_TOKEN permissions`);
     } else {
       debug(`Failed to fetch examples: ${error instanceof Error ? error.message : String(error)}`);
     }

--- a/packages/notes/src/llm/examples/fetcher.ts
+++ b/packages/notes/src/llm/examples/fetcher.ts
@@ -3,8 +3,8 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { RequestError } from '@octokit/request-error';
-import { Octokit } from '@octokit/rest';
 import { debug, warn } from '@releasekit/core';
+import { createGitHubForge } from '@releasekit/forge';
 import { parseReleaseBodyToExample } from './parser.js';
 import type { Example } from './types.js';
 
@@ -77,27 +77,15 @@ export async function fetchExamples(options: FetchExamplesOptions): Promise<Exam
     return [];
   }
 
-  const octokit = new Octokit({ auth: token });
+  const forge = createGitHubForge({ token, owner, repo });
 
   try {
-    const allReleases: Awaited<ReturnType<typeof octokit.rest.repos.listReleases>>['data'] = [];
-    for (let page = 1; page <= 3; page++) {
-      const { data } = await octokit.rest.repos.listReleases({ owner, repo, per_page: 100, page });
-      allReleases.push(...data);
-      const totalScoped = allReleases.filter(
-        (r) => !r.draft && !r.prerelease && matchesPackageScoped(r.tag_name, packageName),
-      ).length;
-      if (totalScoped >= count || data.length < 100) break;
-    }
+    const allReleases = await forge.listReleases();
 
     const nonDraft = allReleases.filter((r) => !r.draft && !r.prerelease);
-    const packageScoped = nonDraft.filter((r) => matchesPackageScoped(r.tag_name, packageName));
+    const packageScoped = nonDraft.filter((r) => matchesPackageScoped(r.tagName, packageName));
     const matching = (
-      packageScoped.length > 0
-        ? packageScoped
-        : isMonorepo
-          ? []
-          : nonDraft.filter((r) => matchesBareVersion(r.tag_name))
+      packageScoped.length > 0 ? packageScoped : isMonorepo ? [] : nonDraft.filter((r) => matchesBareVersion(r.tagName))
     ).slice(0, count);
 
     if (matching.length === 0) {
@@ -105,7 +93,7 @@ export async function fetchExamples(options: FetchExamplesOptions): Promise<Exam
       return [];
     }
 
-    const latestTag = matching[0]!.tag_name;
+    const latestTag = matching[0]!.tagName;
     const key = cacheKey(owner, repo, packageName);
     const cached = readCache(key, latestTag, count);
     if (cached) {
@@ -116,7 +104,7 @@ export async function fetchExamples(options: FetchExamplesOptions): Promise<Exam
     const examples: Example[] = [];
     for (const release of matching) {
       if (!release.body) continue;
-      const version = release.tag_name.replace(/^.*@/, '').replace(/^v/, '');
+      const version = release.tagName.replace(/^.*@/, '').replace(/^v/, '');
       const example = parseReleaseBodyToExample(release.body, version);
       if (example) examples.push(example);
     }

--- a/packages/notes/src/output/github-release.ts
+++ b/packages/notes/src/output/github-release.ts
@@ -1,5 +1,5 @@
-import { Octokit } from '@octokit/rest';
 import { info, success } from '@releasekit/core';
+import { createGitHubForge, type Forge } from '@releasekit/forge';
 import type { TemplateContext } from '../core/types.js';
 import { GitHubError } from '../errors/index.js';
 import { renderMarkdown } from '../output/markdown.js';
@@ -20,20 +20,16 @@ export interface CreateReleaseResult {
 }
 
 export class GitHubClient {
-  private octokit: Octokit;
-  private owner: string;
-  private repo: string;
+  private forge: Forge;
 
-  constructor(options: GitHubReleaseOptions) {
+  constructor(options: GitHubReleaseOptions, forge?: Forge) {
     const token = options.token ?? process.env.GITHUB_TOKEN;
 
     if (!token) {
       throw new GitHubError('GITHUB_TOKEN not set. Set it as an environment variable.');
     }
 
-    this.octokit = new Octokit({ auth: token });
-    this.owner = options.owner;
-    this.repo = options.repo;
+    this.forge = forge ?? createGitHubForge({ token, owner: options.owner, repo: options.repo });
   }
 
   async createRelease(
@@ -53,22 +49,20 @@ export class GitHubClient {
     info(`Creating GitHub release for ${tagName}`);
 
     try {
-      const response = await this.octokit.repos.createRelease({
-        owner: this.owner,
-        repo: this.repo,
-        tag_name: tagName,
+      const ref = await this.forge.createRelease({
+        tagName,
         name: tagName,
         body,
         draft: options.draft ?? false,
         prerelease: options.prerelease ?? false,
-        generate_release_notes: options.generateNotes ?? false,
+        generateReleaseNotes: options.generateNotes ?? false,
       });
 
-      success(`Release created: ${response.data.html_url}`);
+      success(`Release created: ${ref.url}`);
 
       return {
-        id: response.data.id,
-        htmlUrl: response.data.html_url,
+        id: ref.id,
+        htmlUrl: ref.url,
         tagName,
       };
     } catch (error) {
@@ -94,22 +88,19 @@ export class GitHubClient {
     info(`Updating GitHub release ${releaseId}`);
 
     try {
-      const response = await this.octokit.repos.updateRelease({
-        owner: this.owner,
-        repo: this.repo,
-        release_id: releaseId,
-        tag_name: tagName,
+      const ref = await this.forge.updateRelease(releaseId, {
+        tagName,
         name: tagName,
         body,
         draft: options.draft ?? false,
         prerelease: options.prerelease ?? false,
       });
 
-      success(`Release updated: ${response.data.html_url}`);
+      success(`Release updated: ${ref.url}`);
 
       return {
-        id: response.data.id,
-        htmlUrl: response.data.html_url,
+        id: ref.id,
+        htmlUrl: ref.url,
         tagName,
       };
     } catch (error) {
@@ -118,21 +109,8 @@ export class GitHubClient {
   }
 
   async getReleaseByTag(tag: string): Promise<CreateReleaseResult | null> {
-    try {
-      const response = await this.octokit.repos.getReleaseByTag({
-        owner: this.owner,
-        repo: this.repo,
-        tag,
-      });
-
-      return {
-        id: response.data.id,
-        htmlUrl: response.data.html_url,
-        tagName: response.data.tag_name,
-      };
-    } catch {
-      return null;
-    }
+    const ref = await this.forge.getReleaseByTag(tag);
+    return ref ? { id: ref.id, htmlUrl: ref.url, tagName: ref.tagName } : null;
   }
 }
 

--- a/packages/notes/test/unit/examples.spec.ts
+++ b/packages/notes/test/unit/examples.spec.ts
@@ -288,7 +288,9 @@ describe('fetchExamples() - release matching', () => {
     expect(listReleasesMock).toHaveBeenCalledTimes(2);
   });
 
-  it('should stop after page 1 when count package-scoped matches are already found', async () => {
+  it('should return the matching releases when the first page is full of unrelated tags', async () => {
+    // Release listing is bounded to a few pages by the forge; the package-scoped matches near the
+    // top of the first page are still surfaced and sliced to `count`.
     const page1 = Array.from({ length: 100 }, (_, i) =>
       i < 2 ? makeRelease(`my-pkg@${2 - i}.0.0`) : makeRelease(`other-pkg@${i}.0.0`),
     );
@@ -297,7 +299,7 @@ describe('fetchExamples() - release matching', () => {
 
     const result = await fetchExamples({ owner: 'o', repo: 'r-stop', packageName: 'my-pkg', count: 2 });
     expect(result).toHaveLength(2);
-    expect(listReleasesMock).toHaveBeenCalledTimes(1);
+    expect(result.map((e) => e.version)).toEqual(['2.0.0', '1.0.0']);
   });
 
   it('should skip draft and prerelease entries', async () => {

--- a/packages/notes/test/unit/examples.spec.ts
+++ b/packages/notes/test/unit/examples.spec.ts
@@ -1,10 +1,8 @@
-import { Octokit } from '@octokit/rest';
+import { createFakeForge } from '@releasekit/forge';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fetchExamples } from '../../src/llm/examples/fetcher.js';
 import { parseReleaseBodyToExample, renderExamplesBlock } from '../../src/llm/examples/parser.js';
 import type { Example } from '../../src/llm/examples/types.js';
-
-vi.mock('@octokit/rest', () => ({ Octokit: vi.fn() }));
 
 // ---------------------------------------------------------------------------
 // parseReleaseBodyToExample
@@ -139,11 +137,6 @@ describe('fetchExamples()', () => {
   beforeEach(() => {
     vi.stubEnv('GITHUB_TOKEN', 'test-token');
     vi.stubEnv('GH_TOKEN', '');
-    vi.mocked(Octokit).mockImplementation(
-      class {
-        rest = { repos: { listReleases: vi.fn().mockRejectedValue(new Error('network error')) } };
-      } as unknown as typeof Octokit,
-    );
   });
 
   afterEach(() => {
@@ -164,31 +157,30 @@ describe('fetchExamples()', () => {
   });
 
   it('should use provided githubToken over env', async () => {
-    // If an explicit token is provided, it should not need GITHUB_TOKEN
+    // An explicit token lets fetchExamples proceed past the early token check without an env token.
     vi.stubEnv('GITHUB_TOKEN', '');
     vi.stubEnv('GH_TOKEN', '');
-    // We can't actually call GitHub here, so we just verify it doesn't return early
-    // The Octokit call will fail with a network error; that's caught and returns []
+    const forge = createFakeForge({
+      releases: [{ tagName: 'pkg@1.0.0', draft: false, prerelease: false, body: '### New\n- A feature\n' }],
+    });
     const result = await fetchExamples({
       owner: 'o',
-      repo: 'r',
+      repo: 'r-token',
       packageName: 'pkg',
       count: 1,
       githubToken: 'explicit-token',
+      forge,
     });
-    // Either empty (network error caught) or actual results — both are valid in unit test
-    expect(Array.isArray(result)).toBe(true);
+    // Proceeded (didn't early-return) and surfaced the package-scoped release.
+    expect(result).toHaveLength(1);
   });
 
   it('should return empty array and does not throw on API error', async () => {
-    // fetchExamples catches all errors and returns []
-    const result = await fetchExamples({
-      owner: 'nonexistent-owner-xyz',
-      repo: 'nonexistent-repo-xyz',
-      packageName: 'pkg',
-      count: 1,
-    });
-    expect(Array.isArray(result)).toBe(true);
+    // fetchExamples catches all forge errors and returns []
+    const forge = createFakeForge();
+    vi.spyOn(forge, 'listReleases').mockRejectedValue(new Error('boom'));
+    const result = await fetchExamples({ owner: 'o', repo: 'r-err', packageName: 'pkg', count: 1, forge });
+    expect(result).toEqual([]);
   });
 });
 
@@ -197,21 +189,15 @@ describe('fetchExamples()', () => {
 // ---------------------------------------------------------------------------
 
 describe('fetchExamples() - release matching', () => {
-  let listReleasesMock: ReturnType<typeof vi.fn>;
-
+  // Pagination/page-bounding lives in the forge adapter (covered in packages/forge github.spec.ts);
+  // these tests exercise the notes-level matching/filtering against a flat seeded release list.
   function makeRelease(tagName: string, body = '### New\n- Some feature\n') {
-    return { tag_name: tagName, draft: false, prerelease: false, body };
+    return { tagName, draft: false, prerelease: false, body };
   }
 
   beforeEach(() => {
     vi.stubEnv('GITHUB_TOKEN', 'test-token');
     vi.stubEnv('GH_TOKEN', '');
-    listReleasesMock = vi.fn();
-    vi.mocked(Octokit).mockImplementation(
-      class {
-        rest = { repos: { listReleases: listReleasesMock } };
-      } as unknown as typeof Octokit,
-    );
   });
 
   afterEach(() => {
@@ -220,98 +206,63 @@ describe('fetchExamples() - release matching', () => {
   });
 
   it('should use only package-scoped releases when they exist, ignoring bare version tags', async () => {
-    listReleasesMock.mockResolvedValue({
-      data: [makeRelease('@scope/foo@2.0.0'), makeRelease('@scope/bar@2.0.0'), makeRelease('v2.0.0')],
+    const forge = createFakeForge({
+      releases: [makeRelease('@scope/foo@2.0.0'), makeRelease('@scope/bar@2.0.0'), makeRelease('v2.0.0')],
     });
-
-    const result = await fetchExamples({ owner: 'o', repo: 'r1', packageName: '@scope/foo', count: 3 });
+    const result = await fetchExamples({ owner: 'o', repo: 'r1', packageName: '@scope/foo', count: 3, forge });
     expect(result).toHaveLength(1);
     expect(result[0]?.version).toBe('2.0.0');
   });
 
   it('should fall back to bare version tags when no package-scoped releases exist (single-package repo)', async () => {
-    listReleasesMock.mockResolvedValue({
-      data: [makeRelease('v2.0.0'), makeRelease('v1.0.0')],
-    });
-
-    const result = await fetchExamples({ owner: 'o', repo: 'r2', packageName: 'my-package', count: 3 });
+    const forge = createFakeForge({ releases: [makeRelease('v2.0.0'), makeRelease('v1.0.0')] });
+    const result = await fetchExamples({ owner: 'o', repo: 'r2', packageName: 'my-package', count: 3, forge });
     expect(result).toHaveLength(2);
   });
 
   it('should suppress bare version fallback when isMonorepo is true', async () => {
-    listReleasesMock.mockResolvedValue({
-      data: [makeRelease('@scope/bar@1.0.0'), makeRelease('v2.0.0')],
-    });
-
+    const forge = createFakeForge({ releases: [makeRelease('@scope/bar@1.0.0'), makeRelease('v2.0.0')] });
     const result = await fetchExamples({
       owner: 'o',
       repo: 'r3',
       packageName: '@scope/foo',
       count: 3,
       isMonorepo: true,
+      forge,
     });
     expect(result).toHaveLength(0);
   });
 
   it('should use bare version fallback when isMonorepo is false', async () => {
-    listReleasesMock.mockResolvedValue({
-      data: [makeRelease('v2.0.0'), makeRelease('v1.0.0')],
-    });
-
+    const forge = createFakeForge({ releases: [makeRelease('v2.0.0'), makeRelease('v1.0.0')] });
     const result = await fetchExamples({
       owner: 'o',
       repo: 'r3b',
       packageName: 'my-pkg',
       count: 3,
       isMonorepo: false,
+      forge,
     });
     expect(result).toHaveLength(2);
   });
 
   it('should respect count limit on package-scoped results', async () => {
-    listReleasesMock.mockResolvedValue({
-      data: [makeRelease('my-pkg@3.0.0'), makeRelease('my-pkg@2.0.0'), makeRelease('my-pkg@1.0.0')],
+    const forge = createFakeForge({
+      releases: [makeRelease('my-pkg@3.0.0'), makeRelease('my-pkg@2.0.0'), makeRelease('my-pkg@1.0.0')],
     });
-
-    const result = await fetchExamples({ owner: 'o', repo: 'r4', packageName: 'my-pkg', count: 2 });
+    const result = await fetchExamples({ owner: 'o', repo: 'r4', packageName: 'my-pkg', count: 2, forge });
     expect(result).toHaveLength(2);
-  });
-
-  it('should fetch page 2 when page 1 is full but has no package-scoped matches', async () => {
-    const page1 = Array.from({ length: 100 }, (_, i) => makeRelease(`other-pkg@${100 - i}.0.0`));
-    const page2 = [makeRelease('my-pkg@2.0.0'), makeRelease('my-pkg@1.0.0')];
-
-    listReleasesMock.mockResolvedValueOnce({ data: page1 }).mockResolvedValueOnce({ data: page2 });
-
-    const result = await fetchExamples({ owner: 'o', repo: 'r-pg', packageName: 'my-pkg', count: 2 });
-    expect(result).toHaveLength(2);
-    expect(listReleasesMock).toHaveBeenCalledTimes(2);
-  });
-
-  it('should return the matching releases when the first page is full of unrelated tags', async () => {
-    // Release listing is bounded to a few pages by the forge; the package-scoped matches near the
-    // top of the first page are still surfaced and sliced to `count`.
-    const page1 = Array.from({ length: 100 }, (_, i) =>
-      i < 2 ? makeRelease(`my-pkg@${2 - i}.0.0`) : makeRelease(`other-pkg@${i}.0.0`),
-    );
-
-    listReleasesMock.mockResolvedValue({ data: page1 });
-
-    const result = await fetchExamples({ owner: 'o', repo: 'r-stop', packageName: 'my-pkg', count: 2 });
-    expect(result).toHaveLength(2);
-    expect(result.map((e) => e.version)).toEqual(['2.0.0', '1.0.0']);
   });
 
   it('should skip draft and prerelease entries', async () => {
-    listReleasesMock.mockResolvedValue({
-      data: [
-        { tag_name: 'my-pkg@2.0.0', draft: true, prerelease: false, body: '### New\n- A\n' },
-        { tag_name: 'my-pkg@1.0.0', draft: false, prerelease: true, body: '### New\n- B\n' },
+    const forge = createFakeForge({
+      releases: [
+        { tagName: 'my-pkg@2.0.0', draft: true, prerelease: false, body: '### New\n- A\n' },
+        { tagName: 'my-pkg@1.0.0', draft: false, prerelease: true, body: '### New\n- B\n' },
         makeRelease('my-pkg@0.9.0'),
       ],
     });
-
-    const result = await fetchExamples({ owner: 'o', repo: 'r5', packageName: 'my-pkg', count: 3 });
+    const result = await fetchExamples({ owner: 'o', repo: 'r5', packageName: 'my-pkg', count: 3, forge });
     expect(result).toHaveLength(1);
     expect(result[0]?.version).toBe('0.9.0');
   });

--- a/packages/notes/test/unit/prFetcher.spec.ts
+++ b/packages/notes/test/unit/prFetcher.spec.ts
@@ -1,9 +1,7 @@
-import { Octokit } from '@octokit/rest';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createFakeForge } from '@releasekit/forge';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { PRContext } from '../../src/core/types.js';
 import { fetchPullRequestContext, parseIssueNumbers, resolveGitHubToken } from '../../src/llm/context/prFetcher.js';
-
-vi.mock('@octokit/rest', () => ({ Octokit: vi.fn() }));
 
 // ---------------------------------------------------------------------------
 // parseIssueNumbers
@@ -57,27 +55,17 @@ describe('resolveGitHubToken()', () => {
 // fetchPullRequestContext
 // ---------------------------------------------------------------------------
 
+/** A forge whose `getIssue` returns a PR with the given title/body. */
+function forgeWithIssue(number: number, title: string, body: string) {
+  return createFakeForge({ issues: { [number]: { title, body, labels: [], isPullRequest: true } } });
+}
+
 describe('fetchPullRequestContext()', () => {
-  let mockGet: ReturnType<typeof vi.fn>;
-
-  beforeEach(() => {
-    mockGet = vi.fn();
-    vi.mocked(Octokit).mockImplementation(
-      class {
-        rest = { issues: { get: mockGet } };
-      } as unknown as typeof Octokit,
-    );
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
   it('should populate cache with fetched PR data', async () => {
-    mockGet.mockResolvedValue({ data: { title: 'Add feature', body: 'PR body content', pull_request: {} } });
+    const forge = forgeWithIssue(42, 'Add feature', 'PR body content');
     const cache = new Map<number, PRContext | null>();
 
-    await fetchPullRequestContext('owner', 'repo', [42], 'token', cache);
+    await fetchPullRequestContext('owner', 'repo', [42], 'token', cache, forge);
 
     expect(cache.has(42)).toBe(true);
     expect(cache.get(42)).toMatchObject({ number: 42, title: 'Add feature', body: 'PR body content' });
@@ -86,58 +74,55 @@ describe('fetchPullRequestContext()', () => {
   it('should skip numbers already in cache', async () => {
     const existing: PRContext = { number: 1, title: 'Cached', body: 'cached body' };
     const cache = new Map([[1, existing]]);
+    const forge = createFakeForge();
+    const getIssue = vi.spyOn(forge, 'getIssue');
 
-    await fetchPullRequestContext('owner', 'repo', [1], 'token', cache);
+    await fetchPullRequestContext('owner', 'repo', [1], 'token', cache, forge);
 
-    expect(mockGet).not.toHaveBeenCalled();
+    expect(getIssue).not.toHaveBeenCalled();
   });
 
   it('should handle missing PR body gracefully', async () => {
-    mockGet.mockResolvedValue({ data: { title: 'No body', body: null, pull_request: {} } });
+    const forge = forgeWithIssue(7, 'No body', '');
     const cache = new Map<number, PRContext | null>();
 
-    await fetchPullRequestContext('owner', 'repo', [7], 'token', cache);
+    await fetchPullRequestContext('owner', 'repo', [7], 'token', cache, forge);
 
     expect(cache.get(7)?.body).toBe('');
   });
 
   it('should skip entry on fetch error without throwing', async () => {
-    mockGet.mockRejectedValue(new Error('not found'));
+    const forge = createFakeForge();
+    vi.spyOn(forge, 'getIssue').mockRejectedValue(new Error('not found'));
     const cache = new Map<number, PRContext | null>();
 
-    await expect(fetchPullRequestContext('owner', 'repo', [99], 'token', cache)).resolves.not.toThrow();
+    await expect(fetchPullRequestContext('owner', 'repo', [99], 'token', cache, forge)).resolves.not.toThrow();
     expect(cache.has(99)).toBe(false);
   });
 
   it('should sanitise HTML comments from body', async () => {
-    mockGet.mockResolvedValue({
-      data: { title: 'Test', body: 'Before<!-- hidden comment -->After', pull_request: {} },
-    });
+    const forge = forgeWithIssue(1, 'Test', 'Before<!-- hidden comment -->After');
     const cache = new Map<number, PRContext | null>();
 
-    await fetchPullRequestContext('owner', 'repo', [1], 'token', cache);
+    await fetchPullRequestContext('owner', 'repo', [1], 'token', cache, forge);
 
     expect(cache.get(1)?.body).toBe('BeforeAfter');
   });
 
   it('should handle nested/truncated HTML comment patterns', async () => {
-    mockGet.mockResolvedValue({
-      data: { title: 'Test', body: 'A<!--<!---->B<!--unclosedC', pull_request: {} },
-    });
+    const forge = forgeWithIssue(1, 'Test', 'A<!--<!---->B<!--unclosedC');
     const cache = new Map<number, PRContext | null>();
 
-    await fetchPullRequestContext('owner', 'repo', [1], 'token', cache);
+    await fetchPullRequestContext('owner', 'repo', [1], 'token', cache, forge);
 
     expect(cache.get(1)?.body).not.toContain('<!--');
   });
 
   it('should strip images from body', async () => {
-    mockGet.mockResolvedValue({
-      data: { title: 'Test', body: 'Text ![screenshot](https://example.com/img.png) more text', pull_request: {} },
-    });
+    const forge = forgeWithIssue(1, 'Test', 'Text ![screenshot](https://example.com/img.png) more text');
     const cache = new Map<number, PRContext | null>();
 
-    await fetchPullRequestContext('owner', 'repo', [1], 'token', cache);
+    await fetchPullRequestContext('owner', 'repo', [1], 'token', cache, forge);
 
     expect(cache.get(1)?.body).not.toContain('![');
     expect(cache.get(1)?.body).toContain('Text');
@@ -145,16 +130,10 @@ describe('fetchPullRequestContext()', () => {
   });
 
   it('should strip <details> blocks from body', async () => {
-    mockGet.mockResolvedValue({
-      data: {
-        title: 'Test',
-        body: 'Before<details><summary>Click</summary>Hidden</details>After',
-        pull_request: {},
-      },
-    });
+    const forge = forgeWithIssue(1, 'Test', 'Before<details><summary>Click</summary>Hidden</details>After');
     const cache = new Map<number, PRContext | null>();
 
-    await fetchPullRequestContext('owner', 'repo', [1], 'token', cache);
+    await fetchPullRequestContext('owner', 'repo', [1], 'token', cache, forge);
 
     expect(cache.get(1)?.body).not.toContain('<details>');
     expect(cache.get(1)?.body).toContain('Before');
@@ -162,16 +141,10 @@ describe('fetchPullRequestContext()', () => {
   });
 
   it('should strip nested <details> blocks without leaving stray closing tags', async () => {
-    mockGet.mockResolvedValue({
-      data: {
-        title: 'Test',
-        body: 'Before<details><details>inner</details>outer</details>After',
-        pull_request: {},
-      },
-    });
+    const forge = forgeWithIssue(1, 'Test', 'Before<details><details>inner</details>outer</details>After');
     const cache = new Map<number, PRContext | null>();
 
-    await fetchPullRequestContext('owner', 'repo', [1], 'token', cache);
+    await fetchPullRequestContext('owner', 'repo', [1], 'token', cache, forge);
 
     expect(cache.get(1)?.body).not.toContain('details');
     expect(cache.get(1)?.body).not.toContain('outer');
@@ -179,32 +152,40 @@ describe('fetchPullRequestContext()', () => {
   });
 
   it('should truncate long bodies to ~2 KB', async () => {
-    const longBody = 'a'.repeat(4000);
-    mockGet.mockResolvedValue({ data: { title: 'Long', body: longBody, pull_request: {} } });
+    const forge = forgeWithIssue(1, 'Long', 'a'.repeat(4000));
     const cache = new Map<number, PRContext | null>();
 
-    await fetchPullRequestContext('owner', 'repo', [1], 'token', cache);
+    await fetchPullRequestContext('owner', 'repo', [1], 'token', cache, forge);
 
     expect(cache.get(1)!.body.length).toBeLessThanOrEqual(2100);
   });
 
   it('should cache plain issues (non-PR) as null to prevent re-fetching', async () => {
-    mockGet.mockResolvedValue({ data: { title: 'Plain issue', body: 'issue body' } });
+    const forge = createFakeForge({
+      issues: { 5: { title: 'Plain issue', body: 'issue body', labels: [], isPullRequest: false } },
+    });
     const cache = new Map<number, PRContext | null>();
 
-    await fetchPullRequestContext('owner', 'repo', [5], 'token', cache);
+    await fetchPullRequestContext('owner', 'repo', [5], 'token', cache, forge);
 
     expect(cache.has(5)).toBe(true);
     expect(cache.get(5)).toBeNull();
   });
 
   it('should fetch multiple numbers in parallel', async () => {
-    mockGet.mockResolvedValue({ data: { title: 'PR', body: 'body', pull_request: {} } });
+    const forge = createFakeForge({
+      issues: {
+        1: { title: 'PR', body: 'body', labels: [], isPullRequest: true },
+        2: { title: 'PR', body: 'body', labels: [], isPullRequest: true },
+        3: { title: 'PR', body: 'body', labels: [], isPullRequest: true },
+      },
+    });
+    const getIssue = vi.spyOn(forge, 'getIssue');
     const cache = new Map<number, PRContext | null>();
 
-    await fetchPullRequestContext('owner', 'repo', [1, 2, 3], 'token', cache);
+    await fetchPullRequestContext('owner', 'repo', [1, 2, 3], 'token', cache, forge);
 
-    expect(mockGet).toHaveBeenCalledTimes(3);
+    expect(getIssue).toHaveBeenCalledTimes(3);
     expect(cache.size).toBe(3);
   });
 });

--- a/packages/notes/tsup.config.ts
+++ b/packages/notes/tsup.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'tsup';
 export default defineConfig({
   entry: ['src/index.ts', 'src/cli.ts'],
   format: ['esm'],
-  dts: { resolve: ['@releasekit/core', '@releasekit/config'] },
-  noExternal: ['@releasekit/core', '@releasekit/config'],
+  dts: { resolve: ['@releasekit/core', '@releasekit/config', '@releasekit/forge'] },
+  noExternal: ['@releasekit/core', '@releasekit/config', '@releasekit/forge'],
   external: [/^[^.]/],
 });

--- a/packages/release/package.json
+++ b/packages/release/package.json
@@ -55,6 +55,7 @@
   "dependencies": {
     "@manypkg/get-packages": "catalog:",
     "@octokit/rest": "catalog:",
+    "@releasekit/forge": "workspace:*",
     "@releasekit/notes": "workspace:*",
     "@releasekit/publish": "workspace:*",
     "@releasekit/version": "workspace:*",

--- a/packages/release/package.json
+++ b/packages/release/package.json
@@ -55,7 +55,6 @@
   "dependencies": {
     "@manypkg/get-packages": "catalog:",
     "@octokit/rest": "catalog:",
-    "@releasekit/forge": "workspace:*",
     "@releasekit/notes": "workspace:*",
     "@releasekit/publish": "workspace:*",
     "@releasekit/version": "workspace:*",
@@ -74,6 +73,7 @@
     "@biomejs/biome": "catalog:",
     "@releasekit/config": "workspace:*",
     "@releasekit/core": "workspace:*",
+    "@releasekit/forge": "workspace:*",
     "@types/node": "catalog:",
     "@types/semver": "catalog:",
     "@vitest/coverage-v8": "catalog:",

--- a/packages/release/src/commands/labels-command.ts
+++ b/packages/release/src/commands/labels-command.ts
@@ -2,7 +2,7 @@ import { execFileSync } from 'node:child_process';
 import { loadCIConfig } from '@releasekit/config';
 import { EXIT_CODES, error, info, success } from '@releasekit/core';
 import { Command } from 'commander';
-import { createOctokit } from '../github.js';
+import { forgeFor } from '../github.js';
 import { checkLabels, deriveLabelDefinitions, syncLabels } from '../label-definitions.js';
 
 interface LabelsCommandContext {
@@ -99,10 +99,10 @@ export async function runLabelsSync(options: LabelsSyncOptions): Promise<void> {
   const definitions = deriveLabelDefinitions(ciConfig);
 
   const { owner, repo, token } = resolveLabelsContext({ repo: options.repo, projectDir: options.projectDir });
-  const octokit = createOctokit(token);
+  const forge = forgeFor({ token, owner, repo });
 
   if (options.check) {
-    const { missing } = await checkLabels(octokit, owner, repo, definitions);
+    const { missing } = await checkLabels(forge, definitions);
     if (missing.length > 0) {
       error(`Missing ${missing.length} label(s) in ${owner}/${repo}:`);
       for (const name of missing) {
@@ -115,7 +115,7 @@ export async function runLabelsSync(options: LabelsSyncOptions): Promise<void> {
     return;
   }
 
-  const { created, existing } = await syncLabels(octokit, owner, repo, definitions);
+  const { created, existing } = await syncLabels(forge, definitions);
   if (created.length > 0) {
     for (const name of created) {
       info(`Created label: ${name}`);

--- a/packages/release/src/failure-report/failure-report.ts
+++ b/packages/release/src/failure-report/failure-report.ts
@@ -284,10 +284,16 @@ export function parseFailureReportStatus(body: string): FailureReportStatus | nu
  */
 export function parseFailureReportData(body: string): FailureReportData | null {
   if (!body.startsWith(FAILURE_MARKER)) return null;
-  const match = body.match(/<!-- releasekit-publish-failure-data:\s*(\{.*?\})\s*-->/);
-  if (!match?.[1]) return null;
+  // Locate the data block by its fixed delimiters with linear indexOf rather than a backtracking
+  // regex — a regex like `:\s*(\{.*?\})\s*-->` is polynomial on an untrusted comment body with many
+  // `{` and no terminator (ReDoS). JSON.parse + the field checks below still reject anything malformed.
+  const prefix = '<!-- releasekit-publish-failure-data:';
+  const start = body.indexOf(prefix);
+  if (start === -1) return null;
+  const end = body.indexOf('-->', start + prefix.length);
+  if (end === -1) return null;
   try {
-    const parsed = JSON.parse(match[1]) as Partial<FailureReportData>;
+    const parsed = JSON.parse(body.slice(start + prefix.length, end).trim()) as Partial<FailureReportData>;
     if (typeof parsed.label !== 'string' || typeof parsed.published !== 'number' || typeof parsed.total !== 'number') {
       return null;
     }

--- a/packages/release/src/failure-report/post.ts
+++ b/packages/release/src/failure-report/post.ts
@@ -1,8 +1,8 @@
 import * as fs from 'node:fs';
 import type { VersionOutput } from '@releasekit/core';
 import { info, warn } from '@releasekit/core';
+import type { Forge } from '@releasekit/forge';
 import type { PipelineError } from '@releasekit/publish';
-import type { createOctokit } from '../github.js';
 import { findPreviewComment, postOrUpdateComment } from '../github.js';
 import {
   FAILURE_MARKER,
@@ -13,12 +13,8 @@ import {
   renderResolvedReport,
 } from './failure-report.js';
 
-type OctokitInstance = ReturnType<typeof createOctokit>;
-
 export interface PostFailureReportContext {
-  octokit: OctokitInstance;
-  owner: string;
-  repo: string;
+  forge: Forge;
   mode: FailureReportMode;
   /** PR to comment on. Omit for manual dispatch with no PR — the report goes to the step summary. */
   prNumber?: number;
@@ -55,7 +51,7 @@ export async function postFailureReport(
   }
 
   try {
-    await postOrUpdateComment(ctx.octokit, ctx.owner, ctx.repo, ctx.prNumber, body, FAILURE_MARKER);
+    await postOrUpdateComment(ctx.forge, ctx.prNumber, body, FAILURE_MARKER);
     info(`Posted publish-failure report on PR #${ctx.prNumber}`);
   } catch (err) {
     warn(`Failed to post publish-failure report: ${err instanceof Error ? err.message : String(err)}`);
@@ -68,16 +64,14 @@ export async function postFailureReport(
  * exists. Safe to call unconditionally after a successful publish.
  */
 export async function resolveFailureReportIfPresent(
-  octokit: OctokitInstance,
-  owner: string,
-  repo: string,
+  forge: Forge,
   prNumber: number,
   versionOutput: VersionOutput,
 ): Promise<void> {
   try {
-    const existing = await findPreviewComment(octokit, owner, repo, prNumber, FAILURE_MARKER);
+    const existing = await findPreviewComment(forge, prNumber, FAILURE_MARKER);
     if (existing === null) return;
-    await postOrUpdateComment(octokit, owner, repo, prNumber, renderResolvedReport(versionOutput), FAILURE_MARKER);
+    await postOrUpdateComment(forge, prNumber, renderResolvedReport(versionOutput), FAILURE_MARKER);
     info(`Marked publish-failure report on PR #${prNumber} as resolved`);
   } catch (err) {
     warn(`Failed to resolve publish-failure report: ${err instanceof Error ? err.message : String(err)}`);
@@ -114,29 +108,10 @@ export interface UnresolvedFailure {
  * report or it is already resolved. The published/total fraction is recovered from the ledger
  * embedded in the report body so the caller doesn't need the original pipeline output.
  */
-export async function detectUnresolvedFailure(
-  octokit: OctokitInstance,
-  owner: string,
-  repo: string,
-  prNumber: number,
-): Promise<UnresolvedFailure | null> {
+export async function detectUnresolvedFailure(forge: Forge, prNumber: number): Promise<UnresolvedFailure | null> {
   let body: string | undefined;
   try {
-    const iterator = octokit.paginate.iterator(octokit.rest.issues.listComments, {
-      owner,
-      repo,
-      issue_number: prNumber,
-      per_page: 100,
-    });
-    for await (const response of iterator) {
-      for (const comment of response.data) {
-        if (comment.body?.startsWith(FAILURE_MARKER)) {
-          body = comment.body;
-          break;
-        }
-      }
-      if (body) break;
-    }
+    body = (await forge.findComment(prNumber, FAILURE_MARKER))?.body;
   } catch {
     return null;
   }

--- a/packages/release/src/gate/gate.ts
+++ b/packages/release/src/gate/gate.ts
@@ -1,8 +1,9 @@
 import type { CIConfig, ReleaseKitConfig } from '@releasekit/config';
 import { loadConfig as loadReleaseKitConfig } from '@releasekit/config';
 import { info, warn } from '@releasekit/core';
+import type { Forge } from '@releasekit/forge';
 import { getGitHubContext, getHeadCommitMessage, matchesSkipPattern } from '../git.js';
-import { createOctokit, fetchPRLabels, findMergedPRsSinceLastRelease, postOrUpdateComment } from '../github.js';
+import { fetchPRLabels, findMergedPRsSinceLastRelease, forgeFor, postOrUpdateComment } from '../github.js';
 import { DEFAULT_LABELS, type LabelConfig } from '../label-utils.js';
 import { resolveScopeToTarget } from '../release.js';
 import { evaluatePR, type PREvaluation } from './evaluate-pr.js';
@@ -76,13 +77,8 @@ export async function runGate(options: GateOptions): Promise<GateOutput> {
   // Find merged PRs since the last release tag (not just the triggering SHA) so that
   // a labelled PR isn't silently dropped when a subsequent push (e.g. dependabot) cancels
   // the original CI run and fires the gate with a different head_sha.
-  const octokit = createOctokit(token);
-  const prNumbers = await findMergedPRsSinceLastRelease(
-    octokit,
-    githubContext.owner,
-    githubContext.repo,
-    options.projectDir,
-  );
+  const forge = forgeFor({ token, owner: githubContext.owner, repo: githubContext.repo });
+  const prNumbers = await findMergedPRsSinceLastRelease(forge, options.projectDir);
 
   if (prNumbers.length === 0) {
     info('No merged PRs found since last release');
@@ -102,9 +98,7 @@ export async function runGate(options: GateOptions): Promise<GateOutput> {
   // Fetches are independent so we parallelise them.
   const evaluations = await Promise.all(
     prNumbers.map((prNumber) =>
-      fetchPRLabels(octokit, githubContext.owner, githubContext.repo, prNumber).then((labels) =>
-        evaluatePR(prNumber, labels, labelConfig, ciConfig),
-      ),
+      fetchPRLabels(forge, prNumber).then((labels) => evaluatePR(prNumber, labels, labelConfig, ciConfig)),
     ),
   );
 
@@ -120,7 +114,7 @@ export async function runGate(options: GateOptions): Promise<GateOutput> {
   // Notify users of PRs whose labels indicated release intent but didn't trigger one.
   // Idempotent: postOrUpdateComment finds the existing notify-marker comment and updates it.
   if (options.notify !== false) {
-    await notifyInsufficientLabels(octokit, githubContext.owner, githubContext.repo, evaluations, trigger, labelConfig);
+    await notifyInsufficientLabels(forge, evaluations, trigger, labelConfig);
   }
 
   return result;
@@ -238,9 +232,7 @@ function shouldNotifyPR(e: PREvaluation, trigger: 'commit' | 'label'): boolean {
 }
 
 async function notifyInsufficientLabels(
-  octokit: ReturnType<typeof createOctokit>,
-  owner: string,
-  repo: string,
+  forge: Forge,
   evaluations: PREvaluation[],
   trigger: 'commit' | 'label',
   labelConfig: LabelConfig,
@@ -250,7 +242,7 @@ async function notifyInsufficientLabels(
       if (!shouldNotifyPR(e, trigger)) return;
       try {
         const body = buildNotifyBody(e, labelConfig);
-        await postOrUpdateComment(octokit, owner, repo, e.prNumber, body, NOTIFY_MARKER);
+        await postOrUpdateComment(forge, e.prNumber, body, NOTIFY_MARKER);
         info(`Posted gate notify comment on PR #${e.prNumber}`);
       } catch (err) {
         warn(`Failed to post gate notify comment on PR #${e.prNumber}: ${err instanceof Error ? err.message : err}`);

--- a/packages/release/src/github.ts
+++ b/packages/release/src/github.ts
@@ -1,31 +1,26 @@
 import { execFileSync } from 'node:child_process';
-import { Octokit } from '@octokit/rest';
 import type { CIConfig } from '@releasekit/config';
+import { createGitHubForge, type Forge } from '@releasekit/forge';
 
 export const MARKER = '<!-- releasekit-preview -->';
 
-export function createOctokit(token: string): Octokit {
-  return new Octokit({ auth: token });
+/**
+ * Build a {@link Forge} for the repository described by a GitHub context. Callers guard on a present
+ * token before reaching the forge-backed paths; the assertion is a safety net for that invariant.
+ */
+export function forgeFor(context: { token: string | null | undefined; owner: string; repo: string }): Forge {
+  if (!context.token) throw new Error('A GitHub token is required to access the forge.');
+  return createGitHubForge({ token: context.token, owner: context.owner, repo: context.repo });
 }
 
 /**
  * Find merged PR(s) associated with a commit.
  * Returns the PR numbers that were merged and included this commit.
  */
-export async function findMergedPRsForCommit(
-  octokit: Octokit,
-  owner: string,
-  repo: string,
-  commitSha: string,
-): Promise<number[]> {
+export async function findMergedPRsForCommit(forge: Forge, commitSha: string): Promise<number[]> {
   try {
-    const { data: prs } = await octokit.rest.repos.listPullRequestsAssociatedWithCommit({
-      owner,
-      repo,
-      commit_sha: commitSha,
-    });
-
-    return prs.filter((pr) => pr.merged_at !== null).map((pr) => pr.number);
+    const prs = await forge.listPullRequestsForCommit(commitSha);
+    return prs.filter((pr) => pr.mergedAt !== null).map((pr) => pr.number);
   } catch {
     return [];
   }
@@ -34,15 +29,10 @@ export async function findMergedPRsForCommit(
 /**
  * Find all merged PRs since the last release tag.
  * Uses git to enumerate commits in the window `<lastTag>..HEAD`, then looks up each
- * commit's associated PR via the GitHub API. Falls back to the last 50 commits when
+ * commit's associated PR via the forge API. Falls back to the last 50 commits when
  * no release tags exist. Returns a deduped list of PR numbers.
  */
-export async function findMergedPRsSinceLastRelease(
-  octokit: Octokit,
-  owner: string,
-  repo: string,
-  projectDir: string,
-): Promise<number[]> {
+export async function findMergedPRsSinceLastRelease(forge: Forge, projectDir: string): Promise<number[]> {
   let range: string;
   try {
     const lastTag = execFileSync('git', ['describe', '--tags', '--abbrev=0'], {
@@ -62,7 +52,7 @@ export async function findMergedPRsSinceLastRelease(
     return [];
   }
 
-  const prGroups = await Promise.all(mergeShas.map((sha) => findMergedPRsForCommit(octokit, owner, repo, sha)));
+  const prGroups = await Promise.all(mergeShas.map((sha) => findMergedPRsForCommit(forge, sha)));
   const seen = new Set<number>();
   for (const prs of prGroups) {
     for (const n of prs) seen.add(n);
@@ -76,67 +66,33 @@ export async function findMergedPRsSinceLastRelease(
  * gate's notify path uses a distinct marker so it doesn't collide with the preview).
  */
 export async function findPreviewComment(
-  octokit: Octokit,
-  owner: string,
-  repo: string,
+  forge: Forge,
   prNumber: number,
   marker: string = MARKER,
 ): Promise<number | null> {
-  const iterator = octokit.paginate.iterator(octokit.rest.issues.listComments, {
-    owner,
-    repo,
-    issue_number: prNumber,
-    per_page: 100,
-  });
-
-  for await (const response of iterator) {
-    for (const comment of response.data) {
-      if (comment.body?.startsWith(marker)) {
-        return comment.id;
-      }
-    }
-  }
-
-  return null;
+  return (await forge.findComment(prNumber, marker))?.id ?? null;
 }
 
 /**
  * Fetch the label names on a PR.
  */
-export async function fetchPRLabels(
-  octokit: Octokit,
-  owner: string,
-  repo: string,
-  prNumber: number,
-): Promise<string[]> {
-  const { data } = await octokit.rest.issues.get({
-    owner,
-    repo,
-    issue_number: prNumber,
-  });
-  return (data.labels ?? []).map((label) => (typeof label === 'string' ? label : (label.name ?? '')));
+export async function fetchPRLabels(forge: Forge, prNumber: number): Promise<string[]> {
+  const issue = await forge.getIssue(prNumber);
+  return issue.labels;
 }
 
 /**
- * Find the open standing release PR for the configured branch.
+ * Find the open standing release PR for the configured branch. Swallows errors (returns null) and
+ * drops labels — callers that need labels use `forge.findStandingPR(branch)` directly.
  */
 export async function findStandingPR(
-  octokit: Octokit,
-  owner: string,
-  repo: string,
+  forge: Forge,
   ciConfig: CIConfig | undefined,
 ): Promise<{ number: number; url: string } | null> {
   const branch = ciConfig?.standingPr?.branch ?? 'release/next';
   try {
-    const { data: prs } = await octokit.rest.pulls.list({
-      owner,
-      repo,
-      head: `${owner}:${branch}`,
-      state: 'open',
-      per_page: 1,
-    });
-    const pr = prs[0];
-    return pr ? { number: pr.number, url: pr.html_url } : null;
+    const pr = await forge.findStandingPR(branch);
+    return pr ? { number: pr.number, url: pr.url } : null;
   } catch {
     return null;
   }
@@ -150,28 +106,10 @@ export async function findStandingPR(
  * marker (e.g. the gate notify marker) to manage distinct comments on the same PR.
  */
 export async function postOrUpdateComment(
-  octokit: Octokit,
-  owner: string,
-  repo: string,
+  forge: Forge,
   prNumber: number,
   body: string,
   marker: string = MARKER,
 ): Promise<void> {
-  const existingId = await findPreviewComment(octokit, owner, repo, prNumber, marker);
-
-  if (existingId) {
-    await octokit.rest.issues.updateComment({
-      owner,
-      repo,
-      comment_id: existingId,
-      body,
-    });
-  } else {
-    await octokit.rest.issues.createComment({
-      owner,
-      repo,
-      issue_number: prNumber,
-      body,
-    });
-  }
+  await forge.upsertMarkerComment(prNumber, marker, body);
 }

--- a/packages/release/src/label-definitions.ts
+++ b/packages/release/src/label-definitions.ts
@@ -1,5 +1,5 @@
-import type { Octokit } from '@octokit/rest';
 import type { CIConfig } from '@releasekit/config';
+import type { Forge } from '@releasekit/forge';
 import { DEFAULT_LABELS } from './label-utils.js';
 
 /**
@@ -90,19 +90,9 @@ export function deriveLabelDefinitions(ciConfig: CIConfig | undefined): LabelDef
  * names so callers can do case-insensitive comparisons; GitHub's `createLabel` API uses
  * case-insensitive uniqueness, so `bump:minor` and `Bump:Minor` are the same label.
  */
-async function listRepoLabelNames(octokit: Octokit, owner: string, repo: string): Promise<Set<string>> {
-  const names = new Set<string>();
-  const iterator = octokit.paginate.iterator(octokit.rest.issues.listLabelsForRepo, {
-    owner,
-    repo,
-    per_page: 100,
-  });
-  for await (const response of iterator) {
-    for (const label of response.data) {
-      names.add(label.name.toLowerCase());
-    }
-  }
-  return names;
+async function listRepoLabelNames(forge: Forge): Promise<Set<string>> {
+  const names = await forge.listLabelNames();
+  return new Set(names.map((name) => name.toLowerCase()));
 }
 
 export interface LabelSyncResult {
@@ -115,34 +105,15 @@ export interface LabelSyncResult {
  * labels are left untouched (createLabel throws 422; ignored). Returns which labels were created
  * vs already present.
  */
-export async function syncLabels(
-  octokit: Octokit,
-  owner: string,
-  repo: string,
-  definitions: LabelDefinition[],
-): Promise<LabelSyncResult> {
+export async function syncLabels(forge: Forge, definitions: LabelDefinition[]): Promise<LabelSyncResult> {
   const created: string[] = [];
   const existing: string[] = [];
 
   for (const def of definitions) {
-    try {
-      await octokit.rest.issues.createLabel({
-        owner,
-        repo,
-        name: def.name,
-        color: def.color,
-        description: def.description,
-      });
-      created.push(def.name);
-    } catch (err) {
-      // 422 means the label already exists — that's the idempotent happy path. Any other
-      // status is a real failure (auth, rate limit) and should surface to the caller.
-      if (isAlreadyExistsError(err)) {
-        existing.push(def.name);
-      } else {
-        throw err;
-      }
-    }
+    // The forge treats GitHub's "already exists" 422 as idempotent (returns 'exists') and surfaces
+    // any other failure (auth, rate limit, validation) by throwing.
+    const result = await forge.createLabel({ name: def.name, color: def.color, description: def.description });
+    (result === 'created' ? created : existing).push(def.name);
   }
 
   return { created, existing };
@@ -153,12 +124,10 @@ export async function syncLabels(
  * of missing label names; an empty list means the repo is fully provisioned.
  */
 export async function checkLabels(
-  octokit: Octokit,
-  owner: string,
-  repo: string,
+  forge: Forge,
   definitions: LabelDefinition[],
 ): Promise<{ missing: string[]; present: string[] }> {
-  const existing = await listRepoLabelNames(octokit, owner, repo);
+  const existing = await listRepoLabelNames(forge);
   const missing: string[] = [];
   const present: string[] = [];
   for (const def of definitions) {
@@ -169,15 +138,4 @@ export async function checkLabels(
     }
   }
   return { missing, present };
-}
-
-function isAlreadyExistsError(err: unknown): boolean {
-  if (typeof err !== 'object' || err === null) return false;
-  const status = (err as { status?: number }).status;
-  if (status !== 422) return false;
-  // A 422 for "already exists" carries errors[0].code === 'already_exists'.
-  // Other 422s (label name too long, disallowed characters, etc.) are real
-  // validation failures and must surface to the caller.
-  const errors = (err as { response?: { data?: { errors?: { code?: string }[] } } }).response?.data?.errors;
-  return Array.isArray(errors) && errors.some((e) => e?.code === 'already_exists');
 }

--- a/packages/release/src/preview/preview.ts
+++ b/packages/release/src/preview/preview.ts
@@ -2,10 +2,11 @@ import * as fs from 'node:fs';
 import type { CIConfig } from '@releasekit/config';
 import { loadCIConfig, loadConfig } from '@releasekit/config';
 import { info, success, warn } from '@releasekit/core';
+import type { Forge } from '@releasekit/forge';
 import { renderSupersedeWarning } from '../failure-report/failure-report.js';
 import { detectUnresolvedFailure } from '../failure-report/post.js';
 import { evaluatePR } from '../gate/evaluate-pr.js';
-import { createOctokit, fetchPRLabels, postOrUpdateComment } from '../github.js';
+import { fetchPRLabels, forgeFor, postOrUpdateComment } from '../github.js';
 import { composeBumpFromLabels, DEFAULT_LABELS, detectLabelConflicts } from '../label-utils.js';
 import { runRelease } from '../release.js';
 import {
@@ -46,20 +47,20 @@ export async function runPreview(options: PreviewOptions): Promise<void> {
   }
 
   // Resolve GitHub context early so we can fetch PR labels
-  // Note: We create Octokit here and reuse it in applyLabelOverrides to avoid creating multiple instances
+  // Note: We create the forge here and reuse it in applyLabelOverrides to avoid creating multiple instances
   let context: PreviewContext | undefined;
-  let octokit: ReturnType<typeof createOctokit> | undefined;
+  let forge: Forge | undefined;
   if (!options.dryRun) {
     try {
       context = resolvePreviewContext({ pr: options.pr, repo: options.repo });
-      octokit = createOctokit(context.token);
+      forge = forgeFor(context);
     } catch (error) {
       warn(`Cannot post PR comment: ${error instanceof Error ? error.message : String(error)}`);
     }
   }
 
-  // Apply label-driven overrides (pass octokit to avoid creating a second instance)
-  const { options: effectiveOptions, labelContext } = await applyLabelOverrides(options, ciConfig, context, octokit);
+  // Apply label-driven overrides (pass the forge to avoid creating a second instance)
+  const { options: effectiveOptions, labelContext } = await applyLabelOverrides(options, ciConfig, context, forge);
 
   const strategy = ciConfig?.releaseStrategy ?? 'direct';
 
@@ -69,9 +70,9 @@ export async function runPreview(options: PreviewOptions): Promise<void> {
   // not a queued-state outcome.
   let standingPrSnapshot: StandingPRSnapshot | undefined;
   let supersedeWarning: string[] | undefined;
-  if (strategy === 'standing-pr' && !labelContext.immediate && context && octokit) {
+  if (strategy === 'standing-pr' && !labelContext.immediate && context && forge) {
     try {
-      standingPrSnapshot = (await fetchStandingPRSnapshot(octokit, context.owner, context.repo, ciConfig)) ?? undefined;
+      standingPrSnapshot = (await fetchStandingPRSnapshot(forge, ciConfig)) ?? undefined;
     } catch {
       // Non-fatal: preview still renders without the snapshot
     }
@@ -80,9 +81,9 @@ export async function runPreview(options: PreviewOptions): Promise<void> {
     // off the failure-report comment on the most recently merged standing PR. Non-fatal.
     try {
       const branch = ciConfig?.standingPr?.branch ?? 'release/next';
-      const latestMerged = await findLatestMergedStandingPR(octokit, context.owner, context.repo, branch);
+      const latestMerged = await findLatestMergedStandingPR(forge, branch);
       if (latestMerged !== null) {
-        const unresolved = await detectUnresolvedFailure(octokit, context.owner, context.repo, latestMerged);
+        const unresolved = await detectUnresolvedFailure(forge, latestMerged);
         if (unresolved) {
           supersedeWarning = renderSupersedeWarning({
             previousLabel: unresolved.previousLabel,
@@ -173,14 +174,14 @@ export async function runPreview(options: PreviewOptions): Promise<void> {
     supersedeWarning,
   });
 
-  if (!context || !octokit) {
+  if (!context || !forge) {
     // Dry-run mode or GitHub context unavailable — print to stdout
     console.log(commentBody);
     return;
   }
 
   info(`Posting preview comment on PR #${context.prNumber}...`);
-  await postOrUpdateComment(octokit, context.owner, context.repo, context.prNumber, commentBody);
+  await postOrUpdateComment(forge, context.prNumber, commentBody);
   success(`Preview comment posted on PR #${context.prNumber}`);
 }
 
@@ -239,7 +240,7 @@ async function applyLabelOverrides(
   options: PreviewOptions,
   ciConfig: CIConfig | undefined,
   context: PreviewContext | undefined,
-  existingOctokit?: ReturnType<typeof createOctokit>,
+  existingForge?: Forge,
 ): Promise<LabelOverrideResult> {
   const trigger = ciConfig?.releaseTrigger ?? 'label';
   const labels = ciConfig?.labels ?? DEFAULT_LABELS;
@@ -262,9 +263,9 @@ async function applyLabelOverrides(
   }
 
   let prLabels: string[];
-  const octokitToUse = existingOctokit ?? createOctokit(context.token);
+  const forgeToUse = existingForge ?? forgeFor(context);
   try {
-    prLabels = await fetchPRLabels(octokitToUse, context.owner, context.repo, context.prNumber);
+    prLabels = await fetchPRLabels(forgeToUse, context.prNumber);
   } catch {
     warn('Could not fetch PR labels — skipping label-driven overrides');
     return {

--- a/packages/release/src/release.ts
+++ b/packages/release/src/release.ts
@@ -2,10 +2,11 @@ import type { CIConfig, ReleaseConfig } from '@releasekit/config';
 import { loadConfig as loadReleaseKitConfig } from '@releasekit/config';
 import type { VersionOutput } from '@releasekit/core';
 import { error, info, setJsonMode, setLogLevel, setQuietMode, success, warn } from '@releasekit/core';
+import type { Forge } from '@releasekit/forge';
 import { PipelineError } from '@releasekit/publish';
 import { postFailureReport, resolveFailureReportIfPresent } from './failure-report/post.js';
 import { getGitHubContext, getHeadCommitMessage, matchesSkipPattern } from './git.js';
-import { createOctokit, fetchPRLabels, findMergedPRsForCommit } from './github.js';
+import { fetchPRLabels, findMergedPRsForCommit, forgeFor } from './github.js';
 import { DEFAULT_LABELS, detectLabelConflicts } from './label-utils.js';
 import { runNotesStep, runPublishStep, runVersionStep } from './steps.js';
 import type { ReleaseOptions, ReleaseOutput } from './types.js';
@@ -17,25 +18,23 @@ import { publishableUpdates } from './version-display.js';
  * PR): mode 'manual' with no PR number — the report goes to the workflow step summary.
  */
 async function resolveReleaseReportTarget(): Promise<{
-  octokit: ReturnType<typeof createOctokit>;
-  owner: string;
-  repo: string;
+  forge: Forge;
   prNumber?: number;
   mode: 'direct' | 'manual';
 } | null> {
   const githubContext = getGitHubContext();
   if (!githubContext?.token) return null;
-  const octokit = createOctokit(githubContext.token);
-  const { owner, repo, sha } = githubContext;
+  const forge = forgeFor({ token: githubContext.token, owner: githubContext.owner, repo: githubContext.repo });
+  const { sha } = githubContext;
 
   const isManualDispatch = process.env.GITHUB_EVENT_NAME === 'workflow_dispatch';
   let prNumber: number | undefined;
   if (sha && !isManualDispatch) {
-    const prs = await findMergedPRsForCommit(octokit, owner, repo, sha);
+    const prs = await findMergedPRsForCommit(forge, sha);
     prNumber = prs[0];
   }
 
-  return { octokit, owner, repo, prNumber, mode: prNumber !== undefined ? 'direct' : 'manual' };
+  return { forge, prNumber, mode: prNumber !== undefined ? 'direct' : 'manual' };
 }
 
 /**
@@ -51,9 +50,7 @@ async function reportReleaseFailure(versionOutput: VersionOutput, err: PipelineE
     }
     await postFailureReport(
       {
-        octokit: target.octokit,
-        owner: target.owner,
-        repo: target.repo,
+        forge: target.forge,
         mode: target.mode,
         prNumber: target.prNumber,
       },
@@ -107,14 +104,14 @@ async function applyScopeLabelsFromPR(
     return { target: options.target, scopeLabels: [], labels: [] };
   }
 
-  const octokit = createOctokit(token);
+  const forge = forgeFor({ token, owner: githubContext.owner, repo: githubContext.repo });
 
-  const prNumbers = await findMergedPRsForCommit(octokit, githubContext.owner, githubContext.repo, githubContext.sha);
+  const prNumbers = await findMergedPRsForCommit(forge, githubContext.sha);
   const allLabels: string[] = [];
   const perPRLabels: Map<number, string[]> = new Map();
 
   for (const prNumber of prNumbers) {
-    const labels = await fetchPRLabels(octokit, githubContext.owner, githubContext.repo, prNumber);
+    const labels = await fetchPRLabels(forge, prNumber);
     allLabels.push(...labels);
     perPRLabels.set(prNumber, labels);
   }
@@ -335,13 +332,7 @@ export async function runRelease(inputOptions: ReleaseOptions): Promise<ReleaseO
       try {
         const target = await resolveReleaseReportTarget();
         if (target?.prNumber !== undefined) {
-          await resolveFailureReportIfPresent(
-            target.octokit,
-            target.owner,
-            target.repo,
-            target.prNumber,
-            versionOutput,
-          );
+          await resolveFailureReportIfPresent(target.forge, target.prNumber, versionOutput);
         }
       } catch (resolveErr) {
         warn(

--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -4,13 +4,14 @@ import * as fs from 'node:fs';
 import { type CIConfig, loadConfig as loadReleaseKitConfig } from '@releasekit/config';
 import type { VersionOutput } from '@releasekit/core';
 import { error, info, success, warn } from '@releasekit/core';
+import type { Forge, PullRequestDetails } from '@releasekit/forge';
 import { PipelineError } from '@releasekit/publish';
 import { ATTRIBUTION_FOOTER } from '../attribution.js';
 import { formatDuration, parseDuration } from '../duration.js';
 import { renderSupersedeWarning } from '../failure-report/failure-report.js';
 import { detectUnresolvedFailure, postFailureReport, resolveFailureReportIfPresent } from '../failure-report/post.js';
 import { getGitHubContext, getHeadCommitMessage, matchesSkipPattern } from '../git.js';
-import { createOctokit } from '../github.js';
+import { forgeFor } from '../github.js';
 import { deriveLabelDefinitions, syncLabels } from '../label-definitions.js';
 import { DEFAULT_LABELS } from '../label-utils.js';
 import { runNotesStep, runPublishStep, runVersionStep } from '../steps.js';
@@ -476,50 +477,11 @@ export function parseManifest(commentBody: string): StandingPRManifest {
   return m;
 }
 
-type OctokitInstance = ReturnType<typeof createOctokit>;
-
 export async function findManifestComment(
-  octokit: OctokitInstance,
-  owner: string,
-  repo: string,
+  forge: Forge,
   prNumber: number,
 ): Promise<{ id: number; body: string } | null> {
-  const iterator = octokit.paginate.iterator(octokit.rest.issues.listComments, {
-    owner,
-    repo,
-    issue_number: prNumber,
-    per_page: 100,
-  });
-
-  for await (const response of iterator) {
-    for (const comment of response.data) {
-      if (comment.body?.startsWith(MANIFEST_MARKER)) {
-        return { id: comment.id, body: comment.body };
-      }
-    }
-  }
-
-  return null;
-}
-
-export async function findStandingPR(
-  octokit: OctokitInstance,
-  owner: string,
-  repo: string,
-  branch: string,
-): Promise<{ number: number; url: string; labels: string[] } | null> {
-  const { data: prs } = await octokit.rest.pulls.list({
-    owner,
-    repo,
-    head: `${owner}:${branch}`,
-    state: 'open',
-    per_page: 1,
-  });
-
-  const pr = prs[0];
-  if (!pr) return null;
-  const labels = (pr.labels ?? []).map((l) => (typeof l === 'string' ? l : (l.name ?? ''))).filter(Boolean);
-  return { number: pr.number, url: pr.html_url, labels };
+  return forge.findComment(prNumber, MANIFEST_MARKER);
 }
 
 /**
@@ -541,16 +503,14 @@ export interface StandingPRSnapshot {
 }
 
 export async function fetchStandingPRSnapshot(
-  octokit: OctokitInstance,
-  owner: string,
-  repo: string,
+  forge: Forge,
   ciConfig: CIConfig | undefined,
 ): Promise<StandingPRSnapshot | null> {
   const branch = ciConfig?.standingPr?.branch ?? 'release/next';
-  const pr = await findStandingPR(octokit, owner, repo, branch);
+  const pr = await forge.findStandingPR(branch);
   if (!pr) return null;
 
-  const comment = await findManifestComment(octokit, owner, repo, pr.number);
+  const comment = await findManifestComment(forge, pr.number);
   if (!comment) return null;
 
   let manifest: StandingPRManifest;
@@ -754,8 +714,7 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
   let existingStandingPr: { number: number; url: string; labels: string[] } | null = null;
   if (githubContext?.token) {
     try {
-      const lookupOctokit = createOctokit(githubContext.token);
-      existingStandingPr = await findStandingPR(lookupOctokit, githubContext.owner, githubContext.repo, branch);
+      existingStandingPr = await forgeFor(githubContext).findStandingPR(branch);
     } catch (err) {
       warn(`Could not look up standing PR for label overrides: ${err instanceof Error ? err.message : String(err)}`);
     }
@@ -801,19 +760,12 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
     info('No releasable changes found');
 
     if (githubContext?.token && existingStandingPr) {
-      const octokit = createOctokit(githubContext.token);
-      await octokit.rest.issues.createComment({
-        owner: githubContext.owner,
-        repo: githubContext.repo,
-        issue_number: existingStandingPr.number,
-        body: 'No releasable changes found. Closing this PR as the release queue is empty.',
-      });
-      await octokit.rest.pulls.update({
-        owner: githubContext.owner,
-        repo: githubContext.repo,
-        pull_number: existingStandingPr.number,
-        state: 'closed',
-      });
+      const forge = forgeFor(githubContext);
+      await forge.createComment(
+        existingStandingPr.number,
+        'No releasable changes found. Closing this PR as the release queue is empty.',
+      );
+      await forge.updatePullRequest(existingStandingPr.number, { state: 'closed' });
       info(`Closed standing PR #${existingStandingPr.number}`);
       return { action: 'closed', prNumber: existingStandingPr.number, prUrl: existingStandingPr.url };
     }
@@ -829,19 +781,12 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
   if (minPackages !== undefined && publishableCount < minPackages) {
     info(`Package count (${publishableCount}) is below minPackages threshold (${minPackages}), skipping`);
     if (githubContext?.token && existingStandingPr) {
-      const octokit = createOctokit(githubContext.token);
-      await octokit.rest.issues.createComment({
-        owner: githubContext.owner,
-        repo: githubContext.repo,
-        issue_number: existingStandingPr.number,
-        body: `Not enough packages with releasable changes (${publishableCount} of ${minPackages} required). Closing until the threshold is reached.`,
-      });
-      await octokit.rest.pulls.update({
-        owner: githubContext.owner,
-        repo: githubContext.repo,
-        pull_number: existingStandingPr.number,
-        state: 'closed',
-      });
+      const forge = forgeFor(githubContext);
+      await forge.createComment(
+        existingStandingPr.number,
+        `Not enough packages with releasable changes (${publishableCount} of ${minPackages} required). Closing until the threshold is reached.`,
+      );
+      await forge.updatePullRequest(existingStandingPr.number, { state: 'closed' });
       info(`Closed standing PR #${existingStandingPr.number} (minPackages not met)`);
       return { action: 'closed', prNumber: existingStandingPr.number, prUrl: existingStandingPr.url };
     }
@@ -880,13 +825,8 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
   let editedNotes: Record<string, string> = {};
   if (previewNotesEnabled && existingStandingPr && githubContext?.token) {
     try {
-      const previewOctokit = createOctokit(githubContext.token);
-      const { data: livePr } = await previewOctokit.rest.pulls.get({
-        owner: githubContext.owner,
-        repo: githubContext.repo,
-        pull_number: existingStandingPr.number,
-      });
-      editedNotes = extractNotesRegions(livePr.body ?? '', previewPackages);
+      const livePr = await forgeFor(githubContext).getPullRequest(existingStandingPr.number);
+      editedNotes = extractNotesRegions(livePr.body, previewPackages);
     } catch (err) {
       warn(
         `Could not read current PR body to preserve note edits: ${err instanceof Error ? err.message : String(err)}`,
@@ -917,8 +857,7 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
     return { action: 'noop', versionOutput };
   }
 
-  const octokit = createOctokit(githubContext.token);
-  const { owner, repo } = githubContext;
+  const forge = forgeFor(githubContext);
 
   // Build PR title and labels. ${count} and ${version} exclude the root lockstep bump —
   // it isn't a publishable package. Sync releases move as one unit, so the sync default
@@ -947,9 +886,9 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
   // Best-effort — a lookup failure must not block the standing-PR update.
   let supersedeWarning: string[] | undefined;
   try {
-    const latestMerged = await findLatestMergedStandingPR(octokit, owner, repo, branch);
+    const latestMerged = await findLatestMergedStandingPR(forge, branch);
     if (latestMerged !== null) {
-      const unresolved = await detectUnresolvedFailure(octokit, owner, repo, latestMerged);
+      const unresolved = await detectUnresolvedFailure(forge, latestMerged);
       if (unresolved) {
         supersedeWarning = renderSupersedeWarning({
           previousLabel: unresolved.previousLabel,
@@ -981,28 +920,15 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
   let action: StandingPRResult['action'];
 
   if (existing) {
-    await octokit.rest.pulls.update({
-      owner,
-      repo,
-      pull_number: existing.number,
-      title,
-      body,
-    });
+    await forge.updatePullRequest(existing.number, { title, body });
     prNumber = existing.number;
     prUrl = existing.url;
     action = 'updated';
     info(`Updated standing PR #${prNumber}`);
   } else {
-    const { data: newPr } = await octokit.rest.pulls.create({
-      owner,
-      repo,
-      title,
-      body,
-      head: branch,
-      base,
-    });
+    const newPr = await forge.createPullRequest({ title, body, head: branch, base });
     prNumber = newPr.number;
-    prUrl = newPr.html_url;
+    prUrl = newPr.url;
     action = 'created';
     info(`Created standing PR #${prNumber}`);
   }
@@ -1011,7 +937,7 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
   // retry label is created but NOT applied — a maintainer applies it on demand after merge to
   // retry a failed publish (issue #245). Best-effort: a sync failure must not block the update.
   try {
-    await syncLabels(octokit, owner, repo, deriveLabelDefinitions(ciConfig));
+    await syncLabels(forge, deriveLabelDefinitions(ciConfig));
   } catch (err) {
     warn(`Could not ensure ReleaseKit labels exist: ${err instanceof Error ? err.message : String(err)}`);
   }
@@ -1023,12 +949,7 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
     try {
       const currentLabels = existingStandingPr?.labels ?? [];
       const mergedLabels = [...new Set([...currentLabels, ...labels])];
-      await octokit.rest.issues.setLabels({
-        owner,
-        repo,
-        issue_number: prNumber,
-        labels: mergedLabels,
-      });
+      await forge.setLabels(prNumber, mergedLabels);
     } catch {
       warn('Failed to apply labels to standing PR');
     }
@@ -1036,7 +957,7 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
 
   // Find existing manifest to preserve firstUpdatedAt across updates
   let firstUpdatedAt = new Date().toISOString();
-  const existingManifestComment = await findManifestComment(octokit, owner, repo, prNumber);
+  const existingManifestComment = await findManifestComment(forge, prNumber);
   if (existingManifestComment) {
     try {
       const existingManifest = parseManifest(existingManifestComment.body);
@@ -1068,19 +989,9 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
 
   const manifestBody = serializeManifest(manifest);
   if (existingManifestComment) {
-    await octokit.rest.issues.updateComment({
-      owner,
-      repo,
-      comment_id: existingManifestComment.id,
-      body: manifestBody,
-    });
+    await forge.updateComment(existingManifestComment.id, manifestBody);
   } else {
-    await octokit.rest.issues.createComment({
-      owner,
-      repo,
-      issue_number: prNumber,
-      body: manifestBody,
-    });
+    await forge.createComment(prNumber, manifestBody);
   }
   success(`Manifest written to PR #${prNumber}`);
 
@@ -1110,7 +1021,7 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
     }
   }
 
-  await postStandingPRStatusSafe(octokit, owner, repo, releaseBranchSha, statusState, statusDescription);
+  await postStandingPRStatusSafe(forge, releaseBranchSha, statusState, statusDescription);
 
   return { action, prNumber, prUrl, versionOutput };
 }
@@ -1126,8 +1037,7 @@ export async function publishFromManifest(prNumber: number, options: StandingPRO
     return null;
   }
 
-  const octokit = createOctokit(githubContext.token);
-  const { owner, repo } = githubContext;
+  const forge = forgeFor(githubContext);
 
   const releaseKitConfig = loadReleaseKitConfig({ cwd, configPath: options.config });
   const standingPrConfig = releaseKitConfig.ci?.standingPr;
@@ -1135,7 +1045,7 @@ export async function publishFromManifest(prNumber: number, options: StandingPRO
   const deleteBranchOnMerge = standingPrConfig?.deleteBranchOnMerge !== false;
 
   // Find and parse manifest from the PR
-  const manifestComment = await findManifestComment(octokit, owner, repo, prNumber);
+  const manifestComment = await findManifestComment(forge, prNumber);
   if (!manifestComment) {
     throw new Error(`Release manifest not found on PR #${prNumber}. Re-run 'standing-pr update' to regenerate.`);
   }
@@ -1187,9 +1097,9 @@ export async function publishFromManifest(prNumber: number, options: StandingPRO
 
   // Fetch the merged (still-readable) PR once — used for both the override-label staleness guard
   // and the human-edited release notes.
-  let livePr: Awaited<ReturnType<typeof octokit.rest.pulls.get>>['data'] | undefined;
+  let livePr: PullRequestDetails | undefined;
   try {
-    livePr = (await octokit.rest.pulls.get({ owner, repo, pull_number: prNumber })).data;
+    livePr = await forge.getPullRequest(prNumber);
   } catch (err) {
     warn(`Could not read PR #${prNumber}: ${err instanceof Error ? err.message : String(err)}`);
   }
@@ -1212,10 +1122,7 @@ export async function publishFromManifest(prNumber: number, options: StandingPRO
     );
   }
   if (livePr && manifest.overrideLabels !== undefined) {
-    const mergedLabels = extractOverrideLabels(
-      (livePr.labels ?? []).map((l) => (typeof l === 'string' ? l : (l.name ?? ''))).filter(Boolean),
-      releaseKitConfig.ci,
-    );
+    const mergedLabels = extractOverrideLabels((livePr.labels ?? []).filter(Boolean), releaseKitConfig.ci);
     const manifestLabels = [...manifest.overrideLabels].sort();
     if (mergedLabels.join('\n') !== manifestLabels.join('\n')) {
       throw new Error(
@@ -1305,9 +1212,7 @@ export async function publishFromManifest(prNumber: number, options: StandingPRO
       try {
         await postFailureReport(
           {
-            octokit,
-            owner,
-            repo,
+            forge,
             mode: 'standing-pr',
             prNumber,
             standingPrNumber: prNumber,
@@ -1329,7 +1234,7 @@ export async function publishFromManifest(prNumber: number, options: StandingPRO
 
   // Publish succeeded — clear any prior failure report on this PR (resolves it and the supersede
   // warning that would otherwise show on the next standing PR).
-  await resolveFailureReportIfPresent(octokit, owner, repo, prNumber, manifest.versionOutput);
+  await resolveFailureReportIfPresent(forge, prNumber, manifest.versionOutput);
 
   // Cleanup: delete release branch if configured
   if (deleteBranchOnMerge) {
@@ -1351,28 +1256,15 @@ export async function publishFromManifest(prNumber: number, options: StandingPRO
  * Inference fallback for dispatch-funnelled publishes — explicit `--pr` is preferred
  * because a re-run of a stale dispatch can land after a newer standing PR has merged.
  */
-export async function findLatestMergedStandingPR(
-  octokit: OctokitInstance,
-  owner: string,
-  repo: string,
-  branch: string,
-): Promise<number | null> {
-  const { data: prs } = await octokit.rest.pulls.list({
-    owner,
-    repo,
-    head: `${owner}:${branch}`,
-    state: 'closed',
-    sort: 'updated',
-    direction: 'desc',
-    per_page: 10,
-  });
+export async function findLatestMergedStandingPR(forge: Forge, branch: string): Promise<number | null> {
+  const prs = await forge.listRecentlyClosedPullRequests(branch, 10);
 
   // 'updated' ordering only guarantees the newest merge is in the page (merging touches
   // updated_at) — late activity on an older merged PR (a comment, a label) can sort it
-  // above a newer merge. Pick by merged_at, not list position.
+  // above a newer merge. Pick by mergedAt, not list position.
   const merged = prs
-    .filter((pr) => pr.merged_at != null)
-    .sort((a, b) => new Date(b.merged_at as string).getTime() - new Date(a.merged_at as string).getTime());
+    .filter((pr) => pr.mergedAt != null)
+    .sort((a, b) => new Date(b.mergedAt as string).getTime() - new Date(a.mergedAt as string).getTime());
   return merged[0]?.number ?? null;
 }
 
@@ -1435,8 +1327,7 @@ export async function runStandingPRPublish(
     return null;
   }
 
-  const octokit = createOctokit(githubContext.token);
-  const inferred = await findLatestMergedStandingPR(octokit, githubContext.owner, githubContext.repo, releaseBranch);
+  const inferred = await findLatestMergedStandingPR(forgeFor(githubContext), releaseBranch);
   if (inferred === null) {
     error(`No merged standing release PR found for branch '${releaseBranch}' — pass --pr explicitly`);
     return null;
@@ -1466,10 +1357,9 @@ export async function runStandingPRMerge(
     return null;
   }
 
-  const octokit = createOctokit(githubContext.token);
-  const { owner, repo } = githubContext;
+  const forge = forgeFor(githubContext);
 
-  const pr = await findStandingPR(octokit, owner, repo, branch);
+  const pr = await forge.findStandingPR(branch);
   if (!pr) {
     info(`No open standing PR found for branch '${branch}'`);
     return null;
@@ -1477,12 +1367,7 @@ export async function runStandingPRMerge(
 
   info(`Merging standing PR #${pr.number} via ${mergeMethod}...`);
   try {
-    await octokit.rest.pulls.merge({
-      owner,
-      repo,
-      pull_number: pr.number,
-      merge_method: mergeMethod,
-    });
+    await forge.mergePullRequest(pr.number, mergeMethod);
   } catch (err) {
     const reqErr = err as { status?: number; response?: { data?: { message?: string } } };
     if (reqErr.status === 405) {

--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -4,7 +4,7 @@ import * as fs from 'node:fs';
 import { type CIConfig, loadConfig as loadReleaseKitConfig } from '@releasekit/config';
 import type { VersionOutput } from '@releasekit/core';
 import { error, info, success, warn } from '@releasekit/core';
-import type { Forge, PullRequestDetails } from '@releasekit/forge';
+import { type Forge, forgeErrorStatus, type PullRequestDetails } from '@releasekit/forge';
 import { PipelineError } from '@releasekit/publish';
 import { ATTRIBUTION_FOOTER } from '../attribution.js';
 import { formatDuration, parseDuration } from '../duration.js';
@@ -1369,9 +1369,11 @@ export async function runStandingPRMerge(
   try {
     await forge.mergePullRequest(pr.number, mergeMethod);
   } catch (err) {
-    const reqErr = err as { status?: number; response?: { data?: { message?: string } } };
-    if (reqErr.status === 405) {
-      const reason = reqErr.response?.data?.message ?? 'unknown reason';
+    if (forgeErrorStatus(err) === 405) {
+      // Best-effort detail; the forge surfaces the raw error, so a non-GitHub adapter just yields
+      // 'unknown reason' here.
+      const reason =
+        (err as { response?: { data?: { message?: string } } }).response?.data?.message ?? 'unknown reason';
       throw new Error(`Cannot merge standing PR #${pr.number}: GitHub rejected the merge (${reason})`);
     }
     throw err;

--- a/packages/release/src/standing-pr/status.ts
+++ b/packages/release/src/standing-pr/status.ts
@@ -1,40 +1,27 @@
 import { warn } from '@releasekit/core';
-import type { createOctokit } from '../github.js';
-
-type OctokitInstance = ReturnType<typeof createOctokit>;
+import type { Forge } from '@releasekit/forge';
 
 const STATUS_CONTEXT = 'releasekit/standing-pr';
 
 export type CommitStatusState = 'success' | 'pending' | 'failure' | 'error';
 
 export async function postStandingPRStatus(
-  octokit: OctokitInstance,
-  owner: string,
-  repo: string,
+  forge: Forge,
   sha: string,
   state: CommitStatusState,
   description: string,
 ): Promise<void> {
-  await octokit.rest.repos.createCommitStatus({
-    owner,
-    repo,
-    sha,
-    state,
-    description,
-    context: STATUS_CONTEXT,
-  });
+  await forge.setCommitStatus({ sha, state, description, context: STATUS_CONTEXT });
 }
 
 export async function postStandingPRStatusSafe(
-  octokit: OctokitInstance,
-  owner: string,
-  repo: string,
+  forge: Forge,
   sha: string,
   state: CommitStatusState,
   description: string,
 ): Promise<void> {
   try {
-    await postStandingPRStatus(octokit, owner, repo, sha, state, description);
+    await postStandingPRStatus(forge, sha, state, description);
   } catch (err) {
     warn(`Failed to post commit status: ${err instanceof Error ? err.message : String(err)}`);
   }

--- a/packages/release/src/standing-pr/status.ts
+++ b/packages/release/src/standing-pr/status.ts
@@ -1,9 +1,9 @@
 import { warn } from '@releasekit/core';
-import type { Forge } from '@releasekit/forge';
+import type { CommitStatusState, Forge } from '@releasekit/forge';
 
 const STATUS_CONTEXT = 'releasekit/standing-pr';
 
-export type CommitStatusState = 'success' | 'pending' | 'failure' | 'error';
+export type { CommitStatusState };
 
 export async function postStandingPRStatus(
   forge: Forge,

--- a/packages/release/test/unit/failure-report-post.spec.ts
+++ b/packages/release/test/unit/failure-report-post.spec.ts
@@ -1,6 +1,7 @@
 import type { VersionOutput } from '@releasekit/core';
+import { createFakeForge } from '@releasekit/forge';
 import { PipelineError, type PublishOutput, type PublishResult } from '@releasekit/publish';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { FAILURE_MARKER, renderFailureReport, renderResolvedReport } from '../../src/failure-report/failure-report.js';
 import {
   detectUnresolvedFailure,
@@ -43,33 +44,9 @@ function pipelineErrorFor(versionOutput: VersionOutput): PipelineError {
   return new PipelineError('Failed to publish to npm: npm 403', 'npm-publish', publishOutput);
 }
 
-function commentsIterator(bodies: Array<{ id: number; body: string }>) {
-  return {
-    iterator: vi.fn().mockReturnValue({
-      async *[Symbol.asyncIterator]() {
-        yield { data: bodies };
-      },
-    }),
-  };
-}
-
-function mockOctokit(comments: Array<{ id: number; body: string }> = []) {
-  const createComment = vi.fn().mockResolvedValue({});
-  const updateComment = vi.fn().mockResolvedValue({});
-  return {
-    octokit: {
-      paginate: commentsIterator(comments),
-      rest: {
-        issues: {
-          listComments: vi.fn(),
-          createComment,
-          updateComment,
-        },
-      },
-    } as never,
-    createComment,
-    updateComment,
-  };
+/** A forge seeded with existing comments, exposing its recorded create/update writes for assertions. */
+function fakeForgeWith(comments: Array<{ id: number; body: string }> = []) {
+  return createFakeForge({ comments });
 }
 
 const versionOutput = versionOutputFor([
@@ -79,14 +56,14 @@ const versionOutput = versionOutputFor([
 
 describe('postFailureReport', () => {
   it('should create a new marker comment when none exists', async () => {
-    const { octokit, createComment } = mockOctokit([]);
+    const forge = fakeForgeWith([]);
     await postFailureReport(
-      { octokit, owner: 'o', repo: 'r', mode: 'standing-pr', prNumber: 42, standingPrNumber: 42 },
+      { forge, mode: 'standing-pr', prNumber: 42, standingPrNumber: 42 },
       versionOutput,
       pipelineErrorFor(versionOutput),
     );
-    expect(createComment).toHaveBeenCalledTimes(1);
-    const body = createComment.mock.calls[0]?.[0]?.body as string;
+    expect(forge.createdComments).toHaveLength(1);
+    const body = forge.createdComments[0]?.body as string;
     expect(body.startsWith(FAILURE_MARKER)).toBe(true);
     expect(body).toContain('1/2 package(s) published');
   });
@@ -99,15 +76,15 @@ describe('postFailureReport', () => {
       errorMessage: 'older error',
       recovery: { mode: 'standing-pr', standingPrNumber: 42 },
     });
-    const { octokit, createComment, updateComment } = mockOctokit([{ id: 7, body: existing }]);
+    const forge = fakeForgeWith([{ id: 7, body: existing }]);
     await postFailureReport(
-      { octokit, owner: 'o', repo: 'r', mode: 'standing-pr', prNumber: 42, standingPrNumber: 42 },
+      { forge, mode: 'standing-pr', prNumber: 42, standingPrNumber: 42 },
       versionOutput,
       pipelineErrorFor(versionOutput),
     );
-    expect(createComment).not.toHaveBeenCalled();
-    expect(updateComment).toHaveBeenCalledTimes(1);
-    expect(updateComment.mock.calls[0]?.[0]?.comment_id).toBe(7);
+    expect(forge.createdComments).toHaveLength(0);
+    expect(forge.updatedComments).toHaveLength(1);
+    expect(forge.updatedComments[0]?.commentId).toBe(7);
   });
 
   it('should write to the step summary when no PR is available (manual dispatch)', async () => {
@@ -115,13 +92,9 @@ describe('postFailureReport', () => {
     const fs = await import('node:fs');
     process.env.GITHUB_STEP_SUMMARY = tmp;
     try {
-      const { octokit, createComment } = mockOctokit([]);
-      await postFailureReport(
-        { octokit, owner: 'o', repo: 'r', mode: 'manual' },
-        versionOutput,
-        pipelineErrorFor(versionOutput),
-      );
-      expect(createComment).not.toHaveBeenCalled();
+      const forge = fakeForgeWith([]);
+      await postFailureReport({ forge, mode: 'manual' }, versionOutput, pipelineErrorFor(versionOutput));
+      expect(forge.createdComments).toHaveLength(0);
       const written = fs.readFileSync(tmp, 'utf-8');
       expect(written).toContain(FAILURE_MARKER);
       expect(written).toContain('1/2 package(s) published');
@@ -142,18 +115,18 @@ describe('resolveFailureReportIfPresent', () => {
       errorMessage: 'err',
       recovery: { mode: 'standing-pr', standingPrNumber: 42 },
     });
-    const { octokit, updateComment } = mockOctokit([{ id: 7, body: existing }]);
-    await resolveFailureReportIfPresent(octokit, 'o', 'r', 42, versionOutput);
-    expect(updateComment).toHaveBeenCalledTimes(1);
-    const body = updateComment.mock.calls[0]?.[0]?.body as string;
+    const forge = fakeForgeWith([{ id: 7, body: existing }]);
+    await resolveFailureReportIfPresent(forge, 42, versionOutput);
+    expect(forge.updatedComments).toHaveLength(1);
+    const body = forge.updatedComments[0]?.body as string;
     expect(body).toContain('recovered');
   });
 
   it('should be a no-op when there is no existing report', async () => {
-    const { octokit, updateComment, createComment } = mockOctokit([]);
-    await resolveFailureReportIfPresent(octokit, 'o', 'r', 42, versionOutput);
-    expect(updateComment).not.toHaveBeenCalled();
-    expect(createComment).not.toHaveBeenCalled();
+    const forge = fakeForgeWith([]);
+    await resolveFailureReportIfPresent(forge, 42, versionOutput);
+    expect(forge.updatedComments).toHaveLength(0);
+    expect(forge.createdComments).toHaveLength(0);
   });
 });
 
@@ -176,20 +149,20 @@ describe('detectUnresolvedFailure', () => {
       errorMessage: 'npm 403',
       recovery: { mode: 'standing-pr', standingPrNumber: 42 },
     });
-    const { octokit } = mockOctokit([{ id: 9, body: report }]);
-    const result = await detectUnresolvedFailure(octokit, 'o', 'r', 42);
+    const forge = fakeForgeWith([{ id: 9, body: report }]);
+    const result = await detectUnresolvedFailure(forge, 42);
     expect(result).toEqual({ previousLabel: 'v0.24.0', published: 1, total: 2, prNumber: 42 });
   });
 
   it('should return null once the report is resolved', async () => {
     const resolved = renderResolvedReport(versionOutput);
-    const { octokit } = mockOctokit([{ id: 9, body: resolved }]);
-    expect(await detectUnresolvedFailure(octokit, 'o', 'r', 42)).toBeNull();
+    const forge = fakeForgeWith([{ id: 9, body: resolved }]);
+    expect(await detectUnresolvedFailure(forge, 42)).toBeNull();
   });
 
   it('should return null when there is no failure report', async () => {
-    const { octokit } = mockOctokit([{ id: 1, body: 'unrelated comment' }]);
-    expect(await detectUnresolvedFailure(octokit, 'o', 'r', 42)).toBeNull();
+    const forge = fakeForgeWith([{ id: 1, body: 'unrelated comment' }]);
+    expect(await detectUnresolvedFailure(forge, 42)).toBeNull();
   });
 });
 

--- a/packages/release/test/unit/gate.spec.ts
+++ b/packages/release/test/unit/gate.spec.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockLoadReleaseKitConfig = vi.fn();
-const mockCreateOctokit = vi.fn();
+const mockForgeFor = vi.fn();
 const mockFindMergedPRsSinceLastRelease = vi.fn();
 const mockFetchPRLabels = vi.fn();
 const mockPostOrUpdateComment = vi.fn();
@@ -25,7 +25,7 @@ vi.mock('node:child_process', () => ({
 }));
 
 vi.mock('../../src/github.js', () => ({
-  createOctokit: (...args: unknown[]) => mockCreateOctokit(...args),
+  forgeFor: (...args: unknown[]) => mockForgeFor(...args),
   findMergedPRsSinceLastRelease: (...args: unknown[]) => mockFindMergedPRsSinceLastRelease(...args),
   fetchPRLabels: (...args: unknown[]) => mockFetchPRLabels(...args),
   postOrUpdateComment: (...args: unknown[]) => mockPostOrUpdateComment(...args),
@@ -563,9 +563,7 @@ describe('Gate', () => {
       // Notify is only posted on PR #225 (insufficient labels with intent),
       // never on the winning PR #224.
       expect(mockPostOrUpdateComment).toHaveBeenCalledTimes(1);
-      const [, owner, repo, prNumber, body, marker] = mockPostOrUpdateComment.mock.calls[0];
-      expect(owner).toBe('owner');
-      expect(repo).toBe('repo');
+      const [, prNumber, body, marker] = mockPostOrUpdateComment.mock.calls[0];
       expect(prNumber).toBe(225);
       expect(body).toContain('did not trigger a release');
       expect(body).toContain('channel:prerelease');
@@ -606,7 +604,7 @@ describe('Gate', () => {
 
       expect(result.blocked).toBe(true);
       expect(mockPostOrUpdateComment).toHaveBeenCalledTimes(1);
-      const [, , , prNumber, body] = mockPostOrUpdateComment.mock.calls[0];
+      const [, prNumber, body] = mockPostOrUpdateComment.mock.calls[0];
       expect(prNumber).toBe(42);
       expect(body).toContain('conflicting');
       expect(body).toContain('bump:major');

--- a/packages/release/test/unit/label-definitions.spec.ts
+++ b/packages/release/test/unit/label-definitions.spec.ts
@@ -1,4 +1,5 @@
 import type { CIConfig } from '@releasekit/config';
+import { createFakeForge } from '@releasekit/forge';
 import { describe, expect, it, vi } from 'vitest';
 import { checkLabels, deriveLabelDefinitions, type LabelDefinition, syncLabels } from '../../src/label-definitions.js';
 
@@ -94,146 +95,98 @@ describe('deriveLabelDefinitions', () => {
   });
 });
 
-function mockOctokitForCreate(failures: Record<string, number> = {}) {
-  const createLabel = vi.fn(async ({ name }: { name: string }) => {
-    const status = failures[name];
-    if (status) {
-      const err = new Error(`HTTP ${status}`) as Error & { status: number };
-      err.status = status;
-      throw err;
-    }
-    return { data: {} };
-  });
-  return { rest: { issues: { createLabel } }, _createLabel: createLabel };
-}
-
-function mockOctokitForCreateWithErrorBody(failures: Record<string, { status: number; errors?: { code: string }[] }>) {
-  const createLabel = vi.fn(async ({ name }: { name: string }) => {
-    const failure = failures[name];
-    if (failure) {
-      const err = new Error(`HTTP ${failure.status}`) as Error & {
-        status: number;
-        response?: { data: { errors?: { code: string }[] } };
-      };
-      err.status = failure.status;
-      if (failure.errors) {
-        err.response = { data: { errors: failure.errors } };
-      }
-      throw err;
-    }
-    return { data: {} };
-  });
-  return { rest: { issues: { createLabel } }, _createLabel: createLabel };
-}
-
 describe('syncLabels', () => {
   it('should create every definition that does not already exist', async () => {
-    const octokit = mockOctokitForCreate();
+    const forge = createFakeForge();
     const defs: LabelDefinition[] = [
       { name: 'bump:minor', color: '0e8a16', description: 'x' },
       { name: 'release:skip', color: 'd93f0b', description: 'y' },
     ];
 
-    const result = await syncLabels(octokit as never, 'owner', 'repo', defs);
+    const result = await syncLabels(forge, defs);
 
     expect(result.created).toEqual(['bump:minor', 'release:skip']);
     expect(result.existing).toEqual([]);
-    expect(octokit._createLabel).toHaveBeenCalledTimes(2);
+    expect(forge.createdLabels).toHaveLength(2);
   });
 
   it('should treat a 422 with already_exists error code as idempotent', async () => {
-    const octokit = mockOctokitForCreateWithErrorBody({
-      'bump:minor': { status: 422, errors: [{ code: 'already_exists' }] },
-    });
+    // The forge resolves an already-existing label to 'exists' (the raw-422 'already_exists'
+    // detection now lives in the GitHubForge adapter). Seed the existing label to reproduce it.
+    const forge = createFakeForge({ labelNames: ['bump:minor'] });
     const defs: LabelDefinition[] = [
       { name: 'bump:minor', color: '0e8a16', description: 'x' },
       { name: 'release:skip', color: 'd93f0b', description: 'y' },
     ];
 
-    const result = await syncLabels(octokit as never, 'owner', 'repo', defs);
+    const result = await syncLabels(forge, defs);
 
     expect(result.existing).toEqual(['bump:minor']);
     expect(result.created).toEqual(['release:skip']);
   });
 
   it('should rethrow 422 validation errors (e.g. label name too long) so the caller sees the real failure', async () => {
-    const octokit = mockOctokitForCreateWithErrorBody({
-      'scope:very-long-feature-area-name-that-exceeds-the-limit': {
-        status: 422,
-        errors: [{ code: 'invalid' }],
-      },
-    });
+    const forge = createFakeForge();
+    vi.spyOn(forge, 'createLabel').mockRejectedValueOnce(Object.assign(new Error('HTTP 422'), { status: 422 }));
     const defs: LabelDefinition[] = [
-      {
-        name: 'scope:very-long-feature-area-name-that-exceeds-the-limit',
-        color: '5319e7',
-        description: 'x',
-      },
+      { name: 'scope:very-long-feature-area-name-that-exceeds-the-limit', color: '5319e7', description: 'x' },
     ];
 
-    await expect(syncLabels(octokit as never, 'owner', 'repo', defs)).rejects.toThrow('HTTP 422');
+    await expect(syncLabels(forge, defs)).rejects.toThrow('HTTP 422');
   });
 
   it('should rethrow 422 errors without a structured body as a real failure', async () => {
-    const octokit = mockOctokitForCreate({ 'bump:minor': 422 });
+    const forge = createFakeForge();
+    vi.spyOn(forge, 'createLabel').mockRejectedValueOnce(Object.assign(new Error('HTTP 422'), { status: 422 }));
     const defs: LabelDefinition[] = [{ name: 'bump:minor', color: '0e8a16', description: 'x' }];
 
-    await expect(syncLabels(octokit as never, 'owner', 'repo', defs)).rejects.toThrow('HTTP 422');
+    await expect(syncLabels(forge, defs)).rejects.toThrow('HTTP 422');
   });
 
   it('should rethrow non-422 errors (e.g. auth/rate-limit)', async () => {
-    const octokit = mockOctokitForCreate({ 'bump:minor': 403 });
+    const forge = createFakeForge();
+    vi.spyOn(forge, 'createLabel').mockRejectedValueOnce(Object.assign(new Error('HTTP 403'), { status: 403 }));
     const defs: LabelDefinition[] = [{ name: 'bump:minor', color: '0e8a16', description: 'x' }];
 
-    await expect(syncLabels(octokit as never, 'owner', 'repo', defs)).rejects.toThrow('HTTP 403');
+    await expect(syncLabels(forge, defs)).rejects.toThrow('HTTP 403');
   });
 });
 
-function mockOctokitForList(existing: string[]) {
-  const listLabelsForRepo = vi.fn();
-  const iterator = vi.fn().mockReturnValue({
-    async *[Symbol.asyncIterator]() {
-      yield { data: existing.map((name) => ({ name })) };
-    },
-  });
-  return { paginate: { iterator }, rest: { issues: { listLabelsForRepo } } };
-}
-
 describe('checkLabels', () => {
   it('should report all labels missing when the repo has none', async () => {
-    const octokit = mockOctokitForList([]);
+    const forge = createFakeForge({ labelNames: [] });
     const defs: LabelDefinition[] = [
       { name: 'bump:minor', color: '0e8a16', description: 'x' },
       { name: 'release:skip', color: 'd93f0b', description: 'y' },
     ];
 
-    const { missing, present } = await checkLabels(octokit as never, 'owner', 'repo', defs);
+    const { missing, present } = await checkLabels(forge, defs);
 
     expect(missing).toEqual(['bump:minor', 'release:skip']);
     expect(present).toEqual([]);
   });
 
   it('should report only the missing subset', async () => {
-    const octokit = mockOctokitForList(['bump:minor']);
+    const forge = createFakeForge({ labelNames: ['bump:minor'] });
     const defs: LabelDefinition[] = [
       { name: 'bump:minor', color: '0e8a16', description: 'x' },
       { name: 'release:skip', color: 'd93f0b', description: 'y' },
     ];
 
-    const { missing, present } = await checkLabels(octokit as never, 'owner', 'repo', defs);
+    const { missing, present } = await checkLabels(forge, defs);
 
     expect(missing).toEqual(['release:skip']);
     expect(present).toEqual(['bump:minor']);
   });
 
   it('should report nothing missing when the repo is fully provisioned', async () => {
-    const octokit = mockOctokitForList(['bump:minor', 'release:skip']);
+    const forge = createFakeForge({ labelNames: ['bump:minor', 'release:skip'] });
     const defs: LabelDefinition[] = [
       { name: 'bump:minor', color: '0e8a16', description: 'x' },
       { name: 'release:skip', color: 'd93f0b', description: 'y' },
     ];
 
-    const { missing } = await checkLabels(octokit as never, 'owner', 'repo', defs);
+    const { missing } = await checkLabels(forge, defs);
 
     expect(missing).toEqual([]);
   });

--- a/packages/release/test/unit/labels-command.spec.ts
+++ b/packages/release/test/unit/labels-command.spec.ts
@@ -13,44 +13,19 @@ vi.mock('@releasekit/core', async (importOriginal) => {
   };
 });
 vi.mock('../../src/github.js', () => ({
-  createOctokit: vi.fn(),
+  forgeFor: vi.fn(),
 }));
 
 import { EXIT_CODES } from '@releasekit/core';
+import { createFakeForge } from '@releasekit/forge';
 import { runLabelsSync } from '../../src/commands/labels-command.js';
-import { createOctokit } from '../../src/github.js';
+import { forgeFor } from '../../src/github.js';
 
-function mockOctokit(existingLabels: string[] = [], failures: Record<string, number> = {}) {
-  const createLabel = vi.fn(async ({ name }: { name: string }) => {
-    const status = failures[name];
-    if (status) {
-      const err = new Error(`HTTP ${status}`) as Error & {
-        status: number;
-        response?: { data: { errors?: { code: string }[] } };
-      };
-      err.status = status;
-      // GitHub's 422 for "already exists" carries errors[0].code === 'already_exists';
-      // other 422s are real validation failures and must surface. Mock both as 422-with-body
-      // so the test exercises the existing/regression path the same way the real API would.
-      if (status === 422) {
-        err.response = { data: { errors: [{ code: 'already_exists' }] } };
-      }
-      throw err;
-    }
-    return { data: {} };
-  });
-  const iterator = vi.fn().mockReturnValue({
-    async *[Symbol.asyncIterator]() {
-      yield { data: existingLabels.map((name) => ({ name })) };
-    },
-  });
-  return {
-    octokit: {
-      paginate: { iterator },
-      rest: { issues: { createLabel, listLabelsForRepo: vi.fn() } },
-    },
-    createLabel,
-  };
+/** A forge whose repo already has `existingLabels` — `createLabel` resolves 'exists' for those. */
+function mockForge(existingLabels: string[] = []) {
+  const forge = createFakeForge({ labelNames: existingLabels });
+  vi.mocked(forgeFor).mockReturnValue(forge);
+  return forge;
 }
 
 describe('runLabelsSync', () => {
@@ -71,39 +46,37 @@ describe('runLabelsSync', () => {
   });
 
   it('should create missing labels in sync mode', async () => {
-    const { octokit, createLabel } = mockOctokit([]);
-    vi.mocked(createOctokit).mockReturnValue(octokit as never);
+    const forge = mockForge([]);
 
     await runLabelsSync({ repo: 'owner/repo' });
 
     // Default config implies the 8 reserved labels + the default 'release' standing-PR label.
-    expect(createLabel).toHaveBeenCalled();
-    const created = createLabel.mock.calls.map((c) => (c[0] as { name: string }).name);
+    expect(forge.createdLabels.length).toBeGreaterThan(0);
+    const created = forge.createdLabels.map((l) => l.name);
     expect(created).toEqual(expect.arrayContaining(['bump:minor', 'channel:stable', 'release:skip', 'release']));
     expect(exitSpy).not.toHaveBeenCalled();
   });
 
   it('should be idempotent — 422 already-exists does not fail the run', async () => {
-    const { octokit } = mockOctokit([], { 'bump:minor': 422 });
-    vi.mocked(createOctokit).mockReturnValue(octokit as never);
+    // The forge resolves an existing label to 'exists' rather than throwing — the run succeeds.
+    mockForge(['bump:minor']);
 
     await expect(runLabelsSync({ repo: 'owner/repo' })).resolves.toBeUndefined();
     expect(exitSpy).not.toHaveBeenCalled();
   });
 
   it('should exit non-zero in --check mode when labels are missing', async () => {
-    const { octokit, createLabel } = mockOctokit([]); // repo has no labels → all missing
-    vi.mocked(createOctokit).mockReturnValue(octokit as never);
+    const forge = mockForge([]); // repo has no labels → all missing
 
     await runLabelsSync({ repo: 'owner/repo', check: true });
 
     expect(exitSpy).toHaveBeenCalledWith(EXIT_CODES.GENERAL_ERROR);
     // --check performs NO mutations.
-    expect(createLabel).not.toHaveBeenCalled();
+    expect(forge.createdLabels).toHaveLength(0);
   });
 
   it('should not exit in --check mode when all labels are present', async () => {
-    const { octokit, createLabel } = mockOctokit([
+    const forge = mockForge([
       'bump:patch',
       'bump:minor',
       'bump:major',
@@ -115,12 +88,11 @@ describe('runLabelsSync', () => {
       'release:preview-notes',
       'release',
     ]);
-    vi.mocked(createOctokit).mockReturnValue(octokit as never);
 
     await runLabelsSync({ repo: 'owner/repo', check: true });
 
     expect(exitSpy).not.toHaveBeenCalled();
-    expect(createLabel).not.toHaveBeenCalled();
+    expect(forge.createdLabels).toHaveLength(0);
   });
 
   it('should throw when no GitHub token is available', async () => {

--- a/packages/release/test/unit/preview-github.spec.ts
+++ b/packages/release/test/unit/preview-github.spec.ts
@@ -1,3 +1,4 @@
+import { createFakeForge } from '@releasekit/forge';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   fetchPRLabels,
@@ -11,49 +12,15 @@ vi.mock('node:child_process', () => ({
   execFileSync: vi.fn(),
 }));
 
-function createMockOctokit(comments: { id: number; body: string }[] = []) {
-  const listComments = vi.fn();
-  const createComment = vi.fn().mockResolvedValue({});
-  const updateComment = vi.fn().mockResolvedValue({});
-  const getIssue = vi.fn().mockResolvedValue({ data: { labels: [] } });
-
-  const paginate = {
-    iterator: vi.fn().mockReturnValue({
-      async *[Symbol.asyncIterator]() {
-        yield { data: comments };
-      },
-    }),
-  };
-
-  return {
-    octokit: {
-      paginate,
-      rest: {
-        issues: {
-          listComments,
-          createComment,
-          updateComment,
-          get: getIssue,
-        },
-      },
-    } as unknown as Parameters<typeof findPreviewComment>[0],
-    mocks: { listComments, createComment, updateComment, getIssue, paginate },
-  };
-}
-
 describe('findMergedPRsSinceLastRelease', () => {
   afterEach(() => vi.clearAllMocks());
 
-  function createPRLookupOctokit(prsByCommit: Record<string, number[]>) {
-    return {
-      rest: {
-        repos: {
-          listPullRequestsAssociatedWithCommit: vi.fn().mockImplementation(({ commit_sha }) => ({
-            data: (prsByCommit[commit_sha] ?? []).map((n) => ({ number: n, merged_at: '2024-01-01' })),
-          })),
-        },
-      },
-    } as unknown as Parameters<typeof findMergedPRsSinceLastRelease>[0];
+  function createPRLookupForge(prsByCommit: Record<string, number[]>) {
+    const pullRequestsForCommit: Record<string, { number: number; mergedAt: string | null }[]> = {};
+    for (const [sha, nums] of Object.entries(prsByCommit)) {
+      pullRequestsForCommit[sha] = nums.map((n) => ({ number: n, mergedAt: '2024-01-01' }));
+    }
+    return createFakeForge({ pullRequestsForCommit });
   }
 
   it('should return PR numbers from merge commits since last tag', async () => {
@@ -62,8 +29,8 @@ describe('findMergedPRsSinceLastRelease', () => {
       .mockReturnValueOnce('v1.0.0\n') // git describe
       .mockReturnValueOnce('abc123\ndef456\n'); // git log
 
-    const octokit = createPRLookupOctokit({ abc123: [10], def456: [20] });
-    const result = await findMergedPRsSinceLastRelease(octokit, 'owner', 'repo', '/project');
+    const forge = createPRLookupForge({ abc123: [10], def456: [20] });
+    const result = await findMergedPRsSinceLastRelease(forge, '/project');
 
     expect(result).toEqual(expect.arrayContaining([10, 20]));
     expect(result).toHaveLength(2);
@@ -73,8 +40,8 @@ describe('findMergedPRsSinceLastRelease', () => {
     const { execFileSync } = await import('node:child_process');
     vi.mocked(execFileSync).mockReturnValueOnce('v1.0.0\n').mockReturnValueOnce('abc123\ndef456\n');
 
-    const octokit = createPRLookupOctokit({ abc123: [10], def456: [10] });
-    const result = await findMergedPRsSinceLastRelease(octokit, 'owner', 'repo', '/project');
+    const forge = createPRLookupForge({ abc123: [10], def456: [10] });
+    const result = await findMergedPRsSinceLastRelease(forge, '/project');
 
     expect(result).toEqual([10]);
   });
@@ -87,8 +54,8 @@ describe('findMergedPRsSinceLastRelease', () => {
       }) // git describe fails
       .mockReturnValueOnce('abc123\n'); // git log with -50
 
-    const octokit = createPRLookupOctokit({ abc123: [99] });
-    const result = await findMergedPRsSinceLastRelease(octokit, 'owner', 'repo', '/project');
+    const forge = createPRLookupForge({ abc123: [99] });
+    const result = await findMergedPRsSinceLastRelease(forge, '/project');
 
     expect(result).toEqual([99]);
     const calls = vi.mocked(execFileSync).mock.calls;
@@ -99,8 +66,8 @@ describe('findMergedPRsSinceLastRelease', () => {
     const { execFileSync } = await import('node:child_process');
     vi.mocked(execFileSync).mockReturnValueOnce('v1.0.0\n').mockReturnValueOnce('');
 
-    const octokit = createPRLookupOctokit({});
-    const result = await findMergedPRsSinceLastRelease(octokit, 'owner', 'repo', '/project');
+    const forge = createPRLookupForge({});
+    const result = await findMergedPRsSinceLastRelease(forge, '/project');
 
     expect(result).toEqual([]);
   });
@@ -113,8 +80,8 @@ describe('findMergedPRsSinceLastRelease', () => {
         throw new Error('git error');
       });
 
-    const octokit = createPRLookupOctokit({});
-    const result = await findMergedPRsSinceLastRelease(octokit, 'owner', 'repo', '/project');
+    const forge = createPRLookupForge({});
+    const result = await findMergedPRsSinceLastRelease(forge, '/project');
 
     expect(result).toEqual([]);
   });
@@ -122,141 +89,119 @@ describe('findMergedPRsSinceLastRelease', () => {
 
 describe('findPreviewComment', () => {
   it('should return comment ID when marker is found', async () => {
-    const { octokit } = createMockOctokit([
-      { id: 1, body: 'Some other comment' },
-      { id: 2, body: '<!-- releasekit-preview -->\n## Release Preview' },
-    ]);
+    const forge = createFakeForge({
+      comments: [
+        { id: 1, body: 'Some other comment' },
+        { id: 2, body: '<!-- releasekit-preview -->\n## Release Preview' },
+      ],
+    });
 
-    const result = await findPreviewComment(octokit, 'owner', 'repo', 1);
+    const result = await findPreviewComment(forge, 1);
     expect(result).toBe(2);
   });
 
   it('should return null when no marker comment exists', async () => {
-    const { octokit } = createMockOctokit([
-      { id: 1, body: 'Regular comment' },
-      { id: 2, body: 'Another comment' },
-    ]);
+    const forge = createFakeForge({
+      comments: [
+        { id: 1, body: 'Regular comment' },
+        { id: 2, body: 'Another comment' },
+      ],
+    });
 
-    const result = await findPreviewComment(octokit, 'owner', 'repo', 1);
+    const result = await findPreviewComment(forge, 1);
     expect(result).toBeNull();
   });
 
   it('should return null when no comments exist', async () => {
-    const { octokit } = createMockOctokit([]);
+    const forge = createFakeForge({ comments: [] });
 
-    const result = await findPreviewComment(octokit, 'owner', 'repo', 1);
+    const result = await findPreviewComment(forge, 1);
     expect(result).toBeNull();
   });
 });
 
 describe('postOrUpdateComment', () => {
   it('should create a new comment when none exists', async () => {
-    const { octokit, mocks } = createMockOctokit([]);
+    const forge = createFakeForge({ comments: [] });
     const body = '<!-- releasekit-preview -->\n## Release Preview';
 
-    await postOrUpdateComment(octokit, 'owner', 'repo', 1, body);
+    await postOrUpdateComment(forge, 1, body);
 
-    expect(mocks.createComment).toHaveBeenCalledWith({
-      owner: 'owner',
-      repo: 'repo',
-      issue_number: 1,
-      body,
-    });
-    expect(mocks.updateComment).not.toHaveBeenCalled();
+    expect(forge.createdComments).toEqual([{ prNumber: 1, body }]);
+    expect(forge.updatedComments).toEqual([]);
   });
 
   it('should update existing comment when marker is found', async () => {
-    const { octokit, mocks } = createMockOctokit([{ id: 42, body: '<!-- releasekit-preview -->\nOld content' }]);
+    const forge = createFakeForge({ comments: [{ id: 42, body: '<!-- releasekit-preview -->\nOld content' }] });
     const body = '<!-- releasekit-preview -->\n## Release Preview (updated)';
 
-    await postOrUpdateComment(octokit, 'owner', 'repo', 1, body);
+    await postOrUpdateComment(forge, 1, body);
 
-    expect(mocks.updateComment).toHaveBeenCalledWith({
-      owner: 'owner',
-      repo: 'repo',
-      comment_id: 42,
-      body,
-    });
-    expect(mocks.createComment).not.toHaveBeenCalled();
+    expect(forge.updatedComments).toEqual([{ commentId: 42, body }]);
+    expect(forge.createdComments).toEqual([]);
   });
 });
 
 describe('fetchPRLabels', () => {
-  it('should return label names from PR', async () => {
-    const { octokit, mocks } = createMockOctokit();
-    mocks.getIssue.mockResolvedValue({
-      data: { labels: [{ name: 'channel:stable' }, { name: 'bug' }] },
-    });
+  function forgeWithLabels(labels: string[]) {
+    return createFakeForge({ issues: { 1: { body: '', title: '', labels, isPullRequest: true } } });
+  }
 
-    const labels = await fetchPRLabels(octokit, 'owner', 'repo', 1);
+  it('should return label names from PR', async () => {
+    const forge = forgeWithLabels(['channel:stable', 'bug']);
+
+    const labels = await fetchPRLabels(forge, 1);
     expect(labels).toEqual(['channel:stable', 'bug']);
   });
 
   it('should handle string labels', async () => {
-    const { octokit, mocks } = createMockOctokit();
-    mocks.getIssue.mockResolvedValue({
-      data: { labels: ['channel:stable', 'enhancement'] },
-    });
+    const forge = forgeWithLabels(['channel:stable', 'enhancement']);
 
-    const labels = await fetchPRLabels(octokit, 'owner', 'repo', 1);
+    const labels = await fetchPRLabels(forge, 1);
     expect(labels).toEqual(['channel:stable', 'enhancement']);
   });
 
   it('should return empty array when no labels', async () => {
-    const { octokit, mocks } = createMockOctokit();
-    mocks.getIssue.mockResolvedValue({ data: { labels: [] } });
+    const forge = forgeWithLabels([]);
 
-    const labels = await fetchPRLabels(octokit, 'owner', 'repo', 1);
+    const labels = await fetchPRLabels(forge, 1);
     expect(labels).toEqual([]);
   });
 });
 
 describe('findStandingPR', () => {
-  function createPullsOctokit(prs: { number: number; html_url: string }[]) {
-    return {
-      rest: {
-        pulls: {
-          list: vi.fn().mockResolvedValue({ data: prs }),
-        },
-      },
-    } as unknown as Parameters<typeof findStandingPR>[0];
-  }
-
   it('should return the PR number and URL when found', async () => {
-    const octokit = createPullsOctokit([{ number: 42, html_url: 'https://github.com/owner/repo/pull/42' }]);
-    const result = await findStandingPR(octokit, 'owner', 'repo', undefined);
+    const forge = createFakeForge({
+      standingPR: { number: 42, url: 'https://github.com/owner/repo/pull/42', labels: [] },
+    });
+    const result = await findStandingPR(forge, undefined);
     expect(result).toEqual({ number: 42, url: 'https://github.com/owner/repo/pull/42' });
   });
 
   it('should return null when no open standing PR found', async () => {
-    const octokit = createPullsOctokit([]);
-    const result = await findStandingPR(octokit, 'owner', 'repo', undefined);
+    const forge = createFakeForge({ standingPR: null });
+    const result = await findStandingPR(forge, undefined);
     expect(result).toBeNull();
   });
 
   it('should use the configured branch from ciConfig', async () => {
-    const listFn = vi.fn().mockResolvedValue({ data: [] });
-    const octokit = { rest: { pulls: { list: listFn } } } as unknown as Parameters<typeof findStandingPR>[0];
-    await findStandingPR(octokit, 'owner', 'repo', { standingPr: { branch: 'release/staging' } } as Parameters<
-      typeof findStandingPR
-    >[3]);
-    expect(listFn).toHaveBeenCalledWith(expect.objectContaining({ head: 'owner:release/staging' }));
+    const forge = createFakeForge({ standingPR: null });
+    const spy = vi.spyOn(forge, 'findStandingPR');
+    await findStandingPR(forge, { standingPr: { branch: 'release/staging' } } as Parameters<typeof findStandingPR>[1]);
+    expect(spy).toHaveBeenCalledWith('release/staging');
   });
 
   it('should default to release/next when ciConfig has no standingPr', async () => {
-    const listFn = vi.fn().mockResolvedValue({ data: [] });
-    const octokit = { rest: { pulls: { list: listFn } } } as unknown as Parameters<typeof findStandingPR>[0];
-    await findStandingPR(octokit, 'owner', 'repo', undefined);
-    expect(listFn).toHaveBeenCalledWith(expect.objectContaining({ head: 'owner:release/next' }));
+    const forge = createFakeForge({ standingPR: null });
+    const spy = vi.spyOn(forge, 'findStandingPR');
+    await findStandingPR(forge, undefined);
+    expect(spy).toHaveBeenCalledWith('release/next');
   });
 
   it('should return null when API throws', async () => {
-    const octokit = {
-      rest: {
-        pulls: { list: vi.fn().mockRejectedValue(new Error('API error')) },
-      },
-    } as unknown as Parameters<typeof findStandingPR>[0];
-    const result = await findStandingPR(octokit, 'owner', 'repo', undefined);
+    const forge = createFakeForge({ standingPR: null });
+    vi.spyOn(forge, 'findStandingPR').mockRejectedValue(new Error('API error'));
+    const result = await findStandingPR(forge, undefined);
     expect(result).toBeNull();
   });
 });

--- a/packages/release/test/unit/preview.spec.ts
+++ b/packages/release/test/unit/preview.spec.ts
@@ -43,13 +43,13 @@ vi.mock('../../src/release.js', () => ({
 }));
 
 const mockPostOrUpdateComment = vi.fn();
-const mockCreateOctokit = vi.fn();
+const mockForgeFor = vi.fn();
 const mockFetchPRLabels = vi.fn();
 
 vi.mock('../../src/github.js', () => ({
   MARKER: '<!-- releasekit-preview -->',
   postOrUpdateComment: (...args: unknown[]) => mockPostOrUpdateComment(...args),
-  createOctokit: (...args: unknown[]) => mockCreateOctokit(...args),
+  forgeFor: (...args: unknown[]) => mockForgeFor(...args),
   fetchPRLabels: (...args: unknown[]) => mockFetchPRLabels(...args),
 }));
 
@@ -113,7 +113,7 @@ describe('runPreview', () => {
       notesGenerated: false,
     });
     mockResolvePreviewContext.mockReturnValue(defaultContext);
-    mockCreateOctokit.mockReturnValue({});
+    mockForgeFor.mockReturnValue({});
     mockFetchPRLabels.mockResolvedValue([]);
     mockPostOrUpdateComment.mockResolvedValue(undefined);
     mockFetchStandingPRSnapshot.mockResolvedValue(null);
@@ -175,8 +175,6 @@ describe('runPreview', () => {
 
       expect(mockPostOrUpdateComment).toHaveBeenCalledWith(
         expect.anything(),
-        'owner',
-        'repo',
         1,
         expect.stringContaining('No releasable changes detected'),
       );
@@ -308,8 +306,6 @@ describe('runPreview', () => {
         expect(mockRunRelease).toHaveBeenCalledWith(expect.objectContaining({ bump: 'major' }));
         expect(mockPostOrUpdateComment).toHaveBeenCalledWith(
           expect.anything(),
-          'owner',
-          'repo',
           1,
           expect.stringContaining('labeled for a **major** release'),
         );
@@ -324,8 +320,6 @@ describe('runPreview', () => {
         expect(mockRunRelease).toHaveBeenCalledWith(expect.objectContaining({ bump: 'major' }));
         expect(mockPostOrUpdateComment).toHaveBeenCalledWith(
           expect.anything(),
-          'owner',
-          'repo',
           1,
           expect.stringContaining('labeled for a **major** release'),
         );
@@ -340,8 +334,6 @@ describe('runPreview', () => {
         expect(mockRunRelease).not.toHaveBeenCalled();
         expect(mockPostOrUpdateComment).toHaveBeenCalledWith(
           expect.anything(),
-          'owner',
-          'repo',
           1,
           expect.stringContaining('marked to skip release'),
         );
@@ -356,8 +348,6 @@ describe('runPreview', () => {
         expect(mockRunRelease).not.toHaveBeenCalled();
         expect(mockPostOrUpdateComment).toHaveBeenCalledWith(
           expect.anything(),
-          'owner',
-          'repo',
           1,
           expect.stringContaining('marked to skip release'),
         );
@@ -383,8 +373,6 @@ describe('runPreview', () => {
         expect(mockRunRelease).not.toHaveBeenCalled();
         expect(mockPostOrUpdateComment).toHaveBeenCalledWith(
           expect.anything(),
-          'owner',
-          'repo',
           1,
           expect.stringContaining('No bump label detected'),
         );
@@ -486,8 +474,6 @@ describe('runPreview', () => {
         expect(mockRunRelease).not.toHaveBeenCalled();
         expect(mockPostOrUpdateComment).toHaveBeenCalledWith(
           expect.anything(),
-          'owner',
-          'repo',
           1,
           expect.stringContaining('Conflicting bump labels detected'),
         );
@@ -502,8 +488,6 @@ describe('runPreview', () => {
         expect(mockRunRelease).not.toHaveBeenCalled();
         expect(mockPostOrUpdateComment).toHaveBeenCalledWith(
           expect.anything(),
-          'owner',
-          'repo',
           1,
           expect.stringContaining('Conflicting bump labels detected'),
         );
@@ -520,8 +504,6 @@ describe('runPreview', () => {
         expect(mockRunRelease).not.toHaveBeenCalled();
         expect(mockPostOrUpdateComment).toHaveBeenCalledWith(
           expect.anything(),
-          'owner',
-          'repo',
           1,
           expect.stringContaining('Conflicting release type labels detected'),
         );
@@ -540,8 +522,6 @@ describe('runPreview', () => {
         expect(mockRunRelease).not.toHaveBeenCalled();
         expect(mockPostOrUpdateComment).toHaveBeenCalledWith(
           expect.anything(),
-          'owner',
-          'repo',
           1,
           expect.stringContaining('No bump label detected'),
         );
@@ -562,7 +542,7 @@ describe('runPreview', () => {
         // Critically: runRelease (which would compute the misleading version bump) is NOT called.
         expect(mockRunRelease).not.toHaveBeenCalled();
 
-        const body = mockPostOrUpdateComment.mock.calls[0][4] as string;
+        const body = mockPostOrUpdateComment.mock.calls[0][2] as string;
         expect(body).toContain('No bump label detected');
         // The gate reason — surfaced via labelContext.gateReason — explains exactly why.
         expect(body).toContain('channel:prerelease');
@@ -624,13 +604,7 @@ describe('runPreview', () => {
       await runPreview({ projectDir: '/test', dryRun: false, target: '@test/package' });
 
       expect(mockRunRelease).toHaveBeenCalledWith(expect.objectContaining({ target: '@wdio/native-*' }));
-      expect(mockPostOrUpdateComment).toHaveBeenCalledWith(
-        expect.anything(),
-        'owner',
-        'repo',
-        1,
-        expect.stringContaining('**Scope:**'),
-      );
+      expect(mockPostOrUpdateComment).toHaveBeenCalledWith(expect.anything(), 1, expect.stringContaining('**Scope:**'));
     });
 
     it('should NOT trigger release for scope-only PR in label mode (matches gate)', async () => {
@@ -649,8 +623,6 @@ describe('runPreview', () => {
       expect(mockRunRelease).not.toHaveBeenCalled();
       expect(mockPostOrUpdateComment).toHaveBeenCalledWith(
         expect.anything(),
-        'owner',
-        'repo',
         1,
         expect.stringContaining('No bump label detected'),
       );
@@ -717,8 +689,6 @@ describe('runPreview', () => {
       // configured glob pattern. result.target still uses the pattern.
       expect(mockPostOrUpdateComment).toHaveBeenCalledWith(
         expect.anything(),
-        'owner',
-        'repo',
         1,
         expect.stringContaining('**Scope:** scope:shared'),
       );
@@ -780,8 +750,6 @@ describe('runPreview', () => {
       expect(mockRunRelease).not.toHaveBeenCalled();
       expect(mockPostOrUpdateComment).toHaveBeenCalledWith(
         expect.anything(),
-        'owner',
-        'repo',
         1,
         expect.stringContaining('No bump label detected'),
       );
@@ -881,7 +849,7 @@ describe('runPreview', () => {
       await runPreview({ projectDir: '/test', dryRun: false, target: '@test/package' });
 
       expect(mockFetchStandingPRSnapshot).toHaveBeenCalledTimes(1);
-      const body = mockPostOrUpdateComment.mock.calls[0]?.[4] as string;
+      const body = mockPostOrUpdateComment.mock.calls[0]?.[2] as string;
       expect(body).toContain('**Standing release PR:**');
       expect(body).toContain('[#42]');
       expect(body).toContain('### After merge — predicted release');
@@ -894,7 +862,7 @@ describe('runPreview', () => {
 
       await runPreview({ projectDir: '/test', dryRun: false, target: '@test/package' });
 
-      const body = mockPostOrUpdateComment.mock.calls[0]?.[4] as string;
+      const body = mockPostOrUpdateComment.mock.calls[0]?.[2] as string;
       expect(body).toContain('**Standing release PR:**');
       expect(body).not.toContain('### After merge');
     });
@@ -905,7 +873,7 @@ describe('runPreview', () => {
 
       await runPreview({ projectDir: '/test', dryRun: false, target: '@test/package' });
 
-      const body = mockPostOrUpdateComment.mock.calls[0]?.[4] as string;
+      const body = mockPostOrUpdateComment.mock.calls[0]?.[2] as string;
       expect(body).not.toContain('**Standing release PR:**');
     });
 
@@ -916,7 +884,7 @@ describe('runPreview', () => {
       await runPreview({ projectDir: '/test', dryRun: false, target: '@test/package' });
 
       expect(mockPostOrUpdateComment).toHaveBeenCalled();
-      const body = mockPostOrUpdateComment.mock.calls[0]?.[4] as string;
+      const body = mockPostOrUpdateComment.mock.calls[0]?.[2] as string;
       expect(body).not.toContain('**Standing release PR:**');
     });
 
@@ -967,7 +935,7 @@ describe('runPreview', () => {
 
       await runPreview({ projectDir: '/test', dryRun: false, target: '@test/package' });
 
-      const body = mockPostOrUpdateComment.mock.calls[0]?.[4] as string;
+      const body = mockPostOrUpdateComment.mock.calls[0]?.[2] as string;
       // queued-pkg is in the standing PR scope — must appear as a table row (escalated)
       expect(body).toContain('| `queued-pkg`');
       // test-pkg is outside standing PR scope — must NOT appear as a merge-table row

--- a/packages/release/test/unit/release.spec.ts
+++ b/packages/release/test/unit/release.spec.ts
@@ -6,7 +6,7 @@ import type { ReleaseOptions } from '../../src/types.js';
 
 const mockLoadReleaseKitConfig = vi.fn();
 const mockLoadCIConfig = vi.fn();
-const mockCreateOctokit = vi.fn();
+const mockForgeFor = vi.fn();
 const mockFindMergedPRsForCommit = vi.fn();
 const mockFetchPRLabels = vi.fn();
 
@@ -19,7 +19,7 @@ vi.mock('node:child_process', () => ({
 }));
 
 vi.mock('../../src/github.js', () => ({
-  createOctokit: (...args: unknown[]) => mockCreateOctokit(...args),
+  forgeFor: (...args: unknown[]) => mockForgeFor(...args),
   findMergedPRsForCommit: (...args: unknown[]) => mockFindMergedPRsForCommit(...args),
   fetchPRLabels: (...args: unknown[]) => mockFetchPRLabels(...args),
   // Used by the best-effort failure-report resolve path; a plain stub keeps it quiet.
@@ -161,7 +161,7 @@ describe('runRelease', () => {
     vi.clearAllMocks();
 
     // Default mock setup
-    mockCreateOctokit.mockReturnValue({});
+    mockForgeFor.mockReturnValue({});
     mockFindMergedPRsForCommit.mockResolvedValue([]);
     mockFetchPRLabels.mockResolvedValue([]);
     mockLoadReleaseKitConfig.mockReturnValue({});

--- a/packages/release/test/unit/standing-pr.spec.ts
+++ b/packages/release/test/unit/standing-pr.spec.ts
@@ -1,3 +1,4 @@
+import { createFakeForge, type FakeForge, type FakeForgeSeed } from '@releasekit/forge';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderFailureReport, renderResolvedReport } from '../../src/failure-report/failure-report.js';
 import { renderNotesRegion } from '../../src/standing-pr/notes-region.js';
@@ -42,7 +43,7 @@ vi.mock('../../src/steps.js', () => ({
 }));
 
 vi.mock('../../src/github.js', () => ({
-  createOctokit: vi.fn(),
+  forgeFor: vi.fn(),
 }));
 
 function createMockVersionOutput(updates: { packageName: string; newVersion: string }[] = []) {
@@ -56,66 +57,19 @@ function createMockVersionOutput(updates: { packageName: string; newVersion: str
   };
 }
 
-function createMockOctokit(overrides: Record<string, unknown> = {}) {
-  const createComment = vi.fn().mockResolvedValue({});
-  const updateComment = vi.fn().mockResolvedValue({});
-  const pullsList = vi.fn().mockResolvedValue({ data: [] });
-  const pullsCreate = vi
-    .fn()
-    .mockResolvedValue({ data: { number: 42, html_url: 'https://github.com/owner/repo/pull/42' } });
-  const pullsUpdate = vi.fn().mockResolvedValue({});
-  const pullsGet = vi.fn().mockResolvedValue({ data: { body: '' } });
-  const pullsMerge = vi.fn().mockResolvedValue({});
-  const issuesSetLabels = vi.fn().mockResolvedValue({});
-  const issuesCreateLabel = vi.fn().mockResolvedValue({});
-  const createCommitStatus = vi.fn().mockResolvedValue({});
+const MANIFEST_MARKER = '<!-- releasekit-manifest -->';
 
-  const paginate = {
-    iterator: vi.fn().mockReturnValue({
-      async *[Symbol.asyncIterator]() {
-        yield { data: [] };
-      },
-    }),
-  };
+// Build a FakeForge from seed state and point the mocked `forgeFor` at it, so production code
+// that calls `forgeFor(githubContext)` is driven by this fake.
+async function mockForge(seed: FakeForgeSeed = {}): Promise<FakeForge> {
+  const { forgeFor } = await import('../../src/github.js');
+  const forge = createFakeForge(seed);
+  vi.mocked(forgeFor).mockReturnValue(forge);
+  return forge;
+}
 
-  return {
-    octokit: {
-      paginate,
-      rest: {
-        issues: {
-          listComments: vi.fn(),
-          createComment,
-          updateComment,
-          createLabel: issuesCreateLabel,
-          setLabels: issuesSetLabels,
-        },
-        pulls: {
-          list: pullsList,
-          create: pullsCreate,
-          update: pullsUpdate,
-          get: pullsGet,
-          merge: pullsMerge,
-        },
-        repos: {
-          createCommitStatus,
-        },
-      },
-      ...overrides,
-    },
-    mocks: {
-      createComment,
-      updateComment,
-      pullsList,
-      pullsCreate,
-      pullsUpdate,
-      pullsGet,
-      pullsMerge,
-      issuesSetLabels,
-      issuesCreateLabel,
-      paginate,
-      createCommitStatus,
-    },
-  };
+function openStandingPR(number: number, labels: string[] = []) {
+  return { number, url: `https://github.com/owner/repo/pull/${number}`, labels };
 }
 
 const baseManifest: StandingPRManifest = {
@@ -374,17 +328,14 @@ describe('runStandingPRUpdate', () => {
     vi.mocked(runVersionStep).mockResolvedValue(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>);
     vi.mocked(runNotesStep).mockResolvedValue({ packageNotes: {}, releaseNotes: {}, files: [] });
 
-    const { createOctokit } = await import('../../src/github.js');
-    const { mocks, octokit } = createMockOctokit();
-    mocks.pullsList.mockResolvedValue({ data: [{ number: 99, html_url: 'https://github.com/owner/repo/pull/99' }] });
-    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+    const forge = await mockForge({ standingPR: openStandingPR(99) });
 
     const result = await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
 
     expect(result.action).toBe('noop');
     // No PR write — the update bowed out before force-push / PR update.
-    expect(mocks.pullsUpdate).not.toHaveBeenCalled();
-    expect(mocks.pullsCreate).not.toHaveBeenCalled();
+    expect(forge.updatedPullRequests).toHaveLength(0);
+    expect(forge.createdPullRequests).toHaveLength(0);
   });
 
   it('should bypass the skip-pattern guard when reconcile is set', async () => {
@@ -400,10 +351,7 @@ describe('runStandingPRUpdate', () => {
       .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>);
     vi.mocked(runNotesStep).mockResolvedValue({ packageNotes: {}, releaseNotes: {}, files: [] });
 
-    const { createOctokit } = await import('../../src/github.js');
-    const { mocks, octokit } = createMockOctokit();
-    mocks.pullsList.mockResolvedValue({ data: [] });
-    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+    const forge = await mockForge({ standingPR: null });
 
     const result = await runStandingPRUpdate({
       projectDir: '/test',
@@ -414,7 +362,7 @@ describe('runStandingPRUpdate', () => {
     });
 
     expect(result.action).toBe('created');
-    expect(mocks.pullsCreate).toHaveBeenCalled();
+    expect(forge.createdPullRequests).toHaveLength(1);
   });
 
   it('should bypass the initial skip-pattern guard on a pull_request label event (#336)', async () => {
@@ -451,10 +399,7 @@ describe('runStandingPRUpdate', () => {
         .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>);
       vi.mocked(runNotesStep).mockResolvedValue({ packageNotes: {}, releaseNotes: {}, files: [] });
 
-      const { createOctokit } = await import('../../src/github.js');
-      const { mocks, octokit } = createMockOctokit();
-      mocks.pullsList.mockResolvedValue({ data: [{ number: 99, html_url: 'https://github.com/owner/repo/pull/99' }] });
-      vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+      await mockForge({ standingPR: openStandingPR(99) });
 
       const result = await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
 
@@ -474,10 +419,7 @@ describe('runStandingPRUpdate', () => {
       createMockVersionOutput([]) as unknown as Awaited<ReturnType<typeof runVersionStep>>,
     );
 
-    const { createOctokit } = await import('../../src/github.js');
-    const { mocks, octokit } = createMockOctokit();
-    mocks.pullsList.mockResolvedValue({ data: [] });
-    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+    await mockForge({ standingPR: null });
 
     const result = await runStandingPRUpdate({
       projectDir: '/test',
@@ -495,10 +437,7 @@ describe('runStandingPRUpdate', () => {
       createMockVersionOutput([]) as unknown as Awaited<ReturnType<typeof runVersionStep>>,
     );
 
-    const { createOctokit } = await import('../../src/github.js');
-    const { mocks, octokit } = createMockOctokit();
-    mocks.pullsList.mockResolvedValue({ data: [{ number: 10, html_url: 'https://github.com/owner/repo/pull/10' }] });
-    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+    const forge = await mockForge({ standingPR: openStandingPR(10) });
 
     const result = await runStandingPRUpdate({
       projectDir: '/test',
@@ -509,7 +448,9 @@ describe('runStandingPRUpdate', () => {
 
     expect(result.action).toBe('closed');
     expect(result.prNumber).toBe(10);
-    expect(mocks.pullsUpdate).toHaveBeenCalledWith(expect.objectContaining({ state: 'closed', pull_number: 10 }));
+    expect(forge.updatedPullRequests).toContainEqual(
+      expect.objectContaining({ prNumber: 10, changes: expect.objectContaining({ state: 'closed' }) }),
+    );
   });
 
   it('should create a new PR when no existing standing PR', async () => {
@@ -520,10 +461,7 @@ describe('runStandingPRUpdate', () => {
       .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>);
     vi.mocked(runNotesStep).mockResolvedValue({ packageNotes: {}, releaseNotes: {}, files: [] });
 
-    const { createOctokit } = await import('../../src/github.js');
-    const { mocks, octokit } = createMockOctokit();
-    mocks.pullsList.mockResolvedValue({ data: [] });
-    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+    const forge = await mockForge({ standingPR: null });
 
     const result = await runStandingPRUpdate({
       projectDir: '/test',
@@ -534,7 +472,7 @@ describe('runStandingPRUpdate', () => {
 
     expect(result.action).toBe('created');
     expect(result.prNumber).toBe(42);
-    expect(mocks.pullsCreate).toHaveBeenCalled();
+    expect(forge.createdPullRequests).toHaveLength(1);
   });
 
   it('should default the PR title to the release tag in sync mode', async () => {
@@ -560,14 +498,11 @@ describe('runStandingPRUpdate', () => {
       .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>);
     vi.mocked(runNotesStep).mockResolvedValue({ packageNotes: {}, releaseNotes: {}, files: [] });
 
-    const { createOctokit } = await import('../../src/github.js');
-    const { mocks, octokit } = createMockOctokit();
-    mocks.pullsList.mockResolvedValue({ data: [] });
-    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+    const forge = await mockForge({ standingPR: null });
 
     await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
 
-    expect(mocks.pullsCreate).toHaveBeenCalledWith(expect.objectContaining({ title: 'chore: release v1.2.3' }));
+    expect(forge.createdPullRequests[0]).toEqual(expect.objectContaining({ title: 'chore: release v1.2.3' }));
   });
 
   it('should exclude the root lockstep bump from ${count} and the PR body publish table', async () => {
@@ -587,22 +522,19 @@ describe('runStandingPRUpdate', () => {
       .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>);
     vi.mocked(runNotesStep).mockResolvedValue({ packageNotes: {}, releaseNotes: {}, files: [] });
 
-    const { createOctokit } = await import('../../src/github.js');
-    const { mocks, octokit } = createMockOctokit();
-    mocks.pullsList.mockResolvedValue({ data: [] });
-    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+    const forge = await mockForge({ standingPR: null });
 
     await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
 
     // Configured title template counts publishable packages only (root excluded)
-    expect(mocks.pullsCreate).toHaveBeenCalledWith(expect.objectContaining({ title: 'chore: release 2 package(s)' }));
+    expect(forge.createdPullRequests[0]).toEqual(expect.objectContaining({ title: 'chore: release 2 package(s)' }));
 
     // Sync body leads with the version and lists bare package names, root excluded
-    const createCall = mocks.pullsCreate.mock.calls[0]?.[0] as { body?: string } | undefined;
-    expect(createCall?.body).toContain('Merging this PR will publish **v1.2.3**:');
-    expect(createCall?.body).toContain('- `@scope/core`');
-    expect(createCall?.body).toContain('- `@scope/utils`');
-    expect(createCall?.body).not.toContain('my-monorepo');
+    const body = forge.createdPullRequests[0]?.body;
+    expect(body).toContain('Merging this PR will publish **v1.2.3**:');
+    expect(body).toContain('- `@scope/core`');
+    expect(body).toContain('- `@scope/utils`');
+    expect(body).not.toContain('my-monorepo');
   });
 
   it('should include a ### Changelog section in the PR body with changelog entries', async () => {
@@ -628,20 +560,17 @@ describe('runStandingPRUpdate', () => {
       .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>);
     vi.mocked(runNotesStep).mockResolvedValue({ packageNotes: {}, releaseNotes: {}, files: [] });
 
-    const { createOctokit } = await import('../../src/github.js');
-    const { mocks, octokit } = createMockOctokit();
-    mocks.pullsList.mockResolvedValue({ data: [] });
-    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+    const forge = await mockForge({ standingPR: null });
 
     await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
 
-    const createCall = mocks.pullsCreate.mock.calls[0]?.[0] as { body?: string } | undefined;
-    expect(createCall?.body).toContain('### Changelog');
-    expect(createCall?.body).toContain('**Added**');
-    expect(createCall?.body).toContain('Add new widget');
-    expect(createCall?.body).toContain('**Fixed**');
-    expect(createCall?.body).toContain('Fix broken export');
-    expect(createCall?.body).toContain('@scope/core — 1.2.2 → 1.2.3');
+    const body = forge.createdPullRequests[0]?.body;
+    expect(body).toContain('### Changelog');
+    expect(body).toContain('**Added**');
+    expect(body).toContain('Add new widget');
+    expect(body).toContain('**Fixed**');
+    expect(body).toContain('Fix broken export');
+    expect(body).toContain('@scope/core — 1.2.2 → 1.2.3');
   });
 
   it("should truncate the PR body when the changelog would exceed GitHub's limit (#333)", async () => {
@@ -668,14 +597,11 @@ describe('runStandingPRUpdate', () => {
       .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>);
     vi.mocked(runNotesStep).mockResolvedValue({ packageNotes: {}, releaseNotes: {}, files: [] });
 
-    const { createOctokit } = await import('../../src/github.js');
-    const { mocks, octokit } = createMockOctokit();
-    mocks.pullsList.mockResolvedValue({ data: [] });
-    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+    const forge = await mockForge({ standingPR: null });
 
     await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
 
-    const body = mocks.pullsCreate.mock.calls[0]?.[0]?.body as string;
+    const body = forge.createdPullRequests[0]?.body as string;
     // Assert against the module's cap (well under GitHub's 65,536), so a truncation that leaks into
     // the 64,001–65,535 safety margin still fails the test.
     expect(body.length).toBeLessThanOrEqual(STANDING_PR_BODY_CAP);
@@ -693,17 +619,14 @@ describe('runStandingPRUpdate', () => {
       .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>);
     vi.mocked(runNotesStep).mockResolvedValue({ packageNotes: {}, releaseNotes: {}, files: [] });
 
-    const { createOctokit } = await import('../../src/github.js');
-    const { mocks, octokit } = createMockOctokit();
-    mocks.pullsList.mockResolvedValue({ data: [] });
-    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+    const forge = await mockForge({ standingPR: null });
 
     await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
 
-    const createCall = mocks.pullsCreate.mock.calls[0]?.[0] as { body?: string } | undefined;
-    expect(createCall?.body).not.toContain('### Changelog');
-    expect(createCall?.body).toContain('@scope/core');
-    expect(createCall?.body).toContain('1.2.3');
+    const body = forge.createdPullRequests[0]?.body;
+    expect(body).not.toContain('### Changelog');
+    expect(body).toContain('@scope/core');
+    expect(body).toContain('1.2.3');
   });
 
   describe('partial-publish supersede warning on the next standing PR', () => {
@@ -741,12 +664,6 @@ describe('runStandingPRUpdate', () => {
       });
     }
 
-    // pullsList is used both for the open standing PR (findStandingPR) and the most recently
-    // merged one (findLatestMergedStandingPR). Branch on the requested state.
-    function listByState(merged: Array<{ number: number; merged_at: string }>) {
-      return (args: { state?: string }) => Promise.resolve({ data: args.state === 'closed' ? merged : [] });
-    }
-
     it('should include the warning when the latest merged standing PR has an unresolved failure', async () => {
       const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
       const versionOutput = createMockVersionOutput([{ packageName: '@scope/core', newVersion: '0.25.0' }]);
@@ -755,22 +672,20 @@ describe('runStandingPRUpdate', () => {
         .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>);
       vi.mocked(runNotesStep).mockResolvedValue({ packageNotes: {}, releaseNotes: {}, files: [] });
 
-      const { createOctokit } = await import('../../src/github.js');
-      const { mocks, octokit } = createMockOctokit();
-      mocks.pullsList.mockImplementation(listByState([{ number: 7, merged_at: '2026-01-01T00:00:00Z' }]));
-      mocks.paginate.iterator.mockReturnValue({
-        async *[Symbol.asyncIterator]() {
-          yield { data: [{ id: 1, body: failureReportBody() }] };
-        },
+      // No open standing PR (creates a new one); the most-recently-merged standing PR (#7) carries an
+      // unresolved failure-report comment.
+      const forge = await mockForge({
+        standingPR: null,
+        recentlyClosedPRs: [{ number: 7, mergedAt: '2026-01-01T00:00:00Z' }],
+        comments: [{ id: 1, body: failureReportBody() }],
       });
-      vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
 
       await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
 
-      const createCall = mocks.pullsCreate.mock.calls[0]?.[0] as { body?: string } | undefined;
-      expect(createCall?.body).toContain('partially published');
-      expect(createCall?.body).toContain('1/2 packages');
-      expect(createCall?.body).toContain('#7');
+      const body = forge.createdPullRequests[0]?.body;
+      expect(body).toContain('partially published');
+      expect(body).toContain('1/2 packages');
+      expect(body).toContain('#7');
     });
 
     it('should omit the warning when the latest merged standing PR failure is resolved', async () => {
@@ -781,25 +696,21 @@ describe('runStandingPRUpdate', () => {
         .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>);
       vi.mocked(runNotesStep).mockResolvedValue({ packageNotes: {}, releaseNotes: {}, files: [] });
 
-      const { createOctokit } = await import('../../src/github.js');
-      const { mocks, octokit } = createMockOctokit();
-      mocks.pullsList.mockImplementation(listByState([{ number: 7, merged_at: '2026-01-01T00:00:00Z' }]));
       const resolved = renderResolvedReport(
         createMockVersionOutput([{ packageName: '@scope/core', newVersion: '0.24.0' }]) as unknown as Parameters<
           typeof renderResolvedReport
         >[0],
       );
-      mocks.paginate.iterator.mockReturnValue({
-        async *[Symbol.asyncIterator]() {
-          yield { data: [{ id: 1, body: resolved }] };
-        },
+      const forge = await mockForge({
+        standingPR: null,
+        recentlyClosedPRs: [{ number: 7, mergedAt: '2026-01-01T00:00:00Z' }],
+        comments: [{ id: 1, body: resolved }],
       });
-      vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
 
       await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
 
-      const createCall = mocks.pullsCreate.mock.calls[0]?.[0] as { body?: string } | undefined;
-      expect(createCall?.body).not.toContain('partially published');
+      const body = forge.createdPullRequests[0]?.body;
+      expect(body).not.toContain('partially published');
     });
 
     it('should omit the warning when there is no merged standing PR', async () => {
@@ -810,15 +721,12 @@ describe('runStandingPRUpdate', () => {
         .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>);
       vi.mocked(runNotesStep).mockResolvedValue({ packageNotes: {}, releaseNotes: {}, files: [] });
 
-      const { createOctokit } = await import('../../src/github.js');
-      const { mocks, octokit } = createMockOctokit();
-      mocks.pullsList.mockImplementation(listByState([]));
-      vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+      const forge = await mockForge({ standingPR: null, recentlyClosedPRs: [] });
 
       await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
 
-      const createCall = mocks.pullsCreate.mock.calls[0]?.[0] as { body?: string } | undefined;
-      expect(createCall?.body).not.toContain('partially published');
+      const body = forge.createdPullRequests[0]?.body;
+      expect(body).not.toContain('partially published');
     });
   });
 
@@ -830,10 +738,7 @@ describe('runStandingPRUpdate', () => {
       .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>);
     vi.mocked(runNotesStep).mockResolvedValue({ packageNotes: {}, releaseNotes: {}, files: [] });
 
-    const { createOctokit } = await import('../../src/github.js');
-    const { mocks, octokit } = createMockOctokit();
-    mocks.pullsList.mockResolvedValue({ data: [{ number: 99, html_url: 'https://github.com/owner/repo/pull/99' }] });
-    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+    const forge = await mockForge({ standingPR: openStandingPR(99) });
 
     const result = await runStandingPRUpdate({
       projectDir: '/test',
@@ -844,8 +749,8 @@ describe('runStandingPRUpdate', () => {
 
     expect(result.action).toBe('updated');
     expect(result.prNumber).toBe(99);
-    expect(mocks.pullsUpdate).toHaveBeenCalledWith(expect.objectContaining({ pull_number: 99 }));
-    expect(mocks.pullsCreate).not.toHaveBeenCalled();
+    expect(forge.updatedPullRequests).toContainEqual(expect.objectContaining({ prNumber: 99 }));
+    expect(forge.createdPullRequests).toHaveLength(0);
   });
 
   it('should update manifest comment when existing manifest comment found on PR', async () => {
@@ -856,23 +761,16 @@ describe('runStandingPRUpdate', () => {
       .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>);
     vi.mocked(runNotesStep).mockResolvedValue({ packageNotes: {}, releaseNotes: {}, files: [] });
 
-    const { createOctokit } = await import('../../src/github.js');
-    const { mocks, octokit } = createMockOctokit();
-    mocks.pullsList.mockResolvedValue({ data: [{ number: 99, html_url: 'https://github.com/owner/repo/pull/99' }] });
-    // Paginate returns an existing manifest comment so the update path is taken
-    mocks.paginate.iterator.mockReturnValue({
-      async *[Symbol.asyncIterator]() {
-        yield { data: [{ id: 77, body: serializeManifest(baseManifest) }] };
-      },
+    // An existing manifest comment so the update path is taken.
+    const forge = await mockForge({
+      standingPR: openStandingPR(99),
+      comments: [{ id: 77, body: serializeManifest(baseManifest) }],
     });
-    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
 
     await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
 
-    expect(mocks.updateComment).toHaveBeenCalledWith(expect.objectContaining({ comment_id: 77 }));
-    expect(mocks.createComment).not.toHaveBeenCalledWith(
-      expect.objectContaining({ body: expect.stringContaining('<!-- releasekit-manifest -->') }),
-    );
+    expect(forge.updatedComments).toContainEqual(expect.objectContaining({ commentId: 77 }));
+    expect(forge.createdComments.some((c) => c.body.includes(MANIFEST_MARKER))).toBe(false);
   });
 
   it('should return noop with versionOutput when no GitHub context is available but changes exist', async () => {
@@ -905,15 +803,12 @@ describe('runStandingPRUpdate', () => {
     const versionOutput = createMockVersionOutput([{ packageName: '@scope/core', newVersion: '1.2.3' }]);
     vi.mocked(runVersionStep).mockResolvedValue(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>);
 
-    const { createOctokit } = await import('../../src/github.js');
-    const { mocks, octokit } = createMockOctokit();
-    mocks.pullsList.mockResolvedValue({ data: [] });
-    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+    const forge = await mockForge({ standingPR: null });
 
     const result = await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
 
     expect(result.action).toBe('noop');
-    expect(mocks.pullsCreate).not.toHaveBeenCalled();
+    expect(forge.createdPullRequests).toHaveLength(0);
   });
 
   it('should close existing PR when package count is below minPackages threshold', async () => {
@@ -927,17 +822,16 @@ describe('runStandingPRUpdate', () => {
     const versionOutput = createMockVersionOutput([{ packageName: '@scope/core', newVersion: '1.2.3' }]);
     vi.mocked(runVersionStep).mockResolvedValue(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>);
 
-    const { createOctokit } = await import('../../src/github.js');
-    const { mocks, octokit } = createMockOctokit();
-    mocks.pullsList.mockResolvedValue({ data: [{ number: 55, html_url: 'https://github.com/owner/repo/pull/55' }] });
-    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+    const forge = await mockForge({ standingPR: openStandingPR(55) });
 
     const result = await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
 
     expect(result.action).toBe('closed');
     expect(result.prNumber).toBe(55);
-    expect(mocks.pullsUpdate).toHaveBeenCalledWith(expect.objectContaining({ state: 'closed', pull_number: 55 }));
-    expect(mocks.createComment).toHaveBeenCalledWith(
+    expect(forge.updatedPullRequests).toContainEqual(
+      expect.objectContaining({ prNumber: 55, changes: expect.objectContaining({ state: 'closed' }) }),
+    );
+    expect(forge.createdComments).toContainEqual(
       expect.objectContaining({ body: expect.stringContaining('1 of 3 required') }),
     );
   });
@@ -950,17 +844,12 @@ describe('runStandingPRUpdate', () => {
       .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>);
     vi.mocked(runNotesStep).mockResolvedValue({ packageNotes: {}, releaseNotes: {}, files: [] });
 
-    const { createOctokit } = await import('../../src/github.js');
-    const { mocks, octokit } = createMockOctokit();
-    mocks.pullsList.mockResolvedValue({ data: [] });
-    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+    const forge = await mockForge({ standingPR: null });
 
     await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
 
-    expect(mocks.createCommitStatus).toHaveBeenCalledWith(
+    expect(forge.commitStatuses).toContainEqual(
       expect.objectContaining({
-        owner: 'owner',
-        repo: 'repo',
         sha: 'abc123',
         state: 'success',
         description: 'Ready to merge',
@@ -983,26 +872,17 @@ describe('runStandingPRUpdate', () => {
       .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>);
     vi.mocked(runNotesStep).mockResolvedValue({ packageNotes: {}, releaseNotes: {}, files: [] });
 
-    const { createOctokit } = await import('../../src/github.js');
-    const { mocks, octokit } = createMockOctokit();
     // Existing PR with a manifest that has a recent firstUpdatedAt (5 minutes ago)
-    mocks.pullsList.mockResolvedValue({ data: [{ number: 99, html_url: 'https://github.com/owner/repo/pull/99' }] });
     const recentTimestamp = new Date(Date.now() - 5 * 60_000).toISOString();
-    const existingManifest = serializeManifest({
-      ...baseManifest,
-      schemaVersion: 2,
-      firstUpdatedAt: recentTimestamp,
+    const existingManifest = serializeManifest({ ...baseManifest, schemaVersion: 2, firstUpdatedAt: recentTimestamp });
+    const forge = await mockForge({
+      standingPR: openStandingPR(99),
+      comments: [{ id: 77, body: existingManifest }],
     });
-    mocks.paginate.iterator.mockReturnValue({
-      async *[Symbol.asyncIterator]() {
-        yield { data: [{ id: 77, body: existingManifest }] };
-      },
-    });
-    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
 
     await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
 
-    expect(mocks.createCommitStatus).toHaveBeenCalledWith(
+    expect(forge.commitStatuses).toContainEqual(
       expect.objectContaining({
         state: 'pending',
         context: 'releasekit/standing-pr',
@@ -1025,26 +905,17 @@ describe('runStandingPRUpdate', () => {
       .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>);
     vi.mocked(runNotesStep).mockResolvedValue({ packageNotes: {}, releaseNotes: {}, files: [] });
 
-    const { createOctokit } = await import('../../src/github.js');
-    const { mocks, octokit } = createMockOctokit();
-    mocks.pullsList.mockResolvedValue({ data: [{ number: 99, html_url: 'https://github.com/owner/repo/pull/99' }] });
     // firstUpdatedAt is 2 hours ago — minAge of 1h is satisfied
     const oldTimestamp = new Date(Date.now() - 2 * 3_600_000).toISOString();
-    const existingManifest = serializeManifest({
-      ...baseManifest,
-      schemaVersion: 2,
-      firstUpdatedAt: oldTimestamp,
+    const existingManifest = serializeManifest({ ...baseManifest, schemaVersion: 2, firstUpdatedAt: oldTimestamp });
+    const forge = await mockForge({
+      standingPR: openStandingPR(99),
+      comments: [{ id: 77, body: existingManifest }],
     });
-    mocks.paginate.iterator.mockReturnValue({
-      async *[Symbol.asyncIterator]() {
-        yield { data: [{ id: 77, body: existingManifest }] };
-      },
-    });
-    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
 
     await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
 
-    expect(mocks.createCommitStatus).toHaveBeenCalledWith(
+    expect(forge.commitStatuses).toContainEqual(
       expect.objectContaining({ state: 'success', description: 'Ready to merge' }),
     );
   });
@@ -1057,32 +928,23 @@ describe('runStandingPRUpdate', () => {
       .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>);
     vi.mocked(runNotesStep).mockResolvedValue({ packageNotes: {}, releaseNotes: {}, files: [] });
 
-    const { createOctokit } = await import('../../src/github.js');
-    const { mocks, octokit } = createMockOctokit();
-    mocks.pullsList.mockResolvedValue({ data: [{ number: 99, html_url: 'https://github.com/owner/repo/pull/99' }] });
-
     const originalTimestamp = '2024-01-15T08:00:00.000Z';
     const existingManifest = serializeManifest({
       ...baseManifest,
       schemaVersion: 2,
       firstUpdatedAt: originalTimestamp,
     });
-    mocks.paginate.iterator.mockReturnValue({
-      async *[Symbol.asyncIterator]() {
-        yield { data: [{ id: 77, body: existingManifest }] };
-      },
+    const forge = await mockForge({
+      standingPR: openStandingPR(99),
+      comments: [{ id: 77, body: existingManifest }],
     });
-    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
 
     await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
 
     // The manifest comment update should contain the original firstUpdatedAt
-    const updateCall = mocks.updateComment.mock.calls.find(
-      (c) => typeof c[0]?.body === 'string' && c[0].body.includes('<!-- releasekit-manifest -->'),
-    );
+    const updateCall = forge.updatedComments.find((c) => c.body.includes(MANIFEST_MARKER));
     expect(updateCall).toBeDefined();
-    const writtenBody = updateCall?.[0]?.body as string;
-    const writtenManifest = parseManifest(writtenBody);
+    const writtenManifest = parseManifest(updateCall?.body as string);
     expect(writtenManifest.firstUpdatedAt).toBe(originalTimestamp);
   });
 
@@ -1094,26 +956,18 @@ describe('runStandingPRUpdate', () => {
       .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>);
     vi.mocked(runNotesStep).mockResolvedValue({ packageNotes: {}, releaseNotes: {}, files: [] });
 
-    const { createOctokit } = await import('../../src/github.js');
-    const { mocks, octokit } = createMockOctokit();
-    mocks.pullsList.mockResolvedValue({ data: [{ number: 99, html_url: 'https://github.com/owner/repo/pull/99' }] });
-
     // v1 manifest has no firstUpdatedAt — should fall back to createdAt
     const v1Manifest = serializeManifest({ ...baseManifest, schemaVersion: 1 });
-    mocks.paginate.iterator.mockReturnValue({
-      async *[Symbol.asyncIterator]() {
-        yield { data: [{ id: 77, body: v1Manifest }] };
-      },
+    const forge = await mockForge({
+      standingPR: openStandingPR(99),
+      comments: [{ id: 77, body: v1Manifest }],
     });
-    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
 
     await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
 
-    const updateCall = mocks.updateComment.mock.calls.find(
-      (c) => typeof c[0]?.body === 'string' && c[0].body.includes('<!-- releasekit-manifest -->'),
-    );
+    const updateCall = forge.updatedComments.find((c) => c.body.includes(MANIFEST_MARKER));
     expect(updateCall).toBeDefined();
-    const writtenManifest = parseManifest(updateCall?.[0]?.body as string);
+    const writtenManifest = parseManifest(updateCall?.body as string);
     expect(writtenManifest.firstUpdatedAt).toBe(baseManifest.createdAt);
   });
 
@@ -1125,11 +979,8 @@ describe('runStandingPRUpdate', () => {
       .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>);
     vi.mocked(runNotesStep).mockResolvedValue({ packageNotes: {}, releaseNotes: {}, files: [] });
 
-    const { createOctokit } = await import('../../src/github.js');
-    const { mocks, octokit } = createMockOctokit();
-    mocks.pullsList.mockResolvedValue({ data: [] });
-    mocks.createCommitStatus.mockRejectedValue(new Error('API rate limit exceeded'));
-    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+    const forge = await mockForge({ standingPR: null });
+    vi.spyOn(forge, 'setCommitStatus').mockRejectedValue(new Error('API rate limit exceeded'));
 
     // Should resolve (not throw) even when status check post fails
     const result = await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
@@ -1147,20 +998,9 @@ describe('runStandingPRUpdate', () => {
         .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>);
       vi.mocked(runNotesStep).mockResolvedValue({ packageNotes: {}, releaseNotes: {}, files: [] });
 
-      const { createOctokit } = await import('../../src/github.js');
-      const { mocks, octokit } = createMockOctokit();
-      mocks.pullsList.mockResolvedValue({
-        data: [
-          {
-            number: 99,
-            html_url: 'https://github.com/owner/repo/pull/99',
-            labels: labelNames.map((name) => ({ name })),
-          },
-        ],
-      });
-      vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+      const forge = await mockForge({ standingPR: openStandingPR(99, labelNames) });
 
-      return { mocks, octokit, runVersionStepMock: vi.mocked(runVersionStep) };
+      return { forge, runVersionStepMock: vi.mocked(runVersionStep) };
     }
 
     it('should pass bump:major from standing PR labels into version step', async () => {
@@ -1193,16 +1033,14 @@ describe('runStandingPRUpdate', () => {
     });
 
     it('should record the override labels in the manifest, excluding the marker label (#337)', async () => {
-      const { mocks } = await setupWithStandingPRLabels(['release', 'bump:major', 'channel:prerelease']);
+      const { forge } = await setupWithStandingPRLabels(['release', 'bump:major', 'channel:prerelease']);
 
       await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
 
-      const writes = [...mocks.createComment.mock.calls, ...mocks.updateComment.mock.calls];
-      const manifestWrite = writes.find(
-        (c) => typeof c[0]?.body === 'string' && c[0].body.includes('<!-- releasekit-manifest -->'),
-      );
+      const writes = [...forge.createdComments.map((c) => c.body), ...forge.updatedComments.map((c) => c.body)];
+      const manifestWrite = writes.find((b) => b.includes(MANIFEST_MARKER));
       expect(manifestWrite).toBeDefined();
-      const manifest = parseManifest(manifestWrite?.[0]?.body as string);
+      const manifest = parseManifest(manifestWrite as string);
       // Sorted, marker 'release' label excluded.
       expect(manifest.overrideLabels).toEqual(['bump:major', 'channel:prerelease']);
     });
@@ -1219,7 +1057,7 @@ describe('runStandingPRUpdate', () => {
     });
 
     it('should drop conflicting bump labels and posts pending status check', async () => {
-      const { mocks, runVersionStepMock } = await setupWithStandingPRLabels(['release', 'bump:patch', 'bump:major']);
+      const { forge, runVersionStepMock } = await setupWithStandingPRLabels(['release', 'bump:patch', 'bump:major']);
 
       await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
 
@@ -1227,7 +1065,7 @@ describe('runStandingPRUpdate', () => {
       expect(runVersionStepMock.mock.calls[0]?.[0]).not.toHaveProperty('bump', 'major');
       expect(runVersionStepMock.mock.calls[0]?.[0]?.bump).toBeUndefined();
       // Final status check is pending with conflict description
-      const lastStatus = mocks.createCommitStatus.mock.calls.at(-1)?.[0];
+      const lastStatus = forge.commitStatuses.at(-1);
       expect(lastStatus?.state).toBe('pending');
       expect(lastStatus?.description).toMatch(/Conflicting bump labels/);
     });
@@ -1239,22 +1077,22 @@ describe('runStandingPRUpdate', () => {
         ci: { ...defaultConfig.ci, standingPr: { ...defaultConfig.ci.standingPr, minAge: '6h' } },
       } as ReturnType<typeof loadConfig>);
 
-      const { mocks } = await setupWithStandingPRLabels(['release', 'bump:patch', 'bump:major']);
+      const { forge } = await setupWithStandingPRLabels(['release', 'bump:patch', 'bump:major']);
 
       await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
 
-      const lastStatus = mocks.createCommitStatus.mock.calls.at(-1)?.[0];
+      const lastStatus = forge.commitStatuses.at(-1);
       expect(lastStatus?.state).toBe('pending');
       expect(lastStatus?.description).toMatch(/Conflicting bump labels/);
       expect(lastStatus?.description).not.toMatch(/minAge/);
     });
 
     it('should preserve maintainer-added labels in setLabels (union with configured labels)', async () => {
-      const { mocks } = await setupWithStandingPRLabels(['release', 'bump:major']);
+      const { forge } = await setupWithStandingPRLabels(['release', 'bump:major']);
 
       await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
 
-      const lastSetLabels = mocks.issuesSetLabels.mock.calls.at(-1)?.[0];
+      const lastSetLabels = forge.setLabelsCalls.at(-1);
       // Should contain BOTH the configured 'release' and the maintainer-added 'bump:major'
       expect(lastSetLabels?.labels).toContain('release');
       expect(lastSetLabels?.labels).toContain('bump:major');
@@ -1295,25 +1133,16 @@ describe('runStandingPRUpdate', () => {
         files: [],
       });
 
-      const { createOctokit } = await import('../../src/github.js');
-      const { mocks, octokit } = createMockOctokit();
-      mocks.pullsList.mockResolvedValue({
-        data: [
-          {
-            number: 99,
-            html_url: 'https://github.com/owner/repo/pull/99',
-            labels: opts.labels.map((name) => ({ name })),
-          },
-        ],
+      const forge = await mockForge({
+        standingPR: openStandingPR(99, opts.labels),
+        pullRequests: { 99: { body: opts.liveBody ?? '', labels: [] } },
       });
-      mocks.pullsGet.mockResolvedValue({ data: { body: opts.liveBody ?? '' } });
-      vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
 
-      return { mocks, runNotesStepMock: vi.mocked(runNotesStep) };
+      return { forge, runNotesStepMock: vi.mocked(runNotesStep) };
     }
 
     it('should seed generated notes into the editable region when the preview label is present', async () => {
-      const { mocks, runNotesStepMock } = await setupPreviewPR({
+      const { forge, runNotesStepMock } = await setupPreviewPR({
         labels: ['release', 'release:preview-notes'],
         liveBody: '',
         freshNotes: { '@scope/core': 'Generated notes for core' },
@@ -1323,7 +1152,7 @@ describe('runStandingPRUpdate', () => {
 
       // LLM release notes were requested (skipReleaseNotes false) on the seeding run.
       expect(runNotesStepMock.mock.calls.at(-1)?.[1]).toMatchObject({ skipReleaseNotes: false });
-      const body = mocks.pullsUpdate.mock.calls.at(-1)?.[0]?.body as string;
+      const body = forge.updatedPullRequests.at(-1)?.changes.body as string;
       expect(body).toContain('## Release Notes');
       expect(body).toContain('<!-- releasekit-notes:@scope/core -->');
       expect(body).toContain('Generated notes for core');
@@ -1331,7 +1160,7 @@ describe('runStandingPRUpdate', () => {
 
     it('should preserve a human-edited region across an update without regenerating', async () => {
       const editedBody = renderNotesRegion({ '@scope/core': 'HUMAN EDITED notes' });
-      const { mocks, runNotesStepMock } = await setupPreviewPR({
+      const { forge, runNotesStepMock } = await setupPreviewPR({
         labels: ['release', 'release:preview-notes'],
         liveBody: editedBody,
         // Even if the mock returned fresh notes, the edit must win — but generation should be skipped.
@@ -1342,17 +1171,17 @@ describe('runStandingPRUpdate', () => {
 
       // Every releasing package already has a region → LLM generation is skipped.
       expect(runNotesStepMock.mock.calls.at(-1)?.[1]).toMatchObject({ skipReleaseNotes: true });
-      const body = mocks.pullsUpdate.mock.calls.at(-1)?.[0]?.body as string;
+      const body = forge.updatedPullRequests.at(-1)?.changes.body as string;
       expect(body).toContain('HUMAN EDITED notes');
       expect(body).not.toContain('REGENERATED notes');
     });
 
     it('should not add a notes region when the preview label is absent', async () => {
-      const { mocks } = await setupPreviewPR({ labels: ['release'], freshNotes: {} });
+      const { forge } = await setupPreviewPR({ labels: ['release'], freshNotes: {} });
 
       await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
 
-      const body = mocks.pullsUpdate.mock.calls.at(-1)?.[0]?.body as string;
+      const body = forge.updatedPullRequests.at(-1)?.changes.body as string;
       expect(body).not.toContain('## Release Notes');
       expect(body).not.toContain('<!-- releasekit-notes');
     });
@@ -1361,39 +1190,25 @@ describe('runStandingPRUpdate', () => {
 
 describe('findLatestMergedStandingPR', () => {
   it('should pick the most recently merged PR even when an older merge was updated more recently', async () => {
-    const { createOctokit } = await import('../../src/github.js');
-    const { octokit, mocks } = createMockOctokit();
     // List order is the API's 'updated' sort — late activity (a comment, a label) on the
     // older merged #42 floats it above the newer merge #77.
-    mocks.pullsList.mockResolvedValue({
-      data: [
-        { number: 42, merged_at: '2024-01-01T00:00:00Z' },
-        { number: 80, merged_at: null },
-        { number: 77, merged_at: '2024-01-02T00:00:00Z' },
+    const forge = createFakeForge({
+      recentlyClosedPRs: [
+        { number: 42, mergedAt: '2024-01-01T00:00:00Z' },
+        { number: 80, mergedAt: null },
+        { number: 77, mergedAt: '2024-01-02T00:00:00Z' },
       ],
     });
 
-    const result = await findLatestMergedStandingPR(
-      octokit as unknown as ReturnType<typeof createOctokit>,
-      'owner',
-      'repo',
-      'release/next',
-    );
+    const result = await findLatestMergedStandingPR(forge, 'release/next');
 
     expect(result).toBe(77);
   });
 
   it('should return null when no closed PR from the branch was merged', async () => {
-    const { createOctokit } = await import('../../src/github.js');
-    const { octokit, mocks } = createMockOctokit();
-    mocks.pullsList.mockResolvedValue({ data: [{ number: 80, merged_at: null }] });
+    const forge = createFakeForge({ recentlyClosedPRs: [{ number: 80, mergedAt: null }] });
 
-    const result = await findLatestMergedStandingPR(
-      octokit as unknown as ReturnType<typeof createOctokit>,
-      'owner',
-      'repo',
-      'release/next',
-    );
+    const result = await findLatestMergedStandingPR(forge, 'release/next');
 
     expect(result).toBeNull();
   });
@@ -1427,35 +1242,28 @@ describe('runStandingPRPublish', () => {
   it('should infer the latest merged standing PR from the API when GITHUB_EVENT_PATH is not set', async () => {
     delete process.env.GITHUB_EVENT_PATH;
 
-    const { createOctokit } = await import('../../src/github.js');
-    const { octokit, mocks } = createMockOctokit();
-    mocks.pullsList.mockResolvedValue({
-      data: [
-        { number: 80, merged_at: null },
-        { number: 77, merged_at: '2024-01-02T00:00:00Z' },
-      ],
-    });
     // No manifest comment on the inferred PR — the publish attempt throwing proves the
     // inference resolved #77 and proceeded to publishFromManifest.
-    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+    const forge = await mockForge({
+      recentlyClosedPRs: [
+        { number: 80, mergedAt: null },
+        { number: 77, mergedAt: '2024-01-02T00:00:00Z' },
+      ],
+    });
+    const listClosed = vi.spyOn(forge, 'listRecentlyClosedPullRequests');
 
     await expect(
       runStandingPRPublish({ projectDir: '/test', verbose: false, quiet: false, json: false }),
     ).rejects.toThrow(/manifest not found/);
 
-    expect(mocks.pullsList).toHaveBeenCalledWith(
-      expect.objectContaining({ head: 'owner:release/next', state: 'closed' }),
-    );
+    expect(listClosed).toHaveBeenCalledWith('release/next', expect.any(Number));
   });
 
   it('should fall back to API inference when the event payload has no pull_request (workflow_dispatch)', async () => {
     const { readFileSync } = await import('node:fs');
     vi.mocked(readFileSync).mockReturnValue(JSON.stringify({ inputs: {} }));
 
-    const { createOctokit } = await import('../../src/github.js');
-    const { octokit, mocks } = createMockOctokit();
-    mocks.pullsList.mockResolvedValue({ data: [{ number: 42, merged_at: '2024-01-02T00:00:00Z' }] });
-    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+    await mockForge({ recentlyClosedPRs: [{ number: 42, mergedAt: '2024-01-02T00:00:00Z' }] });
 
     await expect(
       runStandingPRPublish({ projectDir: '/test', verbose: false, quiet: false, json: false }),
@@ -1465,10 +1273,7 @@ describe('runStandingPRPublish', () => {
   it('should return null when API inference finds no merged standing PR', async () => {
     delete process.env.GITHUB_EVENT_PATH;
 
-    const { createOctokit } = await import('../../src/github.js');
-    const { octokit, mocks } = createMockOctokit();
-    mocks.pullsList.mockResolvedValue({ data: [{ number: 80, merged_at: null }] });
-    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+    await mockForge({ recentlyClosedPRs: [{ number: 80, mergedAt: null }] });
 
     const result = await runStandingPRPublish({
       projectDir: '/test',
@@ -1538,10 +1343,8 @@ describe('runStandingPRPublish', () => {
       }),
     );
 
-    const { createOctokit } = await import('../../src/github.js');
-    const { octokit } = createMockOctokit();
     // No manifest comment
-    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+    await mockForge({});
 
     await expect(
       runStandingPRPublish({ projectDir: '/test', verbose: false, quiet: false, json: false }),
@@ -1556,15 +1359,7 @@ describe('runStandingPRPublish', () => {
       }),
     );
 
-    const { createOctokit } = await import('../../src/github.js');
-    const { octokit } = createMockOctokit();
-    const manifestBody = serializeManifest(baseManifest);
-    (octokit as unknown as { paginate: { iterator: ReturnType<typeof vi.fn> } }).paginate.iterator.mockReturnValue({
-      async *[Symbol.asyncIterator]() {
-        yield { data: [{ id: 1, body: manifestBody }] };
-      },
-    });
-    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+    await mockForge({ comments: [{ id: 1, body: serializeManifest(baseManifest) }] });
 
     const { runNotesStep, runPublishStep } = await import('../../src/steps.js');
     // publishFromManifest regenerates LLM-enhanced notes against the merged commit set
@@ -1607,17 +1402,12 @@ describe('runStandingPRPublish', () => {
       JSON.stringify({ pull_request: { head: { ref: 'release/next' }, number: 42, merged: true } }),
     );
 
-    const { createOctokit } = await import('../../src/github.js');
-    const { octokit, mocks } = createMockOctokit();
     const manifestBody = serializeManifest({ ...baseManifest, schemaVersion: 2, overrideLabels: ['bump:major'] });
-    (octokit as unknown as { paginate: { iterator: ReturnType<typeof vi.fn> } }).paginate.iterator.mockReturnValue({
-      async *[Symbol.asyncIterator]() {
-        yield { data: [{ id: 1, body: manifestBody }] };
-      },
-    });
     // The merged PR carries a different bump label than the manifest was computed for.
-    mocks.pullsGet.mockResolvedValue({ data: { body: '', labels: [{ name: 'bump:minor' }, { name: 'release' }] } });
-    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+    await mockForge({
+      comments: [{ id: 1, body: manifestBody }],
+      pullRequests: { 42: { body: '', labels: ['bump:minor', 'release'] } },
+    });
 
     await expect(
       runStandingPRPublish({ projectDir: '/test', verbose: false, quiet: false, json: false }),
@@ -1633,19 +1423,12 @@ describe('runStandingPRPublish', () => {
       JSON.stringify({ pull_request: { head: { ref: 'release/next' }, number: 42, merged: true } }),
     );
 
-    const { createOctokit } = await import('../../src/github.js');
-    const { octokit, mocks } = createMockOctokit();
     const manifestBody = serializeManifest({ ...baseManifest, schemaVersion: 2, overrideLabels: ['bump:major'] });
-    (octokit as unknown as { paginate: { iterator: ReturnType<typeof vi.fn> } }).paginate.iterator.mockReturnValue({
-      async *[Symbol.asyncIterator]() {
-        yield { data: [{ id: 1, body: manifestBody }] };
-      },
-    });
     // Same override label; the unrelated 'release' / 'area:ci' labels must not count as a mismatch.
-    mocks.pullsGet.mockResolvedValue({
-      data: { body: '', labels: [{ name: 'release' }, { name: 'bump:major' }, { name: 'area:ci' }] },
+    await mockForge({
+      comments: [{ id: 1, body: manifestBody }],
+      pullRequests: { 42: { body: '', labels: ['release', 'bump:major', 'area:ci'] } },
     });
-    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
 
     const { runPublishStep } = await import('../../src/steps.js');
     vi.mocked(runPublishStep).mockResolvedValue({ publishSucceeded: true } as unknown as Awaited<
@@ -1663,17 +1446,11 @@ describe('runStandingPRPublish', () => {
       JSON.stringify({ pull_request: { head: { ref: 'release/next' }, number: 42, merged: true } }),
     );
 
-    const { createOctokit } = await import('../../src/github.js');
-    const { octokit, mocks } = createMockOctokit();
     // baseManifest has no overrideLabels (pre-#337) — the check must be skipped even if labels differ.
-    const manifestBody = serializeManifest(baseManifest);
-    (octokit as unknown as { paginate: { iterator: ReturnType<typeof vi.fn> } }).paginate.iterator.mockReturnValue({
-      async *[Symbol.asyncIterator]() {
-        yield { data: [{ id: 1, body: manifestBody }] };
-      },
+    await mockForge({
+      comments: [{ id: 1, body: serializeManifest(baseManifest) }],
+      pullRequests: { 42: { body: '', labels: ['bump:major'] } },
     });
-    mocks.pullsGet.mockResolvedValue({ data: { body: '', labels: [{ name: 'bump:major' }] } });
-    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
 
     const { runPublishStep } = await import('../../src/steps.js');
     vi.mocked(runPublishStep).mockResolvedValue({ publishSucceeded: true } as unknown as Awaited<
@@ -1691,17 +1468,10 @@ describe('runStandingPRPublish', () => {
       JSON.stringify({ pull_request: { head: { ref: 'release/next' }, number: 42, merged: true } }),
     );
 
-    const { createOctokit } = await import('../../src/github.js');
-    const { octokit, mocks } = createMockOctokit();
     const manifestBody = serializeManifest({ ...baseManifest, schemaVersion: 2, overrideLabels: ['bump:major'] });
-    (octokit as unknown as { paginate: { iterator: ReturnType<typeof vi.fn> } }).paginate.iterator.mockReturnValue({
-      async *[Symbol.asyncIterator]() {
-        yield { data: [{ id: 1, body: manifestBody }] };
-      },
-    });
+    const forge = await mockForge({ comments: [{ id: 1, body: manifestBody }] });
     // The PR can't be read (transient API failure) — can't verify labels, so fail closed.
-    mocks.pullsGet.mockRejectedValue(new Error('API unavailable'));
-    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+    vi.spyOn(forge, 'getPullRequest').mockRejectedValue(new Error('API unavailable'));
 
     await expect(
       runStandingPRPublish({ projectDir: '/test', verbose: false, quiet: false, json: false }),
@@ -1719,15 +1489,7 @@ describe('runStandingPRPublish', () => {
       }),
     );
 
-    const { createOctokit } = await import('../../src/github.js');
-    const { octokit } = createMockOctokit();
-    const manifestBody = serializeManifest(baseManifest);
-    (octokit as unknown as { paginate: { iterator: ReturnType<typeof vi.fn> } }).paginate.iterator.mockReturnValue({
-      async *[Symbol.asyncIterator]() {
-        yield { data: [{ id: 1, body: manifestBody }] };
-      },
-    });
-    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+    await mockForge({ comments: [{ id: 1, body: serializeManifest(baseManifest) }] });
 
     const { runNotesStep, runPublishStep } = await import('../../src/steps.js');
     vi.mocked(runNotesStep).mockRejectedValue(new Error('LLM provider unavailable'));
@@ -1761,15 +1523,7 @@ describe('runStandingPRPublish', () => {
       }),
     );
 
-    const { createOctokit } = await import('../../src/github.js');
-    const { octokit } = createMockOctokit();
-    const manifestBody = serializeManifest(baseManifest);
-    (octokit as unknown as { paginate: { iterator: ReturnType<typeof vi.fn> } }).paginate.iterator.mockReturnValue({
-      async *[Symbol.asyncIterator]() {
-        yield { data: [{ id: 1, body: manifestBody }] };
-      },
-    });
-    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+    await mockForge({ comments: [{ id: 1, body: serializeManifest(baseManifest) }] });
 
     const { runPublishStep } = await import('../../src/steps.js');
     vi.mocked(runPublishStep).mockResolvedValue({ publishSucceeded: true } as unknown as Awaited<
@@ -1801,15 +1555,7 @@ describe('runStandingPRPublish', () => {
       }),
     );
 
-    const { createOctokit } = await import('../../src/github.js');
-    const { octokit } = createMockOctokit();
-    const manifestBody = serializeManifest(baseManifest);
-    (octokit as unknown as { paginate: { iterator: ReturnType<typeof vi.fn> } }).paginate.iterator.mockReturnValue({
-      async *[Symbol.asyncIterator]() {
-        yield { data: [{ id: 1, body: manifestBody }] };
-      },
-    });
-    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+    await mockForge({ comments: [{ id: 1, body: serializeManifest(baseManifest) }] });
 
     const { runPublishStep } = await import('../../src/steps.js');
     vi.mocked(runPublishStep).mockResolvedValue({ publishSucceeded: true } as unknown as Awaited<
@@ -1850,15 +1596,8 @@ describe('runStandingPRPublish', () => {
       }),
     );
 
-    const { createOctokit } = await import('../../src/github.js');
-    const { octokit } = createMockOctokit();
     const badManifest = '<!-- releasekit-manifest -->\n<!-- json {broken -->';
-    (octokit as unknown as { paginate: { iterator: ReturnType<typeof vi.fn> } }).paginate.iterator.mockReturnValue({
-      async *[Symbol.asyncIterator]() {
-        yield { data: [{ id: 1, body: badManifest }] };
-      },
-    });
-    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+    await mockForge({ comments: [{ id: 1, body: badManifest }] });
 
     await expect(
       runStandingPRPublish({ projectDir: '/test', verbose: false, quiet: false, json: false }),
@@ -1906,9 +1645,7 @@ describe('publishFromManifest', () => {
   });
 
   it('should throw when manifest comment is missing from PR', async () => {
-    const { createOctokit } = await import('../../src/github.js');
-    const { octokit } = createMockOctokit();
-    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+    await mockForge({});
 
     await expect(
       publishFromManifest(42, { projectDir: '/test', verbose: false, quiet: false, json: false }),
@@ -1929,17 +1666,11 @@ describe('publishFromManifest', () => {
       git: { committed: true, tags: [], pushed: true },
     } as unknown as Awaited<ReturnType<typeof runPublishStep>>);
 
-    const { createOctokit } = await import('../../src/github.js');
-    const { mocks, octokit } = createMockOctokit();
-    // Manifest comment present so publish proceeds.
-    mocks.paginate.iterator.mockReturnValue({
-      async *[Symbol.asyncIterator]() {
-        yield { data: [{ id: 77, body: serializeManifest(baseManifest) }] };
-      },
+    // Manifest comment present so publish proceeds; the merged PR body carries a human-edited region.
+    await mockForge({
+      comments: [{ id: 77, body: serializeManifest(baseManifest) }],
+      pullRequests: { 99: { body: renderNotesRegion({ '@scope/core': 'EDITED AT MERGE' }), labels: [] } },
     });
-    // The merged PR body carries a human-edited region for @scope/core.
-    mocks.pullsGet.mockResolvedValue({ data: { body: renderNotesRegion({ '@scope/core': 'EDITED AT MERGE' }) } });
-    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
 
     await publishFromManifest(99, { projectDir: '/test', verbose: false, quiet: false, json: false });
 
@@ -1985,10 +1716,7 @@ describe('runStandingPRMerge', () => {
   });
 
   it('should return null when no open standing PR found', async () => {
-    const { createOctokit } = await import('../../src/github.js');
-    const { mocks, octokit } = createMockOctokit();
-    mocks.pullsList.mockResolvedValue({ data: [] });
-    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+    const forge = await mockForge({ standingPR: null });
 
     const result = await runStandingPRMerge(
       { projectDir: '/test', verbose: false, quiet: false, json: false },
@@ -1996,7 +1724,7 @@ describe('runStandingPRMerge', () => {
     );
 
     expect(result).toBeNull();
-    expect(mocks.pullsMerge).not.toHaveBeenCalled();
+    expect(forge.mergedPullRequests).toHaveLength(0);
   });
 
   it('should call pulls.merge with mergeMethod from config', async () => {
@@ -2008,23 +1736,11 @@ describe('runStandingPRMerge', () => {
       git: { branch: 'main' },
     } as ReturnType<typeof loadConfig>);
 
-    const { createOctokit } = await import('../../src/github.js');
-    const { mocks, octokit } = createMockOctokit();
-    mocks.pullsList.mockResolvedValue({
-      data: [{ number: 42, html_url: 'https://github.com/owner/repo/pull/42' }],
-    });
-    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+    const forge = await mockForge({ standingPR: openStandingPR(42) });
 
     await runStandingPRMerge({ projectDir: '/test', verbose: false, quiet: false, json: false }, { publish: false });
 
-    expect(mocks.pullsMerge).toHaveBeenCalledWith(
-      expect.objectContaining({
-        owner: 'owner',
-        repo: 'repo',
-        pull_number: 42,
-        merge_method: 'squash',
-      }),
-    );
+    expect(forge.mergedPullRequests).toContainEqual({ prNumber: 42, method: 'squash' });
   });
 
   it('should default to merge method when config omits mergeMethod', async () => {
@@ -2036,33 +1752,19 @@ describe('runStandingPRMerge', () => {
       git: { branch: 'main' },
     } as ReturnType<typeof loadConfig>);
 
-    const { createOctokit } = await import('../../src/github.js');
-    const { mocks, octokit } = createMockOctokit();
-    mocks.pullsList.mockResolvedValue({
-      data: [{ number: 42, html_url: 'https://github.com/owner/repo/pull/42' }],
-    });
-    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+    const forge = await mockForge({ standingPR: openStandingPR(42) });
 
     await runStandingPRMerge({ projectDir: '/test', verbose: false, quiet: false, json: false }, { publish: false });
 
-    expect(mocks.pullsMerge).toHaveBeenCalledWith(
-      expect.objectContaining({
-        merge_method: 'merge',
-      }),
-    );
+    expect(forge.mergedPullRequests).toContainEqual(expect.objectContaining({ method: 'merge' }));
   });
 
   it('should throw clear error message on 405 response', async () => {
-    const { createOctokit } = await import('../../src/github.js');
-    const { mocks, octokit } = createMockOctokit();
-    mocks.pullsList.mockResolvedValue({
-      data: [{ number: 42, html_url: 'https://github.com/owner/repo/pull/42' }],
-    });
-    mocks.pullsMerge.mockRejectedValue({
+    const forge = await mockForge({ standingPR: openStandingPR(42) });
+    vi.spyOn(forge, 'mergePullRequest').mockRejectedValue({
       status: 405,
       response: { data: { message: 'Required status checks have not passed' } },
     });
-    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
 
     await expect(
       runStandingPRMerge({ projectDir: '/test', verbose: false, quiet: false, json: false }, { publish: false }),
@@ -2074,14 +1776,9 @@ describe('runStandingPRMerge', () => {
   });
 
   it('should re-throw non-405 errors unchanged', async () => {
-    const { createOctokit } = await import('../../src/github.js');
-    const { mocks, octokit } = createMockOctokit();
-    mocks.pullsList.mockResolvedValue({
-      data: [{ number: 42, html_url: 'https://github.com/owner/repo/pull/42' }],
-    });
+    const forge = await mockForge({ standingPR: openStandingPR(42) });
     const originalError = new Error('Network error');
-    mocks.pullsMerge.mockRejectedValue(originalError);
-    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+    vi.spyOn(forge, 'mergePullRequest').mockRejectedValue(originalError);
 
     await expect(
       runStandingPRMerge({ projectDir: '/test', verbose: false, quiet: false, json: false }, { publish: false }),
@@ -2089,12 +1786,7 @@ describe('runStandingPRMerge', () => {
   });
 
   it('should return null without publishing when publish flag is false', async () => {
-    const { createOctokit } = await import('../../src/github.js');
-    const { mocks, octokit } = createMockOctokit();
-    mocks.pullsList.mockResolvedValue({
-      data: [{ number: 42, html_url: 'https://github.com/owner/repo/pull/42' }],
-    });
-    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+    await mockForge({ standingPR: openStandingPR(42) });
 
     const result = await runStandingPRMerge(
       { projectDir: '/test', verbose: false, quiet: false, json: false },
@@ -2105,18 +1797,10 @@ describe('runStandingPRMerge', () => {
   });
 
   it('should call publishFromManifest when publish flag is true and manifest exists', async () => {
-    const { createOctokit } = await import('../../src/github.js');
-    const { mocks, octokit } = createMockOctokit();
-    mocks.pullsList.mockResolvedValue({
-      data: [{ number: 42, html_url: 'https://github.com/owner/repo/pull/42' }],
+    await mockForge({
+      standingPR: openStandingPR(42),
+      comments: [{ id: 1, body: serializeManifest(baseManifest) }],
     });
-    const manifestBody = serializeManifest(baseManifest);
-    (octokit as unknown as { paginate: { iterator: ReturnType<typeof vi.fn> } }).paginate.iterator.mockReturnValue({
-      async *[Symbol.asyncIterator]() {
-        yield { data: [{ id: 1, body: manifestBody }] };
-      },
-    });
-    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
 
     const { runNotesStep, runPublishStep } = await import('../../src/steps.js');
     vi.mocked(runNotesStep).mockResolvedValue({
@@ -2143,18 +1827,10 @@ describe('runStandingPRMerge', () => {
   });
 
   it('should delete branch after publish when deleteBranchOnMerge is true', async () => {
-    const { createOctokit } = await import('../../src/github.js');
-    const { mocks, octokit } = createMockOctokit();
-    mocks.pullsList.mockResolvedValue({
-      data: [{ number: 42, html_url: 'https://github.com/owner/repo/pull/42' }],
+    await mockForge({
+      standingPR: openStandingPR(42),
+      comments: [{ id: 1, body: serializeManifest(baseManifest) }],
     });
-    const manifestBody = serializeManifest(baseManifest);
-    (octokit as unknown as { paginate: { iterator: ReturnType<typeof vi.fn> } }).paginate.iterator.mockReturnValue({
-      async *[Symbol.asyncIterator]() {
-        yield { data: [{ id: 1, body: manifestBody }] };
-      },
-    });
-    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
 
     const { runPublishStep } = await import('../../src/steps.js');
     vi.mocked(runPublishStep).mockResolvedValue({ publishSucceeded: true } as unknown as Awaited<
@@ -2179,18 +1855,10 @@ describe('runStandingPRMerge', () => {
       git: { branch: 'main' },
     } as ReturnType<typeof loadConfig>);
 
-    const { createOctokit } = await import('../../src/github.js');
-    const { mocks, octokit } = createMockOctokit();
-    mocks.pullsList.mockResolvedValue({
-      data: [{ number: 42, html_url: 'https://github.com/owner/repo/pull/42' }],
+    await mockForge({
+      standingPR: openStandingPR(42),
+      comments: [{ id: 1, body: serializeManifest(baseManifest) }],
     });
-    const manifestBody = serializeManifest(baseManifest);
-    (octokit as unknown as { paginate: { iterator: ReturnType<typeof vi.fn> } }).paginate.iterator.mockReturnValue({
-      async *[Symbol.asyncIterator]() {
-        yield { data: [{ id: 1, body: manifestBody }] };
-      },
-    });
-    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
 
     const { runPublishStep } = await import('../../src/steps.js');
     vi.mocked(runPublishStep).mockResolvedValue({ publishSucceeded: true } as unknown as Awaited<
@@ -2208,12 +1876,7 @@ describe('runStandingPRMerge', () => {
   });
 
   it('should delete branch even when publish flag is false and deleteBranchOnMerge is true', async () => {
-    const { createOctokit } = await import('../../src/github.js');
-    const { mocks, octokit } = createMockOctokit();
-    mocks.pullsList.mockResolvedValue({
-      data: [{ number: 42, html_url: 'https://github.com/owner/repo/pull/42' }],
-    });
-    vi.mocked(createOctokit).mockReturnValue(octokit as unknown as ReturnType<typeof createOctokit>);
+    await mockForge({ standingPR: openStandingPR(42) });
 
     const { execSync } = await import('node:child_process');
 

--- a/packages/release/tsup.config.ts
+++ b/packages/release/tsup.config.ts
@@ -16,6 +16,7 @@ var require = __createRequire(import.meta.url);`.trim(),
   noExternal: [
     '@releasekit/core',
     '@releasekit/config',
+    '@releasekit/forge',
     '@releasekit/version',
     '@releasekit/notes',
     '@releasekit/publish',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -179,6 +179,31 @@ importers:
         specifier: 'catalog:'
         version: 4.1.9(@types/node@22.19.21)(@vitest/coverage-v8@4.1.9)(vite@7.3.1(@types/node@22.19.21)(tsx@4.22.4)(yaml@2.9.0))
 
+  packages/forge:
+    dependencies:
+      '@octokit/rest':
+        specifier: 'catalog:'
+        version: 22.0.1
+    devDependencies:
+      '@biomejs/biome':
+        specifier: 'catalog:'
+        version: 2.5.0
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.19.21
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 4.1.9(vitest@4.1.9)
+      tsup:
+        specifier: 'catalog:'
+        version: 8.5.1(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.9(@types/node@22.19.21)(@vitest/coverage-v8@4.1.9)(vite@7.3.1(@types/node@22.19.21)(tsx@4.22.4)(yaml@2.9.0))
+
   packages/notes:
     dependencies:
       '@anthropic-ai/sdk':
@@ -190,6 +215,9 @@ importers:
       '@octokit/rest':
         specifier: ^22.0.1
         version: 22.0.1
+      '@releasekit/forge':
+        specifier: workspace:*
+        version: link:../forge
       chalk:
         specifier: 'catalog:'
         version: 5.6.2
@@ -318,6 +346,9 @@ importers:
       '@octokit/rest':
         specifier: 'catalog:'
         version: 22.0.1
+      '@releasekit/forge':
+        specifier: workspace:*
+        version: link:../forge
       '@releasekit/notes':
         specifier: workspace:*
         version: link:../notes
@@ -2194,9 +2225,6 @@ packages:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
-  obug@2.1.1:
-    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
-
   obug@2.1.3:
     resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
     engines: {node: '>=12.20.0'}
@@ -3389,7 +3417,7 @@ snapshots:
       istanbul-lib-report: 3.0.1
       istanbul-reports: 3.2.0
       magicast: 0.5.2
-      obug: 2.1.1
+      obug: 2.1.3
       std-env: 4.1.0
       tinyrainbow: 3.1.0
       vitest: 4.1.9(@types/node@22.19.21)(@vitest/coverage-v8@4.1.9)(vite@7.3.1(@types/node@22.19.21)(tsx@4.22.4)(yaml@2.9.0))
@@ -3958,7 +3986,7 @@ snapshots:
 
   make-dir@4.0.0:
     dependencies:
-      semver: 7.8.4
+      semver: 7.8.5
 
   meow@13.2.0: {}
 
@@ -4001,8 +4029,6 @@ snapshots:
       proc-log: 6.1.0
 
   object-assign@4.1.1: {}
-
-  obug@2.1.1: {}
 
   obug@2.1.3: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -209,9 +209,6 @@ importers:
       '@anthropic-ai/sdk':
         specifier: ^0.104.1
         version: 0.104.1(zod@4.4.3)
-      '@releasekit/forge':
-        specifier: workspace:*
-        version: link:../forge
       chalk:
         specifier: 'catalog:'
         version: 5.6.2
@@ -255,6 +252,9 @@ importers:
       '@releasekit/core':
         specifier: workspace:*
         version: link:../core
+      '@releasekit/forge':
+        specifier: workspace:*
+        version: link:../forge
       '@types/ejs':
         specifier: ^3.1.5
         version: 3.1.5
@@ -340,9 +340,6 @@ importers:
       '@octokit/rest':
         specifier: 'catalog:'
         version: 22.0.1
-      '@releasekit/forge':
-        specifier: workspace:*
-        version: link:../forge
       '@releasekit/notes':
         specifier: workspace:*
         version: link:../notes
@@ -392,6 +389,9 @@ importers:
       '@releasekit/core':
         specifier: workspace:*
         version: link:../core
+      '@releasekit/forge':
+        specifier: workspace:*
+        version: link:../forge
       '@types/node':
         specifier: 'catalog:'
         version: 22.19.21

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -209,6 +209,9 @@ importers:
       '@anthropic-ai/sdk':
         specifier: ^0.104.1
         version: 0.104.1(zod@4.4.3)
+      '@octokit/rest':
+        specifier: 'catalog:'
+        version: 22.0.1
       chalk:
         specifier: 'catalog:'
         version: 5.6.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -209,12 +209,6 @@ importers:
       '@anthropic-ai/sdk':
         specifier: ^0.104.1
         version: 0.104.1(zod@4.4.3)
-      '@octokit/request-error':
-        specifier: ^7.1.0
-        version: 7.1.0
-      '@octokit/rest':
-        specifier: ^22.0.1
-        version: 22.0.1
       '@releasekit/forge':
         specifier: workspace:*
         version: link:../forge


### PR DESCRIPTION
## What

Closes #358. `octokit.rest.*` was scattered across ~8 release files and 3 notes files, with **four** `new Octokit()` instantiations, a `findStandingPR` name collision (github.ts vs standing-pr.ts), and tests reaching past the interface into a hand-built 12-method octokit mock.

This introduces **`@releasekit/forge`** — a vendor-neutral `Forge` interface (pull requests · marker comments · labels · commit statuses · releases) behind which sits a `GitHubForge` Octokit adapter (prod) and an in-memory `FakeForge` (tests). Methods take/return **plain data** and never leak Octokit types, so a future GitLab/Bitbucket adapter is a new file with **zero caller changes**. `owner`/`repo`/auth are bound at construction, so callers speak only in domain terms.

> Naming: we deliberately chose **forge** (the term of art for a code-hosting platform: GitHub/GitLab/Gitea/Bitbucket) over `git` (the local CLI, which is a *separate* seam — see #357), `remote` (collides with `git.remote`), and `host` (overloaded). Recorded in `CONTEXT.md`.

## Layout
- `packages/forge/src/types.ts` — the `Forge` interface + plain data types.
- `packages/forge/src/github.ts` — `GitHubForge` adapter + `createGitHubForge({token,owner,repo})`.
- `packages/forge/src/fake.ts` — `FakeForge` / `createFakeForge(seed)`: seeded reads, recorded writes, realistic marker-upsert + idempotent `createLabel`.
- `release` + `notes` migrated to the forge; `github.ts` helpers now take a `Forge`.

## Acceptance criteria
- [x] All GitHub access (release + notes) goes through `Forge`
- [x] The four `new Octokit()` instantiations collapse to **one** (inside `createGitHubForge`)
- [x] `findStandingPR` collision resolved — `forge.findStandingPR(branch)` is the single impl; the config-deriving release helper is a thin wrapper
- [x] The hand-built octokit mock is replaced by the shared in-memory `FakeForge` (standing-pr / failure-report / label specs); the forge package carries its own adapter + fake tests
- [x] Behaviour unchanged; full gate (`lint typecheck test`, 28/28 tasks) green

## Behaviour note
Each migrated call site keeps its existing error handling (status-specific `RequestError` branches, best-effort swallows, fail-fast throws). Two intentional, result-preserving consolidations:
- **pub** already-published detection now matches via `getExecErrorOutput`… *(n/a — that was #386)*; here: the notes **examples fetcher**'s release listing is now bounded by the forge (≤3 pages) and drops the package-scoped early-stop — **result-identical** (matches are still sliced to `count`; only the API-call count changes for repos with 100+ releases). The pagination bound itself is covered by a forge-adapter test.
- The `createLabel` 422 `already_exists` → idempotent-skip detection moved out of `label-definitions` into the `GitHubForge` adapter and is covered by `forge/test/unit/github.spec.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces `@releasekit/forge` — a vendor-neutral `Forge` interface backed by a `GitHubForge` Octokit adapter and an in-memory `FakeForge` — and migrates all GitHub API access in the `release` and `notes` packages through it, collapsing four scattered `new Octokit()` instantiations and a hand-built 12-method mock into a single seam.

- **New `packages/forge` package**: `Forge` interface + plain data types, `GitHubForge` Octokit adapter (with `isAlreadyExistsError` idempotency and 3-page release pagination), `FakeForge` in-memory test double with realistic marker-upsert and recorded writes, and `forgeErrorStatus()` to replace `instanceof RequestError` checks in callers.
- **`release` and `notes` packages migrated**: `createOctokit` replaced by `forgeFor`; all helpers (`findPreviewComment`, `syncLabels`, `postStandingPRStatus`, etc.) now take a `Forge`; tests updated to use `FakeForge` instead of the hand-built Octokit mock.
- **One remaining inconsistency**: `runStandingPRMerge`'s 405 catch block still reaches into Octokit-specific error structure (`err.response.data.message`) rather than the `forgeErrorStatus` helper introduced by this PR.
</details>

<h3>Confidence Score: 5/5</h3>

The refactoring is behaviour-preserving: all existing error-handling branches, best-effort swallows, and status-specific guards were carried over faithfully; the gate passes 28/28 tasks.

Every migrated call site was reviewed. The forge adapter correctly wraps Octokit, the fake is realistic enough to replace the hand-built mock, and forgeErrorStatus() consistently replaces instanceof RequestError throughout. The one catch block in runStandingPRMerge that accesses err.response.data.message is Octokit-specific but harmlessly degrades to 'unknown reason' for other adapters — it does not affect current behaviour.

packages/release/src/standing-pr/standing-pr.ts — the 405 catch block in runStandingPRMerge is the only call site that bypasses forgeErrorStatus.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/forge/src/types.ts | New vendor-neutral Forge interface and plain data types — clean, well-documented seam definition with no leakage of Octokit types. |
| packages/forge/src/github.ts | GitHubForge Octokit adapter — correctly maps all Octokit responses to plain types; isAlreadyExistsError distinguishes idempotent 422 from real validation failures; listReleases is correctly bounded by MAX_RELEASE_PAGES. |
| packages/forge/src/fake.ts | FakeForge in-memory test adapter — realistic marker-upsert and idempotent createLabel; limit is now respected in listRecentlyClosedPullRequests; branch parameter is intentionally ignored (underscore-prefixed). |
| packages/forge/src/errors.ts | forgeErrorStatus utility — replaces instanceof RequestError checks with duck-typed status extraction that works across any forge adapter. |
| packages/release/src/standing-pr/standing-pr.ts | Large migration to forge — all Octokit calls replaced; one call site (runStandingPRMerge 405 check) still accesses Octokit-specific err.response.data.message instead of using forgeErrorStatus. |
| packages/release/src/github.ts | Forge adapter wrapper — createOctokit replaced by forgeFor; all helper functions simplified to take Forge instead of Octokit+owner+repo; postOrUpdateComment now delegates to forge.upsertMarkerComment. |
| packages/notes/src/output/github-release.ts | GitHubClient migrated to forge — forge injection parameter added for testability; createRelease/updateRelease/getReleaseByTag all delegate to forge correctly. |
| packages/notes/src/llm/context/prFetcher.ts | Migrated from Octokit to forge with forgeErrorStatus replacing instanceof RequestError — status-specific error handling (401/403/404) is preserved and now forge-agnostic. |
| packages/notes/src/llm/examples/fetcher.ts | Examples fetcher migrated to forge; forge option added for test injection; pagination bound moved into GitHubForge adapter. |
| packages/release/src/failure-report/post.ts | PostFailureReportContext migrated from octokit+owner+repo to forge; detectUnresolvedFailure also takes Forge directly; all existing error handling preserved. |
| packages/release/src/label-definitions.ts | syncLabels and checkLabels migrated to Forge; isAlreadyExistsError logic correctly moved into GitHubForge.createLabel; CreateLabelResult discriminant cleanly replaces the old try/catch idiom. |
| packages/forge/test/unit/github.spec.ts | Comprehensive adapter tests covering createLabel idempotency, pagination cap (3-page stop), marker upsert, and all CRUD operations. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller as release / notes caller
    participant GH as github.ts / forgeFor()
    participant FI as Forge interface
    participant GHF as GitHubForge (prod)
    participant FF as FakeForge (tests)
    participant OC as Octokit (single instance)

    Caller->>GH: forgeFor(githubContext)
    GH->>GHF: "createGitHubForge({token,owner,repo})"
    GHF->>OC: "new Octokit({auth:token})"

    Caller->>FI: forge.findStandingPR(branch)
    FI->>GHF: octokit.rest.pulls.list(...)
    GHF-->>FI: StandingPullRequest or null

    Note over Caller,FF: In tests
    Caller->>FF: createFakeForge(seed)
    Caller->>FI: forge.upsertMarkerComment(prNumber, marker, body)
    FI->>FF: findComment then createComment or updateComment
    FF-->>Caller: recorded in createdComments / updatedComments
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller as release / notes caller
    participant GH as github.ts / forgeFor()
    participant FI as Forge interface
    participant GHF as GitHubForge (prod)
    participant FF as FakeForge (tests)
    participant OC as Octokit (single instance)

    Caller->>GH: forgeFor(githubContext)
    GH->>GHF: "createGitHubForge({token,owner,repo})"
    GHF->>OC: "new Octokit({auth:token})"

    Caller->>FI: forge.findStandingPR(branch)
    FI->>GHF: octokit.rest.pulls.list(...)
    GHF-->>FI: StandingPullRequest or null

    Note over Caller,FF: In tests
    Caller->>FF: createFakeForge(seed)
    Caller->>FI: forge.upsertMarkerComment(prNumber, marker, body)
    FI->>FF: findComment then createComment or updateComment
    FF-->>Caller: recorded in createdComments / updatedComments
```

</a>
</details>

<sub>Reviews (6): Last reviewed commit: ["refactor(release): reuse forge&#39;s CommitS..."](https://github.com/goosewobbler/releasekit/commit/ad32b001a875f66ae7e2200f0467a9291d564052) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39027251)</sub>

<!-- /greptile_comment -->