### PR TITLE
fix(release): write-step empty release set renders a degenerate `****` body (#396)

### DIFF
--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -710,6 +710,29 @@ function buildBaseReleaseOptions(
   };
 }
 
+/**
+ * Close the standing PR (when one exists and we have a token) or noop — the empty-queue outcome.
+ * Shared by the dry-run empty-queue guard and the write-step empty guard (#396), so a queue that
+ * empties out is handled identically whichever step observes it.
+ */
+async function closeEmptyQueue(
+  existingStandingPr: { number: number; url: string } | null,
+  githubContext: ReturnType<typeof getGitHubContext>,
+): Promise<StandingPRResult> {
+  info('No releasable changes found');
+  if (githubContext?.token && existingStandingPr) {
+    const forge = forgeFor(githubContext);
+    await forge.createComment(
+      existingStandingPr.number,
+      'No releasable changes found. Closing this PR as the release queue is empty.',
+    );
+    await forge.updatePullRequest(existingStandingPr.number, { state: 'closed' });
+    info(`Closed standing PR #${existingStandingPr.number}`);
+    return { action: 'closed', prNumber: existingStandingPr.number, prUrl: existingStandingPr.url };
+  }
+  return { action: 'noop' };
+}
+
 export async function runStandingPRUpdate(options: StandingPROptions): Promise<StandingPRResult> {
   const cwd = options.projectDir;
 
@@ -810,20 +833,7 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
   const versionOutputDry = await runVersionStep(dryRunOptions);
 
   if (versionOutputDry.updates.length === 0) {
-    info('No releasable changes found');
-
-    if (githubContext?.token && existingStandingPr) {
-      const forge = forgeFor(githubContext);
-      await forge.createComment(
-        existingStandingPr.number,
-        'No releasable changes found. Closing this PR as the release queue is empty.',
-      );
-      await forge.updatePullRequest(existingStandingPr.number, { state: 'closed' });
-      info(`Closed standing PR #${existingStandingPr.number}`);
-      return { action: 'closed', prNumber: existingStandingPr.number, prUrl: existingStandingPr.url };
-    }
-
-    return { action: 'noop' };
+    return closeEmptyQueue(existingStandingPr, githubContext);
   }
 
   // minPackages gate: close existing PR and noop if package count is below threshold.
@@ -899,6 +909,15 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
   info('Writing version bumps...');
   const writeOptions = buildBaseReleaseOptions(options, false, { ...buildExtras, exclude: [...effectiveDeselected] });
   const versionOutput = await runVersionStep(writeOptions);
+
+  // The write step recomputes from the post-reset HEAD, which can differ from the dry run when a
+  // release landed on `base` mid-run (a reconcile race exempt from the skip-pattern bail above): the
+  // dry-run guard saw updates, but the write set is now empty. Without this second guard the empty
+  // output renders a degenerate `****` body and an empty `chore: release ` title onto the open PR
+  // (#396). Gate on publishable updates so a sync root-only bump with nothing to publish is caught too.
+  if (publishableUpdates(versionOutput).length === 0) {
+    return closeEmptyQueue(existingStandingPr, githubContext);
+  }
 
   // With the preview-notes label, pull any release notes a human has already edited from the live PR
   // body (fetched once above) so they survive this regenerate-and-force-push. Marker slicing only.

--- a/packages/release/test/unit/standing-pr.spec.ts
+++ b/packages/release/test/unit/standing-pr.spec.ts
@@ -618,6 +618,36 @@ describe('runStandingPRUpdate', () => {
     );
   });
 
