### PR TITLE
refactor(core): one marker codec for machine state behind markers (#360)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -28,3 +28,12 @@ Conflating these is the historical source of the `fix(version)` bug cluster (#33
 
 - **Forge** — the *remote* hosting platform's collaboration API: pull requests, marker comments, labels, commit statuses, releases. GitHub is the only forge today; GitLab/Bitbucket would be additional **adapters** behind the same `Forge` interface (`@releasekit/forge`: `Forge` interface + `GitHubForge` octokit adapter + in-memory fake). Returns plain data — never leaks Octokit types — so a second forge is a new adapter with zero caller changes.
 - **Not** the **git** layer — `git` is the *local* CLI (tags, log, commit, push, status; no token, no PR concept); a forge is the *server-side API* over HTTP with a token. A release run uses both at once.
+
+## Marker codec — machine state behind its own marker
+
+The AGENTS.md invariant ("machine state embedded in comments uses its own marker line — never parse the human-facing prose") is owned by `@releasekit/core`'s marker codec, in two shapes:
+
+- **`markerData<T>`** — a single typed datum on one `<!-- open payload -->` line (manifest base64 blob; failure-report `status`/`data` fields). `encode(T)→line`, `decode(body)→T|null` by linear delimiter slicing (no backtracking regex → no ReDoS).
+- **`markerRegion`** (`wrapMarkerRegion`/`extractMarkerRegion`) — a span of editable content between a distinct open/close marker pair (the editable release-notes region; the future checkbox-selection block). `notes-region` is an adapter over it.
+
+The *find + idempotent upsert* of the whole comment is a separate concern, owned by the **[[forge]]** (`findComment`/`upsertMarkerComment`). Prose-only bot comments (preview, gate-notify) carry no machine state and just upsert a marker-keyed body.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -21,6 +21,7 @@ export {
   trace,
   warn,
 } from './logger.js';
+export { extractMarkerRegion, type MarkerData, markerData, wrapMarkerRegion } from './marker.js';
 export {
   extractNotesRegion,
   NOTES_MARKER,

--- a/packages/core/src/marker.ts
+++ b/packages/core/src/marker.ts
@@ -42,13 +42,17 @@ export function markerData<T>(opts: {
   serialize: (value: T) => string;
   deserialize: (payload: string) => T | null;
 }): MarkerData<T> {
-  const close = opts.close ?? '-->';
+  // The marker format is `<open> <payload> <close>` (space-separated). Bake those spaces into the
+  // delimiters so the opening match is specific: `<!-- base64 ` won't latch onto a stray
+  // `<!-- base64url …` marker (preserving the old regex's specificity without a regex).
+  const open = `${opts.open} `;
+  const close = ` ${opts.close ?? '-->'}`;
   return {
     encode(value) {
-      return `${opts.open} ${opts.serialize(value)} ${close}`;
+      return `${open}${opts.serialize(value)}${close}`;
     },
     decode(body) {
-      const payload = sliceBetween(body, opts.open, close, false);
+      const payload = sliceBetween(body, open, close, false);
       return payload === undefined ? null : opts.deserialize(payload);
     },
   };

--- a/packages/core/src/marker.ts
+++ b/packages/core/src/marker.ts
@@ -1,0 +1,69 @@
+/**
+ * Codecs for machine state carried in HTML-comment markers inside round-trippable surfaces (PR
+ * comments, PR/release bodies). One place owns the AGENTS.md invariant: machine state lives behind
+ * its own marker and is read by slicing fixed delimiters — never by parsing the human-facing prose,
+ * and never with a backtracking regex (which is a ReDoS risk on untrusted bodies).
+ *
+ * Two shapes:
+ * - {@link markerData} — a single typed datum on one `<!-- open payload close -->` line (e.g. a
+ *   status flag, a JSON headline, a base64 blob).
+ * - {@link extractMarkerRegion} / {@link wrapMarkerRegion} — a span of editable content delimited by
+ *   a distinct open/close marker pair (e.g. an editable release-notes region, a selection block).
+ */
+
+/** Linear extract of the trimmed text between `open` and `close`. */
+function sliceBetween(body: string, open: string, close: string, restIfNoClose: boolean): string | undefined {
+  const start = body.indexOf(open);
+  if (start === -1) return undefined;
+  const from = start + open.length;
+  const end = body.indexOf(close, from);
+  if (end === -1) return restIfNoClose ? body.slice(from).trim() : undefined;
+  return body.slice(from, end).trim();
+}
+
+/** A typed datum carried in its own HTML-comment marker. */
+export interface MarkerData<T> {
+  /** Render the value as a `<!-- open payload close -->` marker line. */
+  encode(value: T): string;
+  /** Extract and parse the payload from a body, or null when the marker is absent/malformed. */
+  decode(body: string): T | null;
+}
+
+/**
+ * Build a codec for a single typed datum living behind its own marker. The payload is whatever sits
+ * between `open` and `close`; `serialize`/`deserialize` map it to/from `T`. `deserialize` returns
+ * null to reject a malformed payload (the caller decides whether that means "absent" or an error).
+ */
+export function markerData<T>(opts: {
+  /** Opening token, e.g. `<!-- releasekit-publish-failure-data:`. */
+  open: string;
+  /** Closing token; defaults to the HTML-comment terminator. */
+  close?: string;
+  serialize: (value: T) => string;
+  deserialize: (payload: string) => T | null;
+}): MarkerData<T> {
+  const close = opts.close ?? '-->';
+  return {
+    encode(value) {
+      return `${opts.open} ${opts.serialize(value)} ${close}`;
+    },
+    decode(body) {
+      const payload = sliceBetween(body, opts.open, close, false);
+      return payload === undefined ? null : opts.deserialize(payload);
+    },
+  };
+}
+
+/** Wrap editable content in an open/close marker pair so it can be recognised and extracted later. */
+export function wrapMarkerRegion(content: string, open: string, close: string): string {
+  return `${open}\n\n${content.trim()}\n\n${close}`;
+}
+
+/**
+ * Extract the content of an open/close-delimited region, or undefined when the opener is absent.
+ * Pure marker slicing — never interprets the prose. When the closer is missing (a legacy body that
+ * only carried the opener), returns everything after the opener so older bodies still round-trip.
+ */
+export function extractMarkerRegion(body: string, open: string, close: string): string | undefined {
+  return sliceBetween(body, open, close, true);
+}

--- a/packages/core/src/notesRegion.ts
+++ b/packages/core/src/notesRegion.ts
@@ -11,6 +11,8 @@
  * Multiple packages share one surface (a multi-package standing PR) by keying the markers:
  * `<!-- releasekit-notes:<key> -->` … `<!-- releasekit-notes-end:<key> -->`.
  */
+import { extractMarkerRegion, wrapMarkerRegion } from './marker.js';
+
 export const NOTES_MARKER = '<!-- releasekit-notes -->';
 export const NOTES_MARKER_END = '<!-- releasekit-notes-end -->';
 
@@ -24,23 +26,14 @@ function closeMarker(pkgKey?: string): string {
 
 /** Wrap rendered notes in the editable-region markers so they can be recognised and extracted later. */
 export function wrapNotesRegion(content: string, pkgKey?: string): string {
-  return `${openMarker(pkgKey)}\n\n${content.trim()}\n\n${closeMarker(pkgKey)}`;
+  return wrapMarkerRegion(content, openMarker(pkgKey), closeMarker(pkgKey));
 }
 
 /**
- * Extract the editable-region content from a body, or `undefined` when the opener is absent.
- *
- * Pure marker slicing — it never interprets the prose. An opener with no closer (a legacy body
- * backfilled when only the opener was prepended) falls back to "everything after the opener", so
- * older release bodies still round-trip.
+ * Extract the editable-region content from a body, or `undefined` when the opener is absent. The
+ * notes-region adapter over {@link extractMarkerRegion}: pure marker slicing, with the legacy
+ * "opener but no closer" body falling back to everything after the opener.
  */
 export function extractNotesRegion(body: string, pkgKey?: string): string | undefined {
-  const open = openMarker(pkgKey);
-  const start = body.indexOf(open);
-  if (start === -1) return undefined;
-
-  const afterOpen = start + open.length;
-  const end = body.indexOf(closeMarker(pkgKey), afterOpen);
-  const region = end === -1 ? body.slice(afterOpen) : body.slice(afterOpen, end);
-  return region.trim();
+  return extractMarkerRegion(body, openMarker(pkgKey), closeMarker(pkgKey));
 }

--- a/packages/core/test/unit/marker.spec.ts
+++ b/packages/core/test/unit/marker.spec.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { extractMarkerRegion, markerData, wrapMarkerRegion } from '../../src/marker.js';
+
+describe('markerData', () => {
+  const field = markerData<{ n: number }>({
+    open: '<!-- demo-data:',
+    serialize: (v) => JSON.stringify(v),
+    deserialize: (raw) => {
+      try {
+        const p = JSON.parse(raw);
+        return typeof p.n === 'number' ? { n: p.n } : null;
+      } catch {
+        return null;
+      }
+    },
+  });
+
+  it('should round-trip a value through encode/decode, ignoring surrounding prose', () => {
+    expect(field.encode({ n: 5 })).toBe('<!-- demo-data: {"n":5} -->');
+    expect(field.decode(`## heading\n${field.encode({ n: 5 })}\nmore prose`)).toEqual({ n: 5 });
+  });
+
+  it('should return null when the marker is absent', () => {
+    expect(field.decode('no marker here')).toBeNull();
+  });
+
+  it('should return null when the payload is malformed (deserialize rejects)', () => {
+    expect(field.decode('<!-- demo-data: not-json -->')).toBeNull();
+    expect(field.decode('<!-- demo-data: {"n":"x"} -->')).toBeNull();
+  });
+
+  it('should be linear (ReDoS-safe) on a long unterminated marker', () => {
+    // A backtracking regex would hang here; the indexOf slice returns immediately.
+    expect(field.decode(`<!-- demo-data:${'{'.repeat(100000)}`)).toBeNull();
+  });
+
+  it('should honour a custom-spaced open token (the manifest base64 shape)', () => {
+    const base64 = markerData<string>({ open: '<!-- base64', serialize: (s) => s, deserialize: (s) => s || null });
+    expect(base64.encode('QUJD')).toBe('<!-- base64 QUJD -->');
+    expect(base64.decode('<details>\n<!-- base64 QUJD -->\n</details>')).toBe('QUJD');
+  });
+});
+
+describe('marker region', () => {
+  const open = '<!-- region:x -->';
+  const close = '<!-- region-end:x -->';
+
+  it('should wrap content and extract it back', () => {
+    const wrapped = wrapMarkerRegion('edited notes', open, close);
+    expect(extractMarkerRegion(`before\n${wrapped}\nafter`, open, close)).toBe('edited notes');
+  });
+
+  it('should return undefined when the opener is absent', () => {
+    expect(extractMarkerRegion('nothing here', open, close)).toBeUndefined();
+  });
+
+  it('should fall back to everything after the opener when the closer is missing', () => {
+    expect(extractMarkerRegion(`${open}\n\nlegacy body content`, open, close)).toBe('legacy body content');
+  });
+});

--- a/packages/core/test/unit/marker.spec.ts
+++ b/packages/core/test/unit/marker.spec.ts
@@ -39,6 +39,13 @@ describe('markerData', () => {
     expect(base64.encode('QUJD')).toBe('<!-- base64 QUJD -->');
     expect(base64.decode('<details>\n<!-- base64 QUJD -->\n</details>')).toBe('QUJD');
   });
+
+  it('should not latch onto a broader-prefixed marker before the real one', () => {
+    // `<!-- base64 ` (with the trailing space) must skip a stray `<!-- base64url … -->` and find the
+    // actual manifest marker that follows.
+    const base64 = markerData<string>({ open: '<!-- base64', serialize: (s) => s, deserialize: (s) => s || null });
+    expect(base64.decode('<!-- base64url not-the-manifest -->\n<!-- base64 QUJD -->')).toBe('QUJD');
+  });
 });
 
 describe('marker region', () => {

--- a/packages/core/test/unit/marker.spec.ts
+++ b/packages/core/test/unit/marker.spec.ts
@@ -29,9 +29,11 @@ describe('markerData', () => {
     expect(field.decode('<!-- demo-data: {"n":"x"} -->')).toBeNull();
   });
 
-  it('should be linear (ReDoS-safe) on a long unterminated marker', () => {
-    // A backtracking regex would hang here; the indexOf slice returns immediately.
-    expect(field.decode(`<!-- demo-data:${'{'.repeat(100000)}`)).toBeNull();
+  it('should be linear (ReDoS-safe) scanning a long unterminated payload', () => {
+    // The opener IS matched (note the space after the colon), then the closer is scanned over a
+    // huge payload with no terminator. A backtracking regex would blow up here; the linear indexOf
+    // for the closer returns immediately (no close → null).
+    expect(field.decode(`<!-- demo-data: ${'{'.repeat(100000)}`)).toBeNull();
   });
 
   it('should honour a custom-spaced open token (the manifest base64 shape)', () => {

--- a/packages/release/src/failure-report/failure-report.ts
+++ b/packages/release/src/failure-report/failure-report.ts
@@ -1,4 +1,4 @@
-import type { VersionOutput } from '@releasekit/core';
+import { markerData, type VersionOutput } from '@releasekit/core';
 import type { PublishOutput } from '@releasekit/publish';
 import { ATTRIBUTION_FOOTER } from '../attribution.js';
 import { publishableUpdates, syncVersionDisplay } from '../version-display.js';
@@ -32,6 +32,34 @@ export interface FailureReportData {
   published: number;
   total: number;
 }
+
+/** Resolution status carried behind its own marker. */
+const STATUS_FIELD = markerData<FailureReportStatus>({
+  open: STATUS_PREFIX,
+  serialize: (status) => status,
+  deserialize: (payload) => (payload === 'resolved' || payload === 'unresolved' ? payload : null),
+});
+
+/** Headline data (label + published/total) carried as JSON behind its own marker. */
+const DATA_FIELD = markerData<FailureReportData>({
+  open: DATA_PREFIX,
+  serialize: (data) => JSON.stringify(data),
+  deserialize: (payload) => {
+    try {
+      const parsed = JSON.parse(payload) as Partial<FailureReportData>;
+      if (
+        typeof parsed.label !== 'string' ||
+        typeof parsed.published !== 'number' ||
+        typeof parsed.total !== 'number'
+      ) {
+        return null;
+      }
+      return { label: parsed.label, published: parsed.published, total: parsed.total };
+    } catch {
+      return null;
+    }
+  },
+});
 
 /** Release mode the failed publish ran in — drives the recovery instructions. */
 export type FailureReportMode = 'standing-pr' | 'direct' | 'manual';
@@ -207,8 +235,8 @@ export function renderFailureReport(input: FailureReportInput): string {
 
   const lines: string[] = [
     FAILURE_MARKER,
-    `${STATUS_PREFIX} unresolved -->`,
-    `${DATA_PREFIX} ${JSON.stringify({ label, published, total } satisfies FailureReportData)} -->`,
+    STATUS_FIELD.encode('unresolved'),
+    DATA_FIELD.encode({ label, published, total }),
     '',
     `## ❌ Publish of ${label} failed partway through`,
     '',
@@ -256,7 +284,7 @@ export function renderResolvedReport(versionOutput: VersionOutput): string {
   const label = releaseLabel(versionOutput);
   return [
     FAILURE_MARKER,
-    `${STATUS_PREFIX} resolved -->`,
+    STATUS_FIELD.encode('resolved'),
     '',
     `## ✅ Publish of ${label} recovered`,
     '',
@@ -274,8 +302,7 @@ export function renderResolvedReport(versionOutput: VersionOutput): string {
  */
 export function parseFailureReportStatus(body: string): FailureReportStatus | null {
   if (!body.startsWith(FAILURE_MARKER)) return null;
-  const match = body.match(/<!-- releasekit-publish-failure-status:\s*(unresolved|resolved)\s*-->/);
-  return (match?.[1] as FailureReportStatus | undefined) ?? 'unresolved';
+  return STATUS_FIELD.decode(body) ?? 'unresolved';
 }
 
 /**
@@ -284,23 +311,7 @@ export function parseFailureReportStatus(body: string): FailureReportStatus | nu
  */
 export function parseFailureReportData(body: string): FailureReportData | null {
   if (!body.startsWith(FAILURE_MARKER)) return null;
-  // Locate the data block by its fixed delimiters with linear indexOf rather than a backtracking
-  // regex — a regex like `:\s*(\{.*?\})\s*-->` is polynomial on an untrusted comment body with many
-  // `{` and no terminator (ReDoS). JSON.parse + the field checks below still reject anything malformed.
-  const prefix = '<!-- releasekit-publish-failure-data:';
-  const start = body.indexOf(prefix);
-  if (start === -1) return null;
-  const end = body.indexOf('-->', start + prefix.length);
-  if (end === -1) return null;
-  try {
-    const parsed = JSON.parse(body.slice(start + prefix.length, end).trim()) as Partial<FailureReportData>;
-    if (typeof parsed.label !== 'string' || typeof parsed.published !== 'number' || typeof parsed.total !== 'number') {
-      return null;
-    }
-    return { label: parsed.label, published: parsed.published, total: parsed.total };
-  } catch {
-    return null;
-  }
+  return DATA_FIELD.decode(body);
 }
 
 export interface SupersedeWarningInput {

--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -3,7 +3,7 @@ import { execFileSync, execSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import { type CIConfig, loadConfig as loadReleaseKitConfig } from '@releasekit/config';
 import type { VersionOutput } from '@releasekit/core';
-import { error, info, success, warn } from '@releasekit/core';
+import { error, info, markerData, success, warn } from '@releasekit/core';
 import { type Forge, forgeErrorStatus, type PullRequestDetails } from '@releasekit/forge';
 import { PipelineError } from '@releasekit/publish';
 import { ATTRIBUTION_FOOTER } from '../attribution.js';
@@ -23,6 +23,14 @@ import { postStandingPRStatusSafe } from './status.js';
 const MANIFEST_MARKER = '<!-- releasekit-manifest -->';
 const MANIFEST_SCHEMA_VERSION = 2;
 const MANIFEST_SCHEMA_MIN_VERSION = 1;
+
+// The manifest payload rides as a base64 blob in its own marker; base64/JSON/schema decoding (with
+// its specific error messages) stays in parseManifest below.
+const MANIFEST_BASE64 = markerData<string>({
+  open: '<!-- base64',
+  serialize: (encoded) => encoded,
+  deserialize: (payload) => payload || null,
+});
 
 export interface StandingPROptions {
   config?: string;
@@ -435,27 +443,26 @@ function renderPrBody(versionOutput: VersionOutput, supersedeWarning?: string[],
 }
 
 export function serializeManifest(m: StandingPRManifest): string {
-  const json = JSON.stringify(m);
-  const encoded = Buffer.from(json).toString('base64');
+  const encoded = Buffer.from(JSON.stringify(m)).toString('base64');
   return [
     MANIFEST_MARKER,
     '<details><summary>Release manifest (do not edit)</summary>',
     '',
-    `<!-- base64 ${encoded} -->`,
+    MANIFEST_BASE64.encode(encoded),
     '',
     '</details>',
   ].join('\n');
 }
 
 export function parseManifest(commentBody: string): StandingPRManifest {
-  const b64Match = commentBody.match(/<!-- base64 ([A-Za-z0-9+/=]+) -->/);
-  if (!b64Match?.[1]) {
+  const encoded = MANIFEST_BASE64.decode(commentBody);
+  if (!encoded) {
     throw new Error('Release manifest not found or malformed in PR comment');
   }
 
   let json: string;
   try {
-    json = Buffer.from(b64Match[1], 'base64').toString('utf-8');
+    json = Buffer.from(encoded, 'base64').toString('utf-8');
   } catch {
     throw new Error('Release manifest encoding is invalid');
   }


### PR DESCRIPTION
## What

Closes #360. Four bot-comment types each hand-rolled the encode/decode of machine state in HTML markers; this consolidates that into one codec in `@releasekit/core`.

> Scope note: the issue framed this as "one `MarkerComment<T>` for all four comment types." But after #358 the **find + idempotent upsert** half already lives in the forge (`findComment` / `upsertMarkerComment`), and the marker types aren't uniform — so this lands the genuinely-shared part (the typed encode/decode) and leaves the rest where it belongs. See the table.

| Site | Shape | Before | After |
|---|---|---|---|
| manifest | typed-payload | `/<!-- base64 (…) -->/` regex | `markerData<string>` |
| failure-report `status` | embedded field | `/…status:\s*(…)\s*-->/` regex | `markerData<FailureReportStatus>` |
| failure-report `data` | embedded field | **ReDoS** regex (hand-patched in #387) | `markerData<FailureReportData>` |
| notes-region | open/close region | bespoke `indexOf` slicing | `markerRegion` adapter |
| preview, gate-notify | prose comment | — (no machine state) | unchanged — `forge.upsertMarkerComment` |

## The codec (`@releasekit/core/marker.ts`)
- **`markerData<T>`** — a single typed datum on one `<!-- open payload -->` line. `encode(T)→line`, `decode(body)→T|null` by **linear delimiter slicing** — so it's ReDoS-safe by construction (the failure-report `data` ReDoS the #387 hotfix patched by hand is now structurally impossible).
- **`wrapMarkerRegion`/`extractMarkerRegion`** — a span between a distinct open/close marker pair (with the legacy "opener but no closer" round-trip fallback). `core/notesRegion` is now an adapter over it.

## Why a region primitive too (the option we discussed)
#360 blocks #367, and #367's checkbox-selection block is a **region** (open/close), structurally a sibling of notes-region — not a data field. Lifting notes-region's slicing into `markerRegion` now means #367 becomes a **second adapter** (typed decode of checkbox state) rather than a 5th bespoke parser. That's the whole reason #360 sits before #367.

## Acceptance criteria
- [x] Single codec drives the marker machine-state; per-type adapters only declare encode/decode (serialize/deserialize)
- [x] Idempotent upsert defined once (in the forge, from #358)
- [x] Fragile regex parsing of machine state retired in favour of typed, linear decode
- [x] encode/decode covered by direct unit tests (`core/test/unit/marker.spec.ts`)
- [x] Behaviour unchanged; affected suites green (manifest / failure-report / notes-region); full gate (`lint typecheck test:coverage`) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR consolidates four hand-rolled encode/decode implementations (regex + bespoke `indexOf` slicing) into a single typed codec in `@releasekit/core`, retiring the ReDoS-vulnerable `failure-report data` regex that was hot-patched in #387 by construction rather than by patch.

- **`packages/core/src/marker.ts`** introduces `markerData<T>` (linear `indexOf` codec for single-datum markers) and `wrapMarkerRegion`/`extractMarkerRegion` (open/close region primitives). The trailing-space baking in `markerData` preserves the specificity of the old regexes (e.g. `<!-- base64 ` vs `<!-- base64url`) without any backtracking.
- **`failure-report.ts`** and **`standing-pr.ts`** become thin adapters: `STATUS_FIELD`, `DATA_FIELD`, and `MANIFEST_BASE64` each declare only their `serialize`/`deserialize` logic; the encode/decode mechanics are shared. Encoded output format is byte-identical to the previous hand-rolled strings, so persisted comment bodies round-trip correctly.
- **`notesRegion.ts`** is refactored to delegate to the new region primitives, and unit tests in `marker.spec.ts` cover round-trip, absent/malformed markers, ReDoS safety, and the broader-prefix disambiguation case.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — a structural refactor with no behaviour change, backed by identical encoded output and direct unit tests on the new codec.

Every encoded string produced by the new codec is byte-identical to what the old hand-rolled code produced, so existing persisted comment bodies decode correctly. The ReDoS fix from #387 is now structurally impossible rather than patched-in-place. Unit tests cover the key edge cases (round-trip, absent marker, malformed payload, ReDoS probe, broader-prefix disambiguation, legacy no-closer fallback) and the affected integration suites are reported green.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/core/src/marker.ts | New shared codec module — `markerData<T>` and `markerRegion` primitives implemented correctly with linear `indexOf` slicing, proper space-baking for specificity, and sound null semantics throughout. |
| packages/core/src/notesRegion.ts | Clean thin adapter over `extractMarkerRegion`/`wrapMarkerRegion`; behaviour identical to the removed bespoke `indexOf` slicing. |
| packages/release/src/failure-report/failure-report.ts | STATUS_FIELD and DATA_FIELD codecs replace hand-rolled regex/indexOf parsing. Encoded format is byte-identical to the previous output, preserving backward compat with persisted comments. |
| packages/release/src/standing-pr/standing-pr.ts | MANIFEST_BASE64 codec replaces the old regex. Trailing-space baking in `markerData` ensures `<!-- base64url …` markers are skipped. Encoded format unchanged. |
| packages/core/test/unit/marker.spec.ts | Good unit coverage: round-trip, absent/malformed marker, ReDoS safety, custom-spaced open token, and the broader-prefix disambiguation case are all exercised. |
| CONTEXT.md | Documentation update describing the two codec shapes and the ownership split between core (codec) and forge (upsert). |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph core ["@releasekit/core — marker.ts (new)"]
        SD["sliceBetween(body, open, close, restIfNoClose)\nlinear indexOf — no backtracking"]
        MD["markerData<T>\nencode(value) → line\ndecode(body) → T | null"]
        WR["wrapMarkerRegion(content, open, close)"]
        ER["extractMarkerRegion(body, open, close)\nrestIfNoClose=true for legacy fallback"]
        SD --> MD
        SD --> ER
    end

    subgraph release ["@releasekit/release adapters"]
        SF["STATUS_FIELD\nmarkerData<FailureReportStatus>"]
        DF["DATA_FIELD\nmarkerData<FailureReportData>"]
        MB["MANIFEST_BASE64\nmarkerData<string>"]
    end

    subgraph notesRegion ["@releasekit/core — notesRegion.ts"]
        WNR["wrapNotesRegion → wrapMarkerRegion"]
        ENR["extractNotesRegion → extractMarkerRegion"]
    end

    MD --> SF
    MD --> DF
    MD --> MB
    WR --> WNR
    ER --> ENR

    SF -->|"parseFailureReportStatus / renderFailureReport"| FR["failure-report.ts"]
    DF -->|"parseFailureReportData / renderFailureReport"| FR
    MB -->|"serializeManifest / parseManifest"| SPR["standing-pr.ts"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    subgraph core ["@releasekit/core — marker.ts (new)"]
        SD["sliceBetween(body, open, close, restIfNoClose)\nlinear indexOf — no backtracking"]
        MD["markerData<T>\nencode(value) → line\ndecode(body) → T | null"]
        WR["wrapMarkerRegion(content, open, close)"]
        ER["extractMarkerRegion(body, open, close)\nrestIfNoClose=true for legacy fallback"]
        SD --> MD
        SD --> ER
    end

    subgraph release ["@releasekit/release adapters"]
        SF["STATUS_FIELD\nmarkerData<FailureReportStatus>"]
        DF["DATA_FIELD\nmarkerData<FailureReportData>"]
        MB["MANIFEST_BASE64\nmarkerData<string>"]
    end

    subgraph notesRegion ["@releasekit/core — notesRegion.ts"]
        WNR["wrapNotesRegion → wrapMarkerRegion"]
        ENR["extractNotesRegion → extractMarkerRegion"]
    end

    MD --> SF
    MD --> DF
    MD --> MB
    WR --> WNR
    ER --> ENR

    SF -->|"parseFailureReportStatus / renderFailureReport"| FR["failure-report.ts"]
    DF -->|"parseFailureReportData / renderFailureReport"| FR
    MB -->|"serializeManifest / parseManifest"| SPR["standing-pr.ts"]
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["test(core): exercise the open-matched pa..."](https://github.com/goosewobbler/releasekit/commit/7e022ecaf3027fb5f684c92a0fd358aea6953a97) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39049853)</sub>

<!-- /greptile_comment -->