### PR TITLE
feat(release): standing-PR target + derive UX via release:with-prerequisites (#366)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -404,6 +404,7 @@ PR label names used for release control. Override to match your repository's lab
 | `major` | string | `"bump:major"` | Label to force a major bump |
 | `minor` | string | `"bump:minor"` | Label to force a minor bump |
 | `patch` | string | `"bump:patch"` | Label to force a patch bump |
+| `withPrerequisites` | string | `"release:with-prerequisites"` | Label on the standing PR that also releases the changed prerequisites (transitive internal dependencies) of the targeted/scoped packages — each at its own commit-driven bump. Standing-pr mode only. |
 
 ### `ci.standingPr`
 

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -512,6 +512,12 @@ export const CILabelsConfigSchema = z.object({
   major: z.string().default('bump:major').describe('Label to force a major bump'),
   minor: z.string().default('bump:minor').describe('Label to force a minor bump'),
   patch: z.string().default('bump:patch').describe('Label to force a patch bump'),
+  withPrerequisites: z
+    .string()
+    .default('release:with-prerequisites')
+    .describe(
+      'Label on the standing PR that also releases the changed prerequisites (transitive internal dependencies) of the targeted/scoped packages — each at its own commit-driven bump. Standing-pr mode only.',
+    ),
 });
 
 export const StandingPrConfigSchema = z.object({
@@ -590,6 +596,7 @@ export const CIConfigSchema = z.object({
     major: 'bump:major',
     minor: 'bump:minor',
     patch: 'bump:patch',
+    withPrerequisites: 'release:with-prerequisites',
   }).describe("PR label names used for release control. Override to match your repository's label conventions."),
   scopeLabels: z
     .record(z.string(), z.string())

--- a/packages/config/test/unit/schema.spec.ts
+++ b/packages/config/test/unit/schema.spec.ts
@@ -517,6 +517,7 @@ describe('CIConfigSchema', () => {
       major: 'bump:major',
       minor: 'bump:minor',
       patch: 'bump:patch',
+      withPrerequisites: 'release:with-prerequisites',
     });
   });
 

--- a/packages/core/src/prerequisites.ts
+++ b/packages/core/src/prerequisites.ts
@@ -25,6 +25,12 @@ export interface PrerequisiteResolution {
   prerequisites: string[];
   /** Everything that will release: targets ∪ prerequisites. */
   targetSet: Set<string>;
+  /**
+   * For each derived prerequisite, the explicit target(s) that pulled it in (i.e. the targets that
+   * transitively depend on it). A shared dependency can serve several targets. Lets callers render
+   * "target → its prerequisites" without re-walking the graph.
+   */
+  prerequisiteOf: Record<string, string[]>;
 }
 
 export function resolvePrerequisites(
@@ -35,11 +41,16 @@ export function resolvePrerequisites(
   const changed = new Set(changedPackages);
   const targetSet = new Set(explicitTargets);
   const prereqSet = new Set<string>();
+  const prerequisiteOf: Record<string, string[]> = {};
 
   for (const target of explicitTargets) {
     for (const dep of graph.transitiveDependencies(target)) {
       // A dependency is a prerequisite only when it actually changed and isn't itself a target.
-      if (changed.has(dep) && !targetSet.has(dep)) prereqSet.add(dep);
+      // `targetSet` here still holds only the explicit targets (prerequisites are added below).
+      if (changed.has(dep) && !targetSet.has(dep)) {
+        prereqSet.add(dep);
+        prerequisiteOf[dep] = [...(prerequisiteOf[dep] ?? []), target];
+      }
     }
   }
   for (const name of prereqSet) targetSet.add(name);
@@ -49,6 +60,6 @@ export function resolvePrerequisites(
   // alone would miss that cross-boundary edge (the target isn't in the slice).
   const prerequisites = graph.topologicalOrder([...targetSet]).filter((name) => prereqSet.has(name));
 
-  // Return a copy of the targets, not the caller's array, so all three fields are freshly owned.
-  return { targets: [...explicitTargets], prerequisites, targetSet };
+  // Return a copy of the targets, not the caller's array, so all fields are freshly owned.
+  return { targets: [...explicitTargets], prerequisites, targetSet, prerequisiteOf };
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -86,4 +86,18 @@ export interface VersionPackageUpdate {
    * expand a scope label that matches part of a group to the whole group).
    */
   group?: string;
+  /**
+   * Role in a `--include-prerequisites` release: `'target'` for an explicitly-selected
+   * (group-expanded) package that receives the bump/prerelease/stable override, `'prerequisite'`
+   * for a changed transitive dependency pulled in to keep the targets installable (it keeps its own
+   * commit-driven bump). Absent on plain releases and for the root lockstep bump — consumers treat
+   * an absent role as a target.
+   */
+  role?: 'target' | 'prerequisite';
+  /**
+   * For a `'prerequisite'` update, the target package(s) it was pulled in for (a shared dependency
+   * can serve several). Lets CI surfaces render "target → its prerequisites" without re-deriving
+   * the dependency graph. Absent for targets.
+   */
+  prerequisiteOf?: string[];
 }

--- a/packages/core/test/unit/prerequisites.spec.ts
+++ b/packages/core/test/unit/prerequisites.spec.ts
@@ -68,6 +68,19 @@ describe('resolvePrerequisites', () => {
     expect(prerequisites).toEqual(['core']);
   });
 
+  it('should record which target each prerequisite was pulled in for', () => {
+    const { prerequisiteOf } = resolvePrerequisites(graph, ['app'], ['app', 'utils', 'types', 'core']);
+    expect(prerequisiteOf.utils).toEqual(['app']);
+    expect(prerequisiteOf.types).toEqual(['app']);
+    expect(prerequisiteOf.core).toEqual(['app']);
+  });
+
+  it('should list a shared prerequisite under every target that depends on it', () => {
+    // Both utils and types depend on core, so core is a prerequisite of both.
+    const { prerequisiteOf } = resolvePrerequisites(graph, ['utils', 'types'], ['utils', 'types', 'core']);
+    expect(new Set(prerequisiteOf.core)).toEqual(new Set(['utils', 'types']));
+  });
+
   it('should not throw and derive nothing for a target outside the graph', () => {
     const { targets, prerequisites } = resolvePrerequisites(graph, ['ghost'], ['ghost', 'core']);
     expect(targets).toEqual(['ghost']);

--- a/packages/release/src/label-definitions.ts
+++ b/packages/release/src/label-definitions.ts
@@ -57,6 +57,11 @@ export function deriveLabelDefinitions(ciConfig: CIConfig | undefined): LabelDef
       color: COLOR_RELEASE,
       description: 'ReleaseKit: generate editable release notes in the standing PR body',
     },
+    {
+      name: labels.withPrerequisites,
+      color: COLOR_RELEASE,
+      description: "ReleaseKit: also release the targeted packages' changed prerequisites",
+    },
   ];
 
   for (const scopeLabel of Object.keys(scopeLabels)) {

--- a/packages/release/src/label-utils.ts
+++ b/packages/release/src/label-utils.ts
@@ -8,6 +8,7 @@ export interface LabelConfig {
   major: string;
   minor: string;
   patch: string;
+  withPrerequisites: string;
 }
 
 export const DEFAULT_LABELS: LabelConfig = {
@@ -20,6 +21,7 @@ export const DEFAULT_LABELS: LabelConfig = {
   major: 'bump:major',
   minor: 'bump:minor',
   patch: 'bump:patch',
+  withPrerequisites: 'release:with-prerequisites',
 };
 
 export interface LabelConflictResult {

--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -396,15 +396,26 @@ function bumpSuffix(versionOutput: VersionOutput, packageName: string, newVersio
 function renderPrerequisiteSet(versionOutput: VersionOutput, updates: VersionOutput['updates']): string[] {
   const lines = ['Merging this PR will publish the targeted packages and their changed prerequisites:', ''];
   const prerequisites = updates.filter((u) => u.role === 'prerequisite');
+  const rendered = new Set<string>();
   for (const target of updates.filter((u) => u.role === 'target')) {
     lines.push(
       `- **\`${target.packageName}\`** → ${target.newVersion}${bumpSuffix(versionOutput, target.packageName, target.newVersion)}`,
     );
+    rendered.add(target.packageName);
     for (const prereq of prerequisites.filter((p) => p.prerequisiteOf?.includes(target.packageName))) {
       lines.push(
         `  - ↳ prerequisite \`${prereq.packageName}\` → ${prereq.newVersion}${bumpSuffix(versionOutput, prereq.packageName, prereq.newVersion)}`,
       );
+      rendered.add(prereq.packageName);
     }
+  }
+  // A prerequisite whose target had no releasable change of its own never gets an update entry, so it
+  // is never tagged 'target' and nothing nests under it — yet the prerequisite still publishes. List
+  // any update not already shown flat, so the package list is never empty while a publish is pending.
+  for (const update of updates.filter((u) => !rendered.has(u.packageName))) {
+    lines.push(
+      `- \`${update.packageName}\` → ${update.newVersion}${bumpSuffix(versionOutput, update.packageName, update.newVersion)}`,
+    );
   }
   return lines;
 }

--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -6,6 +6,7 @@ import type { VersionOutput } from '@releasekit/core';
 import { error, info, markerData, success, warn } from '@releasekit/core';
 import { type Forge, forgeErrorStatus, type PullRequestDetails } from '@releasekit/forge';
 import { PipelineError } from '@releasekit/publish';
+import semver from 'semver';
 import { ATTRIBUTION_FOOTER } from '../attribution.js';
 import { formatDuration, parseDuration } from '../duration.js';
 import { renderSupersedeWarning } from '../failure-report/failure-report.js';
@@ -379,6 +380,35 @@ function truncateAtLineBoundary(text: string, maxChars: number): string {
   return lastNewline > 0 ? slice.slice(0, lastNewline) : slice;
 }
 
+/** A ` (minor)`-style bump suffix derived from the package's previous→new version, when known. */
+function bumpSuffix(versionOutput: VersionOutput, packageName: string, newVersion: string): string {
+  const previous = versionOutput.changelogs.find((c) => c.packageName === packageName)?.previousVersion;
+  if (!previous) return '';
+  const kind = semver.diff(previous, newVersion);
+  return kind ? ` (${kind})` : '';
+}
+
+/**
+ * Render the release set grouped by target → its derived prerequisites (a `--include-prerequisites`
+ * / `release:with-prerequisites` run). Each prerequisite shows its own commit-driven bump; a shared
+ * prerequisite is listed under every target that pulled it in.
+ */
+function renderPrerequisiteSet(versionOutput: VersionOutput, updates: VersionOutput['updates']): string[] {
+  const lines = ['Merging this PR will publish the targeted packages and their changed prerequisites:', ''];
+  const prerequisites = updates.filter((u) => u.role === 'prerequisite');
+  for (const target of updates.filter((u) => u.role === 'target')) {
+    lines.push(
+      `- **\`${target.packageName}\`** → ${target.newVersion}${bumpSuffix(versionOutput, target.packageName, target.newVersion)}`,
+    );
+    for (const prereq of prerequisites.filter((p) => p.prerequisiteOf?.includes(target.packageName))) {
+      lines.push(
+        `  - ↳ prerequisite \`${prereq.packageName}\` → ${prereq.newVersion}${bumpSuffix(versionOutput, prereq.packageName, prereq.newVersion)}`,
+      );
+    }
+  }
+  return lines;
+}
+
 function renderPrBody(versionOutput: VersionOutput, supersedeWarning?: string[], notesRegion?: string): string {
   // Build the body around a given changelog section so we can re-render with a truncated changelog
   // if the full one would exceed GitHub's limit, without disturbing the editable notes region.
@@ -394,7 +424,10 @@ function renderPrBody(versionOutput: VersionOutput, supersedeWarning?: string[],
     // The root lockstep bump (sync mode) is never published — keep it out of the package list.
     const updates = publishableUpdates(versionOutput);
 
-    if (versionOutput.strategy === 'sync') {
+    if (updates.some((u) => u.role === 'prerequisite')) {
+      // Prerequisite mode: group targets → their derived prerequisites instead of a flat list.
+      lines.push(...renderPrerequisiteSet(versionOutput, updates));
+    } else if (versionOutput.strategy === 'sync') {
       // Sync releases move as one unit — lead with the version; a per-row version column
       // would repeat the same value for every package.
       lines.push(`Merging this PR will publish **${syncVersionDisplay(versionOutput)}**:`, '');
@@ -564,6 +597,8 @@ interface StandingPrOverrides {
   target?: string;
   stable?: boolean;
   prerelease?: boolean;
+  /** Also release the targeted packages' changed prerequisites (the `release:with-prerequisites` label). */
+  withPrerequisites?: boolean;
   /** Human-readable conflict descriptions (used for the pending status check). Empty when no conflict. */
   conflicts: string[];
 }
@@ -583,6 +618,7 @@ function extractOverrideLabels(prLabels: string[], ciConfig: CIConfig | undefine
     labels.patch,
     labels.stable,
     labels.prerelease,
+    labels.withPrerequisites,
     ...Object.keys(scopeLabels),
   ]);
   return [...new Set(prLabels.filter((l) => relevant.has(l)))].sort();
@@ -640,7 +676,11 @@ function resolveStandingPrLabelOverrides(prLabels: string[], ciConfig: CIConfig 
   // channel:prerelease label still lets commits pick the magnitude.)
   const composedBump = stable ? undefined : bump && prerelease ? (`pre${bump}` as const) : bump;
 
-  return { bump: composedBump, target, stable, prerelease, conflicts };
+  // Orthogonal to bump/channel/scope: pull in the targets' changed prerequisites. Only takes effect
+  // when there is a target (the engine derives prerequisites from the targeted set).
+  const withPrerequisites = prLabels.includes(labels.withPrerequisites) || undefined;
+
+  return { bump: composedBump, target, stable, prerelease, withPrerequisites, conflicts };
 }
 
 interface BuildOptionsExtras {
@@ -744,18 +784,19 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
   const sync = releaseKitConfig.version?.sync ?? false;
   // When labels conflict, drop the override (fall back to commit-driven) but keep the
   // conflict descriptions for the final status check.
-  // CLI --target (ad-hoc override) wins over the label-derived target; --include-prerequisites opts
-  // the targeted set's changed dependencies into the release either way.
+  // CLI --target (ad-hoc override) wins over the label-derived target; prerequisites are opted in by
+  // the CLI flag OR the `release:with-prerequisites` label, either way.
   const cliTarget = options.target ?? overrides.target;
+  const includePrerequisites = options.includePrerequisites || overrides.withPrerequisites;
   const buildExtras: BuildOptionsExtras = overrides.conflicts.length
-    ? { sync, target: cliTarget, includePrerequisites: options.includePrerequisites }
+    ? { sync, target: cliTarget, includePrerequisites }
     : {
         sync,
         bump: overrides.bump,
         target: cliTarget,
         stable: overrides.stable,
         prerelease: overrides.prerelease,
-        includePrerequisites: options.includePrerequisites,
+        includePrerequisites,
       };
 
   // Dry-run version analysis to compute bumps without writing

--- a/packages/release/test/unit/labels-command.spec.ts
+++ b/packages/release/test/unit/labels-command.spec.ts
@@ -86,6 +86,7 @@ describe('runLabelsSync', () => {
       'release:immediate',
       'release:retry',
       'release:preview-notes',
+      'release:with-prerequisites',
       'release',
     ]);
 

--- a/packages/release/test/unit/standing-pr.spec.ts
+++ b/packages/release/test/unit/standing-pr.spec.ts
@@ -273,6 +273,7 @@ describe('runStandingPRUpdate', () => {
         major: 'bump:major',
         minor: 'bump:minor',
         patch: 'bump:patch',
+        withPrerequisites: 'release:with-prerequisites',
       },
     },
     git: { branch: 'main', remote: 'origin', pushMethod: 'auto' },
@@ -363,6 +364,68 @@ describe('runStandingPRUpdate', () => {
 
     expect(result.action).toBe('created');
     expect(forge.createdPullRequests).toHaveLength(1);
+  });
+
+  it('should enable prerequisites in the version run when the with-prerequisites label is present', async () => {
+    const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
+    const versionOutput = createMockVersionOutput([{ packageName: '@scope/app', newVersion: '1.2.3' }]);
+    vi.mocked(runVersionStep).mockResolvedValue(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>);
+    vi.mocked(runNotesStep).mockResolvedValue({ packageNotes: {}, releaseNotes: {}, files: [] });
+
+    await mockForge({ standingPR: openStandingPR(99, ['release:with-prerequisites']) });
+
+    await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
+
+    // The label OR'd `includePrerequisites` into the version run (dry-run call is the first one).
+    const firstCall = vi.mocked(runVersionStep).mock.calls[0]?.[0] as { includePrerequisites?: boolean };
+    expect(firstCall.includePrerequisites).toBe(true);
+  });
+
+  it('should render the PR body grouped by target → its prerequisites', async () => {
+    const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
+    const versionOutput = {
+      ...createMockVersionOutput([
+        { packageName: '@scope/app', newVersion: '2.0.0' },
+        { packageName: '@scope/core', newVersion: '1.1.0' },
+      ]),
+      strategy: 'async' as const,
+      changelogs: [
+        {
+          packageName: '@scope/app',
+          version: '2.0.0',
+          previousVersion: '1.0.0',
+          revisionRange: '',
+          repoUrl: null,
+          entries: [],
+        },
+        {
+          packageName: '@scope/core',
+          version: '1.1.0',
+          previousVersion: '1.0.0',
+          revisionRange: '',
+          repoUrl: null,
+          entries: [],
+        },
+      ],
+    };
+    versionOutput.updates[0]!.role = 'target';
+    versionOutput.updates[1]!.role = 'prerequisite';
+    versionOutput.updates[1]!.prerequisiteOf = ['@scope/app'];
+    vi.mocked(runVersionStep)
+      .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>)
+      .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>);
+    vi.mocked(runNotesStep).mockResolvedValue({ packageNotes: {}, releaseNotes: {}, files: [] });
+
+    const forge = await mockForge({ standingPR: null });
+
+    await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
+
+    const body = forge.createdPullRequests[0]?.body ?? '';
+    expect(body).toContain('@scope/app');
+    expect(body).toContain('(major)'); // target's overridden bump
+    expect(body).toContain('prerequisite');
+    expect(body).toContain('@scope/core');
+    expect(body).toContain('(minor)'); // prerequisite's own commit-driven bump
   });
 
   it('should bypass the initial skip-pattern guard on a pull_request label event (#336)', async () => {

--- a/packages/release/test/unit/standing-pr.spec.ts
+++ b/packages/release/test/unit/standing-pr.spec.ts
@@ -428,6 +428,41 @@ describe('runStandingPRUpdate', () => {
     expect(body).toContain('(minor)'); // prerequisite's own commit-driven bump
   });
 
+  it('should list a prerequisite whose target has no update entry rather than render an empty body', async () => {
+    // The targeted package (@scope/app) had no releasable change of its own, so the engine never
+    // emits an update for it and it is never tagged 'target'. Its changed prerequisite (@scope/core)
+    // still publishes — the body must show it, not just the intro line.
+    const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
+    const versionOutput = {
+      ...createMockVersionOutput([{ packageName: '@scope/core', newVersion: '1.1.0' }]),
+      strategy: 'async' as const,
+      changelogs: [
+        {
+          packageName: '@scope/core',
+          version: '1.1.0',
+          previousVersion: '1.0.0',
+          revisionRange: '',
+          repoUrl: null,
+          entries: [],
+        },
+      ],
+    };
+    versionOutput.updates[0]!.role = 'prerequisite';
+    versionOutput.updates[0]!.prerequisiteOf = ['@scope/app'];
+    vi.mocked(runVersionStep)
+      .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>)
+      .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>);
+    vi.mocked(runNotesStep).mockResolvedValue({ packageNotes: {}, releaseNotes: {}, files: [] });
+
+    const forge = await mockForge({ standingPR: null });
+
+    await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
+
+    const body = forge.createdPullRequests[0]?.body ?? '';
+    expect(body).toContain('@scope/core');
+    expect(body).toContain('(minor)');
+  });
+
   it('should bypass the initial skip-pattern guard on a pull_request label event (#336)', async () => {
     // A label event checks out the standing PR's `chore: release preparation` commit (matches the
     // skip pattern) — the first guard would noop. A label-triggered run must proceed. The post-reset

--- a/packages/version/src/core/prerequisiteScope.ts
+++ b/packages/version/src/core/prerequisiteScope.ts
@@ -20,6 +20,8 @@ export interface PrerequisiteTargets {
   targets: string[];
   /** The packages the bump/prerelease/stable override applies to (the group-expanded explicit set). */
   overrideScope: string[];
+  /** For each derived prerequisite, the (group-expanded) target(s) that pulled it in. */
+  prerequisiteOf: Record<string, string[]>;
 }
 
 export function resolvePrerequisiteTargets(
@@ -50,6 +52,6 @@ export function resolvePrerequisiteTargets(
   }
   const changed = [...candidateDeps].filter((name) => isChanged(name));
 
-  const { targetSet } = resolvePrerequisites(graph, [...overrideSet], changed);
-  return { targets: [...targetSet], overrideScope: [...overrideSet] };
+  const { targetSet, prerequisiteOf } = resolvePrerequisites(graph, [...overrideSet], changed);
+  return { targets: [...targetSet], overrideScope: [...overrideSet], prerequisiteOf };
 }

--- a/packages/version/src/core/versionEngine.ts
+++ b/packages/version/src/core/versionEngine.ts
@@ -11,6 +11,7 @@ import { createVersionError, VersionError, VersionErrorCode } from '../errors/ve
 import { getCommitsLength, getLatestTag, getLatestTagForPackage } from '../git/tagsAndBranches.js';
 import type { Config, VersionRunOptions } from '../types.js';
 import { formatVersionPrefix } from '../utils/formatting.js';
+import { tagPrerequisiteRoles } from '../utils/jsonOutput.js';
 import { log } from '../utils/logging.js';
 import { resolvePrerequisiteTargets } from './prerequisiteScope.js';
 import { createStrategy, createStrategyMap, type StrategyFunction, type StrategyType } from './versionStrategies.js';
@@ -31,6 +32,9 @@ export class VersionEngine {
   private currentStrategy: StrategyFunction;
   private runtimeTargets: string[] = [];
   private includePrerequisites = false;
+  /** Prereq → target(s) it was pulled in for, captured during prerequisite resolution; used after
+   *  `run()` to tag each update's role/prerequisiteOf. Empty unless prerequisites were derived. */
+  private prerequisiteOf: Record<string, string[]> = {};
 
   constructor(config: Config, runOptions?: VersionRunOptions) {
     // Validate required configuration
@@ -417,7 +421,7 @@ export class VersionEngine {
       if (this.includePrerequisites && this.runtimeTargets.length > 0) {
         const graph = buildWorkspaceGraph(mergedPackages.packages);
         const changed = await this.detectChangedPackages(mergedPackages.packages);
-        const { targets, overrideScope } = resolvePrerequisiteTargets(
+        const { targets, overrideScope, prerequisiteOf } = resolvePrerequisiteTargets(
           graph,
           mergedPackages.packages,
           this.config,
@@ -430,6 +434,7 @@ export class VersionEngine {
         );
         this.runtimeTargets = targets;
         this.config.overrideScope = overrideScope;
+        this.prerequisiteOf = prerequisiteOf;
         // Rebuild strategies so they pick up the override scope derived from the workspace graph.
         this.strategies = createStrategyMap(this.config);
         this.currentStrategy = createStrategy(this.config);
@@ -506,7 +511,13 @@ export class VersionEngine {
   public async run(packages: PackagesWithRoot, targets: string[] = []): Promise<void> {
     try {
       // Execute the strategy function
-      return this.currentStrategy(packages, targets);
+      await this.currentStrategy(packages, targets);
+      // Once the strategy has produced the updates, tag each one's role: explicit (group-expanded)
+      // targets keep the override; derived prerequisites carry their own bump and record the
+      // target(s) they were pulled in for. Only when prerequisites were actually derived.
+      if (Object.keys(this.prerequisiteOf).length > 0) {
+        tagPrerequisiteRoles(this.config.overrideScope ?? [], this.prerequisiteOf);
+      }
     } catch (error) {
       if (error instanceof VersionError || error instanceof GitError) {
         log(`Version engine failed: ${error.message} (${error.code || 'UNKNOWN'})`, 'error');

--- a/packages/version/src/utils/jsonOutput.ts
+++ b/packages/version/src/utils/jsonOutput.ts
@@ -125,6 +125,25 @@ export function setPackageUpdateGroup(packageName: string, group: string): void 
 }
 
 /**
+ * Tag each package update's role for a `--include-prerequisites` run: a package in `overrideScope`
+ * is a `'target'`; one listed in `prerequisiteOf` is a `'prerequisite'` carrying the target(s) it
+ * was pulled in for. Updates in neither (e.g. the root lockstep bump) are left untagged. Called by
+ * the engine after the strategy has produced the updates.
+ */
+export function tagPrerequisiteRoles(overrideScope: string[], prerequisiteOf: Record<string, string[]>): void {
+  if (!_jsonOutputMode) return;
+  const targets = new Set(overrideScope);
+  for (const update of _jsonData.updates) {
+    if (targets.has(update.packageName)) {
+      update.role = 'target';
+    } else if (prerequisiteOf[update.packageName]) {
+      update.role = 'prerequisite';
+      update.prerequisiteOf = prerequisiteOf[update.packageName];
+    }
+  }
+}
+
+/**
  * Add changelog data for a package to the JSON output
  */
 export function addChangelogData(data: VersionPackageChangelog): void {

--- a/packages/version/test/unit/core/prerequisiteScope.spec.ts
+++ b/packages/version/test/unit/core/prerequisiteScope.spec.ts
@@ -35,6 +35,7 @@ describe('resolvePrerequisiteTargets', () => {
     const result = resolvePrerequisiteTargets(graph, packages, baseConfig(), ['app'], () => true);
     expect(new Set(result.targets)).toEqual(new Set(['app', 'utils', 'types', 'core']));
     expect(result.overrideScope).toEqual(['app']);
+    expect(result.prerequisiteOf).toEqual({ utils: ['app'], types: ['app'], core: ['app'] });
   });
 
   it('should not pull in unchanged dependencies', () => {

--- a/packages/version/test/unit/utils/jsonOutput.spec.ts
+++ b/packages/version/test/unit/utils/jsonOutput.spec.ts
@@ -13,6 +13,7 @@ import {
   setCommitMessage,
   setPackageUpdateTag,
   setVersioningStrategy,
+  tagPrerequisiteRoles,
 } from '../../../src/utils/jsonOutput.js';
 
 vi.mock('node:fs');
@@ -46,6 +47,7 @@ describe('JSON Output Utilities', () => {
       addPackageUpdate('test-package', '1.0.0', '/path/to/package.json');
       addTag('v1.0.0');
       setCommitMessage('Release v1.0.0');
+      // (tagPrerequisiteRoles is exercised in its own describe below.)
 
       // Check data was added
       const updatedData = getJsonData();
@@ -363,6 +365,25 @@ describe('JSON Output Utilities', () => {
       const parsed = JSON.parse(output);
       expect(parsed.changelogs).toHaveLength(1);
       expect(parsed.changelogs[0].entries[0].description).toBe('New feature');
+    });
+  });
+
+  describe('tagPrerequisiteRoles', () => {
+    it('should tag override-scope packages as targets and the rest as prerequisites', () => {
+      enableJsonOutput(true);
+      addPackageUpdate('app', '2.0.0', 'packages/app/package.json');
+      addPackageUpdate('core', '1.1.0', 'packages/core/package.json');
+      addPackageUpdate('root', '0.0.1', 'package.json', true);
+
+      tagPrerequisiteRoles(['app'], { core: ['app'] });
+
+      const updates = getJsonData().updates;
+      const byName = (n: string) => updates.find((u) => u.packageName === n);
+      expect(byName('app')).toMatchObject({ role: 'target' });
+      expect(byName('app')?.prerequisiteOf).toBeUndefined();
+      expect(byName('core')).toMatchObject({ role: 'prerequisite', prerequisiteOf: ['app'] });
+      // The root lockstep bump is neither a target nor a prerequisite — left untagged.
+      expect(byName('root')?.role).toBeUndefined();
     });
   });
 });

--- a/releasekit.schema.json
+++ b/releasekit.schema.json
@@ -1149,6 +1149,11 @@
               "type": "string",
               "default": "bump:patch",
               "description": "Label to force a patch bump"
+            },
+            "withPrerequisites": {
+              "type": "string",
+              "default": "release:with-prerequisites",
+              "description": "Label on the standing PR that also releases the changed prerequisites (transitive internal dependencies) of the targeted/scoped packages — each at its own commit-driven bump. Standing-pr mode only."
             }
           },
           "description": "PR label names used for release control. Override to match your repository's label conventions."


### PR DESCRIPTION
## What

Closes #366 (feature Phase 5). Surfaces #365's prerequisite derivation in the standing PR via a label, and makes the target→prerequisite structure first-class so it renders without re-deriving the graph.

A maintainer adds **`release:with-prerequisites`** to the standing PR (alongside a scope/target label) and the next update also releases the targets' **changed prerequisites** — transitive internal dependencies — each at its own commit-driven bump. It's the standing-PR UI for the existing `--include-prerequisites` flag.

## Design (the two decisions we locked: 1A + 2A)

**1A — contract on `VersionPackageUpdate`** (mirrors the existing optional `group?`, survives the old-manifest rule):
- `role?: 'target' | 'prerequisite'`
- `prerequisiteOf?: string[]` — the target(s) a shared prerequisite was pulled in for

**2A — the version engine populates them.** The #365 resolution block now captures `prerequisiteOf` (from `resolvePrerequisites`), and after the strategy runs, `tagPrerequisiteRoles` tags each update from `overrideScope` + the map. Correct-by-construction, and any consumer (preview, future) gets it for free. The root lockstep bump stays untagged.

## Surface
- **config:** `ci.labels.withPrerequisites` (default `release:with-prerequisites`) + label definition; `releasekit.schema.json` + `docs/configuration.md` regenerated (`schema:check` green).
- **standing-pr:** label OR's `includePrerequisites` into the version run; joins `extractOverrideLabels` so the #337 staleness guard trips if it's removed after the manifest was computed; PR body renders grouped **target → its prerequisites**, each prereq showing its own bump (`semver.diff` when the previous version is known).

## Acceptance criteria
- [x] `release:with-prerequisites` drives `overrideScope` + prerequisite derivation (via the engine's #365 path)
- [x] New contract fields are OPTIONAL; old manifests parse (they ride in the manifest's `versionOutput` JSON)
- [x] PR body groups targets → prerequisites with independent bumps
- [x] Staleness guard trips on label removal
- [x] Tests extended (standing-pr via the forge fake; core/version units for `prerequisiteOf` + `tagPrerequisiteRoles`); gate + `schema:check` green

## Boundary with #367
This is the **label** path. #367 adds the per-row **checkbox** selection region (over the #360 marker codec) on top of these same contract fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a `release:with-prerequisites` label to the standing-PR workflow that drives `--include-prerequisites` mode, releasing targeted packages' changed transitive dependencies alongside the targets at their own commit-driven bumps. The contract (`role`, `prerequisiteOf`) is added to `VersionPackageUpdate` as optional fields so old manifests parse without change.

- **Config + schema**: `ci.labels.withPrerequisites` is added to `CILabelsConfigSchema` with default `"release:with-prerequisites"`; schema JSON and docs are regenerated.
- **Core data flow**: `resolvePrerequisites` now tracks `prerequisiteOf` (prereq → target list), threaded through `resolvePrerequisiteTargets`, stored on `VersionEngine`, then applied via `tagPrerequisiteRoles` after the strategy runs.
- **Standing-PR rendering**: `renderPrerequisiteSet` groups the PR body as target → indented prerequisites, with a flat fallback for orphaned prerequisites (targets that had no releasable changes themselves); the label is wired into `extractOverrideLabels` so the staleness guard fires on removal.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge; the feature is additive, all new fields are optional, and old manifests parse without change.

The data flows cleanly from label detection through prerequisite resolution, engine tagging, and PR body rendering. The previously flagged empty-body edge case (target with no releasable changes) is explicitly handled with a flat fallback and covered by a dedicated test. Module-level singleton state in `jsonOutput.ts` is properly reset by `enableJsonOutput` before each run, and a fresh `VersionEngine` instance is created per `runVersionStep` call so no `prerequisiteOf` state leaks between dry-run and real runs.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/version/src/core/versionEngine.ts | Adds instance-level `prerequisiteOf` field; populated in `getPackages()` and consumed in `run()` via `tagPrerequisiteRoles`; `return` → `await` change is semantically correct; fresh engine instance per call prevents state leakage. |
| packages/version/src/utils/jsonOutput.ts | Adds `tagPrerequisiteRoles`: iterates module-level `_jsonData.updates`, tags targets vs prerequisites; `enableJsonOutput` already resets `updates = []` so no stale roles carry over between runs. |
| packages/release/src/standing-pr/standing-pr.ts | Adds `renderPrerequisiteSet` with flat fallback for orphaned prerequisites; wires `withPrerequisites` through `extractOverrideLabels` (staleness guard) and `resolveStandingPrLabelOverrides`; previously flagged empty-body edge case is now handled and tested. |
| packages/core/src/prerequisites.ts | Adds `prerequisiteOf` map to `PrerequisiteResolution`; correctly accumulates targets per shared dependency using array spread. |
| packages/version/src/core/prerequisiteScope.ts | Threads `prerequisiteOf` from `resolvePrerequisites` through `PrerequisiteTargets` and `resolvePrerequisiteTargets` return value; no logic changes. |
| packages/core/src/types.ts | Adds optional `role` and `prerequisiteOf` fields to `VersionPackageUpdate`; both are optional so existing manifests parse without breaking. |
| packages/release/test/unit/standing-pr.spec.ts | Three new test cases: label enables prerequisites in version run, PR body renders grouped target → prerequisites with bumps, and the previously flagged orphaned-prerequisite fallback case. |
| packages/config/src/schema.ts | Adds `withPrerequisites` to `CILabelsConfigSchema` with correct default and description; also adds to the `CIConfigSchema` default object. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant PR as Standing PR
    participant SPR as standing-pr.ts
    participant VE as VersionEngine
    participant PS as prerequisiteScope
    participant JO as jsonOutput

    PR->>SPR: labels include release:with-prerequisites
    SPR->>SPR: "resolveStandingPrLabelOverrides()<br/>withPrerequisites = true"
    SPR->>SPR: "extractOverrideLabels()<br/>(staleness guard includes label)"
    SPR->>VE: "runVersionStep(dryRun=true, includePrerequisites=true)"
    VE->>JO: "enableJsonOutput(dryRun=true) — resets _jsonData"
    VE->>PS: resolvePrerequisiteTargets(graph, targets)
    PS-->>VE: "{ targets, overrideScope, prerequisiteOf }"
    Note over VE: stores prerequisiteOf on instance
    VE->>VE: "currentStrategy(packages, targets)<br/>addPackageUpdate() per package"
    VE->>JO: tagPrerequisiteRoles(overrideScope, prerequisiteOf)
    Note over JO: tags each update as role:'target' or 'prerequisite'
    JO-->>SPR: versionOutput (updates with role + prerequisiteOf)
    SPR->>SPR: renderPrBody()
    Note over SPR: updates.some(u => u.role==='prerequisite')
    SPR->>SPR: "renderPrerequisiteSet()<br/>groups: target → prereqs (with bump suffix)<br/>flat fallback for orphaned prereqs"
    SPR->>PR: Update PR body with grouped package list
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant PR as Standing PR
    participant SPR as standing-pr.ts
    participant VE as VersionEngine
    participant PS as prerequisiteScope
    participant JO as jsonOutput

    PR->>SPR: labels include release:with-prerequisites
    SPR->>SPR: "resolveStandingPrLabelOverrides()<br/>withPrerequisites = true"
    SPR->>SPR: "extractOverrideLabels()<br/>(staleness guard includes label)"
    SPR->>VE: "runVersionStep(dryRun=true, includePrerequisites=true)"
    VE->>JO: "enableJsonOutput(dryRun=true) — resets _jsonData"
    VE->>PS: resolvePrerequisiteTargets(graph, targets)
    PS-->>VE: "{ targets, overrideScope, prerequisiteOf }"
    Note over VE: stores prerequisiteOf on instance
    VE->>VE: "currentStrategy(packages, targets)<br/>addPackageUpdate() per package"
    VE->>JO: tagPrerequisiteRoles(overrideScope, prerequisiteOf)
    Note over JO: tags each update as role:'target' or 'prerequisite'
    JO-->>SPR: versionOutput (updates with role + prerequisiteOf)
    SPR->>SPR: renderPrBody()
    Note over SPR: updates.some(u => u.role==='prerequisite')
    SPR->>SPR: "renderPrerequisiteSet()<br/>groups: target → prereqs (with bump suffix)<br/>flat fallback for orphaned prereqs"
    SPR->>PR: Update PR body with grouped package list
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(release): list prerequisites whose t..."](https://github.com/goosewobbler/releasekit/commit/1a7cde18b10160982b5f0fd655e31323a8423c7f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39068354)</sub>

<!-- /greptile_comment -->