### PR TITLE
feat(release): gate standing-PR checkbox selection to authorized actors (#401)

### DIFF
--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -17,7 +17,7 @@ import { DEFAULT_LABELS } from '../label-utils.js';
 import { runNotesStep, runPublishStep, runVersionStep } from '../steps.js';
 import type { ReleaseOptions, ReleaseOutput } from '../types.js';
 import { publishableUpdates, syncVersionDisplay } from '../version-display.js';
-import { getEventActor, isAuthorizedActor } from './authorization.js';
+import { type EventActor, getEventActor, isAuthorizedActor, type StandingPrAuthorization } from './authorization.js';
 import { extractNotesRegions, mergeNotesRegions, renderNotesRegion } from './notes-region.js';
 import { extractSelection, renderSelectionRegion, selectionWarnings } from './selection-region.js';
 import { postStandingPRStatusSafe } from './status.js';
@@ -741,6 +741,23 @@ function setsEqual(a: ReadonlySet<string>, b: ReadonlySet<string>): boolean {
   return a.size === b.size && [...a].every((x) => b.has(x));
 }
 
+/**
+ * {@link isAuthorizedActor}, but it never throws. The permission check is a forge API call that can
+ * fail (rate-limit, network, a mis-scoped token — `getActorPermission` rethrows non-404s); on failure
+ * we warn and fail **closed** (treat the actor as unauthorized), so a transient hiccup reverts the
+ * standing PR to its authoritative manifest state rather than crashing the whole update (#401).
+ */
+async function authorizedOrWarn(forge: Forge, actor: EventActor, authz: StandingPrAuthorization): Promise<boolean> {
+  try {
+    return await isAuthorizedActor(forge, actor.login, actor.type, authz);
+  } catch (err) {
+    warn(
+      `Could not verify permission for '${actor.login ?? 'unknown'}' — treating as unauthorized: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return false;
+  }
+}
+
 export async function runStandingPRUpdate(options: StandingPROptions): Promise<StandingPRResult> {
   const cwd = options.projectDir;
 
@@ -828,18 +845,18 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
   if (authz && existingStandingPr && githubContext?.token) {
     const manifestDeselected = new Set<string>(existingManifest?.deselected ?? []);
     const actor = getEventActor();
-    const authorizedEdit =
-      actor.action === 'edited' && (await isAuthorizedActor(forgeFor(githubContext), actor.login, actor.type, authz));
+    const authorizedEdit = actor.action === 'edited' && (await authorizedOrWarn(forgeFor(githubContext), actor, authz));
     if (!authorizedEdit) {
       priorDeselected = manifestDeselected;
       // An unauthorized actor changed the checklist — tell them it was ignored (idempotent comment).
       if (actor.action === 'edited' && !setsEqual(bodyDeselected, manifestDeselected)) {
-        const permission = authz.requiredPermission;
+        // Only mention the allow-list when one is actually configured.
+        const allowClause = authz.allowedActors?.length ? ', or an allow-listed actor' : '';
         await forgeFor(githubContext)
           .upsertMarkerComment(
             existingStandingPr.number,
             SELECTION_DENIED_MARKER,
-            `${SELECTION_DENIED_MARKER}\n\n> ⚠️ **Selection change ignored.** Only authorized maintainers (\`${permission}\`+, or an allow-listed actor) can hold packages back from the release. The **Packages to release** checklist has been reset to the approved selection.`,
+            `${SELECTION_DENIED_MARKER}\n\n> ⚠️ **Selection change ignored.** Only authorized maintainers (\`${authz.requiredPermission}\`+${allowClause}) can hold packages back from the release. The **Packages to release** checklist has been reset to the approved selection.`,
           )
           .catch((err) =>
             warn(`Could not post selection-denied notice: ${err instanceof Error ? err.message : String(err)}`),

--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -17,12 +17,15 @@ import { DEFAULT_LABELS } from '../label-utils.js';
 import { runNotesStep, runPublishStep, runVersionStep } from '../steps.js';
 import type { ReleaseOptions, ReleaseOutput } from '../types.js';
 import { publishableUpdates, syncVersionDisplay } from '../version-display.js';
+import { getEventActor, isAuthorizedActor } from './authorization.js';
 import { extractNotesRegions, mergeNotesRegions, renderNotesRegion } from './notes-region.js';
 import { extractSelection, renderSelectionRegion, selectionWarnings } from './selection-region.js';
 import { postStandingPRStatusSafe } from './status.js';
 
 const MANIFEST_MARKER = '<!-- releasekit-manifest -->';
 const MANIFEST_SCHEMA_VERSION = 2;
+/** Marker for the idempotent "your selection change was ignored" notice posted to an unauthorized editor (#401). */
+const SELECTION_DENIED_MARKER = '<!-- releasekit-selection-denied -->';
 const MANIFEST_SCHEMA_MIN_VERSION = 1;
 
 // The manifest payload rides as a base64 blob in its own marker; base64/JSON/schema decoding (with
@@ -733,6 +736,11 @@ async function closeEmptyQueue(
   return { action: 'noop' };
 }
 
+/** Whether two string sets hold the same members. */
+function setsEqual(a: ReadonlySet<string>, b: ReadonlySet<string>): boolean {
+  return a.size === b.size && [...a].every((x) => b.has(x));
+}
+
 export async function runStandingPRUpdate(options: StandingPROptions): Promise<StandingPRResult> {
   const cwd = options.projectDir;
 
@@ -780,6 +788,21 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
     }
   }
 
+  // Read the standing PR's manifest once up front. Its recorded `deselected` is the AUTHORITATIVE
+  // selection used by the gate below (publish reads the manifest, not the body), and its
+  // `firstUpdatedAt` is preserved when the manifest is rewritten at the end of the run.
+  let existingManifestComment: Awaited<ReturnType<typeof findManifestComment>> = null;
+  let existingManifest: StandingPRManifest | undefined;
+  if (existingStandingPr && githubContext?.token) {
+    try {
+      existingManifestComment = await findManifestComment(forgeFor(githubContext), existingStandingPr.number);
+      if (existingManifestComment) existingManifest = parseManifest(existingManifestComment.body);
+    } catch {
+      // An unreadable/malformed manifest is treated as absent — the gate falls back to an empty
+      // authoritative selection and firstUpdatedAt defaults to the current time below.
+    }
+  }
+
   // Read the standing PR's live body once (reused for the ad-hoc selection region and edited notes).
   // A maintainer ticks/unticks packages and edits notes in place; both are read back by marker
   // slicing so their choices survive this run's regenerate + force-push.
@@ -793,7 +816,37 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
   }
   // The maintainer's prior package selection — names whose row was unticked (held back). Reconciled
   // against the actually-changed set after the dry-run below (a name no longer changed is dropped).
-  const priorDeselected = new Set<string>((liveBody && extractSelection(liveBody)?.deselected) || []);
+  //
+  // Authorization (#401): when `ci.standingPr.authorization` is set, the manifest's recorded
+  // selection is AUTHORITATIVE; the live body is only trusted when an authorized actor `edited` it.
+  // Otherwise (an unauthorized edit, or a push/schedule run) we keep the manifest's selection so the
+  // re-render reverts any unauthorized tick/untick. With no policy configured, the body is
+  // authoritative (original behavior).
+  const bodyDeselected = new Set<string>((liveBody && extractSelection(liveBody)?.deselected) || []);
+  const authz = standingPrConfig?.authorization;
+  let priorDeselected = bodyDeselected;
+  if (authz && existingStandingPr && githubContext?.token) {
+    const manifestDeselected = new Set<string>(existingManifest?.deselected ?? []);
+    const actor = getEventActor();
+    const authorizedEdit =
+      actor.action === 'edited' && (await isAuthorizedActor(forgeFor(githubContext), actor.login, actor.type, authz));
+    if (!authorizedEdit) {
+      priorDeselected = manifestDeselected;
+      // An unauthorized actor changed the checklist — tell them it was ignored (idempotent comment).
+      if (actor.action === 'edited' && !setsEqual(bodyDeselected, manifestDeselected)) {
+        const permission = authz.requiredPermission;
+        await forgeFor(githubContext)
+          .upsertMarkerComment(
+            existingStandingPr.number,
+            SELECTION_DENIED_MARKER,
+            `${SELECTION_DENIED_MARKER}\n\n> ⚠️ **Selection change ignored.** Only authorized maintainers (\`${permission}\`+, or an allow-listed actor) can hold packages back from the release. The **Packages to release** checklist has been reset to the approved selection.`,
+          )
+          .catch((err) =>
+            warn(`Could not post selection-denied notice: ${err instanceof Error ? err.message : String(err)}`),
+          );
+      }
+    }
+  }
 
   // Preview-notes opt-in (#200): when the standing PR carries the preview-notes label, generate LLM
   // release notes on demand into an editable region in the PR body. Default path stays LLM-free.
@@ -1060,20 +1113,10 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
     }
   }
 
-  // Find existing manifest to preserve firstUpdatedAt across updates
+  // Preserve firstUpdatedAt across updates, from the manifest read once up front.
   let firstUpdatedAt = new Date().toISOString();
-  const existingManifestComment = await findManifestComment(forge, prNumber);
-  if (existingManifestComment) {
-    try {
-      const existingManifest = parseManifest(existingManifestComment.body);
-      if (existingManifest.firstUpdatedAt) {
-        firstUpdatedAt = existingManifest.firstUpdatedAt;
-      } else {
-        firstUpdatedAt = existingManifest.createdAt;
-      }
-    } catch {
-      // Use current time if the existing manifest can't be parsed
-    }
+  if (existingManifest) {
+    firstUpdatedAt = existingManifest.firstUpdatedAt ?? existingManifest.createdAt;
   }
 
   // Store manifest as a bot comment. `releaseNotes` is intentionally omitted — publishFromManifest

--- a/packages/release/test/unit/standing-pr.spec.ts
+++ b/packages/release/test/unit/standing-pr.spec.ts
@@ -501,6 +501,90 @@ describe('runStandingPRUpdate', () => {
     expect(updatedBody).toContain('- [x] `@scope/a`');
   });
 
+  const selectionBody = (untickedB = true) =>
+    [
+      '<!-- releasekit-selection -->',
+      '',
+      '- [x] `@scope/a` → 1.1.0 <!-- rk-sel:@scope/a -->',
+      `- [${untickedB ? ' ' : 'x'}] \`@scope/b\` → 2.0.0 <!-- rk-sel:@scope/b -->`,
+      '',
+      '<!-- releasekit-selection-end -->',
+    ].join('\n');
+
+  const withAuthz = async () => {
+    const { loadConfig } = await import('@releasekit/config');
+    vi.mocked(loadConfig).mockReturnValue({
+      ...defaultConfig,
+      ci: {
+        ...defaultConfig.ci,
+        standingPr: { ...defaultConfig.ci.standingPr, authorization: { requiredPermission: 'admin' } },
+      },
+    } as unknown as ReturnType<typeof loadConfig>);
+  };
+
+  const asEditedBy = async (login: string) => {
+    const { readFileSync } = await import('node:fs');
+    vi.mocked(readFileSync).mockReturnValue(JSON.stringify({ action: 'edited', sender: { login, type: 'User' } }));
+    process.env.GITHUB_EVENT_NAME = 'pull_request';
+    process.env.GITHUB_EVENT_PATH = '/event.json';
+  };
+
+  it('should honour an authorized actor’s checkbox untick (#401)', async () => {
+    await withAuthz();
+    await asEditedBy('admin-user');
+    const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
+    const versionOutput = {
+      ...createMockVersionOutput([
+        { packageName: '@scope/a', newVersion: '1.1.0' },
+        { packageName: '@scope/b', newVersion: '2.0.0' },
+      ]),
+      strategy: 'async' as const,
+    };
+    vi.mocked(runVersionStep).mockResolvedValue(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>);
+    vi.mocked(runNotesStep).mockResolvedValue({ packageNotes: {}, releaseNotes: {}, files: [] });
+
+    await mockForge({
+      standingPR: openStandingPR(99),
+      pullRequests: { 99: { body: selectionBody(), labels: [] } },
+      actorPermissions: { 'admin-user': 'admin' },
+    });
+
+    await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
+
+    const writeCall = vi.mocked(runVersionStep).mock.calls[1]?.[0] as { exclude?: string[] };
+    expect(writeCall.exclude).toEqual(['@scope/b']); // admin's untick is applied
+  });
+
+  it('should ignore an unauthorized actor’s untick (manifest stays authoritative) and post a notice (#401)', async () => {
+    await withAuthz();
+    await asEditedBy('rando');
+    const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
+    const versionOutput = {
+      ...createMockVersionOutput([
+        { packageName: '@scope/a', newVersion: '1.1.0' },
+        { packageName: '@scope/b', newVersion: '2.0.0' },
+      ]),
+      strategy: 'async' as const,
+    };
+    vi.mocked(runVersionStep).mockResolvedValue(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>);
+    vi.mocked(runNotesStep).mockResolvedValue({ packageNotes: {}, releaseNotes: {}, files: [] });
+
+    // Body unticks @scope/b, but the authoritative manifest holds back @scope/a — the unauthorized
+    // edit must be ignored and the manifest's selection used instead.
+    const forge = await mockForge({
+      standingPR: openStandingPR(99),
+      pullRequests: { 99: { body: selectionBody(), labels: [] } },
+      actorPermissions: { rando: 'write' }, // below the 'admin' threshold
+      comments: [{ id: 5, prNumber: 99, body: serializeManifest({ ...baseManifest, deselected: ['@scope/a'] }) }],
+    });
+
+    await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
+
+    const writeCall = vi.mocked(runVersionStep).mock.calls[1]?.[0] as { exclude?: string[] };
+    expect(writeCall.exclude).toEqual(['@scope/a']); // manifest's selection wins, not the body's
+    expect(forge.upsertedComments.some((c) => c.marker === '<!-- releasekit-selection-denied -->')).toBe(true);
+  });
+
   it('should never honour a residual selection region in a sync release (#367)', async () => {
     // A repo that switched to sync may carry a leftover selection region. Sync ships atomically, so a
     // stale deselection must NOT narrow it into a partial release — exclude stays empty.

--- a/packages/release/test/unit/standing-pr.spec.ts
+++ b/packages/release/test/unit/standing-pr.spec.ts
@@ -585,6 +585,36 @@ describe('runStandingPRUpdate', () => {
     expect(forge.upsertedComments.some((c) => c.marker === '<!-- releasekit-selection-denied -->')).toBe(true);
   });
 
+  it('should not crash the run when the permission check throws — fails closed to the manifest (#401)', async () => {
+    await withAuthz();
+    await asEditedBy('rando');
+    const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
+    const versionOutput = {
+      ...createMockVersionOutput([
+        { packageName: '@scope/a', newVersion: '1.1.0' },
+        { packageName: '@scope/b', newVersion: '2.0.0' },
+      ]),
+      strategy: 'async' as const,
+    };
+    vi.mocked(runVersionStep).mockResolvedValue(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>);
+    vi.mocked(runNotesStep).mockResolvedValue({ packageNotes: {}, releaseNotes: {}, files: [] });
+
+    const forge = await mockForge({
+      standingPR: openStandingPR(99),
+      pullRequests: { 99: { body: selectionBody(), labels: [] } },
+      comments: [{ id: 5, prNumber: 99, body: serializeManifest({ ...baseManifest, deselected: [] }) }],
+    });
+    // A transient permission-check failure (rate-limit, etc.) must not abort the whole update.
+    vi.spyOn(forge, 'getActorPermission').mockRejectedValue(Object.assign(new Error('429'), { status: 429 }));
+
+    const result = await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
+
+    expect(result.action).toBe('updated'); // run completed, no crash
+    // Failed closed → the body's untick is ignored and the authoritative (empty) manifest selection wins.
+    const writeCall = vi.mocked(runVersionStep).mock.calls[1]?.[0] as { exclude?: string[] };
+    expect(writeCall.exclude).toEqual([]);
+  });
+
   it('should never honour a residual selection region in a sync release (#367)', async () => {
     // A repo that switched to sync may carry a leftover selection region. Sync ships atomically, so a
     // stale deselection must NOT narrow it into a partial release — exclude stays empty.


### PR DESCRIPTION
Closes #401. Second slice of the standing-PR authorization feature (after the #399 foundation). Builds on `getEventActor` / `isAuthorizedActor`.

## What this does

When `ci.standingPr.authorization` is configured, the **checkbox selection only takes effect for authorized actors**. The model: the **manifest is authoritative** (publish already reads `manifest.versionOutput`/`manifest.deselected`, never the body), so the gate just controls when the body is trusted:

- An **authorized** actor's `edited` event → the body's selection is applied and recorded in the manifest.
- An **unauthorized** edit (or any push/schedule run) → the manifest's recorded selection is used instead, so the re-render **reverts** the unauthorized tick/untick, and a one-time `<!-- releasekit-selection-denied -->` marker comment tells the editor it was ignored.
- **No `authorization` configured** → the body stays authoritative (unchanged behavior).

The manifest is now read **once up front** and reused for both the gate and `firstUpdatedAt` (no extra API call).

## Acceptance

- [x] An authorized actor's untick is honoured (package excluded) and recorded in the manifest
- [x] An unauthorized actor's untick is ignored; the body re-renders from the manifest's authoritative selection
- [x] A one-time 'selection change ignored' marker comment is posted for unauthorized edits
- [x] Unconfigured authorization ⇒ body remains authoritative (back-compatible — existing tests unchanged)
- [x] Unit tests for authorized vs unauthorized selection edits

Full gate: `pnpm turbo run lint typecheck test:coverage` → **27/27**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR gates standing-PR checkbox selection behind the `ci.standingPr.authorization` config: only an authorized actor's `edited` event can write a new package selection to the manifest; all other events revert to the manifest's recorded selection and optionally post a one-time denied notice to the editor.

- The manifest is read once up front (replacing a late read) and reused for both the authorization gate (`manifestDeselected`) and the existing `firstUpdatedAt` preservation logic, eliminating a redundant API call.
- The previously flagged unhandled-rejection path in `isAuthorizedActor` is addressed by the new `authorizedOrWarn` wrapper, which catches forge API errors, emits a warning, and fails closed (treats the actor as unauthorized) so a transient rate-limit or network error does not abort the run.
- The denied-notice message now conditionally includes the allow-list clause only when `authz.allowedActors` is configured, fixing the previously flagged misleading message.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the authorization gate is correctly implemented, fails closed on API errors, and the refactored manifest read preserves existing firstUpdatedAt semantics exactly.

Both previously flagged issues (unhandled permission-check rejection and unconditional allowedActors message) are cleanly addressed. The manifest early-read refactoring is a straightforward equivalence transformation. The authorization gate short-circuits the permission API call for non-edit events and wraps the call in a warn-and-fail-closed guard, so transient forge errors leave the standing PR in a known valid state. All three key branches (authorized, unauthorized, API error) are covered by new unit tests.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/release/src/standing-pr/standing-pr.ts | Adds authorization gate for checkbox selection: reads manifest once up front, uses `authorizedOrWarn` wrapper to handle permission-check failures gracefully, and posts a one-time denied-notice via `upsertMarkerComment`. `firstUpdatedAt` preservation is refactored to reuse the early manifest read. |
| packages/release/test/unit/standing-pr.spec.ts | Adds three focused unit tests for the authorization gate: authorized-actor untick honoured, unauthorized-actor untick reverted with denied notice, and permission-API throw fails closed to the manifest. Env var isolation is properly handled via `afterEach(() => { process.env = { ...originalEnv }; })`. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[runStandingPRUpdate] --> B{existingStandingPr
& githubContext.token?}
    B -- No --> C[existingManifest = undefined]
    B -- Yes --> D[findManifestComment
parseManifest]
    D --> E[existingManifest set]
    D --> C

    C --> F[Read liveBody
extract bodyDeselected]
    E --> F

    F --> G{authz configured
& existingStandingPr
& token?}
    G -- No --> H[priorDeselected = bodyDeselected
body authoritative]
    G -- Yes --> I[getEventActor]

    I --> J{actor.action
=== 'edited'?}
    J -- No --> K[priorDeselected = manifestDeselected
non-edit run uses manifest]
    J -- Yes --> L[authorizedOrWarn
permission API call]

    L -- API throws --> M[warn + return false]
    M --> K
    L -- authorized --> N[priorDeselected = bodyDeselected
body trusted]
    L -- unauthorized --> O{selection
changed?}
    O -- Yes --> P[upsertMarkerComment
denied notice]
    O -- No --> K
    P --> K

    H --> Q[reconcile against dry-run
effectiveDeselected]
    N --> Q
    K --> Q

    Q --> R[write version bumps
exclude effectiveDeselected]
    R --> S[create/update PR
write manifest with deselected]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[runStandingPRUpdate] --> B{existingStandingPr
& githubContext.token?}
    B -- No --> C[existingManifest = undefined]
    B -- Yes --> D[findManifestComment
parseManifest]
    D --> E[existingManifest set]
    D --> C

    C --> F[Read liveBody
extract bodyDeselected]
    E --> F

    F --> G{authz configured
& existingStandingPr
& token?}
    G -- No --> H[priorDeselected = bodyDeselected
body authoritative]
    G -- Yes --> I[getEventActor]

    I --> J{actor.action
=== 'edited'?}
    J -- No --> K[priorDeselected = manifestDeselected
non-edit run uses manifest]
    J -- Yes --> L[authorizedOrWarn
permission API call]

    L -- API throws --> M[warn + return false]
    M --> K
    L -- authorized --> N[priorDeselected = bodyDeselected
body trusted]
    L -- unauthorized --> O{selection
changed?}
    O -- Yes --> P[upsertMarkerComment
denied notice]
    O -- No --> K
    P --> K

    H --> Q[reconcile against dry-run
effectiveDeselected]
    N --> Q
    K --> Q

    Q --> R[write version bumps
exclude effectiveDeselected]
    R --> S[create/update PR
write manifest with deselected]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(release): don&#39;t crash on a permissio..."](https://github.com/goosewobbler/releasekit/commit/e7ae2e1934637f57b9277d979471547d37b740b8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39172067)</sub>

<!-- /greptile_comment -->