### PR TITLE
feat(release): standing-PR ad-hoc checkbox selection (#367)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -23,6 +23,7 @@ Conflating these is the historical source of the `fix(version)` bug cluster (#33
 - **Explicit group** — a declared coordination invariant over related packages: `fixed` (shared version, all move) · `linked` (shared version, changed-only) · `independent` (own version lines, changed-only, atomic).
 - **Prerequisite** — *derived* from the dependency graph at release time; keeps its own commit-driven bump; pulled in only if changed; dependency-ordered.
 - **Selection** — orthogonal *"what to act on now"* (scope labels / checkboxes / CLI). Under this taxonomy, scope labels revert to pure selection — they are not the home for co-release coupling.
+- **Selection region** — the standing-PR ad-hoc selection surface: a GitHub task-list in the PR body (one ticked row per changed package). Unticking holds a package back; the engine drops it via the `exclude` knob (never bumped → no orphan version on `main`), and the choice round-trips by marker slicing so it survives regeneration. A `markerRegion` adapter (see below). Sync releases are atomic and carry none; lockstep group members can't be held back individually.
 
 ## Forge — the hosting platform, distinct from git
 
@@ -34,6 +35,6 @@ Conflating these is the historical source of the `fix(version)` bug cluster (#33
 The AGENTS.md invariant ("machine state embedded in comments uses its own marker line — never parse the human-facing prose") is owned by `@releasekit/core`'s marker codec, in two shapes:
 
 - **`markerData<T>`** — a single typed datum on one `<!-- open payload -->` line (manifest base64 blob; failure-report `status`/`data` fields). `encode(T)→line`, `decode(body)→T|null` by linear delimiter slicing (no backtracking regex → no ReDoS).
-- **`markerRegion`** (`wrapMarkerRegion`/`extractMarkerRegion`) — a span of editable content between a distinct open/close marker pair (the editable release-notes region; the future checkbox-selection block). `notes-region` is an adapter over it.
+- **`markerRegion`** (`wrapMarkerRegion`/`extractMarkerRegion`) — a span of editable content between a distinct open/close marker pair. Two adapters today: `notes-region` (editable release notes) and `selection-region` (the [[Selection region]] task-list; per-row `<!-- rk-sel:NAME -->` identity markers, with the `[x]`/`[ ]` glyph the human toggles).
 
 The *find + idempotent upsert* of the whole comment is a separate concern, owned by the **[[forge]]** (`findComment`/`upsertMarkerComment`). Prose-only bot comments (preview, gate-notify) carry no machine state and just upsert a marker-keyed body.

--- a/examples/ci/standing-pr/standing-pr.yml
+++ b/examples/ci/standing-pr/standing-pr.yml
@@ -40,9 +40,10 @@ jobs:
     # push/schedule rebuild the PR; a label change or selection-region edit on the OPEN standing PR
     # re-runs the update so bump/scope/channel overrides and held-back packages take effect within
     # seconds. `state == 'open'` keeps this off the merged-PR label events that drive publish/retry
-    # below. The `sender.login != 'github-actions[bot]'` guard is load-bearing for `edited`: the
-    # update rewrites the PR body (an `edited` event), so without it the bot would re-trigger forever.
-    # The `release/` prefix is hardcoded (workflow `if` can't read config) — in-step config is authoritative.
+    # below. The `sender.type != 'Bot'` guard is load-bearing for `edited`: the update rewrites the PR
+    # body (an `edited` event), so without it the bot would re-trigger forever. Match on type, not a
+    # hardcoded `github-actions[bot]` login, so a custom GitHub App token (its own `*[bot]` login) is
+    # filtered too. The `release/` prefix is hardcoded (workflow `if` can't read config) — in-step config is authoritative.
     if: >-
       github.event_name == 'push' ||
       github.event_name == 'schedule' ||
@@ -55,7 +56,7 @@ jobs:
         ) &&
         github.event.pull_request.state == 'open' &&
         startsWith(github.event.pull_request.head.ref, 'release/') &&
-        github.event.sender.login != 'github-actions[bot]'
+        github.event.sender.type != 'Bot'
       )
     runs-on: ubuntu-latest
     steps:

--- a/examples/ci/standing-pr/standing-pr.yml
+++ b/examples/ci/standing-pr/standing-pr.yml
@@ -16,7 +16,10 @@ on:
     # closed: publish on merge. labeled/unlabeled: (1) apply bump/scope/channel
     # override labels to the OPEN standing PR immediately instead of waiting for the
     # next push or the hourly cron; (2) the release:retry path on the merged PR.
-    types: [closed, labeled, unlabeled]
+    # edited: a maintainer ticked/unticked packages in the PR's selection region —
+    # re-run so the held-back set applies (the bot's own body edits are filtered by
+    # the sender guard below to avoid a loop).
+    types: [closed, labeled, unlabeled, edited]
     branches: [main]
   schedule:
     - cron: '0 * * * *' # hourly: advances the minAge status check as time passes
@@ -34,18 +37,25 @@ permissions:
 jobs:
   update:
     name: Update Release PR
-    # push/schedule rebuild the PR; a label change on the OPEN standing PR re-runs the update
-    # so bump/scope/channel overrides take effect within seconds. `state == 'open'` keeps this
-    # off the merged-PR label events that drive publish/retry below. The `release/` prefix is
-    # hardcoded (workflow `if` can't read config) — the in-step config is authoritative.
+    # push/schedule rebuild the PR; a label change or selection-region edit on the OPEN standing PR
+    # re-runs the update so bump/scope/channel overrides and held-back packages take effect within
+    # seconds. `state == 'open'` keeps this off the merged-PR label events that drive publish/retry
+    # below. The `sender.login != 'github-actions[bot]'` guard is load-bearing for `edited`: the
+    # update rewrites the PR body (an `edited` event), so without it the bot would re-trigger forever.
+    # The `release/` prefix is hardcoded (workflow `if` can't read config) — in-step config is authoritative.
     if: >-
       github.event_name == 'push' ||
       github.event_name == 'schedule' ||
       (
         github.event_name == 'pull_request' &&
-        (github.event.action == 'labeled' || github.event.action == 'unlabeled') &&
+        (
+          github.event.action == 'labeled' ||
+          github.event.action == 'unlabeled' ||
+          github.event.action == 'edited'
+        ) &&
         github.event.pull_request.state == 'open' &&
-        startsWith(github.event.pull_request.head.ref, 'release/')
+        startsWith(github.event.pull_request.head.ref, 'release/') &&
+        github.event.sender.login != 'github-actions[bot]'
       )
     runs-on: ubuntu-latest
     steps:

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -34,6 +34,13 @@ export {
   shouldProcessPackage,
 } from './packageUtils.js';
 export { type PrerequisiteResolution, resolvePrerequisites } from './prerequisites.js';