+  it('should close (not render ****) when the write step recomputes to an empty release set (#396)', async () => {
+    // Reconcile-race: the dry run sees updates (guard passes), but a release landing on base mid-run
+    // makes the write step recompute to 0 publishable updates. The second guard must close the PR
+    // instead of rendering a degenerate `****` body.
+    const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
+    const withUpdates = createMockVersionOutput([{ packageName: '@scope/core', newVersion: '1.2.3' }]);
+    const empty = createMockVersionOutput([]);
+    vi.mocked(runVersionStep)
+      .mockResolvedValueOnce(withUpdates as unknown as Awaited<ReturnType<typeof runVersionStep>>) // dry run
+      .mockResolvedValueOnce(empty as unknown as Awaited<ReturnType<typeof runVersionStep>>); // write step
+    vi.mocked(runNotesStep).mockResolvedValue({ packageNotes: {}, releaseNotes: {}, files: [] });
+
+    const forge = await mockForge({ standingPR: openStandingPR(42) });
+
+    const result = await runStandingPRUpdate({
+      projectDir: '/test',
+      verbose: false,
+      quiet: false,
+      json: false,
+      reconcile: true,
+    });
+
+    expect(result.action).toBe('closed');
+    expect(forge.updatedPullRequests).toContainEqual(
+      expect.objectContaining({ prNumber: 42, changes: expect.objectContaining({ state: 'closed' }) }),
+    );
+    // The empty body must never be rendered onto the PR.
+    expect(forge.updatedPullRequests.some((u) => u.changes.body !== undefined)).toBe(false);
+  });
+
   it('should create a new PR when no existing standing PR', async () => {
     const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
     const versionOutput = createMockVersionOutput([{ packageName: '@scope/core', newVersion: '1.2.3' }]);


### PR DESCRIPTION
## Symptom

A sync standing PR renders a degenerate body when the release queue empties out mid-run:

```
## Release

Merging this PR will publish ****:

---
> Merge this PR to publish. The release will be triggered automatically.
```

with title `chore: release ` (empty version). The PR stays **open** showing this.

## Root cause

The empty-queue guard only checks the **dry-run** output (`versionOutputDry.updates.length === 0`). The dry run is computed *before* `resetReleaseBranch`, which can pull in a release commit that landed on `base` mid-run; the skip-pattern bail that would catch it is exempt for `--reconcile` runs; and the **write** step then recomputes `versionOutput` to **0 updates**. There was **no second guard** between the write step and the render — so a post-release reconcile racing with a release landing on `base` rendered, persisted, and pushed an empty body to the open PR.

(Distinct from the bumpSuffix crash #394, fixed in 0.31.1 — that left a *stale* body; this produces a *fresh empty* one.)

## Fix

Mirror the empty-queue handling on the **write-step** output, gating on `publishableUpdates(versionOutput).length === 0` (so a sync root-only bump with nothing publishable is also caught): close the standing PR ("No releasable changes found…") or noop instead of rendering. The shared close-or-noop is factored into `closeEmptyQueue`, used by both guards.

## Acceptance

- [x] A reconcile run whose write-step `versionOutput` is empty **closes** (or noops on) the PR rather than rendering `****`
- [x] Unit test: dry-run has updates + write-step empty + reconcile → PR closed, body never rendered
- [x] The `****` / `chore: release ` (empty) body can no longer be produced via this path

Full gate: `pnpm turbo run lint typecheck test:coverage` → **27/27**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a second empty-queue guard after the write step in `runStandingPRUpdate`, preventing a racing reconcile run from pushing a degenerate `****` body onto an open standing PR. The shared `closeEmptyQueue` helper is factored out so both the dry-run guard and the new write-step guard behave identically.

- **`standing-pr.ts`**: Extracts the inline close-or-noop block into `closeEmptyQueue`; calls it from the existing dry-run guard and from a new guard placed after `runVersionStep(writeOptions)`, gating on `publishableUpdates(versionOutput).length === 0` to also catch sync root-only-bump cases.
- **`standing-pr.spec.ts`**: Adds a targeted regression test — dry run returns updates, write step returns empty, `reconcile: true` — asserting the PR is closed and no body update is ever applied.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change closes a narrow but real gap that caused an open PR to receive a degenerate body on a reconcile race.

The new guard is placed before commitAndForcePush, so the degenerate body can never be committed or pushed. The closeEmptyQueue refactor is a straightforward extraction with identical behaviour at both call sites. The regression test covers the exact race scenario and verifies both the closed action and the absence of any body write.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/release/src/standing-pr/standing-pr.ts | Introduces closeEmptyQueue helper and adds a post-write-step guard; logic is correct and guard placement (before commitAndForcePush) is verified to prevent the degenerate body from ever being written. |
| packages/release/test/unit/standing-pr.spec.ts | Adds a well-scoped regression test covering the reconcile-race scenario; correctly asserts both the closed action and the absence of any body update. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[runStandingPRUpdate] --> B{bypassSkipGuard?}
    B -- No --> C{HEAD matches skip pattern?}
    C -- Yes --> NOOP1[return noop]
    C -- No --> D
    B -- Yes --> D[runVersionStep dry-run]
    D --> E{versionOutputDry.updates.length === 0?}
    E -- Yes --> CEQ1[closeEmptyQueue close PR or noop]
    E -- No --> F{minPackages gate}
    F -- Below threshold --> CEQ2[close PR or noop]
    F -- OK --> G[resetReleaseBranch]
    G --> H{reconcile? check reset HEAD}
    H -- skip pattern match --> NOOP2[return noop]
    H -- OK --> I[runVersionStep write]
    I --> J{publishableUpdates.length === 0? NEW GUARD #396}
    J -- Yes --> CEQ3[closeEmptyQueue close PR or noop]
    J -- No --> K[runNotesStep]
    K --> L[commitAndForcePush]
    L --> M[createOrUpdatePR]
    M --> N[return created/updated]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[runStandingPRUpdate] --> B{bypassSkipGuard?}
    B -- No --> C{HEAD matches skip pattern?}
    C -- Yes --> NOOP1[return noop]
    C -- No --> D
    B -- Yes --> D[runVersionStep dry-run]
    D --> E{versionOutputDry.updates.length === 0?}
    E -- Yes --> CEQ1[closeEmptyQueue close PR or noop]
    E -- No --> F{minPackages gate}
    F -- Below threshold --> CEQ2[close PR or noop]
    F -- OK --> G[resetReleaseBranch]
    G --> H{reconcile? check reset HEAD}
    H -- skip pattern match --> NOOP2[return noop]
    H -- OK --> I[runVersionStep write]
    I --> J{publishableUpdates.length === 0? NEW GUARD #396}
    J -- Yes --> CEQ3[closeEmptyQueue close PR or noop]
    J -- No --> K[runNotesStep]
    K --> L[commitAndForcePush]
    L --> M[createOrUpdatePR]
    M --> N[return created/updated]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(release): guard the write-step empty..."](https://github.com/goosewobbler/releasekit/commit/747dc1f3752f31e86f1beb9307a37cd89f8e0d44) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39164544)</sub>

<!-- /greptile_comment -->