### PR TITLE
fix(version): repo-level changelog classifier — full workspace + configurable shared packages

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -65,6 +65,7 @@ Versioning configuration.
 | `preset` | string | `"conventional"` | Commit convention preset |
 | `sync` | boolean | `true` | Global lockstep versioning. true is sugar for one implicit fixed group of every package — it shares the same mechanism as version.groups. Set to false when using version.groups; sync: true alongside groups is treated as the implicit all-packages fixed group taking precedence (a config conflict, warned about at runtime). |
 | `packages` | `string[]` | `[]` | Packages to include in versioning |
+| `sharedPackages` | `string[]` | — | Foundational packages whose changes belong in every package’s changelog. A commit touching only a shared package (exact name or glob) is classified as repo-level and surfaced under "Project-wide changes" rather than attributed to that one package. Default: none — no package is treated as shared unless declared. |
 | `mainPackage` | string | — | Package to use for version determination |
 | `updateInternalDependencies` | `"major"` \| `"minor"` \| `"patch"` \| `"no-internal-update"` | `"minor"` | How to bump internal dependencies |
 | `skip` | `string[]` | — | Packages to exclude from versioning |

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -93,6 +93,12 @@ export const VersionConfigSchema = z.object({
       'Named version groups. Each group binds a set of package patterns to a fixed, linked, or independent sync mode. fixed: any releasable change in any member releases ALL members at the shared group version (bump(max(member baselines))). linked: only members with releasable changes release, but every releasing member shares the same computed version. independent: only members with releasable changes release, each on its own commit-driven version line (no shared version), but the set is atomic — targeting any member pulls in the whole group. Packages not matched by any group version independently. A package may belong to at most one group. Set version.sync to false when using groups.',
     ),
   packages: z.array(z.string()).default([]).describe('Packages to include in versioning'),
+  sharedPackages: z
+    .array(z.string())
+    .optional()
+    .describe(
+      'Foundational packages whose changes belong in every package’s changelog. A commit touching only a shared package (exact name or glob) is classified as repo-level and surfaced under "Project-wide changes" rather than attributed to that one package. Default: none — no package is treated as shared unless declared.',
+    ),
   mainPackage: z.string().optional().describe('Package to use for version determination'),
   updateInternalDependencies: z
     .enum(['major', 'minor', 'patch', 'no-internal-update'])

--- a/packages/version/src/core/versionEngine.ts
+++ b/packages/version/src/core/versionEngine.ts
@@ -417,6 +417,14 @@ export class VersionEngine {
         mergedPackages.root = workspaceRoot;
       }
 
+      // Capture the FULL discovered workspace (name+dir) before any release-set filtering below, so
+      // the repo-level changelog classifier can tell "touches a non-releasing package" apart from
+      // "genuinely repo-level" (#397) and resolve shared-package globs against every package (#406).
+      this.config.allWorkspacePackages = mergedPackages.packages.map((p) => ({
+        name: p.packageJson.name,
+        dir: p.dir,
+      }));
+
       // --include-prerequisites: expand the explicit targets to the full release set (their changed
       // transitive dependencies + the rest of any group they belong to) and scope the bump/prerelease/
       // stable override to just the explicit, group-expanded targets. Runs on the full discovered set,

--- a/packages/version/src/package/packageProcessor.ts
+++ b/packages/version/src/package/packageProcessor.ts
@@ -2,7 +2,7 @@ import * as fs from 'node:fs';
 import path from 'node:path';
 import type { Package } from '@manypkg/get-packages';
 import type { VersionChangelogEntry } from '@releasekit/core';
-import { shouldProcessPackage } from '@releasekit/core';
+import { shouldMatchPackageTargets, shouldProcessPackage } from '@releasekit/core';
 import { extractChangelogEntriesFromCommits, extractRepoLevelChangelogEntries } from '../changelog/commitParser.js';
 import { BaselineResolver } from '../core/baselineResolver.js';
 import { calculateVersion } from '../core/versionCalculator.js';
@@ -240,15 +240,22 @@ export class PackageProcessor {
 
         changelogEntries = extractChangelogEntriesFromCommits(pkgPath, revisionRange);
 
-        // Also extract repo-level commits (those that don't touch any non-shared package directory)
-        // These include CI changes, infrastructure updates, and changes to shared packages (config, core)
-        // that affect all packages
-        const allPackageDirs = packages.map((p) => p.dir);
-        // Define shared packages that should be included in all package changelogs
-        const sharedPackageNames = ['config', 'core', '@releasekit/config', '@releasekit/core'];
-        const sharedPackageDirs = packages
-          .filter((p) => sharedPackageNames.includes(p.packageJson.name))
-          .map((p) => p.dir);
+        // Also extract repo-level commits (those touching no package dir, plus declared shared
+        // packages whose changes belong project-wide). Classify against the FULL discovered
+        // workspace, not the filtered release set (`packages`) — otherwise a commit touching only a
+        // *non-releasing* package's dir touches "no package" and wrongly leaks into the shared block
+        // (#397). Falls back to the processing set when the engine didn't populate the workspace
+        // (e.g. a direct PackageProcessor construction in tests).
+        const workspace =
+          this.fullConfig.allWorkspacePackages ?? packages.map((p) => ({ name: p.packageJson.name, dir: p.dir }));
+        const allPackageDirs = workspace.map((p) => p.dir);
+        // Foundational packages whose changes route to repo-level, from config (exact name or glob).
+        // No hardcoded names — a consumer declares its own via `version.sharedPackages` (#406).
+        const sharedPackagePatterns = this.fullConfig.sharedPackages ?? [];
+        const sharedPackageDirs =
+          sharedPackagePatterns.length === 0
+            ? []
+            : workspace.filter((p) => shouldMatchPackageTargets(p.name, sharedPackagePatterns)).map((p) => p.dir);
         // Bound the repo-level ("shared") entries by the run's nearest-reachable floor when this
         // package's own range collapsed to full history (untagged / unreachable), so a single
         // untagged package doesn't flood "Project-wide changes" with the entire history (#348).

--- a/packages/version/src/types.ts
+++ b/packages/version/src/types.ts
@@ -94,6 +94,9 @@ export interface Config extends VersionConfigBase {
    */
   groups?: Record<string, VersionGroup>;
   packages: string[];
+  /** Foundational packages whose changes route to repo-level ("Project-wide changes") in every
+   *  package's changelog (exact name or glob). See VersionConfig.sharedPackages. Default: none. */
+  sharedPackages?: string[];
   mainPackage?: string;
   updateInternalDependencies: 'major' | 'minor' | 'patch' | 'no-internal-update';
   skip?: string[];
@@ -111,6 +114,11 @@ export interface Config extends VersionConfigBase {
   /** Runtime override: package patterns the forced bump/prerelease/stable applies to. When set,
    *  non-matching packages ignore the override and compute commit-driven. See VersionRunOptions.overrideScope. */
   overrideScope?: string[];
+  /** Runtime (engine-populated): the FULL discovered workspace — every package's name+dir, before
+   *  the release-set filters (targets/exclude/config.packages). The repo-level changelog classifier
+   *  uses this so a commit touching a non-releasing package's dir is attributed to that package, not
+   *  leaked into "Project-wide changes" (#397). Not user config. */
+  allWorkspacePackages?: Array<{ name: string; dir: string }>;
   mismatchStrategy?: 'error' | 'warn' | 'ignore' | 'prefer-package' | 'prefer-git';
   strictReachable?: boolean;
   /** Pre-1.0 inferred-breaking bump policy ('spec' | 'strict'). See docs/configuration.md#versionzeromajor. */
@@ -192,6 +200,7 @@ export function toVersionConfig(config: VersionConfig | undefined, gitConfig?: G
     sync: config.sync ?? true,
     groups: config.groups,
     packages: config.packages ?? [],
+    sharedPackages: config.sharedPackages,
     mainPackage: config.mainPackage,
     updateInternalDependencies: config.updateInternalDependencies ?? 'minor',
     skip: config.skip,

--- a/packages/version/test/unit/package/packageProcessor.spec.ts
+++ b/packages/version/test/unit/package/packageProcessor.spec.ts
@@ -612,6 +612,71 @@ describe('Package Processor', () => {
       expect(extractSharedSpy).toHaveBeenCalledWith(expect.any(String), 'HEAD', expect.any(Array), expect.any(Array));
     });
 
+    it('should classify against the full workspace, not the release set, so a non-releasing package does not leak into shared (#397)', async () => {
+      const extractSharedSpy = vi.spyOn(commitParser, 'extractRepoLevelChangelogEntries').mockReturnValue([]);
+      const processor = new PackageProcessor({
+        ...defaultOptions,
+        fullConfig: {
+          ...mockConfig,
+          allWorkspacePackages: [
+            { name: 'package-a', dir: '/path/to/package-a' },
+            { name: 'package-b', dir: '/path/to/package-b' },
+          ],
+        },
+      });
+
+      // Release set is only package-a, but package-b's dir must still count as "a package dir" so a
+      // commit touching only package-b is attributed to it (absent here), not dumped into shared.
+      await processor.processPackages([mockPackages[0]]);
+
+      expect(extractSharedSpy).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(String),
+        ['/path/to/package-a', '/path/to/package-b'],
+        expect.any(Array),
+      );
+    });
+
+    it('should route a configured sharedPackages package to repo-level via its dir (#406)', async () => {
+      const extractSharedSpy = vi.spyOn(commitParser, 'extractRepoLevelChangelogEntries').mockReturnValue([]);
+      const processor = new PackageProcessor({
+        ...defaultOptions,
+        fullConfig: {
+          ...mockConfig,
+          sharedPackages: ['package-b'],
+          allWorkspacePackages: [
+            { name: 'package-a', dir: '/path/to/package-a' },
+            { name: 'package-b', dir: '/path/to/package-b' },
+          ],
+        },
+      });
+
+      await processor.processPackages([mockPackages[0]]);
+
+      expect(extractSharedSpy).toHaveBeenCalledWith(expect.any(String), expect.any(String), expect.any(Array), [
+        '/path/to/package-b',
+      ]);
+    });
+
+    it('should treat no package as shared when sharedPackages is unset — no hardcoded names (#406)', async () => {
+      const extractSharedSpy = vi.spyOn(commitParser, 'extractRepoLevelChangelogEntries').mockReturnValue([]);
+      const processor = new PackageProcessor({
+        ...defaultOptions,
+        fullConfig: {
+          ...mockConfig,
+          // @releasekit/core was formerly hardcoded as shared; it must no longer auto-match.
+          allWorkspacePackages: [
+            { name: '@releasekit/core', dir: '/path/to/core' },
+            { name: 'package-a', dir: '/path/to/package-a' },
+          ],
+        },
+      });
+
+      await processor.processPackages([mockPackages[0]]);
+
+      expect(extractSharedSpy).toHaveBeenCalledWith(expect.any(String), expect.any(String), expect.any(Array), []);
+    });
+
     it('should emit repo-level entries as sharedEntries, not in individual package changelogs', async () => {
       const repoLevelEntry = { type: 'chore', description: 'Update CI workflow' };
       const pkgAEntry = { type: 'added', description: 'New feature in pkg-a' };

--- a/releasekit.schema.json
+++ b/releasekit.schema.json
@@ -147,6 +147,13 @@
           },
           "description": "Packages to include in versioning"
         },
+        "sharedPackages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Foundational packages whose changes belong in every package’s changelog. A commit touching only a shared package (exact name or glob) is classified as repo-level and surfaced under \"Project-wide changes\" rather than attributed to that one package. Default: none — no package is treated as shared unless declared."
+        },
         "mainPackage": {
           "type": "string",
           "description": "Package to use for version determination"


### PR DESCRIPTION
Fixes the "Project-wide changes" changelog block, which over-collects for `packageSpecificTags`/async consumers (surfaced live in wdio-desktop-mobile PR #400: 147 shared entries vs 53 per-package, ~74% of the changelog). Two coupled bugs in the same classifier (`packageProcessor.ts`), done together per the issues' coordination note.

## #397 — non-releasing packages leaked into "Project-wide changes"

`allPackageDirs` was built from the **filtered release set**, not the full workspace. So a commit touching only a package *outside* the current release set touched "no package dir" → classified repo-level → dumped into the shared block. This is also why deselecting a package didn't shrink the changelog — its commits just **migrated** from a per-package section into "Project-wide".

**Fix:** classify against the **full discovered workspace**. The engine now captures every package's `name`+`dir` *before* the release-set filters (`getWorkspacePackages`) and threads it to the classifier via the live config (`Config.allWorkspacePackages`, engine-populated runtime field). A commit touching a non-releasing package's dir is attributed to that package (absent from this run), not leaked.

## #406 — shared-package routing hardcoded to releasekit's names

`sharedPackageNames` was `['config','core','@releasekit/config','@releasekit/core']` — so the "foundational packages bubble up to Project-wide" feature **never activated for any other consumer**.

**Fix:** a configurable **`version.sharedPackages`** (exact name or glob; default none). No implicit names. (releasekit's own repo is `sync`, so the async classifier never ran for it — no config change needed; the hardcoded names were dead here too.)

## Acceptance

- [x] A commit touching only a non-releasing package's dir is **not** in `sharedEntries` (#397)
- [x] Deselecting a package no longer moves its entries into "Project-wide changes" (#397 — follows from the dir-set fix)
- [x] A consumer can declare shared packages in config; with none configured, `sharedPackageDirs` is empty — no releasekit-specific names (#406)
- [x] `version.sharedPackages` documented via Zod → `releasekit.schema.json` → `docs/configuration.md`; `pnpm schema:check` passes
- [x] Unit tests: full-workspace dir set, configured shared routing, no-hardcoded-default

Full gate: `pnpm turbo run lint typecheck test:coverage` → **27/27**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes two coupled bugs in `PackageProcessor`'s repo-level changelog classifier. Previously, commits touching only a non-releasing package leaked into "Project-wide changes" (because `allPackageDirs` was built from the filtered release set, not the full workspace), and the "shared packages" routing was hardcoded to releasekit's own package names, making the feature unusable for any other consumer.

- **#397**: The engine now captures every discovered package's `name`+`dir` into `Config.allWorkspacePackages` (before any release-set filters) and threads it to the classifier; a commit touching a non-releasing package's dir is correctly attributed to that package rather than leaked into the shared block.
- **#406**: The hardcoded `sharedPackageNames` list is replaced with a configurable `version.sharedPackages` field (exact name or glob) — with no implicit defaults — documented via Zod schema, JSON schema, and `docs/configuration.md`; three new unit tests cover full-workspace classification, configured shared routing, and the no-hardcoded-defaults guarantee.
</details>

<h3>Confidence Score: 5/5</h3>

The change is safe to merge; it narrows an over-broad classifier and replaces hardcoded names with a user-configurable field, with no side effects on the sync path or the baseline resolver.

Both bugs are fixed at the right layer: the full workspace snapshot is taken before any filter, the reference is shared so the later mutation is visible to the already-constructed PackageProcessor, and the fallback for direct construction is documented and intentional. The new Zod field is optional with no default, consistent with the ?? [] guard in the processor. Three targeted unit tests cover the full-workspace dir set, configured shared routing, and the no-hardcoded-defaults invariant. Schema, JSON schema, and docs are all updated in step.

No files require special attention; all changed files are self-consistent and the test coverage directly exercises the two regression scenarios.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/version/src/package/packageProcessor.ts | Core bug fix: replaces hardcoded allPackageDirs (release set) + sharedPackageNames with workspace-sourced allPackageDirs and configurable sharedPackageDirs; logic is correct and well-commented |
| packages/version/src/core/versionEngine.ts | Adds allWorkspacePackages snapshot to this.config immediately after package discovery and before any release-set filtering; ordering with respect to strategy construction and caching is correct |
| packages/version/src/types.ts | Adds sharedPackages (user config) and allWorkspacePackages (runtime-only) to Config; toVersionConfig correctly threads sharedPackages and leaves allWorkspacePackages engine-populated |
| packages/config/src/schema.ts | Adds optional sharedPackages array to VersionConfigSchema with no default, consistent with the ?? [] fallback in the processor |
| packages/version/test/unit/package/packageProcessor.spec.ts | Three new unit tests covering full-workspace dir set (#397), configured shared-package routing (#406), and the no-hardcoded-defaults guarantee (#406); all are well-scoped |
| docs/configuration.md | Documents sharedPackages in the version config table; description and default (none) are accurate and consistent with schema |
| releasekit.schema.json | Adds sharedPackages array-of-strings to the version section of the JSON schema; consistent with Zod definition and docs |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant E as VersionEngine
    participant PP as PackageProcessor
    participant CP as commitParser

    E->>E: discoverPackages() → mergedPackages (full workspace)
    E->>E: "config.allWorkspacePackages = mergedPackages.map(name+dir)"
    Note over E: captured BEFORE release-set filters
    E->>E: apply config.packages / targets / exclude filters
    E->>PP: "new PackageProcessor({ fullConfig: config })"
    Note over PP: fullConfig holds reference to same config object

    loop for each package in release set
        PP->>PP: "workspace = fullConfig.allWorkspacePackages ?? packages(fallback)"
        PP->>PP: "allPackageDirs = workspace.map(dir)"
        PP->>PP: "sharedPatterns = fullConfig.sharedPackages ?? []"
        PP->>PP: "sharedPackageDirs = workspace.filter(shouldMatchPackageTargets)"
        PP->>CP: extractRepoLevelChangelogEntries(pkgPath, range, allPackageDirs, sharedPackageDirs)
        CP-->>PP: repoLevelEntries
        PP->>PP: sharedEntriesMap.set(dedup key, entry)
    end

    PP->>PP: setSharedEntries([...sharedEntriesMap.values()])
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant E as VersionEngine
    participant PP as PackageProcessor
    participant CP as commitParser

    E->>E: discoverPackages() → mergedPackages (full workspace)
    E->>E: "config.allWorkspacePackages = mergedPackages.map(name+dir)"
    Note over E: captured BEFORE release-set filters
    E->>E: apply config.packages / targets / exclude filters
    E->>PP: "new PackageProcessor({ fullConfig: config })"
    Note over PP: fullConfig holds reference to same config object

    loop for each package in release set
        PP->>PP: "workspace = fullConfig.allWorkspacePackages ?? packages(fallback)"
        PP->>PP: "allPackageDirs = workspace.map(dir)"
        PP->>PP: "sharedPatterns = fullConfig.sharedPackages ?? []"
        PP->>PP: "sharedPackageDirs = workspace.filter(shouldMatchPackageTargets)"
        PP->>CP: extractRepoLevelChangelogEntries(pkgPath, range, allPackageDirs, sharedPackageDirs)
        CP-->>PP: repoLevelEntries
        PP->>PP: sharedEntriesMap.set(dedup key, entry)
    end

    PP->>PP: setSharedEntries([...sharedEntriesMap.values()])
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(version): classify repo-level change..."](https://github.com/goosewobbler/releasekit/commit/516c63c3ca08ae9ce600323474cc539b53b96a72) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39163689)</sub>

<!-- /greptile_comment -->