+export {
+  extractSelectionRegion,
+  rkSelMarker,
+  SELECTION_MARKER,
+  SELECTION_MARKER_END,
+  wrapSelectionRegion,
+} from './selectionRegion.js';
 export type {
   VersionChangelogEntry,
   VersionOutput,

--- a/packages/core/src/selectionRegion.ts
+++ b/packages/core/src/selectionRegion.ts
@@ -1,0 +1,37 @@
+/**
+ * Markers delimiting a maintainer-editable *selection* region inside a standing-PR body: a GitHub
+ * task-list where a ticked row means "release this package". The tool seeds the region (all ticked
+ * by default), a maintainer ticks/unticks rows, and the tool reads the choice back out on the next
+ * run — by marker slicing, never by parsing the surrounding prose.
+ *
+ * Two layers of marker:
+ * - The region opener/closer ({@link SELECTION_MARKER} / {@link SELECTION_MARKER_END}) bound the
+ *   whole block so it can be extracted as a unit (the second {@link extractMarkerRegion} adapter,
+ *   after notes-region — this is why the region primitive exists).
+ * - A per-row identity marker ({@link rkSelMarker}) carries the package name. The row's checked
+ *   state is the GitHub `- [x]` / `- [ ]` glyph (the only thing a human can toggle); the package it
+ *   refers to is read from this marker, NOT from the backticked display text — so a maintainer
+ *   editing or truncating the visible label can never mis-identify which package a row selects.
+ */
+import { extractMarkerRegion, wrapMarkerRegion } from './marker.js';
+
+export const SELECTION_MARKER = '<!-- releasekit-selection -->';
+export const SELECTION_MARKER_END = '<!-- releasekit-selection-end -->';
+
+/** The per-row identity marker carrying a package name (machine-read; never the row's prose). */
+export function rkSelMarker(packageName: string): string {
+  return `<!-- rk-sel:${packageName} -->`;
+}
+
+/** Wrap rendered selection rows in the region markers so the block can be recognised and extracted. */
+export function wrapSelectionRegion(content: string): string {
+  return wrapMarkerRegion(content, SELECTION_MARKER, SELECTION_MARKER_END);
+}
+
+/**
+ * Extract the selection region's content from a body, or `undefined` when the opener is absent —
+ * the selection-region adapter over {@link extractMarkerRegion} (pure marker slicing).
+ */
+export function extractSelectionRegion(body: string): string | undefined {
+  return extractMarkerRegion(body, SELECTION_MARKER, SELECTION_MARKER_END);
+}

--- a/packages/core/test/unit/selectionRegion.spec.ts
+++ b/packages/core/test/unit/selectionRegion.spec.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import {
+  extractSelectionRegion,
+  rkSelMarker,
+  SELECTION_MARKER,
+  SELECTION_MARKER_END,
+  wrapSelectionRegion,
+} from '../../src/selectionRegion.js';
+
+describe('selectionRegion', () => {
+  describe('rkSelMarker', () => {
+    it('should carry the package name in a per-row identity marker', () => {
+      expect(rkSelMarker('@scope/pkg')).toBe('<!-- rk-sel:@scope/pkg -->');
+    });
+  });
+
+  describe('wrapSelectionRegion', () => {
+    it('should wrap content in the opener and closer markers', () => {
+      const wrapped = wrapSelectionRegion('- [x] `a`');
+      expect(wrapped).toBe(`${SELECTION_MARKER}\n\n- [x] \`a\`\n\n${SELECTION_MARKER_END}`);
+    });
+  });
+
+  describe('extractSelectionRegion', () => {
+    it('should round-trip wrapped content', () => {
+      expect(extractSelectionRegion(wrapSelectionRegion('rows here'))).toBe('rows here');
+    });
+
+    it('should extract only the region, ignoring surrounding prose', () => {
+      const body = `## Release\n\n${wrapSelectionRegion('the rows')}\n\nchangelog...`;
+      expect(extractSelectionRegion(body)).toBe('the rows');
+    });
+
+    it('should return undefined when the opener is absent', () => {
+      expect(extractSelectionRegion('no selection here')).toBeUndefined();
+    });
+
+    it('should not match the closer as if it were the opener', () => {
+      expect(extractSelectionRegion(SELECTION_MARKER_END)).toBeUndefined();
+    });
+  });
+});

--- a/packages/release/docs/ci-setup.md
+++ b/packages/release/docs/ci-setup.md
@@ -367,9 +367,10 @@ jobs:
     # push/schedule rebuild the PR; a label change or selection-region edit on the OPEN standing PR
     # re-runs the update so bump/scope/channel overrides and held-back packages take effect within
     # seconds. `state == 'open'` keeps this off the merged-PR label events that drive publish/retry.
-    # The `sender.login != 'github-actions[bot]'` guard is load-bearing for `edited`: the update
-    # rewrites the PR body (an `edited` event), so without it the bot would re-trigger forever. The
-    # `release/` prefix is hardcoded (workflow `if` can't read config) — the in-step config is authoritative.
+    # The `sender.type != 'Bot'` guard is load-bearing for `edited`: the update rewrites the PR body
+    # (an `edited` event), so without it the bot would re-trigger forever. Match on type, not a
+    # hardcoded `github-actions[bot]` login, so a custom GitHub App token (its own `*[bot]` login) is
+    # filtered too. The `release/` prefix is hardcoded (workflow `if` can't read config) — in-step config is authoritative.
     if: >-
       github.event_name == 'push' ||
       github.event_name == 'schedule' ||
@@ -382,7 +383,7 @@ jobs:
         ) &&
         github.event.pull_request.state == 'open' &&
         startsWith(github.event.pull_request.head.ref, 'release/') &&
-        github.event.sender.login != 'github-actions[bot]'
+        github.event.sender.type != 'Bot'
       )
     runs-on: ubuntu-latest
     steps:

--- a/packages/release/docs/ci-setup.md
+++ b/packages/release/docs/ci-setup.md
@@ -344,7 +344,9 @@ on:
   pull_request:
     # closed: publish on merge. labeled/unlabeled: apply bump/scope/channel override labels to
     # the OPEN standing PR immediately (#336); also the release:retry path on the merged PR.
-    types: [closed, labeled, unlabeled]
+    # edited: a maintainer ticked/unticked packages in the PR's selection region — re-run so the
+    # held-back set applies (the bot's own body edits are filtered by the sender guard below).
+    types: [closed, labeled, unlabeled, edited]
     branches: [main]
   schedule:
     - cron: '0 * * * *'  # Hourly — re-evaluates minAge status check as time passes
@@ -362,18 +364,25 @@ permissions:
 jobs:
   update-release-pr:
     name: Update Release PR
-    # push/schedule rebuild the PR; a label change on the OPEN standing PR re-runs the update so
-    # bump/scope/channel overrides take effect within seconds. `state == 'open'` keeps this off the
-    # merged-PR label events that drive publish/retry. The `release/` prefix is hardcoded (workflow
-    # `if` can't read config) — the in-step config is authoritative.
+    # push/schedule rebuild the PR; a label change or selection-region edit on the OPEN standing PR
+    # re-runs the update so bump/scope/channel overrides and held-back packages take effect within
+    # seconds. `state == 'open'` keeps this off the merged-PR label events that drive publish/retry.
+    # The `sender.login != 'github-actions[bot]'` guard is load-bearing for `edited`: the update
+    # rewrites the PR body (an `edited` event), so without it the bot would re-trigger forever. The
+    # `release/` prefix is hardcoded (workflow `if` can't read config) — the in-step config is authoritative.
     if: >-
       github.event_name == 'push' ||
       github.event_name == 'schedule' ||
       (
         github.event_name == 'pull_request' &&
-        (github.event.action == 'labeled' || github.event.action == 'unlabeled') &&
+        (
+          github.event.action == 'labeled' ||
+          github.event.action == 'unlabeled' ||
+          github.event.action == 'edited'
+        ) &&
         github.event.pull_request.state == 'open' &&
-        startsWith(github.event.pull_request.head.ref, 'release/')
+        startsWith(github.event.pull_request.head.ref, 'release/') &&
+        github.event.sender.login != 'github-actions[bot]'
       )
     runs-on: ubuntu-latest
     steps:
