### PR TITLE
fix(release): standing-PR update crashes on package-specific-tag previousVersion (0.31.0 regression)

### DIFF
--- a/packages/release/src/standing-pr/selection-region.ts
+++ b/packages/release/src/standing-pr/selection-region.ts
@@ -22,8 +22,17 @@ const REGION_HINT =
 export function bumpSuffix(versionOutput: VersionOutput, packageName: string, newVersion: string): string {
   const previous = versionOutput.changelogs.find((c) => c.packageName === packageName)?.previousVersion;
   if (!previous) return '';
-  const kind = semver.diff(previous, newVersion);
-  return kind ? ` (${kind})` : '';
+  // `previousVersion` can carry a package-specific tag prefix (e.g. `name@v1.2.3`) in repos using
+  // `packageSpecificTags` — not valid semver, so a bare `semver.diff` throws and would crash the
+  // whole standing-PR render. Strip to the part after the last `@`, then diff inside a guard: a
+  // cosmetic bump suffix must never abort the update (regressed packageSpecificTags repos on 0.31.0).
+  const prev = previous.includes('@') ? previous.slice(previous.lastIndexOf('@') + 1) : previous;
+  try {
+    const kind = semver.diff(prev, newVersion);
+    return kind ? ` (${kind})` : '';
+  } catch {
+    return '';
+  }
 }
 
 function checkbox(selected: boolean): string {

--- a/packages/release/test/unit/selection-region.spec.ts
+++ b/packages/release/test/unit/selection-region.spec.ts
@@ -56,6 +56,29 @@ describe('selection-region', () => {
       expect(region).toContain('→ 1.1.0 (minor)');
     });
 
+    it('should not crash and still derive the bump kind from a package-specific tag previousVersion', () => {
+      // packageSpecificTags repos carry previousVersion as a full tag (`name@vX.Y.Z`) — a bare
+      // semver.diff throws "Invalid Version" and would abort the whole render (regression #NNN).
+      const updates: Update[] = [{ packageName: 'wdio-electron-cdp-bridge', newVersion: '10.1.0', filePath: '' }];
+      const region = renderSelectionRegion(
+        mockOutput(updates, [changelog('wdio-electron-cdp-bridge', 'wdio-electron-cdp-bridge@v10.0.0', '10.1.0')]),
+        updates,
+        new Set(),
+      );
+      expect(region).toContain('→ 10.1.0 (minor)');
+    });
+
+    it('should drop the suffix rather than throw on an unparseable previousVersion', () => {
+      const updates: Update[] = [{ packageName: 'pkg', newVersion: '1.1.0', filePath: '' }];
+      const region = renderSelectionRegion(
+        mockOutput(updates, [changelog('pkg', 'not-a-version', '1.1.0')]),
+        updates,
+        new Set(),
+      );
+      expect(region).toContain('→ 1.1.0');
+      expect(region).not.toContain('(');
+    });
+
     it('should group targets above their derived prerequisites', () => {
       const updates: Update[] = [
         { packageName: '@scope/app', newVersion: '2.0.0', filePath: '', role: 'target' },


### PR DESCRIPTION
**0.31.0 regression — breaks `standing-pr update` for any `packageSpecificTags` repo.** Needs a **0.31.1** patch.

## Symptom

On 0.31.0, `releasekit standing-pr update` fails for repos using `version.packageSpecificTags: true` with a `${packageName}@v${version}` tag template (e.g. [webdriverio/desktop-mobile](https://github.com/webdriverio/desktop-mobile)):

```
[SUCCESS] Release branch 'release/next' updated
Invalid Version: wdio-electron-cdp-bridge@v10.0.0
ReleaseKit standing-pr-update failed with exit code 1
```

It fails **after** writing/pushing the release branch but **before** rewriting the PR body, so the standing PR silently goes stale — already-released packages linger in the queue and the #367 selection checklist never renders. (Surfaced as "no checkboxes on the standing PR" — the body simply never regenerated.)

## Root cause

`bumpSuffix` (`selection-region.ts`) called `semver.diff(previousVersion, newVersion)` with no guard. In `packageSpecificTags` repos `previousVersion` is the full tag string `wdio-electron-cdp-bridge@v10.0.0`, which isn't valid semver — `semver.diff` throws and aborts the whole render. This was introduced in 0.31.0: `bumpSuffix` came in with #366 and is now called for every row by the new async/per-package selection-region render from #367 (0.30.2 rendered a static table with no semver calls, so it was never hit).

## Fix

Strip `previousVersion` to the part after the last `@`, then diff inside a `try/catch`. The bump suffix is cosmetic — it must never abort the update. Suffix is preserved for the common `name@vX.Y.Z` case and dropped (no suffix, no crash) for anything else unparseable.

## Tests

- `selection-region.spec`: a `name@vX.Y.Z` previousVersion still yields the correct `(minor)` suffix (no throw); an unparseable previousVersion drops the suffix instead of throwing.

Full gate green: `pnpm turbo run lint typecheck test:coverage` → **27/27**.

## Follow-up (not in this PR)

That `previousVersion` reaches the renderer as a *full tag* rather than its display-stripped form (`v10.0.0`) looks like a separate, pre-existing stripping gap in the `packageSpecificTags` path — worth a look, but this guard makes the render robust regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Patches a 0.31.0 regression where `standing-pr update` aborts for repos with `packageSpecificTags` because `bumpSuffix` passed an unstripped full tag string (e.g. `wdio-electron-cdp-bridge@v10.0.0`) directly to `semver.diff`, which throws on non-semver input.

- **`selection-region.ts`**: strips the package-name prefix before the last `@` from `previousVersion` before calling `semver.diff`, and wraps the call in a `try/catch` so an unparseable version silently drops the cosmetic suffix instead of aborting the whole render.
- **`selection-region.spec.ts`**: two new tests cover the `name@vX.Y.Z` tag path (suffix preserved) and the fully unparseable fallback path (suffix dropped, no throw).
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is tightly scoped to a cosmetic display function, all non-happy paths now return an empty string rather than propagating an exception, and the two new tests directly exercise the regression scenario and the fallback.

The fix is minimal and surgical: two lines replaced with a prefix-strip and a try/catch guard on a purely cosmetic helper. No shared state, no data mutation, and the worst possible outcome of the catch branch is a missing bump label in the PR body — the same behavior as when no previous version is recorded. Tests cover both the fixed path and the general unparseable fallback.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/release/src/standing-pr/selection-region.ts | Targeted guard in bumpSuffix: strips @-prefix from previousVersion and wraps semver.diff in try/catch; all other logic unchanged. |
| packages/release/test/unit/selection-region.spec.ts | Two new unit tests added: one for the packageSpecificTags tag-prefix path (expects suffix preserved) and one for fully unparseable input (expects suffix dropped). |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[bumpSuffix called\nwith previousVersion] --> B{previousVersion\ncontains '@'?}
    B -- Yes --> C["Strip to part after last '@'\ne.g. 'pkg@v1.0.0' → 'v1.0.0'"]
    B -- No --> D[Use previousVersion as-is]
    C --> E[semver.diff prev, newVersion]
    D --> E
    E --> F{diff succeeds?}
    F -- Yes, kind returned --> G["Return ' (kind)'\ne.g. ' (minor)'"]
    F -- Yes, null returned --> H[Return '']
    F -- No, throws --> I[catch: Return '']
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[bumpSuffix called\nwith previousVersion] --> B{previousVersion\ncontains '@'?}
    B -- Yes --> C["Strip to part after last '@'\ne.g. 'pkg@v1.0.0' → 'v1.0.0'"]
    B -- No --> D[Use previousVersion as-is]
    C --> E[semver.diff prev, newVersion]
    D --> E
    E --> F{diff succeeds?}
    F -- Yes, kind returned --> G["Return ' (kind)'\ne.g. ' (minor)'"]
    F -- Yes, null returned --> H[Return '']
    F -- No, throws --> I[catch: Return '']
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(release): don&#39;t crash the standing-P..."](https://github.com/goosewobbler/releasekit/commit/0a4c7d256b9321e076e9344259dfafadfdea5b4f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39121443)</sub>

<!-- /greptile_comment -->