### PR TITLE
fix(version): strictReachable aborts the run instead of silently degrading (#372)

### DIFF
--- a/packages/version/src/core/baselineResolver.ts
+++ b/packages/version/src/core/baselineResolver.ts
@@ -1,3 +1,4 @@
+import { StrictReachableError } from '../errors/strictReachableError.js';
 import { getLatestStableTag, getLatestStableTagForPackage, getNearestReachableTag } from '../git/tagsAndBranches.js';
 import { verifyTag } from '../git/tagVerification.js';
 import { displayTag } from '../utils/formatting.js';
@@ -116,7 +117,11 @@ export class BaselineResolver {
         revisionRange = `${baseForRange}..HEAD`;
       } else {
         if (!baseRef && strictReachable) {
-          throw new Error(
+          // A dedicated type, not a bare Error: the per-package changelog try/catch in each strategy
+          // degrades genuine extraction failures to a minimal entry, but must rethrow THIS so it
+          // aborts the run (#372) — strictReachable's whole job is to fail loudly on an unreachable
+          // baseline (shallow clone / fetch-depth), not ship a silently whole-history changelog.
+          throw new StrictReachableError(
             `Cannot generate changelog: ref '${baseForRange}' is not reachable from the current commit. ` +
               `When strictReachable is enabled, all refs must be reachable. ` +
               `To allow fallback to all commits, set strictReachable to false.`,

--- a/packages/version/src/core/groupStrategy.ts
+++ b/packages/version/src/core/groupStrategy.ts
@@ -24,6 +24,7 @@ import { shouldMatchPackageTargets, shouldProcessPackage as shouldProcessPackage
 import semver from 'semver';
 import { extractChangelogEntriesFromCommits } from '../changelog/commitParser.js';
 import { BaseVersionError } from '../errors/baseError.js';
+import { StrictReachableError } from '../errors/strictReachableError.js';
 import { getLatestTag, getLatestTagForPackage } from '../git/tagsAndBranches.js';
 import { updatePackageVersion } from '../package/packageManagement.js';
 import type { Config } from '../types.js';
@@ -244,6 +245,8 @@ async function extractEntries(
     previousVersion = baseline.previousVersion;
     entries = extractChangelogEntriesFromCommits(input.pkgDir, revisionRange);
   } catch (error) {
+    // A strictReachable violation must abort the run, not degrade to a minimal entry (#372).
+    if (error instanceof StrictReachableError) throw error;
     log(`Error extracting changelog entries: ${error instanceof Error ? error.message : String(error)}`, 'warning');
   }
   if (entries.length === 0) {

--- a/packages/version/src/core/versionStrategies.ts
+++ b/packages/version/src/core/versionStrategies.ts
@@ -9,6 +9,7 @@ import type { VersionChangelogEntry } from '@releasekit/core';
 import { shouldMatchPackageTargets, shouldProcessPackage as shouldProcessPackageUtil } from '@releasekit/core';
 import { extractChangelogEntriesFromCommits } from '../changelog/commitParser.js';
 import { BaseVersionError } from '../errors/baseError.js';
+import { StrictReachableError } from '../errors/strictReachableError.js';
 import { createVersionError, VersionErrorCode } from '../errors/versionError.js';
 import { getLatestTag, getLatestTagForPackage } from '../git/tagsAndBranches.js';
 import { updatePackageVersion } from '../package/packageManagement.js';
@@ -311,6 +312,8 @@ export function createSyncStrategy(config: Config): StrategyFunction {
           changelogEntries = [{ type: 'changed', description: `Update version to ${nextVersion}` }];
         }
       } catch (error) {
+        // A strictReachable violation must abort the run, not degrade to a minimal entry (#372).
+        if (error instanceof StrictReachableError) throw error;
         log(`Error extracting changelog entries: ${error instanceof Error ? error.message : String(error)}`, 'warning');
         changelogEntries = [{ type: 'changed', description: `Update version to ${nextVersion}` }];
       }
@@ -569,6 +572,8 @@ export function createSingleStrategy(config: Config): StrategyFunction {
           changelogEntries = [{ type: 'changed', description: `Update version to ${nextVersion}` }];
         }
       } catch (error) {
+        // A strictReachable violation must abort the run, not degrade to a minimal entry (#372).
+        if (error instanceof StrictReachableError) throw error;
         log(`Error extracting changelog entries: ${error instanceof Error ? error.message : String(error)}`, 'warning');
         // Fall back to minimal entry
         changelogEntries = [{ type: 'changed', description: `Update version to ${nextVersion}` }];
@@ -680,6 +685,9 @@ export function createAsyncStrategy(config: Config): StrategyFunction {
       baseBranch: config.baseBranch || 'main',
       prereleaseIdentifier: config.prereleaseIdentifier,
       type: config.type,
+      // Without this the per-package resolver always saw strictReachable=false, so the async path
+      // never enforced it — the guard silently no-op'd for per-package repos (#372).
+      strictReachable: config.strictReachable,
     },
   };
 

--- a/packages/version/src/errors/strictReachableError.ts
+++ b/packages/version/src/errors/strictReachableError.ts
@@ -1,0 +1,17 @@
+import { BaseVersionError } from './baseError.js';
+
+/**
+ * Thrown by {@link BaselineResolver.resolve} when `version.strictReachable` is set and a baseline ref
+ * is not reachable from HEAD (typically a shallow clone / `fetch-depth` misconfiguration).
+ *
+ * It is a distinct type purely so the per-package changelog `try/catch` in each strategy can tell it
+ * apart from a genuine changelog-extraction failure: genuine failures degrade to a minimal entry and
+ * the run continues, but this one is **rethrown** so it aborts the whole run — which is the entire
+ * point of `strictReachable` (surface the misconfiguration loudly, don't ship a silently-degraded
+ * whole-history changelog on a green run). See #372.
+ */
+export class StrictReachableError extends BaseVersionError {
+  constructor(message: string) {
+    super(message, 'STRICT_REACHABLE_UNREACHABLE');
+  }
+}

--- a/packages/version/src/package/packageProcessor.ts
+++ b/packages/version/src/package/packageProcessor.ts
@@ -6,6 +6,7 @@ import { shouldProcessPackage } from '@releasekit/core';
 import { extractChangelogEntriesFromCommits, extractRepoLevelChangelogEntries } from '../changelog/commitParser.js';
 import { BaselineResolver } from '../core/baselineResolver.js';
 import { calculateVersion } from '../core/versionCalculator.js';
+import { StrictReachableError } from '../errors/strictReachableError.js';
 import { getLatestTagForPackage } from '../git/tagsAndBranches.js';
 import type { Config, VersionConfigBase } from '../types.js';
 import { deriveBaselineTagPrefix, formatCommitMessage, formatTag, formatVersionPrefix } from '../utils/formatting.js';
@@ -280,6 +281,8 @@ export class PackageProcessor {
           ];
         }
       } catch (error) {
+        // A strictReachable violation must abort the run, not degrade to a minimal entry (#372).
+        if (error instanceof StrictReachableError) throw error;
         log(`Error extracting changelog entries: ${error instanceof Error ? error.message : String(error)}`, 'warning');
         // Fall back to minimal entry
         changelogEntries = [

--- a/packages/version/test/unit/core/baselineResolver.spec.ts
+++ b/packages/version/test/unit/core/baselineResolver.spec.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { BaselineResolver, type BaselineResolverOptions } from '../../../src/core/baselineResolver.js';
+import { StrictReachableError } from '../../../src/errors/strictReachableError.js';
 import {
   getLatestStableTag,
   getLatestStableTagForPackage,
@@ -55,11 +56,14 @@ describe('BaselineResolver.resolve', () => {
     expect(result.baselineUnreachable).toBe(true);
   });
 
-  it('should throw on an unreachable baseline when strictReachable is set', async () => {
+  it('should throw a StrictReachableError on an unreachable baseline when strictReachable is set', async () => {
     vi.mocked(verifyTag).mockReturnValue(unreachable);
-    await expect(new BaselineResolver(makeOpts({ strictReachable: true })).resolve(makeInput())).rejects.toThrow(
-      /not reachable/,
-    );
+    // The type — not just the message — is the contract (#372): the per-package changelog catch in
+    // each strategy distinguishes this from a genuine extraction error by `instanceof` and rethrows
+    // it so the run aborts, instead of degrading to a minimal changelog entry.
+    const promise = new BaselineResolver(makeOpts({ strictReachable: true })).resolve(makeInput());
+    await expect(promise).rejects.toBeInstanceOf(StrictReachableError);
+    await expect(promise).rejects.toThrow(/not reachable/);
   });
 
   it('should not throw under strictReachable when baseRef is set (baseRef takes precedence)', async () => {

--- a/packages/version/test/unit/package/packageProcessor.spec.ts
+++ b/packages/version/test/unit/package/packageProcessor.spec.ts
@@ -6,6 +6,7 @@ import * as cargoHandler from '../../../src/cargo/cargoHandler.js';
 import * as commitParser from '../../../src/changelog/commitParser.js';
 import * as calculator from '../../../src/core/versionCalculator.js';
 import * as versionCalculatorModule from '../../../src/core/versionCalculator.js';
+import { StrictReachableError } from '../../../src/errors/strictReachableError.js';
 import * as gitTags from '../../../src/git/tagsAndBranches.js';
 import * as tagVerification from '../../../src/git/tagVerification.js';
 import * as packageManagement from '../../../src/package/packageManagement.js';
@@ -1412,6 +1413,51 @@ describe('Package Processor', () => {
 
       // Verify the tag was tracked via JSON output with the correct format
       expect(jsonOutput.addTag).toHaveBeenCalledWith('ver1.1.0');
+    });
+  });
+
+  // #372 — strictReachable must abort the run, not silently degrade. Both tests run with the SAME
+  // strictReachable:true config so the only variable is the error TYPE: an unreachable-baseline
+  // StrictReachableError aborts; a genuine extraction error still degrades to a minimal entry.
+  describe('strictReachable (#372)', () => {
+    beforeEach(() => {
+      // A real per-package tag so the resolver takes the verify-baseline branch (hasRealTag = true).
+      vi.spyOn(gitTags, 'getLatestTagForPackage').mockResolvedValue('v1.0.0');
+    });
+
+    it('should abort the run with a StrictReachableError when the baseline is unreachable', async () => {
+      vi.spyOn(tagVerification, 'verifyTag').mockReturnValue({
+        exists: true,
+        reachable: false,
+        error: 'exists but is not an ancestor of HEAD',
+      });
+      const processor = new PackageProcessor({
+        ...defaultOptions,
+        config: { ...defaultOptions.config, strictReachable: true },
+        fullConfig: { ...mockConfig, strictReachable: true },
+      });
+
+      await expect(processor.processPackages(mockPackages)).rejects.toBeInstanceOf(StrictReachableError);
+    });
+
+    it('should still degrade a genuine changelog-extraction error to a minimal entry', async () => {
+      // Baseline reachable (no strict violation), but commit parsing throws — the catch must swallow
+      // this and fall back, not abort, even though strictReachable is on.
+      vi.spyOn(tagVerification, 'verifyTag').mockReturnValue({ exists: true, reachable: true });
+      vi.spyOn(commitParser, 'extractChangelogEntriesFromCommits').mockImplementation(() => {
+        throw new Error('git log failed');
+      });
+      const processor = new PackageProcessor({
+        ...defaultOptions,
+        config: { ...defaultOptions.config, strictReachable: true },
+        fullConfig: { ...mockConfig, strictReachable: true },
+      });
+
+      await expect(processor.processPackages(mockPackages)).resolves.toBeDefined();
+      expect(vi.mocked(logging.log)).toHaveBeenCalledWith(
+        expect.stringContaining('Error extracting changelog entries'),
+        'warning',
+      );
     });
   });
 });


### PR DESCRIPTION
Closes #372.

`version.strictReachable: true` is documented as a hard failure when a baseline tag isn't reachable from HEAD (the shallow-clone / `fetch-depth` misconfiguration guard), but it never actually aborted. Investigating turned up **two** distinct bugs — both had to be fixed for the guard to work, especially on the per-package path real consumers use.

## Bug 1 — the throw was swallowed (the issue as filed)

`BaselineResolver.resolve()` throws, but every strategy wraps the resolve + changelog extraction in a `try/catch` that logs `Error extracting changelog entries` and degrades to a minimal `Update version to X` entry — swallowing the strictReachable error alongside genuine extraction failures. Result: a silently whole-history changelog on a **green** run.

**Fix:** the throw is now a dedicated `StrictReachableError`. Each of the four catch sites (sync/single, async, group) rethrows it (`if (error instanceof StrictReachableError) throw error;`) so it aborts the run, while genuine extraction errors still degrade exactly as before.

## Bug 2 — strictReachable was never threaded into the async path

Found while writing the test: `createAsyncStrategy` builds `PackageProcessor`'s runtime `config` subset **without** `strictReachable`, so the per-package resolver always received `false` — the throw never even fired on the async path, independent of the swallow. So per-package repos (e.g. mixed npm/cargo consumers) got *no* enforcement at all.

**Fix:** thread `config.strictReachable` into `processorOptions.config`. The other three constructions already passed it.

With both, an unreachable baseline under `strictReachable` now fails loudly (non-zero exit) on **every** strategy.

## Acceptance criteria

- [x] With `strictReachable: true` and an unreachable baseline, the run fails loudly (surfaced `StrictReachableError`, non-zero exit), not a minimal entry
- [x] Genuine changelog-extraction errors still degrade gracefully (unchanged)
- [x] Unit coverage for both paths

## Tests

- `baselineResolver.spec`: asserts the throw is a `StrictReachableError` (the type is the contract — that's what the catches key on) with the expected message.
- `packageProcessor.spec` (the async path): under the **same** `strictReachable: true` config, an unreachable baseline **rejects** with `StrictReachableError`, but a genuine `extractChangelogEntriesFromCommits` failure still **resolves** with a degraded minimal entry — proving the catch distinguishes by error type, not config.

Full gate green: `pnpm turbo run lint typecheck test:coverage` → **27/27**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Fixes two related bugs that caused `version.strictReachable: true` to silently no-op instead of aborting the run when a baseline tag is unreachable. The approach — introducing a typed `StrictReachableError` and rethrowing it past each strategy's degradation catch — is the correct minimal-surface fix.

- **Bug 1 (all strategies):** `BaselineResolver.resolve()` now throws `StrictReachableError` instead of a bare `Error`; four catch sites across `groupStrategy`, `versionStrategies` (sync + single), and `packageProcessor` rethrow it while continuing to swallow genuine extraction errors.
- **Bug 2 (async path):** `createAsyncStrategy` now threads `config.strictReachable` into the `processorOptions.config` subset, matching what the other three constructions already did.
- **Tests:** `baselineResolver.spec` verifies the error type (the `instanceof` contract), and new `packageProcessor.spec` tests cover both abort and graceful-degradation paths under the same `strictReachable: true` config.
</details>

<h3>Confidence Score: 5/5</h3>

The change is safe to merge: it tightens a previously silent no-op into a loud failure only when the caller has explicitly opted in via `strictReachable: true`, so existing repos with the default config are completely unaffected.

Both bug fixes are targeted and well-understood. The new error type gives the catch sites a reliable discriminant, and threading `strictReachable` into the async processor config is a one-liner completing a pre-existing pattern. Degradation behaviour for genuine extraction errors is explicitly tested and unchanged. No unintended catch sites or error-swallowing paths were introduced.

No files require special attention. All four catch sites (groupStrategy, versionStrategies sync, versionStrategies single, packageProcessor) have been updated consistently.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/version/src/errors/strictReachableError.ts | New dedicated error class extending BaseVersionError; well-documented with a clear purpose. |
| packages/version/src/core/baselineResolver.ts | Changed bare Error throw to StrictReachableError so the catch sites in strategies can distinguish it from genuine extraction failures. |
| packages/version/src/core/versionStrategies.ts | Added StrictReachableError rethrow in three catch sites (sync, single, async strategy) and threads strictReachable into the async processorOptions config. |
| packages/version/src/core/groupStrategy.ts | Added StrictReachableError rethrow at the group strategy catch site — consistent with the other three strategies. |
| packages/version/src/package/packageProcessor.ts | Added StrictReachableError rethrow in PackageProcessor's catch; correctness depends on strictReachable being threaded in (fixed in versionStrategies.ts). |
| packages/version/test/unit/core/baselineResolver.spec.ts | Test updated to assert instanceof StrictReachableError (not just message regex) — correctly tests the type contract the catch sites depend on. |
| packages/version/test/unit/package/packageProcessor.spec.ts | Two new tests cover the async path: one verifies StrictReachableError aborts, one verifies genuine extraction errors still degrade gracefully — good isolation of the two behaviours. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant S as Strategy (sync/single/group/async)
    participant BR as BaselineResolver
    participant V as verifyTag

    S->>BR: resolve(input)
    BR->>V: verifyTag(baseForRange, pkgDir)
    V-->>BR: "{ exists: true, reachable: false }"

    alt "strictReachable=true AND no baseRef"
        BR-->>S: throw StrictReachableError
        S->>S: catch(error)
        S->>S: instanceof StrictReachableError? → rethrow
        S-->>S: run aborts (non-zero exit)
    else "strictReachable=false OR baseRef set"
        BR-->>S: "{ revisionRange: 'HEAD', baselineUnreachable: true }"
        S->>S: extractChangelogEntriesFromCommits()
        alt genuine extraction error
            S->>S: catch(error) → log warning → minimal entry
        else success
            S-->>S: changelog entries used
        end
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant S as Strategy (sync/single/group/async)
    participant BR as BaselineResolver
    participant V as verifyTag

    S->>BR: resolve(input)
    BR->>V: verifyTag(baseForRange, pkgDir)
    V-->>BR: "{ exists: true, reachable: false }"

    alt "strictReachable=true AND no baseRef"
        BR-->>S: throw StrictReachableError
        S->>S: catch(error)
        S->>S: instanceof StrictReachableError? → rethrow
        S-->>S: run aborts (non-zero exit)
    else "strictReachable=false OR baseRef set"
        BR-->>S: "{ revisionRange: 'HEAD', baselineUnreachable: true }"
        S->>S: extractChangelogEntriesFromCommits()
        alt genuine extraction error
            S->>S: catch(error) → log warning → minimal entry
        else success
            S-->>S: changelog entries used
        end
    end
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(version): make strictReachable abort..."](https://github.com/goosewobbler/releasekit/commit/3127821bb351b52e0b474d4fcea805dcbb26c2bc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39103869)</sub>

<!-- /greptile_comment -->