@@ -541,6 +550,8 @@ A maintainer can edit labels directly on the standing PR (via the GitHub UI or `
 Conflicts (e.g. both `bump:patch` and `bump:major`) surface as a `pending` `releasekit/standing-pr` status check on the release branch and a workflow warning. The override is dropped (falls back to commit-driven) until the conflict is resolved by removing one of the labels.
 
 The `standing-pr update` workflow **preserves maintainer-added labels across runs** — labels you add stick until you remove them.
+
+**Ad-hoc package selection.** The standing PR body carries a **Packages to release** checklist — one ticked row per changed package. Untick a package to hold it back from the next release and save; the `edited` trigger re-runs `standing-pr update`, which excludes it from the version bump entirely (no orphan version lands on `main`) and records the held-back set in the manifest. The choice survives later pushes — a held-back package re-renders as an unticked row until you re-tick it. The package each row refers to is read from its `<!-- rk-sel:… -->` marker comment, so keep those intact. Unticking a member of an `independent` group, or a prerequisite still needed by a ticked target, surfaces a ⚠️ warning in the body; members of a lockstep (`fixed`/`linked`) group can't be held back individually and re-tick automatically. (Sync releases ship atomically and carry no checklist.)
 
 **Staleness guard.** The manifest records the override labels it was computed under. If the standing PR's labels are changed and it's merged before the triggered update re-runs (a narrow race), `standing-pr publish` detects that the merged PR's override labels no longer match the manifest and **refuses to publish** rather than shipping a release the labels no longer describe — re-run `standing-pr update` and merge again (or apply the retry label after updating). So a mismatched manifest can never be released, even though merge itself isn't blocked.
 

--- a/packages/release/src/standing-pr/selection-region.ts
+++ b/packages/release/src/standing-pr/selection-region.ts
@@ -1,0 +1,143 @@
+import type { VersionOutput } from '@releasekit/core';
+import { extractSelectionRegion, rkSelMarker, wrapSelectionRegion } from '@releasekit/core';
+import semver from 'semver';
+
+/**
+ * The ad-hoc *selection* region of a standing-PR body: a GitHub task-list where a ticked row means
+ * "release this package in the next merge". The bot seeds it (all ticked by default — the same set
+ * that would release today), a maintainer ticks/unticks rows on the PR, and the bot reads the choice
+ * back on the next run to narrow the release set. State round-trips by marker slicing, never by
+ * parsing prose: the package each row refers to comes from its `<!-- rk-sel:NAME -->` marker, and
+ * only the GitHub `[x]`/`[ ]` glyph (the one thing a human can toggle) carries the checked state.
+ *
+ * Built over the core selection-region codec — the second markerRegion adapter after notes-region.
+ */
+
+const REGION_HEADING = '### Packages to release';
+const REGION_HINT =
+  '> Untick a package to hold it back from the next release, then save — the bot re-runs and updates this PR. ' +
+  'Keep the `<!-- rk-sel... -->` marker comments; they identify each row.';
+
+/** A ` (minor)`-style bump suffix derived from the package's previous→new version, when known. */
+export function bumpSuffix(versionOutput: VersionOutput, packageName: string, newVersion: string): string {
+  const previous = versionOutput.changelogs.find((c) => c.packageName === packageName)?.previousVersion;
+  if (!previous) return '';
+  const kind = semver.diff(previous, newVersion);
+  return kind ? ` (${kind})` : '';
+}
+
+function checkbox(selected: boolean): string {
+  return selected ? '[x]' : '[ ]';
+}
+
+function row(
+  versionOutput: VersionOutput,
+  update: VersionOutput['updates'][number],
+  selected: boolean,
+  opts: { indent?: boolean; bold?: boolean; prefix?: string } = {},
+): string {
+  const indent = opts.indent ? '  ' : '';
+  const name = opts.bold ? `**\`${update.packageName}\`**` : `\`${update.packageName}\``;
+  const prefix = opts.prefix ?? '';
+  const suffix = bumpSuffix(versionOutput, update.packageName, update.newVersion);
+  return `${indent}- ${checkbox(selected)} ${prefix}${name} → ${update.newVersion}${suffix} ${rkSelMarker(update.packageName)}`;
+}
+
+/**
+ * Render the selection region for a set of publishable updates. When prerequisite roles are present
+ * (a `--include-prerequisites` / `release:with-prerequisites` run) rows group target → its derived
+ * prerequisites; otherwise they render flat. Every row is ticked unless its package is in
+ * `deselected`. Returns the marker-wrapped block ready to embed in the PR body.
+ */
+export function renderSelectionRegion(
+  versionOutput: VersionOutput,
+  updates: VersionOutput['updates'],
+  deselected: ReadonlySet<string>,
+): string {
+  const selected = (name: string) => !deselected.has(name);
+  const lines: string[] = [REGION_HEADING, '', REGION_HINT, ''];
+  const prerequisites = updates.filter((u) => u.role === 'prerequisite');
+  const rendered = new Set<string>();
+
+  if (prerequisites.length > 0) {
+    for (const target of updates.filter((u) => u.role === 'target')) {
+      lines.push(row(versionOutput, target, selected(target.packageName), { bold: true }));
+      rendered.add(target.packageName);
+      for (const prereq of prerequisites.filter((p) => p.prerequisiteOf?.includes(target.packageName))) {
+        lines.push(
+          row(versionOutput, prereq, selected(prereq.packageName), { indent: true, prefix: '↳ prerequisite ' }),
+        );
+        rendered.add(prereq.packageName);
+      }
+    }
+  }
+  // Flat rows for the plain-async case, and for any prerequisite whose target had no update entry of
+  // its own (it would otherwise be silently dropped — see renderPrerequisiteSet's orphan handling).
+  for (const update of updates.filter((u) => !rendered.has(u.packageName))) {
+    lines.push(row(versionOutput, update, selected(update.packageName)));
+  }
+
+  return wrapSelectionRegion(lines.join('\n'));
+}
+
+/**
+ * Read the maintainer's prior selection back from a live PR body: the package names whose row is
+ * unticked (`[ ]`). Returns `undefined` when no selection region is present (a body that predates
+ * this feature, or a sync release that carries none). Pure marker slicing — the package identity is
+ * taken from the `rk-sel` marker, the checked state from the glyph anchored to that marker's line.
+ */
+export function extractSelection(body: string): { deselected: string[] } | undefined {
+  const region = extractSelectionRegion(body);
+  if (region === undefined) return undefined;
+
+  const deselected: string[] = [];
+  for (const line of region.split('\n')) {
+    const markerStart = line.indexOf('<!-- rk-sel:');
+    if (markerStart === -1) continue;
+    const nameStart = markerStart + '<!-- rk-sel:'.length;
+    const nameEnd = line.indexOf(' -->', nameStart);
+    if (nameEnd === -1) continue;
+    const name = line.slice(nameStart, nameEnd);
+    // A row is selected unless its checkbox glyph is explicitly empty. `includes('[ ]')` is a fixed
+    // substring check on the row text before the marker — no prose parsing, no backtracking regex.
+    if (line.slice(0, markerStart).includes('[ ]')) deselected.push(name);
+  }
+  return { deselected };
+}
+
+export interface SelectionWarning {
+  packageName: string;
+  reason: string;
+}
+
+/**
+ * Coherence warnings for a deselection. Unticking a member of an `independent` group ships a partial
+ * group; unticking a prerequisite that a still-ticked target depends on may publish that target
+ * against an unreleased dependency. Lockstep (`fixed`/`linked`) members are handled upstream (their
+ * untick is ignored, not warned here) since they cannot be held back individually.
+ */
+export function selectionWarnings(
+  updates: VersionOutput['updates'],
+  deselected: ReadonlySet<string>,
+  groups: Record<string, { sync?: string }>,
+): SelectionWarning[] {
+  const warnings: SelectionWarning[] = [];
+  for (const update of updates) {
+    if (!deselected.has(update.packageName)) continue;
+    if (update.group && groups[update.group]?.sync === 'independent') {
+      warnings.push({
+        packageName: update.packageName,
+        reason: `\`${update.packageName}\` belongs to independent group \`${update.group}\` — unticking it ships a partial group.`,
+      });
+    }
+    const dependents = (update.prerequisiteOf ?? []).filter((t) => !deselected.has(t));
+    if (dependents.length > 0) {
+      const list = dependents.map((t) => `\`${t}\``).join(', ');
+      warnings.push({
+        packageName: update.packageName,
+        reason: `\`${update.packageName}\` is a prerequisite of still-selected ${list} — unticking it publishes ${dependents.length > 1 ? 'them' : 'it'} against an unreleased dependency.`,
+      });
+    }
+  }
+  return warnings;
+}

