### PR TITLE
feat(release): standing-PR authorization primitive (actor permission + config) (#399)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -421,6 +421,7 @@ Configuration for the standing release PR feature (ci.releaseStrategy: 'standing
 | `mergeMethod` | `"merge"` \| `"squash"` \| `"rebase"` | `"merge"` | Merge method to use when merging the standing release PR via CLI. |
 | `minAge` | string | — | Minimum age of the standing PR before it can be merged. Duration string, e.g. '6h', '30m', '1d'. Gate enforced via the releasekit/standing-pr commit status check; configure it as a required status check in branch protection to block merges. |
 | `minPackages` | integer | — | Minimum number of packages with releasable changes required to create or maintain the standing PR. Below this threshold the PR is closed and no new PR is opened. |
+| `authorization` | object | — | Restrict who can steer the standing PR — its selection checkboxes, release labels, and merge. Omit to allow anyone with the GitHub permission GitHub itself requires for each action (today’s behavior). |
 
 ---
 

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -549,6 +549,25 @@ export const StandingPrConfigSchema = z.object({
     .describe(
       'Minimum number of packages with releasable changes required to create or maintain the standing PR. Below this threshold the PR is closed and no new PR is opened.',
     ),
+  authorization: z
+    .object({
+      requiredPermission: z
+        .enum(['admin', 'maintain', 'write'])
+        .default('admin')
+        .describe(
+          'Minimum repository permission an actor needs to steer the standing PR — tick/untick selection checkboxes, apply release labels, and (with branch protection) merge. Default: admin.',
+        ),
+      allowedActors: z
+        .array(z.string())
+        .optional()
+        .describe(
+          'Extra actors authorized regardless of permission level: GitHub usernames. (Team support via "@org/team" entries is added separately and requires an org-read token, not the default GITHUB_TOKEN.)',
+        ),
+    })
+    .optional()
+    .describe(
+      'Restrict who can steer the standing PR — its selection checkboxes, release labels, and merge. Omit to allow anyone with the GitHub permission GitHub itself requires for each action (today’s behavior).',
+    ),
 });
 
 export const CIConfigSchema = z.object({

--- a/packages/forge/src/fake.ts
+++ b/packages/forge/src/fake.ts
@@ -14,6 +14,7 @@ import type {
   ReleaseChanges,
   ReleaseRef,
   ReleaseSummary,
+  RepoPermission,
   StandingPullRequest,
 } from './types.js';
 
@@ -39,6 +40,8 @@ export interface FakeForgeSeed {
   labelNames?: string[];
   releases?: ReleaseSummary[];
   releasesByTag?: Record<string, ReleaseRef>;
+  /** Per-username repo permission. Unseeded usernames resolve to 'none'. */
+  actorPermissions?: Record<string, RepoPermission>;
 }
 
 /**
@@ -57,6 +60,7 @@ export class FakeForge implements Forge {
   labelNames: string[];
   private readonly releases: ReleaseSummary[];
   private readonly releasesByTag: Record<string, ReleaseRef>;
+  private readonly actorPermissions: Record<string, RepoPermission>;
 
   // Recorded writes, for assertions.
   readonly createdComments: Array<{ prNumber: number; body: string }> = [];
@@ -85,7 +89,12 @@ export class FakeForge implements Forge {
     this.labelNames = [...(seed.labelNames ?? [])];
     this.releases = seed.releases ?? [];
     this.releasesByTag = seed.releasesByTag ?? {};
+    this.actorPermissions = seed.actorPermissions ?? {};
     this.nextCommentId = Math.max(0, ...this.comments.map((c) => c.id)) + 1;
+  }
+
+  async getActorPermission(username: string): Promise<RepoPermission> {
+    return this.actorPermissions[username] ?? 'none';
   }
 
   async listPullRequestsForCommit(commitSha: string): Promise<AssociatedPullRequest[]> {

--- a/packages/forge/src/fake.ts
+++ b/packages/forge/src/fake.ts
@@ -94,7 +94,11 @@ export class FakeForge implements Forge {
   }
 
   async getActorPermission(username: string): Promise<RepoPermission> {
-    return this.actorPermissions[username] ?? 'none';
+    // GitHub resolves usernames case-insensitively (Alice === alice); match the real adapter so the
+    // fake doesn't diverge. Unseeded → 'none'.
+    const lc = username.toLowerCase();
+    const key = Object.keys(this.actorPermissions).find((k) => k.toLowerCase() === lc);
+    return (key !== undefined ? this.actorPermissions[key] : undefined) ?? 'none';
   }
 
   async listPullRequestsForCommit(commitSha: string): Promise<AssociatedPullRequest[]> {

--- a/packages/forge/src/github.ts
+++ b/packages/forge/src/github.ts
@@ -16,8 +16,11 @@ import type {
   ReleaseChanges,
   ReleaseRef,
   ReleaseSummary,
+  RepoPermission,
   StandingPullRequest,
 } from './types.js';
+
+const REPO_PERMISSIONS: readonly RepoPermission[] = ['admin', 'maintain', 'write', 'triage', 'read', 'none'];
 
 /** Releases are listed at most this many pages deep (100/page) — bounds the examples fetch. */
 const MAX_RELEASE_PAGES = 3;
@@ -111,6 +114,20 @@ export class GitHubForge implements Forge {
 
   async mergePullRequest(prNumber: number, method: MergeMethod): Promise<void> {
     await this.octokit.rest.pulls.merge({ ...this.base, pull_number: prNumber, merge_method: method });
+  }
+
+  async getActorPermission(username: string): Promise<RepoPermission> {
+    try {
+      const { data } = await this.octokit.rest.repos.getCollaboratorPermissionLevel({ ...this.base, username });
+      // Prefer `role_name` — it distinguishes maintain/triage, which the coarse `permission`
+      // ('admin'|'write'|'read'|'none') collapses. Fall back to `permission` for older API shapes.
+      const role = data.role_name as RepoPermission | undefined;
+      if (role && REPO_PERMISSIONS.includes(role)) return role;
+      return (data.permission as RepoPermission) ?? 'none';
+    } catch {
+      // 404 = not a collaborator / unknown user. Treat as no permission rather than failing the run.
+      return 'none';
+    }
   }
 
   async findComment(prNumber: number, marker: string): Promise<ForgeComment | null> {

--- a/packages/forge/src/github.ts
+++ b/packages/forge/src/github.ts
@@ -1,4 +1,5 @@
 import { Octokit } from '@octokit/rest';
+import { forgeErrorStatus } from './errors.js';
 import type {
   AssociatedPullRequest,
   CommitStatus,
@@ -124,9 +125,13 @@ export class GitHubForge implements Forge {
       const role = data.role_name as RepoPermission | undefined;
       if (role && REPO_PERMISSIONS.includes(role)) return role;
       return (data.permission as RepoPermission) ?? 'none';
-    } catch {
-      // 404 = not a collaborator / unknown user. Treat as no permission rather than failing the run.
-      return 'none';
+    } catch (error) {
+      // 404 = not a collaborator / unknown user → genuinely no permission. Any other error (403 from a
+      // mis-scoped token, 429 rate limit, 5xx, network) means we CAN'T determine permission — surface
+      // it rather than silently reporting 'none', which would fail the gate closed for every real
+      // actor (even admins) with no diagnostic.
+      if (forgeErrorStatus(error) === 404) return 'none';
+      throw error;
     }
   }
 

--- a/packages/forge/src/index.ts
+++ b/packages/forge/src/index.ts
@@ -20,5 +20,6 @@ export type {
   ReleaseChanges,
   ReleaseRef,
   ReleaseSummary,
+  RepoPermission,
   StandingPullRequest,
 } from './types.js';

--- a/packages/forge/src/types.ts
+++ b/packages/forge/src/types.ts
@@ -108,6 +108,13 @@ export interface ReleaseChanges {
   prerelease: boolean;
 }
 
+/**
+ * A user's permission level on the repository, highest→lowest. Vendor-neutral: GitHub's role names
+ * map directly; another forge's roles would map to the nearest rung. `none` covers an outside/unknown
+ * actor. Used to authorize who may steer the standing PR (selection, labels, merge).
+ */
+export type RepoPermission = 'admin' | 'maintain' | 'write' | 'triage' | 'read' | 'none';
+
 export interface Forge {
   // — Pull requests —
   /** PRs associated with a commit (used to map merge commits back to their PRs). */
@@ -139,6 +146,11 @@ export interface Forge {
   createLabel(label: NewLabel): Promise<CreateLabelResult>;
   /** Replace the full label set on an issue/PR. */
   setLabels(issueNumber: number, labels: string[]): Promise<void>;
+
+  // — Authorization —
+  /** The actor's permission level on the repo (for gating who may steer the standing PR). Returns
+   *  'none' for an unknown/outside actor rather than throwing. */
+  getActorPermission(username: string): Promise<RepoPermission>;
 
   // — Commit status —
   setCommitStatus(status: CommitStatus): Promise<void>;

--- a/packages/forge/test/unit/fake.spec.ts
+++ b/packages/forge/test/unit/fake.spec.ts
@@ -118,10 +118,10 @@ describe('FakeForge', () => {
     expect(await forge.listReleases()).toEqual(releases);
   });
 
-  it('should return seeded actor permission, and none for unseeded actors', async () => {
-    const forge = createFakeForge({ actorPermissions: { alice: 'admin', bob: 'write' } });
-    expect(await forge.getActorPermission('alice')).toBe('admin');
-    expect(await forge.getActorPermission('bob')).toBe('write');
+  it('should return seeded actor permission (case-insensitively), and none for unseeded actors', async () => {
+    const forge = createFakeForge({ actorPermissions: { Alice: 'admin', bob: 'write' } });
+    expect(await forge.getActorPermission('alice')).toBe('admin'); // seeded as 'Alice'
+    expect(await forge.getActorPermission('BOB')).toBe('write');
     expect(await forge.getActorPermission('stranger')).toBe('none');
   });
 });

--- a/packages/forge/test/unit/fake.spec.ts
+++ b/packages/forge/test/unit/fake.spec.ts
@@ -117,4 +117,11 @@ describe('FakeForge', () => {
     const forge = createFakeForge({ releases });
     expect(await forge.listReleases()).toEqual(releases);
   });
+
+  it('should return seeded actor permission, and none for unseeded actors', async () => {
+    const forge = createFakeForge({ actorPermissions: { alice: 'admin', bob: 'write' } });
+    expect(await forge.getActorPermission('alice')).toBe('admin');
+    expect(await forge.getActorPermission('bob')).toBe('write');
+    expect(await forge.getActorPermission('stranger')).toBe('none');
+  });
 });

--- a/packages/forge/test/unit/github.spec.ts
+++ b/packages/forge/test/unit/github.spec.ts
@@ -12,6 +12,7 @@ function makeOctokit() {
     createRelease: vi.fn(),
     updateRelease: vi.fn(),
     getReleaseByTag: vi.fn(),
+    getCollaboratorPermissionLevel: vi.fn(),
     pullsList: vi.fn(),
     pullsGet: vi.fn(),
     pullsCreate: vi.fn(),
@@ -33,6 +34,7 @@ function makeOctokit() {
         createRelease: fns.createRelease,
         updateRelease: fns.updateRelease,
         getReleaseByTag: fns.getReleaseByTag,
+        getCollaboratorPermissionLevel: fns.getCollaboratorPermissionLevel,
       },
       pulls: {
         list: fns.pullsList,
@@ -372,6 +374,27 @@ describe('GitHubForge', () => {
 describe('createGitHubForge', () => {
   it('should build a GitHubForge bound to owner/repo', () => {
     expect(createGitHubForge({ token: 't', owner: 'o', repo: 'r' })).toBeInstanceOf(GitHubForge);
+  });
+});
+
+describe('GitHubForge.getActorPermission', () => {
+  it('should prefer role_name so maintain/triage are distinguished', async () => {
+    const { octokit, fns } = makeOctokit();
+    fns.getCollaboratorPermissionLevel.mockResolvedValue({ data: { permission: 'write', role_name: 'maintain' } });
+    expect(await new GitHubForge(octokit, 'o', 'r').getActorPermission('alice')).toBe('maintain');
+    expect(fns.getCollaboratorPermissionLevel).toHaveBeenCalledWith({ owner: 'o', repo: 'r', username: 'alice' });
+  });
+
+  it('should fall back to permission when role_name is unrecognised', async () => {
+    const { octokit, fns } = makeOctokit();
+    fns.getCollaboratorPermissionLevel.mockResolvedValue({ data: { permission: 'admin', role_name: 'custom' } });
+    expect(await new GitHubForge(octokit, 'o', 'r').getActorPermission('bob')).toBe('admin');
+  });
+
+  it('should return none when the user is not a collaborator (404)', async () => {
+    const { octokit, fns } = makeOctokit();
+    fns.getCollaboratorPermissionLevel.mockRejectedValue(Object.assign(new Error('404'), { status: 404 }));
+    expect(await new GitHubForge(octokit, 'o', 'r').getActorPermission('stranger')).toBe('none');
   });
 });
 

--- a/packages/forge/test/unit/github.spec.ts
+++ b/packages/forge/test/unit/github.spec.ts
@@ -396,6 +396,12 @@ describe('GitHubForge.getActorPermission', () => {
     fns.getCollaboratorPermissionLevel.mockRejectedValue(Object.assign(new Error('404'), { status: 404 }));
     expect(await new GitHubForge(octokit, 'o', 'r').getActorPermission('stranger')).toBe('none');
   });
+
+  it('should rethrow non-404 errors (e.g. a mis-scoped token) rather than silently report none', async () => {
+    const { octokit, fns } = makeOctokit();
+    fns.getCollaboratorPermissionLevel.mockRejectedValue(Object.assign(new Error('403'), { status: 403 }));
+    await expect(new GitHubForge(octokit, 'o', 'r').getActorPermission('alice')).rejects.toThrow('403');
+  });
 });
 
 describe('forgeErrorStatus', () => {

--- a/packages/release/src/standing-pr/authorization.ts
+++ b/packages/release/src/standing-pr/authorization.ts
@@ -1,0 +1,77 @@
+import * as fs from 'node:fs';
+import type { StandingPrConfig } from '@releasekit/config';
+import type { Forge, RepoPermission } from '@releasekit/forge';
+
+/**
+ * Authorization for the standing PR — decides who may steer it (tick/untick selection, apply release
+ * labels, and, at publish time, who merged it). The enforcement itself lives in the standing-pr flow;
+ * this module is the shared primitive: read the acting GitHub user from the event, and test whether a
+ * user is authorized under the configured policy. No-op until `ci.standingPr.authorization` is set.
+ */
+
+export type StandingPrAuthorization = NonNullable<StandingPrConfig['authorization']>;
+
+/** Repo-permission ranks, highest→lowest, for threshold comparison. */
+const PERMISSION_RANK: Record<RepoPermission, number> = {
+  admin: 5,
+  maintain: 4,
+  write: 3,
+  triage: 2,
+  read: 1,
+  none: 0,
+};
+
+export interface EventActor {
+  /** The `pull_request` event action (labeled / unlabeled / edited / closed / …), if any. */
+  action?: string;
+  /** The actor who triggered the event (`event.sender.login`). */
+  login?: string;
+  /** The actor's GitHub type (`event.sender.type`) — `'Bot'` for app/bot actors. */
+  type?: string;
+  /** Who merged the PR (`event.pull_request.merged_by.login`), for the publish-author gate. */
+  mergedBy?: string;
+}
+
+/** Read the triggering actor (and the merger, for publish) from the GitHub Actions event payload. */
+export function getEventActor(): EventActor {
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (!eventPath) return {};
+  try {
+    const event = JSON.parse(fs.readFileSync(eventPath, 'utf-8')) as {
+      action?: string;
+      sender?: { login?: string; type?: string };
+      pull_request?: { merged_by?: { login?: string } | null };
+    };
+    return {
+      action: event.action,
+      login: event.sender?.login,
+      type: event.sender?.type,
+      mergedBy: event.pull_request?.merged_by?.login,
+    };
+  } catch {
+    return {};
+  }
+}
+
+/** A bot actor (the tool itself / a GitHub App) — always authorized; its own runs drive the PR. */
+function isBot(login: string | undefined, type: string | undefined): boolean {
+  return type === 'Bot' || (login !== undefined && login.endsWith('[bot]'));
+}
+
+/**
+ * Whether `login` may steer the standing PR under `authz`. Bots are always authorized (the tool runs
+ * as one). Otherwise the actor passes if explicitly allow-listed, or if their repository permission
+ * meets the configured threshold. An unknown actor (no login, or no repo access) is not authorized.
+ */
+export async function isAuthorizedActor(
+  forge: Forge,
+  login: string | undefined,
+  type: string | undefined,
+  authz: StandingPrAuthorization,
+): Promise<boolean> {
+  if (isBot(login, type)) return true;
+  if (!login) return false;
+  if (authz.allowedActors?.includes(login)) return true;
+  const permission = await forge.getActorPermission(login);
+  return PERMISSION_RANK[permission] >= PERMISSION_RANK[authz.requiredPermission];
+}

--- a/packages/release/src/standing-pr/authorization.ts
+++ b/packages/release/src/standing-pr/authorization.ts
@@ -71,7 +71,10 @@ export async function isAuthorizedActor(
 ): Promise<boolean> {
   if (isBot(login, type)) return true;
   if (!login) return false;
-  if (authz.allowedActors?.includes(login)) return true;
+  // GitHub usernames are case-insensitive, so compare case-folded — a `allowedActors: ['Alice']`
+  // entry must still match an event delivering `login: 'alice'`.
+  const lc = login.toLowerCase();
+  if (authz.allowedActors?.some((a) => a.toLowerCase() === lc)) return true;
   const permission = await forge.getActorPermission(login);
   return PERMISSION_RANK[permission] >= PERMISSION_RANK[authz.requiredPermission];
 }

--- a/packages/release/test/unit/authorization.spec.ts
+++ b/packages/release/test/unit/authorization.spec.ts
@@ -1,0 +1,81 @@
+import * as fs from 'node:fs';
+import { createFakeForge } from '@releasekit/forge';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { getEventActor, isAuthorizedActor, type StandingPrAuthorization } from '../../src/standing-pr/authorization.js';
+
+const authz = (overrides: Partial<StandingPrAuthorization> = {}): StandingPrAuthorization => ({
+  requiredPermission: 'admin',
+  ...overrides,
+});
+
+describe('isAuthorizedActor', () => {
+  it('should always authorize a bot actor (the tool runs as one)', async () => {
+    const forge = createFakeForge();
+    expect(await isAuthorizedActor(forge, 'github-actions[bot]', 'Bot', authz())).toBe(true);
+    // Type-based detection too (login not suffixed).
+    expect(await isAuthorizedActor(forge, 'my-app', 'Bot', authz())).toBe(true);
+  });
+
+  it('should authorize an actor whose permission meets the threshold', async () => {
+    const forge = createFakeForge({ actorPermissions: { alice: 'admin', bob: 'write' } });
+    expect(await isAuthorizedActor(forge, 'alice', 'User', authz({ requiredPermission: 'admin' }))).toBe(true);
+    expect(await isAuthorizedActor(forge, 'bob', 'User', authz({ requiredPermission: 'write' }))).toBe(true);
+  });
+
+  it('should reject an actor below the threshold', async () => {
+    const forge = createFakeForge({ actorPermissions: { bob: 'write', carol: 'triage' } });
+    expect(await isAuthorizedActor(forge, 'bob', 'User', authz({ requiredPermission: 'admin' }))).toBe(false);
+    expect(await isAuthorizedActor(forge, 'carol', 'User', authz({ requiredPermission: 'write' }))).toBe(false);
+  });
+
+  it('should authorize an explicitly allow-listed actor regardless of permission', async () => {
+    const forge = createFakeForge({ actorPermissions: { dave: 'read' } });
+    expect(await isAuthorizedActor(forge, 'dave', 'User', authz({ allowedActors: ['dave'] }))).toBe(true);
+  });
+
+  it('should reject an unknown actor (no login, or no repo access)', async () => {
+    const forge = createFakeForge();
+    expect(await isAuthorizedActor(forge, undefined, 'User', authz())).toBe(false);
+    expect(await isAuthorizedActor(forge, 'stranger', 'User', authz())).toBe(false); // unseeded → 'none'
+  });
+});
+
+describe('getEventActor', () => {
+  const ORIG = process.env.GITHUB_EVENT_PATH;
+  let tmpFile: string;
+
+  beforeEach(() => {
+    tmpFile = `${process.env.TMPDIR ?? '/tmp'}/rk-event-${process.pid}.json`;
+  });
+  afterEach(() => {
+    if (ORIG === undefined) delete process.env.GITHUB_EVENT_PATH;
+    else process.env.GITHUB_EVENT_PATH = ORIG;
+    try {
+      fs.unlinkSync(tmpFile);
+    } catch {}
+  });
+
+  it('should read action, sender, and merged_by from the event payload', () => {
+    fs.writeFileSync(
+      tmpFile,
+      JSON.stringify({
+        action: 'edited',
+        sender: { login: 'alice', type: 'User' },
+        pull_request: { merged_by: { login: 'maintainer' } },
+      }),
+    );
+    process.env.GITHUB_EVENT_PATH = tmpFile;
+
+    expect(getEventActor()).toEqual({
+      action: 'edited',
+      login: 'alice',
+      type: 'User',
+      mergedBy: 'maintainer',
+    });
+  });
+
+  it('should return an empty actor when no event path is set', () => {
+    delete process.env.GITHUB_EVENT_PATH;
+    expect(getEventActor()).toEqual({});
+  });
+});

--- a/packages/release/test/unit/authorization.spec.ts
+++ b/packages/release/test/unit/authorization.spec.ts
@@ -33,6 +33,12 @@ describe('isAuthorizedActor', () => {
     expect(await isAuthorizedActor(forge, 'dave', 'User', authz({ allowedActors: ['dave'] }))).toBe(true);
   });
 
+  it('should match the allow-list case-insensitively (GitHub usernames are case-insensitive)', async () => {
+    const forge = createFakeForge({ actorPermissions: { Alice: 'read' } });
+    // Configured as `Alice`, event delivers `alice` — must still authorize.
+    expect(await isAuthorizedActor(forge, 'alice', 'User', authz({ allowedActors: ['Alice'] }))).toBe(true);
+  });
+
   it('should reject an unknown actor (no login, or no repo access)', async () => {
     const forge = createFakeForge();
     expect(await isAuthorizedActor(forge, undefined, 'User', authz())).toBe(false);

--- a/releasekit.schema.json
+++ b/releasekit.schema.json
@@ -1214,6 +1214,30 @@
               "type": "integer",
               "minimum": 1,
               "description": "Minimum number of packages with releasable changes required to create or maintain the standing PR. Below this threshold the PR is closed and no new PR is opened."
+            },
+            "authorization": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "requiredPermission": {
+                  "type": "string",
+                  "enum": [
+                    "admin",
+                    "maintain",
+                    "write"
+                  ],
+                  "default": "admin",
+                  "description": "Minimum repository permission an actor needs to steer the standing PR — tick/untick selection checkboxes, apply release labels, and (with branch protection) merge. Default: admin."
+                },
+                "allowedActors": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "Extra actors authorized regardless of permission level: GitHub usernames. (Team support via \"@org/team\" entries is added separately and requires an org-read token, not the default GITHUB_TOKEN.)"
+                }
+              },
+              "description": "Restrict who can steer the standing PR — its selection checkboxes, release labels, and merge. Omit to allow anyone with the GitHub permission GitHub itself requires for each action (today’s behavior)."
             }
           },
           "description": "Configuration for the standing release PR feature (ci.releaseStrategy: 'standing-pr')."


### PR DESCRIPTION
Closes #399. The foundation for the standing-PR authorization feature — the primitive the enforcement slices (#401 checkboxes, #402 labels, #403 publish) build on. **No behavior change yet:** absent `ci.standingPr.authorization`, everything is a no-op.

## What's added

- **Forge** `getActorPermission(username): RepoPermission` (`'admin'|'maintain'|'write'|'triage'|'read'|'none'`). The GitHub adapter wraps `repos.getCollaboratorPermissionLevel`, preferring `role_name` so `maintain`/`triage` aren't collapsed by the coarse `permission`, and returns `'none'` on a 404 (unknown/outside actor) rather than throwing. `FakeForge` seeds `actorPermissions`.
- **Config** `ci.standingPr.authorization`: `requiredPermission` (default `admin`) + `allowedActors` (usernames). Optional. `releasekit.schema.json` + `docs/configuration.md` regenerated from Zod.
- **`standing-pr/authorization.ts`**: `getEventActor()` reads the triggering actor (`sender`) and the merger (`pull_request.merged_by`) from the event payload; `isAuthorizedActor(forge, login, type, authz)` — bots always pass (the tool runs as one), then explicit allow-list, then the permission threshold.

(`@org/team` allow-list support is split into #400; the publish-author `enforceMergeAuthor` field lands with #403.)

## Acceptance

- [x] Forge actor-permission lookup (GitHub adapter + fake), role mapped to admin/maintain/write/triage/read/none
- [x] `isAuthorizedActor` true for bot / threshold-met / allow-listed; false otherwise
- [x] Triggering actor + merger read from the event payload
- [x] `ci.standingPr.authorization` in the Zod schema; schema + docs regenerated; `schema:check` green
- [x] Unit tests (forge adapter + fake; `isAuthorizedActor`; event parsing)
- [x] Absent config is a no-op

Full gate: `pnpm turbo run lint typecheck test:coverage` → **27/27**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces the authorization primitive that future standing-PR enforcement slices will build on. It is a no-op until `ci.standingPr.authorization` is configured, so there is no behavior change today.

- **Forge layer**: `getActorPermission(username)` is added to the `Forge` interface, implemented in `GitHubForge` (preferring `role_name` over the coarser `permission` field) and `FakeForge` (case-insensitive seed lookup). Non-404 errors are rethrown instead of silently swallowed.
- **Authorization logic**: `getEventActor()` reads `sender` / `merged_by` from the GitHub Actions event payload; `isAuthorizedActor()` grants access to bots unconditionally, then explicit allow-list (case-insensitive), then the `requiredPermission` rank threshold.
- **Config / schema**: `ci.standingPr.authorization` (`requiredPermission` + `allowedActors`) is added to the Zod schema and regenerated JSON Schema + docs.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — purely additive, no behavior change until authorization config is present, and previous review findings are resolved.

Both previously flagged issues (error swallowing in getActorPermission, case-sensitive allow-list comparison) are correctly addressed. The core permission-rank logic, bot detection, and case-folding are all sound. The change is gated behind an optional config key, so existing workflows are unaffected.

No files require special attention. The authorization primitive is well-isolated and the tests cover the important decision paths.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/release/src/standing-pr/authorization.ts | New module: getEventActor reads sender/merged_by from the event payload; isAuthorizedActor enforces bot/allow-list/permission-rank logic. Both previous review findings (silent error swallow, case-sensitive allow-list) are addressed. |
| packages/forge/src/github.ts | Adds getActorPermission: prefers role_name over permission, returns 'none' for 404, and correctly rethrows all other errors (addressing the previous review comment). |
| packages/forge/src/fake.ts | FakeForge.getActorPermission performs case-insensitive seed lookup and returns 'none' for unseeded actors, correctly mirroring the real adapter's semantics. |
| packages/config/src/schema.ts | Adds authorization object to StandingPrConfigSchema with requiredPermission (enum admin/maintain/write, default admin) and optional allowedActors array. |
| packages/forge/test/unit/github.spec.ts | Good coverage: role_name preference, fallback to permission, 404→none, and non-404 rethrow are all tested. |
| packages/release/test/unit/authorization.spec.ts | isAuthorizedActor tests cover bot, threshold met/unmet, allow-list, case-insensitive match, and unknown actor. getEventActor tests cover the happy path and absent env var; parse-error path is untested but fail-closed. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant CI as GitHub Actions CI
    participant Auth as authorization.ts
    participant Forge as GitHubForge
    participant GH as GitHub API

    CI->>Auth: getEventActor()
    Auth->>Auth: read GITHUB_EVENT_PATH
    Auth-->>CI: "{ login, type, action, mergedBy }"

    CI->>Auth: isAuthorizedActor(forge, login, type, authz)
    Auth->>Auth: isBot(login, type)?
    alt bot actor
        Auth-->>CI: true
    else human actor
        Auth->>Auth: allowedActors includes login (case-insensitive)?
        alt on allow-list
            Auth-->>CI: true
        else check permission
            Auth->>Forge: getActorPermission(login)
            Forge->>GH: repos.getCollaboratorPermissionLevel
            alt 404 (not a collaborator)
                GH-->>Forge: 404
                Forge-->>Auth: 'none'
            else non-404 error
                GH-->>Forge: 403 / 5xx
                Forge-->>Auth: throw
            else success
                GH-->>Forge: "{ permission, role_name }"
                Forge->>Forge: prefer role_name if in REPO_PERMISSIONS
                Forge-->>Auth: RepoPermission
            end
            Auth->>Auth: "PERMISSION_RANK[permission] >= PERMISSION_RANK[requiredPermission]"
            Auth-->>CI: true / false
        end
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant CI as GitHub Actions CI
    participant Auth as authorization.ts
    participant Forge as GitHubForge
    participant GH as GitHub API

    CI->>Auth: getEventActor()
    Auth->>Auth: read GITHUB_EVENT_PATH
    Auth-->>CI: "{ login, type, action, mergedBy }"

    CI->>Auth: isAuthorizedActor(forge, login, type, authz)
    Auth->>Auth: isBot(login, type)?
    alt bot actor
        Auth-->>CI: true
    else human actor
        Auth->>Auth: allowedActors includes login (case-insensitive)?
        alt on allow-list
            Auth-->>CI: true
        else check permission
            Auth->>Forge: getActorPermission(login)
            Forge->>GH: repos.getCollaboratorPermissionLevel
            alt 404 (not a collaborator)
                GH-->>Forge: 404
                Forge-->>Auth: 'none'
            else non-404 error
                GH-->>Forge: 403 / 5xx
                Forge-->>Auth: throw
            else success
                GH-->>Forge: "{ permission, role_name }"
                Forge->>Forge: prefer role_name if in REPO_PERMISSIONS
                Forge-->>Auth: RepoPermission
            end
            Auth->>Auth: "PERMISSION_RANK[permission] >= PERMISSION_RANK[requiredPermission]"
            Auth-->>CI: true / false
        end
    end
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(forge): FakeForge.getActorPermission..."](https://github.com/goosewobbler/releasekit/commit/3e8d3f19e98e94d9c1a0be06f778eac0d04837ee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39166130)</sub>

<!-- /greptile_comment -->