--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -103,7 +103,7 @@ function getHeadSha(cwd: string): string {
  * the skip pattern, so the guard would otherwise no-op every PR-driven update. The body re-render is
  * idempotent and the workflow guards out the bot's own edits, so an `edited` re-trigger is safe.
  */
-function isLabelTriggeredRun(): boolean {
+function isStandingPrEventRun(): boolean {
   if (process.env.GITHUB_EVENT_NAME !== 'pull_request') return false;
   const eventPath = process.env.GITHUB_EVENT_PATH;
   if (!eventPath) return false;
@@ -725,7 +725,7 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
   // must bypass the skip-pattern guards just like reconcile: the guards reject runs reacting to a
   // release commit on HEAD, but a label event isn't reacting to HEAD at all — skipping would leave
   // the new override unapplied until the next push or the hourly cron.
-  const bypassSkipGuard = options.reconcile || isLabelTriggeredRun();
+  const bypassSkipGuard = options.reconcile || isStandingPrEventRun();
 
   // Skip-pattern guard. Bypassed by reconcile (HEAD is a release commit by design then) and by
   // label-triggered runs (the trigger is a label, not the commit on HEAD).
@@ -876,15 +876,22 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
   const groups = releaseKitConfig.version?.groups ?? {};
   const changedNames = new Set(dryUpdates.map((u) => u.packageName));
   const effectiveDeselected = new Set<string>();
-  for (const name of priorDeselected) {
-    if (!changedNames.has(name)) continue;
-    const update = dryUpdates.find((u) => u.packageName === name);
-    const groupSync = update?.group ? groups[update.group]?.sync : undefined;
-    if (groupSync === 'fixed' || groupSync === 'linked') {
-      warn(`Selection: ignoring held-back \`${name}\` — lockstep group \`${update?.group}\` members release together.`);
-      continue;
+  // Sync releases ship atomically and never render a selection region, so ignore any deselection —
+  // a residual region (e.g. a body left over from before the repo switched to sync) must not
+  // silently narrow a sync release into a partial one. Same guard the selection-block render uses.
+  if (versionOutputDry.strategy !== 'sync') {
+    for (const name of priorDeselected) {
+      if (!changedNames.has(name)) continue;
+      const update = dryUpdates.find((u) => u.packageName === name);
+      const groupSync = update?.group ? groups[update.group]?.sync : undefined;
+      if (groupSync === 'fixed' || groupSync === 'linked') {
+        warn(
+          `Selection: ignoring held-back \`${name}\` — lockstep group \`${update?.group}\` members release together.`,
+        );
+        continue;
+      }
+      effectiveDeselected.add(name);
     }
-    effectiveDeselected.add(name);
   }
 
   // Materialize changes on release branch. Held-back packages are excluded from the version step so

--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -6,7 +6,6 @@ import type { VersionOutput } from '@releasekit/core';
 import { error, info, markerData, success, warn } from '@releasekit/core';
 import { type Forge, forgeErrorStatus, type PullRequestDetails } from '@releasekit/forge';
 import { PipelineError } from '@releasekit/publish';
-import semver from 'semver';
 import { ATTRIBUTION_FOOTER } from '../attribution.js';
 import { formatDuration, parseDuration } from '../duration.js';
 import { renderSupersedeWarning } from '../failure-report/failure-report.js';
@@ -19,6 +18,7 @@ import { runNotesStep, runPublishStep, runVersionStep } from '../steps.js';
 import type { ReleaseOptions, ReleaseOutput } from '../types.js';
 import { publishableUpdates, syncVersionDisplay } from '../version-display.js';
 import { extractNotesRegions, mergeNotesRegions, renderNotesRegion } from './notes-region.js';
+import { extractSelection, renderSelectionRegion, selectionWarnings } from './selection-region.js';
 import { postStandingPRStatusSafe } from './status.js';
 
 const MANIFEST_MARKER = '<!-- releasekit-manifest -->';
@@ -76,6 +76,13 @@ export interface StandingPRManifest {
    * Optional: absent on manifests written before this field existed — consumers must tolerate that.
    */
   overrideLabels?: string[];
+  /**
+   * Packages a maintainer unticked in the PR's selection region, so they were held back from this
+   * release (excluded from `versionOutput`). Recorded for provenance/auditing; the release set is
+   * already narrowed in `versionOutput`. Optional: absent when nothing was deselected, and on
+   * manifests written before this field existed.
+   */
+  deselected?: string[];
 }
 
 function getHeadSha(cwd: string): string {
@@ -87,12 +94,14 @@ function getHeadSha(cwd: string): string {
 }
 
 /**
- * True when this run was triggered by a label being added/removed on a PR (#336) — a maintainer
- * adjusting the standing PR's override labels, not a commit landing. The CLI reads the event itself
+ * True when this run was triggered by a maintainer acting on the standing PR itself (#336/#367),
+ * not by a commit landing: a label added/removed (`labeled`/`unlabeled`) adjusting override labels,
+ * or the body `edited` to tick/untick the ad-hoc selection region. The CLI reads the event itself
  * (rather than taking a flag) so it works whether the workflow invokes the action, the reusable
  * workflow, or the CLI directly. Such runs must bypass the initial skip-pattern guard: a
  * pull_request event checks out the standing PR's `chore: release preparation` commit, which matches
- * the skip pattern, so the guard would otherwise no-op every label-driven update.
+ * the skip pattern, so the guard would otherwise no-op every PR-driven update. The body re-render is
+ * idempotent and the workflow guards out the bot's own edits, so an `edited` re-trigger is safe.
  */
 function isLabelTriggeredRun(): boolean {
   if (process.env.GITHUB_EVENT_NAME !== 'pull_request') return false;
@@ -100,7 +109,7 @@ function isLabelTriggeredRun(): boolean {
   if (!eventPath) return false;
   try {
     const event = JSON.parse(fs.readFileSync(eventPath, 'utf-8')) as { action?: string };
-    return event.action === 'labeled' || event.action === 'unlabeled';
+    return event.action === 'labeled' || event.action === 'unlabeled' || event.action === 'edited';
   } catch {
     return false;
   }
@@ -380,47 +389,12 @@ function truncateAtLineBoundary(text: string, maxChars: number): string {
   return lastNewline > 0 ? slice.slice(0, lastNewline) : slice;
 }
 
-/** A ` (minor)`-style bump suffix derived from the package's previous→new version, when known. */
-function bumpSuffix(versionOutput: VersionOutput, packageName: string, newVersion: string): string {
-  const previous = versionOutput.changelogs.find((c) => c.packageName === packageName)?.previousVersion;
-  if (!previous) return '';
-  const kind = semver.diff(previous, newVersion);
-  return kind ? ` (${kind})` : '';
-}
-
-/**
- * Render the release set grouped by target → its derived prerequisites (a `--include-prerequisites`
- * / `release:with-prerequisites` run). Each prerequisite shows its own commit-driven bump; a shared
- * prerequisite is listed under every target that pulled it in.
- */
-function renderPrerequisiteSet(versionOutput: VersionOutput, updates: VersionOutput['updates']): string[] {
-  const lines = ['Merging this PR will publish the targeted packages and their changed prerequisites:', ''];
-  const prerequisites = updates.filter((u) => u.role === 'prerequisite');
-  const rendered = new Set<string>();
-  for (const target of updates.filter((u) => u.role === 'target')) {
-    lines.push(
-      `- **\`${target.packageName}\`** → ${target.newVersion}${bumpSuffix(versionOutput, target.packageName, target.newVersion)}`,
-    );
-    rendered.add(target.packageName);
-    for (const prereq of prerequisites.filter((p) => p.prerequisiteOf?.includes(target.packageName))) {
-      lines.push(
-        `  - ↳ prerequisite \`${prereq.packageName}\` → ${prereq.newVersion}${bumpSuffix(versionOutput, prereq.packageName, prereq.newVersion)}`,
-      );
-      rendered.add(prereq.packageName);
-    }
-  }
-  // A prerequisite whose target had no releasable change of its own never gets an update entry, so it
-  // is never tagged 'target' and nothing nests under it — yet the prerequisite still publishes. List
-  // any update not already shown flat, so the package list is never empty while a publish is pending.
-  for (const update of updates.filter((u) => !rendered.has(u.packageName))) {
-    lines.push(
-      `- \`${update.packageName}\` → ${update.newVersion}${bumpSuffix(versionOutput, update.packageName, update.newVersion)}`,
-    );
-  }
-  return lines;
-}
-
-function renderPrBody(versionOutput: VersionOutput, supersedeWarning?: string[], notesRegion?: string): string {
+function renderPrBody(
+  versionOutput: VersionOutput,
+  supersedeWarning?: string[],
+  notesRegion?: string,
+  selectionBlock?: string,
+): string {
   // Build the body around a given changelog section so we can re-render with a truncated changelog
   // if the full one would exceed GitHub's limit, without disturbing the editable notes region.
   const build = (changelogSection: string): string => {
@@ -435,12 +409,14 @@ function renderPrBody(versionOutput: VersionOutput, supersedeWarning?: string[],
     // The root lockstep bump (sync mode) is never published — keep it out of the package list.
     const updates = publishableUpdates(versionOutput);
 
-    if (updates.some((u) => u.role === 'prerequisite')) {
-      // Prerequisite mode: group targets → their derived prerequisites instead of a flat list.
-      lines.push(...renderPrerequisiteSet(versionOutput, updates));
+    if (selectionBlock) {
+      // Non-sync releases render the interactive selection region in place of a static list — it is
+      // the package list (ticked rows = will release), built from the full changed set upstream so a
+      // held-back package still shows as an unticked row. Includes the prerequisite grouping.
+      lines.push(selectionBlock);
     } else if (versionOutput.strategy === 'sync') {
       // Sync releases move as one unit — lead with the version; a per-row version column
-      // would repeat the same value for every package.
+      // would repeat the same value for every package. Selection does not apply (atomic).
       lines.push(`Merging this PR will publish **${syncVersionDisplay(versionOutput)}**:`, '');
       for (const update of updates) {
         lines.push(`- \`${update.packageName}\``);
@@ -702,6 +678,8 @@ interface BuildOptionsExtras {
   stable?: boolean;
   prerelease?: boolean;
   includePrerequisites?: boolean;
+  /** Packages to hold back from the release (standing-PR ad-hoc deselection). Exact name match. */
+  exclude?: string[];
 }
 
 function buildBaseReleaseOptions(
@@ -716,6 +694,7 @@ function buildBaseReleaseOptions(
     bump: extras?.bump,
     target: extras?.target,
     includePrerequisites: extras?.includePrerequisites,
+    exclude: extras?.exclude,
     stable: extras?.stable,
     prerelease: extras?.prerelease ? true : undefined,
     skipNotes: true,
@@ -777,6 +756,21 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
       warn(`Could not look up standing PR for label overrides: ${err instanceof Error ? err.message : String(err)}`);
     }
   }
+
+  // Read the standing PR's live body once (reused for the ad-hoc selection region and edited notes).
+  // A maintainer ticks/unticks packages and edits notes in place; both are read back by marker
+  // slicing so their choices survive this run's regenerate + force-push.
+  let liveBody: string | undefined;
+  if (existingStandingPr && githubContext?.token) {
+    try {
+      liveBody = (await forgeFor(githubContext).getPullRequest(existingStandingPr.number)).body;
+    } catch (err) {
+      warn(`Could not read current PR body to preserve selection: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+  // The maintainer's prior package selection — names whose row was unticked (held back). Reconciled
+  // against the actually-changed set after the dry-run below (a name no longer changed is dropped).
+  const priorDeselected = new Set<string>((liveBody && extractSelection(liveBody)?.deselected) || []);
 
   // Preview-notes opt-in (#200): when the standing PR carries the preview-notes label, generate LLM
   // release notes on demand into an editable region in the PR body. Default path stays LLM-free.
@@ -873,24 +867,38 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
     }
   }
 
-  // Materialize changes on release branch
+  // Reconcile the maintainer's prior selection against this run's changed set: keep a deselection
+  // only when the package still has a releasable change, and never honour one for a lockstep
+  // (fixed/linked) group member — those release together, so holding one back would split the group
+  // (its untick is ignored and the row re-renders ticked next run). The result both narrows the
+  // write below (excluded packages are never bumped) and seeds the rendered selection region.
+  const dryUpdates = publishableUpdates(versionOutputDry);
+  const groups = releaseKitConfig.version?.groups ?? {};
+  const changedNames = new Set(dryUpdates.map((u) => u.packageName));
+  const effectiveDeselected = new Set<string>();
+  for (const name of priorDeselected) {
+    if (!changedNames.has(name)) continue;
+    const update = dryUpdates.find((u) => u.packageName === name);
+    const groupSync = update?.group ? groups[update.group]?.sync : undefined;
+    if (groupSync === 'fixed' || groupSync === 'linked') {
+      warn(`Selection: ignoring held-back \`${name}\` — lockstep group \`${update?.group}\` members release together.`);
+      continue;
+    }
+    effectiveDeselected.add(name);
+  }
+
+  // Materialize changes on release branch. Held-back packages are excluded from the version step so
+  // they are never bumped — no orphan bump lands on the base branch with no tag (roll-forward model).
   info('Writing version bumps...');
-  const writeOptions = buildBaseReleaseOptions(options, false, buildExtras);
+  const writeOptions = buildBaseReleaseOptions(options, false, { ...buildExtras, exclude: [...effectiveDeselected] });
   const versionOutput = await runVersionStep(writeOptions);
 
-  // With the preview-notes label, pull any release notes a human has already edited into the live PR
-  // body so they survive this regenerate-and-force-push. Marker slicing only — never parse the prose.
+  // With the preview-notes label, pull any release notes a human has already edited from the live PR
+  // body (fetched once above) so they survive this regenerate-and-force-push. Marker slicing only.
   const previewPackages = publishableUpdates(versionOutput).map((u) => u.packageName);
   let editedNotes: Record<string, string> = {};
-  if (previewNotesEnabled && existingStandingPr && githubContext?.token) {
-    try {
-      const livePr = await forgeFor(githubContext).getPullRequest(existingStandingPr.number);
-      editedNotes = extractNotesRegions(livePr.body, previewPackages);
-    } catch (err) {
-      warn(
-        `Could not read current PR body to preserve note edits: ${err instanceof Error ? err.message : String(err)}`,
-      );
-    }
+  if (previewNotesEnabled && liveBody) {
+    editedNotes = extractNotesRegions(liveBody, previewPackages);
   }
 
   // Generate per-package CHANGELOG.md always; LLM release notes only when previewing. To keep LLM
@@ -972,7 +980,19 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
     if (Object.keys(merged).length > 0) notesRegion = renderNotesRegion(merged);
   }
 
-  const body = renderPrBody(versionOutput, supersedeWarning, notesRegion);
+  // The interactive selection region — the package list for non-sync releases. Rendered from the
+  // full changed set (dry run) so a held-back package still shows as an unticked row; sync releases
+  // are atomic and carry none. Coherence warnings (partial independent group, held-back prerequisite
+  // of a still-selected target) ride below the region and surface in the run log.
+  let selectionBlock: string | undefined;
+  if (versionOutputDry.strategy !== 'sync') {
+    const region = renderSelectionRegion(versionOutputDry, dryUpdates, effectiveDeselected);
+    const warnings = selectionWarnings(dryUpdates, effectiveDeselected, groups);
+    for (const w of warnings) warn(`Selection: ${w.reason}`);
+    selectionBlock = warnings.length > 0 ? `${region}\n\n${warnings.map((w) => `> ⚠️ ${w.reason}`).join('\n')}` : region;
+  }
+
+  const body = renderPrBody(versionOutput, supersedeWarning, notesRegion, selectionBlock);
 
   let prNumber: number;
   let prUrl: string;
@@ -1044,6 +1064,9 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
     // Record the labels this manifest was computed under so publish can detect a stale manifest if
     // they're changed after this update without a re-run (#337).
     overrideLabels: extractOverrideLabels(existingStandingPr?.labels ?? [], ciConfig),
+    // Record any packages held back via the selection region (provenance; the release set in
+    // `versionOutput` is already narrowed). Omitted when nothing was deselected.
+    deselected: effectiveDeselected.size > 0 ? [...effectiveDeselected].sort() : undefined,
   };
 
   const manifestBody = serializeManifest(manifest);

--- a/packages/release/src/steps.ts
+++ b/packages/release/src/steps.ts
@@ -25,6 +25,7 @@ export async function runVersionStep(options: ReleaseOptions): Promise<VersionOu
     targets,
     baseRef: options.baseRef,
     includePrerequisites: options.includePrerequisites,
+    exclude: options.exclude,
   };
 
   const engine = new VersionEngine(config, runOptions);

--- a/packages/release/src/types.ts
+++ b/packages/release/src/types.ts
@@ -11,6 +11,8 @@ export interface ReleaseOptions {
   target?: string;
   /** Also release the changed internal dependencies of `target` packages (and the rest of their groups). */
   includePrerequisites?: boolean;
+  /** Package names to drop from the release set (standing-PR ad-hoc deselection). Exact name match. */
+  exclude?: string[];
   scope?: string;
   branch?: string;
   skipNotes: boolean;

--- a/packages/release/test/unit/selection-region.spec.ts
+++ b/packages/release/test/unit/selection-region.spec.ts
@@ -1,0 +1,172 @@
+import type { VersionOutput } from '@releasekit/core';
+import { describe, expect, it } from 'vitest';
+import { extractSelection, renderSelectionRegion, selectionWarnings } from '../../src/standing-pr/selection-region.js';
+
+type Update = VersionOutput['updates'][number];
+
+function mockOutput(updates: Update[], changelogs: VersionOutput['changelogs'] = []): VersionOutput {
+  return {
+    dryRun: true,
+    strategy: 'async',
+    updates,
+    changelogs,
+    tags: [],
+    commitMessage: '',
+    sharedEntries: [],
+  } as unknown as VersionOutput;
+}
+
+function changelog(packageName: string, previousVersion: string, version: string) {
+  return { packageName, version, previousVersion, revisionRange: '', repoUrl: null, entries: [] };
+}
+
+describe('selection-region', () => {
+  describe('renderSelectionRegion', () => {
+    it('should render every package ticked by default with a per-row identity marker', () => {
+      const updates: Update[] = [
+        { packageName: '@scope/a', newVersion: '1.1.0', filePath: '' },
+        { packageName: '@scope/b', newVersion: '2.0.0', filePath: '' },
+      ];
+      const region = renderSelectionRegion(mockOutput(updates), updates, new Set());
+
+      expect(region).toContain('- [x] `@scope/a` → 1.1.0 <!-- rk-sel:@scope/a -->');
+      expect(region).toContain('- [x] `@scope/b` → 2.0.0 <!-- rk-sel:@scope/b -->');
+      expect(region).toContain('<!-- releasekit-selection -->');
+      expect(region).toContain('<!-- releasekit-selection-end -->');
+    });
+
+    it('should untick rows for deselected packages', () => {
+      const updates: Update[] = [
+        { packageName: '@scope/a', newVersion: '1.1.0', filePath: '' },
+        { packageName: '@scope/b', newVersion: '2.0.0', filePath: '' },
+      ];
+      const region = renderSelectionRegion(mockOutput(updates), updates, new Set(['@scope/b']));
+
+      expect(region).toContain('- [x] `@scope/a` → 1.1.0 <!-- rk-sel:@scope/a -->');
+      expect(region).toContain('- [ ] `@scope/b` → 2.0.0 <!-- rk-sel:@scope/b -->');
+    });
+
+    it('should show the commit-driven bump kind when the previous version is known', () => {
+      const updates: Update[] = [{ packageName: '@scope/a', newVersion: '1.1.0', filePath: '' }];
+      const region = renderSelectionRegion(
+        mockOutput(updates, [changelog('@scope/a', '1.0.0', '1.1.0')]),
+        updates,
+        new Set(),
+      );
+      expect(region).toContain('→ 1.1.0 (minor)');
+    });
+
+    it('should group targets above their derived prerequisites', () => {
+      const updates: Update[] = [
+        { packageName: '@scope/app', newVersion: '2.0.0', filePath: '', role: 'target' },
+        {
+          packageName: '@scope/core',
+          newVersion: '1.1.0',
+          filePath: '',
+          role: 'prerequisite',
+          prerequisiteOf: ['@scope/app'],
+        },
+      ];
+      const region = renderSelectionRegion(mockOutput(updates), updates, new Set());
+
+      expect(region).toContain('- [x] **`@scope/app`** → 2.0.0 <!-- rk-sel:@scope/app -->');
+      expect(region).toContain('  - [x] ↳ prerequisite `@scope/core` → 1.1.0 <!-- rk-sel:@scope/core -->');
+    });
+
+    it('should list a prerequisite whose target has no update entry rather than drop it', () => {
+      // @scope/app (the target) had no change of its own, so only its prerequisite is in updates.
+      const updates: Update[] = [
+        {
+          packageName: '@scope/core',
+          newVersion: '1.1.0',
+          filePath: '',
+          role: 'prerequisite',
+          prerequisiteOf: ['@scope/app'],
+        },
+      ];
+      const region = renderSelectionRegion(mockOutput(updates), updates, new Set());
+
+      expect(region).toContain('rk-sel:@scope/core');
+    });
+  });
+
+  describe('extractSelection', () => {
+    it('should return undefined when no selection region is present', () => {
+      expect(extractSelection('## Release\n\nno region here')).toBeUndefined();
+    });
+
+    it('should report unticked rows as deselected and ticked rows as selected', () => {
+      const updates: Update[] = [
+        { packageName: '@scope/a', newVersion: '1.1.0', filePath: '' },
+        { packageName: '@scope/b', newVersion: '2.0.0', filePath: '' },
+      ];
+      const body = `## Release\n\n${renderSelectionRegion(mockOutput(updates), updates, new Set(['@scope/b']))}\n\nchangelog`;
+
+      expect(extractSelection(body)).toEqual({ deselected: ['@scope/b'] });
+    });
+
+    it('should take package identity from the marker, not the edited display text', () => {
+      // A maintainer mangles the visible label but leaves the marker — identity must follow the marker.
+      const body = `<!-- releasekit-selection -->\n\n- [ ] \`whatever the human typed\` <!-- rk-sel:@scope/real -->\n\n<!-- releasekit-selection-end -->`;
+      expect(extractSelection(body)).toEqual({ deselected: ['@scope/real'] });
+    });
+
+    it('should round-trip a deselection through render → extract → render (merge-preserve)', () => {
+      const updates: Update[] = [
+        { packageName: '@scope/a', newVersion: '1.1.0', filePath: '' },
+        { packageName: '@scope/b', newVersion: '2.0.0', filePath: '' },
+      ];
+      // First render all-ticked, simulate the human unticking b, then re-render from the extracted set.
+      const seeded = renderSelectionRegion(mockOutput(updates), updates, new Set());
+      const edited = seeded.replace('[x] `@scope/b`', '[ ] `@scope/b`');
+      const extracted = extractSelection(edited);
+      const rerendered = renderSelectionRegion(mockOutput(updates), updates, new Set(extracted?.deselected));
+
+      expect(rerendered).toContain('- [ ] `@scope/b`');
+      expect(rerendered).toContain('- [x] `@scope/a`');
+    });
+  });
+
+  describe('selectionWarnings', () => {
+    it('should warn when a deselected package is an independent-group member', () => {
+      const updates: Update[] = [{ packageName: '@scope/a', newVersion: '1.1.0', filePath: '', group: 'g' }];
+      const warnings = selectionWarnings(updates, new Set(['@scope/a']), { g: { sync: 'independent' } });
+
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]?.reason).toContain('independent group');
+    });
+
+    it('should warn when a deselected prerequisite is still needed by a selected target', () => {
+      const updates: Update[] = [
+        { packageName: '@scope/app', newVersion: '2.0.0', filePath: '', role: 'target' },
+        {
+          packageName: '@scope/core',
+          newVersion: '1.1.0',
+          filePath: '',
+          role: 'prerequisite',
+          prerequisiteOf: ['@scope/app'],
+        },
+      ];
+      const warnings = selectionWarnings(updates, new Set(['@scope/core']), {});
+
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]?.reason).toContain('prerequisite of still-selected');
+    });
+
+    it('should not warn when the prerequisite and all its targets are deselected together', () => {
+      const updates: Update[] = [
+        { packageName: '@scope/app', newVersion: '2.0.0', filePath: '', role: 'target' },
+        {
+          packageName: '@scope/core',
+          newVersion: '1.1.0',
+          filePath: '',
+          role: 'prerequisite',
+          prerequisiteOf: ['@scope/app'],
+        },
+      ];
+      const warnings = selectionWarnings(updates, new Set(['@scope/app', '@scope/core']), {});
+
+      expect(warnings).toHaveLength(0);
+    });
+  });
+});

--- a/packages/release/test/unit/standing-pr.spec.ts
+++ b/packages/release/test/unit/standing-pr.spec.ts
@@ -463,6 +463,44 @@ describe('runStandingPRUpdate', () => {
     expect(body).toContain('(minor)');
   });
 
+  it('should exclude a package the maintainer unticked in the selection region (#367)', async () => {
+    const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
+    const versionOutput = {
+      ...createMockVersionOutput([
+        { packageName: '@scope/a', newVersion: '1.1.0' },
+        { packageName: '@scope/b', newVersion: '2.0.0' },
+      ]),
+      strategy: 'async' as const,
+    };
+    vi.mocked(runVersionStep).mockResolvedValue(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>);
+    vi.mocked(runNotesStep).mockResolvedValue({ packageNotes: {}, releaseNotes: {}, files: [] });
+
+    // The live PR body carries a prior selection with @scope/b unticked.
+    const priorBody = [
+      '<!-- releasekit-selection -->',
+      '',
+      '- [x] `@scope/a` → 1.1.0 <!-- rk-sel:@scope/a -->',
+      '- [ ] `@scope/b` → 2.0.0 <!-- rk-sel:@scope/b -->',
+      '',
+      '<!-- releasekit-selection-end -->',
+    ].join('\n');
+    const forge = await mockForge({
+      standingPR: openStandingPR(99),
+      pullRequests: { 99: { body: priorBody, labels: [] } },
+    });
+
+    await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
+
+    // The write run (second call) excludes the unticked package so it is never bumped.
+    const writeCall = vi.mocked(runVersionStep).mock.calls[1]?.[0] as { exclude?: string[] };
+    expect(writeCall.exclude).toEqual(['@scope/b']);
+
+    // The regenerated body preserves the untick (merge-preserve) — @scope/b stays unticked, @scope/a ticked.
+    const updatedBody = forge.updatedPullRequests[0]?.changes.body ?? '';
+    expect(updatedBody).toContain('- [ ] `@scope/b`');
+    expect(updatedBody).toContain('- [x] `@scope/a`');
+  });
+
   it('should bypass the initial skip-pattern guard on a pull_request label event (#336)', async () => {
     // A label event checks out the standing PR's `chore: release preparation` commit (matches the
     // skip pattern) — the first guard would noop. A label-triggered run must proceed. The post-reset
@@ -704,8 +742,8 @@ describe('runStandingPRUpdate', () => {
     // the 64,001–65,535 safety margin still fails the test.
     expect(body.length).toBeLessThanOrEqual(STANDING_PR_BODY_CAP);
     expect(body).toContain('Changelog truncated');
-    // The package table above the changelog is preserved so the PR is still usable.
-    expect(body).toContain('| `@scope/core` | 1.0.0 |');
+    // The selection region above the changelog is preserved so the PR is still usable.
+    expect(body).toContain('- [x] `@scope/core` → 1.0.0');
   });
 
   it('should omit the ### Changelog section when all updates are sync-bumped (no entries)', async () => {

--- a/packages/release/test/unit/standing-pr.spec.ts
+++ b/packages/release/test/unit/standing-pr.spec.ts
@@ -501,6 +501,35 @@ describe('runStandingPRUpdate', () => {
     expect(updatedBody).toContain('- [x] `@scope/a`');
   });
 
+  it('should never honour a residual selection region in a sync release (#367)', async () => {
+    // A repo that switched to sync may carry a leftover selection region. Sync ships atomically, so a
+    // stale deselection must NOT narrow it into a partial release — exclude stays empty.
+    const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
+    const versionOutput = {
+      ...createMockVersionOutput([
+        { packageName: '@scope/a', newVersion: '1.1.0' },
+        { packageName: '@scope/b', newVersion: '1.1.0' },
+      ]),
+      strategy: 'sync' as const,
+    };
+    vi.mocked(runVersionStep).mockResolvedValue(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>);
+    vi.mocked(runNotesStep).mockResolvedValue({ packageNotes: {}, releaseNotes: {}, files: [] });
+
+    const priorBody = [
+      '<!-- releasekit-selection -->',
+      '',
+      '- [ ] `@scope/b` → 1.1.0 <!-- rk-sel:@scope/b -->',
+      '',
+      '<!-- releasekit-selection-end -->',
+    ].join('\n');
+    await mockForge({ standingPR: openStandingPR(99), pullRequests: { 99: { body: priorBody, labels: [] } } });
+
+    await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
+
+    const writeCall = vi.mocked(runVersionStep).mock.calls[1]?.[0] as { exclude?: string[] };
+    expect(writeCall.exclude).toEqual([]);
+  });
+
   it('should bypass the initial skip-pattern guard on a pull_request label event (#336)', async () => {
     // A label event checks out the standing PR's `chore: release preparation` commit (matches the
     // skip pattern) — the first guard would noop. A label-triggered run must proceed. The post-reset

--- a/packages/version/src/core/versionEngine.ts
+++ b/packages/version/src/core/versionEngine.ts
@@ -32,6 +32,8 @@ export class VersionEngine {
   private currentStrategy: StrategyFunction;
   private runtimeTargets: string[] = [];
   private includePrerequisites = false;
+  /** Package names to drop from the release set as the final discovery filter (see VersionRunOptions.exclude). */
+  private excludePackages: string[] = [];
   /** Prereq → target(s) it was pulled in for, captured during prerequisite resolution; used after
    *  `run()` to tag each update's role/prerequisiteOf. Empty unless prerequisites were derived. */
   private prerequisiteOf: Record<string, string[]> = {};
@@ -60,6 +62,7 @@ export class VersionEngine {
       if (runOptions.baseRef) effective.baseRef = runOptions.baseRef;
       if (runOptions.overrideScope) effective.overrideScope = runOptions.overrideScope;
       if (runOptions.includePrerequisites) this.includePrerequisites = true;
+      if (runOptions.exclude?.length) this.excludePackages = runOptions.exclude;
     }
 
     // Default values for required properties
@@ -487,6 +490,16 @@ export class VersionEngine {
           shouldMatchPackageTargets(pkg.packageJson.name, this.runtimeTargets),
         );
         log(`Runtime targets filter: ${beforeCount} → ${mergedPackages.packages.length} packages`, 'info');
+      }
+
+      // Final filter: drop explicitly excluded packages from the release set (standing-PR ad-hoc
+      // deselection). Applied last so it overrides every inclusion above — an excluded package never
+      // gets bumped, even if a target or prerequisite expansion pulled it in. Exact name match.
+      if (this.excludePackages.length > 0) {
+        const excluded = new Set(this.excludePackages);
+        const beforeCount = mergedPackages.packages.length;
+        mergedPackages.packages = mergedPackages.packages.filter((pkg) => !excluded.has(pkg.packageJson.name));
+        log(`Exclude filter: ${beforeCount} → ${mergedPackages.packages.length} packages`, 'info');
       }
 
       // Cache the result for subsequent calls

--- a/packages/version/src/types.ts
+++ b/packages/version/src/types.ts
@@ -46,6 +46,14 @@ export interface VersionRunOptions {
    * commit-driven bump.
    */
   includePrerequisites?: boolean;
+  /**
+   * Package names to drop from the release set, applied as the final discovery filter — after
+   * `targets`, `packages`, and prerequisite expansion. An excluded package is never bumped, so its
+   * `package.json` is untouched and it produces no update. Used by standing-PR ad-hoc selection: a
+   * maintainer unchecks a package and it falls out of the release entirely (no orphan bump landing
+   * on the base branch with no tag). Exact name match, not a pattern.
+   */
+  exclude?: string[];
 }
 
 export interface GitInfo {

--- a/packages/version/test/unit/core/versionEngine.spec.ts
+++ b/packages/version/test/unit/core/versionEngine.spec.ts
@@ -265,6 +265,21 @@ describe('Version Engine', () => {
       expect(getPackagesSync).toHaveBeenCalledTimes(1);
     });
 
+    it('should drop excluded packages from the release set as the final filter', async () => {
+      const engine = new VersionEngine(defaultConfig as Config, { exclude: ['package-b'] });
+      const result = await engine.getWorkspacePackages();
+
+      expect(result.packages.map((p) => p.packageJson.name)).toEqual(['package-a']);
+      expect(log).toHaveBeenCalledWith('Exclude filter: 2 → 1 packages', 'info');
+    });
+
+    it('should leave the release set untouched when exclude is empty', async () => {
+      const engine = new VersionEngine(defaultConfig as Config, { exclude: [] });
+      const result = await engine.getWorkspacePackages();
+
+      expect(result.packages).toHaveLength(2);
+    });
+
     it('should handle missing root property by setting it to cwd', async () => {
       // Mock packages WITHOUT root - the merge function will use npmPackages.root as fallback
       const mockPackagesWithoutRoot = {

--- a/templates/workflows/standing-pr.yml
+++ b/templates/workflows/standing-pr.yml
@@ -41,9 +41,10 @@ jobs:
     # push/schedule rebuild the PR; a label change or selection-region edit on the OPEN standing PR
     # re-runs the update so bump/scope/channel overrides and held-back packages apply within seconds.
     # `state == 'open'` keeps this off the merged-PR label events that drive the jobs below. The
-    # `sender.login != 'github-actions[bot]'` guard is load-bearing for `edited`: the update itself
-    # rewrites the PR body (an `edited` event), so without it the bot would re-trigger forever.
-    # `release/` prefix hardcoded (workflow `if` can't read config) — the in-step config is authoritative.
+    # `sender.type != 'Bot'` guard is load-bearing for `edited`: the update itself rewrites the PR
+    # body (an `edited` event), so without it the bot would re-trigger forever. Match on type, not a
+    # hardcoded `github-actions[bot]` login, so a custom GitHub App token (its own `*[bot]` login) is
+    # filtered too. `release/` prefix hardcoded (workflow `if` can't read config) — in-step config is authoritative.
     if: >-
       github.event_name == 'push' ||
       github.event_name == 'schedule' ||
@@ -56,7 +57,7 @@ jobs:
         ) &&
         github.event.pull_request.state == 'open' &&
         startsWith(github.event.pull_request.head.ref, 'release/') &&
-        github.event.sender.login != 'github-actions[bot]'
+        github.event.sender.type != 'Bot'
       )
     runs-on: ubuntu-latest
     steps:

--- a/templates/workflows/standing-pr.yml
+++ b/templates/workflows/standing-pr.yml
@@ -15,9 +15,12 @@ on:
     branches: [main]  # Should match git.branch in releasekit.config.json
   pull_request:
     # closed: publish / immediate-release on merge. labeled/unlabeled: apply
-    # bump/scope/channel override labels to the OPEN standing PR immediately
-    # (the merge-gated jobs below add `action == 'closed'` so they ignore these).
-    types: [closed, labeled, unlabeled]
+    # bump/scope/channel override labels to the OPEN standing PR immediately.
+    # edited: a maintainer ticked/unticked packages in the PR's selection region —
+    # re-run so the held-back set is applied (the bot's own body edits are filtered
+    # out by the sender guard below to avoid a loop).
+    # (The merge-gated jobs below add `action == 'closed'` so they ignore these.)
+    types: [closed, labeled, unlabeled, edited]
     branches: [main]
   schedule:
     - cron: '0 * * * *'  # Hourly — re-evaluates minAge status check as time passes
@@ -35,18 +38,25 @@ permissions:
 jobs:
   update-release-pr:
     name: Update Release PR
-    # push/schedule rebuild the PR; a label change on the OPEN standing PR re-runs the update so
-    # bump/scope/channel overrides apply within seconds. `state == 'open'` keeps this off the
-    # merged-PR label events that drive the jobs below. `release/` prefix hardcoded (workflow `if`
-    # can't read config) — the in-step config is authoritative.
+    # push/schedule rebuild the PR; a label change or selection-region edit on the OPEN standing PR
+    # re-runs the update so bump/scope/channel overrides and held-back packages apply within seconds.
+    # `state == 'open'` keeps this off the merged-PR label events that drive the jobs below. The
+    # `sender.login != 'github-actions[bot]'` guard is load-bearing for `edited`: the update itself
+    # rewrites the PR body (an `edited` event), so without it the bot would re-trigger forever.
+    # `release/` prefix hardcoded (workflow `if` can't read config) — the in-step config is authoritative.
     if: >-
       github.event_name == 'push' ||
       github.event_name == 'schedule' ||
       (
         github.event_name == 'pull_request' &&
-        (github.event.action == 'labeled' || github.event.action == 'unlabeled') &&
+        (
+          github.event.action == 'labeled' ||
+          github.event.action == 'unlabeled' ||
+          github.event.action == 'edited'
+        ) &&
         github.event.pull_request.state == 'open' &&
-        startsWith(github.event.pull_request.head.ref, 'release/')
+        startsWith(github.event.pull_request.head.ref, 'release/') &&
+        github.event.sender.login != 'github-actions[bot]'
       )
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Closes #367. Feature Phase 6 (Wave D) of the deepen-and-ship epic (#369). Builds on #366 (merged in #390) and the #360 marker codec.

## What this adds

An interactive **selection region** in the standing-PR body — a GitHub task-list with one ticked row per changed package (ticked = will release, all ticked by default). A maintainer unticks a package to hold it back from the next release; the choice round-trips by marker slicing so it survives the body being regenerated and force-pushed.

```
### Packages to release
> Untick a package to hold it back from the next release, then save…

- [x] **`@scope/app`** → 2.0.0 (major) <!-- rk-sel:@scope/app -->
  - [ ] ↳ prerequisite `@scope/core` → 1.1.0 (minor) <!-- rk-sel:@scope/core -->
> ⚠️ `@scope/core` is a prerequisite of still-selected `@scope/app` — unticking it publishes it against an unreleased dependency.
```

## How it works

- **Held-back = excluded at the version step.** New `VersionRunOptions.exclude` knob, applied as the final discovery filter in `getWorkspacePackages`, so an unticked package is never bumped — no orphan version lands on `main` with no tag (preserves the roll-forward / idempotency invariant). This is the **Approach A** decision: feed the exclusion into the version step rather than post-hoc narrowing the output.
- **Second markerRegion adapter** (after `notes-region`), built on the #360 codec: a new `core/selectionRegion.ts` (region open/close + per-row `<!-- rk-sel:NAME -->` identity marker) and a `release/standing-pr/selection-region.ts` (render / extract / warnings). Package identity is read from the marker, never the prose; the `[x]`/`[ ]` glyph is the one thing the human toggles.
- **Grouping** reuses #366's `role`/`prerequisiteOf` to render target → its prerequisites (absorbs the old `renderPrerequisiteSet`).
- **Manifest** records the held-back set (optional `deselected` — absent ⇒ all selected ⇒ today's behavior).
- **Coherence warnings**: unticking an `independent`-group member, or a prerequisite still needed by a ticked target. Lockstep (`fixed`/`linked`) members can't be held back individually (their untick is ignored and re-ticks). Sync releases are atomic and carry no checklist.

## Consumer-facing workflow change

The standing-pr workflow gains a `pull_request: edited` trigger + an `if` guard adding `action == 'edited'` **and** `sender.login != 'github-actions[bot]'`. The latter is load-bearing: the update itself rewrites the PR body (an `edited` event), so without it the bot would re-trigger forever. Updated in the template, the `examples/` copy, and `ci-setup.md`. (The repo's own dogfood workflow is sync — no checklist — so it's deliberately left unchanged.)

## Acceptance criteria

- [x] Checkbox region renders changed packages; checked = released; default all-checked
- [x] Per-row state behind `<!-- rk-sel:NAME -->` markers (never prose); survives regeneration
- [x] Derived set pre-populates; manual toggles narrow the update set; recorded in manifest (optional field)
- [x] Warns on unchecking an independent-group member / a checked package's prerequisite
- [x] Workflow template gains `edited` trigger + sender guard; ci-setup.md updated
- [x] Unit tests: marker parse / merge-preserve / idempotent render; gate passes

## Verification

- Full CI-equivalent gate green: `pnpm turbo run lint typecheck test:coverage` → **27/27**; `pnpm schema:check` up to date (no config field added).
- New tests: core `selectionRegion.spec.ts` (6); release `selection-region.spec.ts` (12, incl. merge-preserve + marker-identity); version-engine exclude filter (2); standing-pr wiring (unticked package excluded from the write run + body preserves untick).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces an interactive **selection region** in the standing-PR body — a GitHub task-list that lets a maintainer untick packages to hold them back from the next release. The choice round-trips via per-row `<!-- rk-sel:NAME -->` identity markers (never prose), survives PR body regeneration, and is enforced by feeding the held-back set into the version engine's new `exclude` knob so no orphan version bump lands on `main`. All three issues raised in the previous review cycle — the missing sync-strategy guard on `effectiveDeselected`, the hard-coded `github-actions[bot]` sender-login filter, and the misleading `isLabelTriggeredRun` name — have been addressed in this revision.

- **Core codec (`packages/core/src/selectionRegion.ts`)**: Adds the second `markerRegion` adapter (after `notes-region`), exposing region open/close markers and a per-row `rkSelMarker(name)` identity helper; `extractSelectionRegion` is pure marker slicing with no regex backtracking.
- **Release-layer logic (`packages/release/src/standing-pr/selection-region.ts` + `standing-pr.ts`)**: `renderSelectionRegion` builds the task-list from the dry-run's full changed set so held-back packages still appear as unticked rows; `extractSelection` reads it back; `selectionWarnings` surfaces partial-group and broken-prerequisite coherence issues. The write run receives `exclude: [...effectiveDeselected]`, and a `strategy === 'sync'` guard prevents a residual region from narrowing an atomic sync release.
- **Version engine (`packages/version/src/core/versionEngine.ts`)**: A new final `exclude` filter drops named packages from the release set after all other inclusion logic, preserving the roll-forward/no-orphan-bump invariant.
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge — all three previously-flagged issues have been fixed and no new defects were found in this revision.

The core invariants are solid: held-back packages are excluded from the write run (never bumped, no orphan version on main), the sync-strategy guard correctly prevents a residual selection region from narrowing an atomic sync release, and the sender.type != 'Bot' filter correctly covers custom GitHub App tokens. The marker-based state round-trip (package identity from the rk-sel comment, checked state from the glyph) is ReDoS-safe fixed-substring slicing. Tests cover the primary flows including the merge-preserve round-trip and the sync residual-region guard.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/core/src/selectionRegion.ts | New codec: thin adapter over extractMarkerRegion/wrapMarkerRegion exposing the selection region open/close markers and per-row rkSelMarker identity helper; no logic concerns. |
| packages/release/src/standing-pr/selection-region.ts | New file: renders/extracts the interactive checkbox task-list and computes coherence warnings; extractSelection uses fixed substring detection (no regex) and marker-identity slicing; logic is sound. |
| packages/release/src/standing-pr/standing-pr.ts | Key orchestration changes: liveBody fetched once and reused for both selection and notes extraction; sync-strategy guard correctly wraps effectiveDeselected reconciliation; dead else-branch (flat table) left in renderPrBody is unreachable for non-sync strategies but harmless. |
| packages/version/src/core/versionEngine.ts | Adds final exclude filter after all inclusion logic (targets, packages, prerequisite expansion); applied only when excludePackages is non-empty; exact name-match set lookup is correct. |
| templates/workflows/standing-pr.yml | Adds edited trigger + sender.type != 'Bot' guard (correctly uses type not login, preventing infinite-loop for custom GitHub App tokens); guard comment accurately explains the load-bearing intent. |
| examples/ci/standing-pr/standing-pr.yml | Example workflow updated in sync with the template; uses sender.type != 'Bot' consistently. |
| packages/release/test/unit/standing-pr.spec.ts | New integration tests cover the unticked-package exclusion path and the sync residual-region guard; existing truncation test updated to check selection-region rows instead of the removed table format. |
| packages/release/test/unit/selection-region.spec.ts | 12 unit tests covering render (default ticked, deselected, bump suffix, prerequisite grouping, orphan prereq), extract (round-trip, marker-identity, merge-preserve), and warnings (independent group, broken prereq, safe both-deselected). |
| packages/version/test/unit/core/versionEngine.spec.ts | Two new tests verify exclude filter drops named packages and is a no-op on empty array; both match observed engine logging. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant M as Maintainer
    participant GH as GitHub PR
    participant WF as Workflow (edited trigger)
    participant CLI as standing-pr update
    participant VE as VersionEngine

    M->>GH: Untick package row (body edit)
    GH->>WF: "pull_request edited event (sender.type != 'Bot' guard passes)"
    WF->>CLI: standing-pr update

    CLI->>GH: getPullRequest(number).body
    GH-->>CLI: liveBody with rk-sel markers

    CLI->>CLI: extractSelection(liveBody) → priorDeselected
    CLI->>VE: "dryRun=true (no exclude)"
    VE-->>CLI: versionOutputDry (all packages)

    CLI->>CLI: Reconcile priorDeselected vs dryUpdates
    Note over CLI: skip if not changed, skip if sync,
    Note over CLI: skip lockstep groups → effectiveDeselected

    CLI->>VE: "dryRun=false, exclude=[X]"
    VE-->>CLI: versionOutput (X excluded, never bumped)

    CLI->>CLI: renderSelectionRegion(versionOutputDry, dryUpdates, effectiveDeselected)
    CLI->>CLI: selectionWarnings() → warn if partial group or broken prereq
    CLI->>GH: updatePullRequest(body with selection block)
    GH->>WF: "pull_request edited (sender.type == 'Bot' → filtered out)"
    Note over WF: No re-trigger loop
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant M as Maintainer
    participant GH as GitHub PR
    participant WF as Workflow (edited trigger)
    participant CLI as standing-pr update
    participant VE as VersionEngine

    M->>GH: Untick package row (body edit)
    GH->>WF: "pull_request edited event (sender.type != 'Bot' guard passes)"
    WF->>CLI: standing-pr update

    CLI->>GH: getPullRequest(number).body
    GH-->>CLI: liveBody with rk-sel markers

    CLI->>CLI: extractSelection(liveBody) → priorDeselected
    CLI->>VE: "dryRun=true (no exclude)"
    VE-->>CLI: versionOutputDry (all packages)

    CLI->>CLI: Reconcile priorDeselected vs dryUpdates
    Note over CLI: skip if not changed, skip if sync,
    Note over CLI: skip lockstep groups → effectiveDeselected

    CLI->>VE: "dryRun=false, exclude=[X]"
    VE-->>CLI: versionOutput (X excluded, never bumped)

    CLI->>CLI: renderSelectionRegion(versionOutputDry, dryUpdates, effectiveDeselected)
    CLI->>CLI: selectionWarnings() → warn if partial group or broken prereq
    CLI->>GH: updatePullRequest(body with selection block)
    GH->>WF: "pull_request edited (sender.type == 'Bot' → filtered out)"
    Note over WF: No re-trigger loop
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/release/src/standing-pr/standing-pr.ts`, line 433 ([link](https://github.com/goosewobbler/releasekit/blob/81df39f7ee216ade4fd9e9aa1232d9207c08341e/packages/release/src/standing-pr/standing-pr.ts#L433)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`isLabelTriggeredRun` name is now misleading**

   The function also returns `true` for `action === 'edited'` events (body ticks/unticks), not just label events. Its name and JSDoc only describe the label case, so anyone maintaining this code could reasonably add a label-specific branch in the wrong place or misread the control flow. Consider renaming to `isPrActionTriggeredRun` (or `isStandingPrEventRun`) and updating the comment.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Frelease%2Fsrc%2Fstanding-pr%2Fstanding-pr.ts%0ALine%3A%20433%0A%0AComment%3A%0A**%60isLabelTriggeredRun%60%20name%20is%20now%20misleading**%0A%0AThe%20function%20also%20returns%20%60true%60%20for%20%60action%20%3D%3D%3D%20'edited'%60%20events%20%28body%20ticks%2Funticks%29%2C%20not%20just%20label%20events.%20Its%20name%20and%20JSDoc%20only%20describe%20the%20label%20case%2C%20so%20anyone%20maintaining%20this%20code%20could%20reasonably%20add%20a%20label-specific%20branch%20in%20the%20wrong%20place%20or%20misread%20the%20control%20flow.%20Consider%20renaming%20to%20%60isPrActionTriggeredRun%60%20%28or%20%60isStandingPrEventRun%60%29%20and%20updating%20the%20comment.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=goosewobbler%2Freleasekit&pr=391&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Frelease%2Fsrc%2Fstanding-pr%2Fstanding-pr.ts%0ALine%3A%20433%0A%0AComment%3A%0A**%60isLabelTriggeredRun%60%20name%20is%20now%20misleading**%0A%0AThe%20function%20also%20returns%20%60true%60%20for%20%60action%20%3D%3D%3D%20'edited'%60%20events%20%28body%20ticks%2Funticks%29%2C%20not%20just%20label%20events.%20Its%20name%20and%20JSDoc%20only%20describe%20the%20label%20case%2C%20so%20anyone%20maintaining%20this%20code%20could%20reasonably%20add%20a%20label-specific%20branch%20in%20the%20wrong%20place%20or%20misread%20the%20control%20flow.%20Consider%20renaming%20to%20%60isPrActionTriggeredRun%60%20%28or%20%60isStandingPrEventRun%60%29%20and%20updating%20the%20comment.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=391&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix(release): guard sync selection + mat..."](https://github.com/goosewobbler/releasekit/commit/f57ab5a0bb1e913f4e4d6a69f686d087b054659c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39081058)</sub>

<!-- /greptile_comment -->