### PR TITLE
feat(release): gate standing-PR release-label overrides to authorized actors (#402)

### DIFF
--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -26,6 +26,8 @@ const MANIFEST_MARKER = '<!-- releasekit-manifest -->';
 const MANIFEST_SCHEMA_VERSION = 2;
 /** Marker for the idempotent "your selection change was ignored" notice posted to an unauthorized editor (#401). */
 const SELECTION_DENIED_MARKER = '<!-- releasekit-selection-denied -->';
+/** Marker for the idempotent "your release-label change was ignored" notice (#402). */
+const LABEL_DENIED_MARKER = '<!-- releasekit-label-denied -->';
 const MANIFEST_SCHEMA_MIN_VERSION = 1;
 
 // The manifest payload rides as a base64 blob in its own marker; base64/JSON/schema decoding (with
@@ -593,16 +595,11 @@ interface StandingPrOverrides {
   conflicts: string[];
 }
 
-/**
- * The override-relevant labels (bump/channel/scope) present on a PR, sorted and de-duplicated.
- * This is the set that actually drives the next release, so it's what the manifest records and what
- * publish compares against the merged PR to detect a stale manifest (#337). The standing-PR marker
- * label and any unrelated labels (area:*, etc.) are deliberately excluded — they don't affect output.
- */
-function extractOverrideLabels(prLabels: string[], ciConfig: CIConfig | undefined): string[] {
+/** The release-control label names (bump/channel/scope/with-prerequisites) — those that drive output. */
+function relevantOverrideLabelNames(ciConfig: CIConfig | undefined): Set<string> {
   const labels = ciConfig?.labels ?? DEFAULT_LABELS;
   const scopeLabels = ciConfig?.scopeLabels ?? {};
-  const relevant = new Set<string>([
+  return new Set<string>([
     labels.major,
     labels.minor,
     labels.patch,
@@ -611,6 +608,16 @@ function extractOverrideLabels(prLabels: string[], ciConfig: CIConfig | undefine
     labels.withPrerequisites,
     ...Object.keys(scopeLabels),
   ]);
+}
+
+/**
+ * The override-relevant labels (bump/channel/scope) present on a PR, sorted and de-duplicated.
+ * This is the set that actually drives the next release, so it's what the manifest records and what
+ * publish compares against the merged PR to detect a stale manifest (#337). The standing-PR marker
+ * label and any unrelated labels (area:*, etc.) are deliberately excluded — they don't affect output.
+ */
+function extractOverrideLabels(prLabels: string[], ciConfig: CIConfig | undefined): string[] {
+  const relevant = relevantOverrideLabelNames(ciConfig);
   return [...new Set(prLabels.filter((l) => relevant.has(l)))].sort();
 }
 
@@ -865,12 +872,45 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
     }
   }
 
+  // Label authorization (#402): release-control labels (bump:/scope:/channel:/with-prerequisites and
+  // configured scope:*) on the standing PR drive the next release, but GitHub can't restrict who
+  // applies a label. When authorization is set, the manifest's `overrideLabels` are AUTHORITATIVE; an
+  // unauthorized `labeled`/`unlabeled` event is ignored and the PR's release-control labels are
+  // reconciled back to the authorized set (the rogue label removed; non-release labels like area:*
+  // preserved). `effectiveLabels` then drives override resolution, the label re-apply, and the
+  // manifest below — so the bot's own re-apply can't re-add the rogue label.
+  let effectiveLabels = existingStandingPr?.labels ?? [];
+  if (authz && existingStandingPr && githubContext?.token) {
+    const actor = getEventActor();
+    const isLabelEvent = actor.action === 'labeled' || actor.action === 'unlabeled';
+    if (isLabelEvent && !(await authorizedOrWarn(forgeFor(githubContext), actor, authz))) {
+      const relevant = relevantOverrideLabelNames(ciConfig);
+      const authorizedOverrides = (existingManifest?.overrideLabels ?? []).filter((l) => relevant.has(l));
+      const reconciled = [...new Set([...effectiveLabels.filter((l) => !relevant.has(l)), ...authorizedOverrides])];
+      // Tell the unauthorized labeller their change was ignored — parity with the selection gate
+      // (the label removal is also visible in the timeline, but the comment says why). Idempotent.
+      if (!setsEqual(new Set(effectiveLabels), new Set(reconciled))) {
+        const allowClause = authz.allowedActors?.length ? ', or an allow-listed actor' : '';
+        await forgeFor(githubContext)
+          .upsertMarkerComment(
+            existingStandingPr.number,
+            LABEL_DENIED_MARKER,
+            `${LABEL_DENIED_MARKER}\n\n> ⚠️ **Release-label change ignored.** Only authorized maintainers (\`${authz.requiredPermission}\`+${allowClause}) can change the standing PR's release labels (\`bump:\`/\`scope:\`/\`channel:\`/…). The labels have been reset to the approved set.`,
+          )
+          .catch((err) =>
+            warn(`Could not post label-denied notice: ${err instanceof Error ? err.message : String(err)}`),
+          );
+      }
+      effectiveLabels = reconciled;
+    }
+  }
+
   // Preview-notes opt-in (#200): when the standing PR carries the preview-notes label, generate LLM
   // release notes on demand into an editable region in the PR body. Default path stays LLM-free.
   const previewNotesLabel = (ciConfig?.labels ?? DEFAULT_LABELS).previewNotes;
-  const previewNotesEnabled = (existingStandingPr?.labels ?? []).includes(previewNotesLabel);
+  const previewNotesEnabled = effectiveLabels.includes(previewNotesLabel);
 
-  const overrides = resolveStandingPrLabelOverrides(existingStandingPr?.labels ?? [], ciConfig);
+  const overrides = resolveStandingPrLabelOverrides(effectiveLabels, ciConfig);
   if (overrides.bump) info(`Standing PR label override: bump=${overrides.bump}`);
   if (overrides.target) info(`Standing PR label override: target=${overrides.target}`);
   if (overrides.stable) info(`Standing PR label override: channel:stable`);
@@ -1118,12 +1158,14 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
   }
 
   // Apply the standing-PR labels — preserve any maintainer-added labels (e.g. bump:major,
-  // scope:foo) by taking the union of currently-applied labels and the configured set. Without
-  // this, every update would wipe maintainer overrides.
-  if (labels.length > 0) {
+  // scope:foo) by taking the union of the currently-applied labels and the configured set. Without
+  // this, every update would wipe maintainer overrides. Base the union on `effectiveLabels` (not the
+  // raw live labels) so an unauthorized release-control label reconciled out above is removed here
+  // rather than re-added (#402); run even with no configured labels when that reconcile changed the set.
+  const labelsReconciled = !setsEqual(new Set(effectiveLabels), new Set(existingStandingPr?.labels ?? []));
+  if (labels.length > 0 || labelsReconciled) {
     try {
-      const currentLabels = existingStandingPr?.labels ?? [];
-      const mergedLabels = [...new Set([...currentLabels, ...labels])];
+      const mergedLabels = [...new Set([...effectiveLabels, ...labels])];
       await forge.setLabels(prNumber, mergedLabels);
     } catch {
       warn('Failed to apply labels to standing PR');
@@ -1149,7 +1191,7 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
     firstUpdatedAt,
     // Record the labels this manifest was computed under so publish can detect a stale manifest if
     // they're changed after this update without a re-run (#337).
-    overrideLabels: extractOverrideLabels(existingStandingPr?.labels ?? [], ciConfig),
+    overrideLabels: extractOverrideLabels(effectiveLabels, ciConfig),
     // Record any packages held back via the selection region (provenance; the release set in
     // `versionOutput` is already narrowed). Omitted when nothing was deselected.
     deselected: effectiveDeselected.size > 0 ? [...effectiveDeselected].sort() : undefined,

--- a/packages/release/test/unit/standing-pr.spec.ts
+++ b/packages/release/test/unit/standing-pr.spec.ts
@@ -649,6 +649,36 @@ describe('runStandingPRUpdate', () => {
     expect(forge.upsertedComments.some((c) => c.marker === '<!-- releasekit-label-denied -->')).toBe(true);
   });
 
+  it('should restore an authorized label that an unauthorized actor removed (unlabeled) (#402)', async () => {
+    await withAuthz();
+    await asActionBy('unlabeled', 'rando');
+    const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
+    const versionOutput = {
+      ...createMockVersionOutput([{ packageName: '@scope/core', newVersion: '1.2.3' }]),
+      strategy: 'async' as const,
+    };
+    vi.mocked(runVersionStep).mockResolvedValue(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>);
+    vi.mocked(runNotesStep).mockResolvedValue({ packageNotes: {}, releaseNotes: {}, files: [] });
+
+    // 'rando' (write, below admin) removed bump:major; the authoritative manifest still has it.
+    const forge = await mockForge({
+      standingPR: openStandingPR(99, ['release', 'area:ci']), // bump:major already removed by rando
+      pullRequests: { 99: { body: '', labels: [] } },
+      actorPermissions: { rando: 'write' },
+      comments: [{ id: 5, prNumber: 99, body: serializeManifest({ ...baseManifest, overrideLabels: ['bump:major'] }) }],
+    });
+
+    await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
+
+    // The authorized bump:major is RESTORED — honoured in the version run and re-applied to the PR.
+    const writeCall = vi.mocked(runVersionStep).mock.calls[1]?.[0] as { bump?: string };
+    expect(writeCall.bump).toBe('major');
+    const lastSetLabels = forge.setLabelsCalls.at(-1)?.labels ?? [];
+    expect(lastSetLabels).toContain('bump:major'); // restored from the manifest
+    expect(lastSetLabels).toContain('area:ci'); // non-release label preserved
+    expect(forge.upsertedComments.some((c) => c.marker === '<!-- releasekit-label-denied -->')).toBe(true);
+  });
+
   it('should honour an authorized actor’s release label (#402)', async () => {
     await withAuthz();
     await asActionBy('labeled', 'admin-user');

--- a/packages/release/test/unit/standing-pr.spec.ts
+++ b/packages/release/test/unit/standing-pr.spec.ts
@@ -522,12 +522,13 @@ describe('runStandingPRUpdate', () => {
     } as unknown as ReturnType<typeof loadConfig>);
   };
 
-  const asEditedBy = async (login: string) => {
+  const asActionBy = async (action: string, login: string) => {
     const { readFileSync } = await import('node:fs');
-    vi.mocked(readFileSync).mockReturnValue(JSON.stringify({ action: 'edited', sender: { login, type: 'User' } }));
+    vi.mocked(readFileSync).mockReturnValue(JSON.stringify({ action, sender: { login, type: 'User' } }));
     process.env.GITHUB_EVENT_NAME = 'pull_request';
     process.env.GITHUB_EVENT_PATH = '/event.json';
   };
+  const asEditedBy = (login: string) => asActionBy('edited', login);
 
   it('should honour an authorized actor’s checkbox untick (#401)', async () => {
     await withAuthz();
@@ -613,6 +614,62 @@ describe('runStandingPRUpdate', () => {
     // Failed closed → the body's untick is ignored and the authoritative (empty) manifest selection wins.
     const writeCall = vi.mocked(runVersionStep).mock.calls[1]?.[0] as { exclude?: string[] };
     expect(writeCall.exclude).toEqual([]);
+  });
+
+  it('should ignore + remove an unauthorized actor’s release label, preserving non-release labels (#402)', async () => {
+    await withAuthz();
+    await asActionBy('labeled', 'rando');
+    const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
+    const versionOutput = {
+      ...createMockVersionOutput([{ packageName: '@scope/core', newVersion: '1.2.3' }]),
+      strategy: 'async' as const,
+    };
+    vi.mocked(runVersionStep).mockResolvedValue(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>);
+    vi.mocked(runNotesStep).mockResolvedValue({ packageNotes: {}, releaseNotes: {}, files: [] });
+
+    // 'rando' (write, below admin) added bump:major; the authoritative manifest has no override.
+    const forge = await mockForge({
+      standingPR: openStandingPR(99, ['release', 'bump:major', 'area:ci']),
+      pullRequests: { 99: { body: '', labels: [] } },
+      actorPermissions: { rando: 'write' },
+      comments: [{ id: 5, prNumber: 99, body: serializeManifest({ ...baseManifest, overrideLabels: [] }) }],
+    });
+
+    await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
+
+    // The rogue bump:major is not honoured (no forced bump on the version run)…
+    const writeCall = vi.mocked(runVersionStep).mock.calls[1]?.[0] as { bump?: string };
+    expect(writeCall.bump).toBeUndefined();
+    // …and it is removed from the PR, while non-release labels (area:ci) and the standing label survive.
+    const lastSetLabels = forge.setLabelsCalls.at(-1)?.labels ?? [];
+    expect(lastSetLabels).not.toContain('bump:major');
+    expect(lastSetLabels).toContain('area:ci');
+    expect(lastSetLabels).toContain('release');
+    // The unauthorized labeller is told their label was rejected (idempotent notice).
+    expect(forge.upsertedComments.some((c) => c.marker === '<!-- releasekit-label-denied -->')).toBe(true);
+  });
+
+  it('should honour an authorized actor’s release label (#402)', async () => {
+    await withAuthz();
+    await asActionBy('labeled', 'admin-user');
+    const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
+    const versionOutput = {
+      ...createMockVersionOutput([{ packageName: '@scope/core', newVersion: '1.2.3' }]),
+      strategy: 'async' as const,
+    };
+    vi.mocked(runVersionStep).mockResolvedValue(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>);
+    vi.mocked(runNotesStep).mockResolvedValue({ packageNotes: {}, releaseNotes: {}, files: [] });
+
+    await mockForge({
+      standingPR: openStandingPR(99, ['release', 'bump:major']),
+      pullRequests: { 99: { body: '', labels: [] } },
+      actorPermissions: { 'admin-user': 'admin' },
+    });
+
+    await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
+
+    const writeCall = vi.mocked(runVersionStep).mock.calls[1]?.[0] as { bump?: string };
+    expect(writeCall.bump).toBe('major'); // authorized override honoured
   });
 
   it('should never honour a residual selection region in a sync release (#367)', async () => {


### PR DESCRIPTION
Closes #402. Third slice of the standing-PR authorization feature. **Stacked on #411 (#401)** — base is `feat/401-gate-checkbox-selection`; GitHub auto-retargets to `main` when #411 merges. Shares the early-manifest-read + auth helpers from #401.

## What this does

GitHub can't restrict label application per-label (it's a single Triage+ capability), so releasekit gates the **interpretation** of release-control labels. When `ci.standingPr.authorization` is set, the manifest's `overrideLabels` is **authoritative**:

- An **unauthorized** `labeled`/`unlabeled` event → the override is ignored, and the PR's release-control labels (`bump:`/`scope:`/`channel:`/`with-prerequisites`/configured `scope:*`) are reconciled back to the authorized set: **the rogue label is removed**, and **non-release labels (`area:*` etc.) are preserved**.
- **Authorized** label events and **no-authz** runs are unchanged.

The computed `effectiveLabels` drives override resolution, the label re-apply, and the manifest's `overrideLabels` — so the bot's own union-merge re-apply can't re-add the rogue label (the loop the issue warned about). The release-control label set was factored into `relevantOverrideLabelNames`.

## Acceptance

- [x] An unauthorized `bump:major` (etc.) is removed and not honoured for the next release
- [x] Authorized label overrides are honoured unchanged
- [x] Non-release-control labels are preserved
- [x] No re-trigger loop from the bot's own label reconciliation (re-apply bases on `effectiveLabels`, not the live labels)
- [x] Unit tests for unauthorized (removed + not honoured + non-release preserved) vs authorized label events

Full gate: `pnpm turbo run lint typecheck test:coverage` → **27/27**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds the third slice of the standing-PR authorization feature, gating which actors can change release-control labels (`bump:`, `scope:`, `channel:`, `with-prerequisites`) on the standing PR. The manifest's `overrideLabels` becomes authoritative when `ci.standingPr.authorization` is set, and any label change by an unauthorized actor is reconciled back to that authoritative set — rogue labels removed, non-release labels (e.g. `area:*`) preserved, and a `LABEL_DENIED_MARKER` comment posted for feedback.

- Extracted `relevantOverrideLabelNames` from `extractOverrideLabels` so the authorization gate and the override resolver share the same label-name set, and moved the existing JSDoc to its correct home on `extractOverrideLabels`.
- Introduced `effectiveLabels` (replacing direct `existingStandingPr?.labels` accesses) so override resolution, the label re-apply union, and the manifest's `overrideLabels` all flow from the reconciled set, preventing the bot's own label-sync from re-adding a just-removed rogue label.
- Three new unit tests cover the unauthorized-add, unauthorized-remove (restore from manifest), and authorized-add paths.
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge. The change is self-contained, additive, and consistently mirrors the existing selection-gate pattern.

The label-gate logic correctly reconciles live labels against the manifest's authoritative set, and threads effectiveLabels through every downstream consumer. No mis-scoped logic or broken contracts were found.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/release/src/standing-pr/standing-pr.ts | Adds label-authorization gate: `relevantOverrideLabelNames` extracted from `extractOverrideLabels`, `effectiveLabels` reconciled from manifest on unauthorized label events, `LABEL_DENIED_MARKER` comment posted, and label re-apply bases on reconciled effective labels to prevent re-add loop. |
| packages/release/test/unit/standing-pr.spec.ts | Adds three new test cases for the label gate: unauthorized add (label removed, comment posted, non-release labels preserved), unauthorized remove (authorized label restored, comment posted), and authorized add (label honoured). Generalises `asEditedBy` into `asActionBy`. |

</details>


</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/release/src/standing-pr/standing-pr.ts`, line 596-602 ([link](https://github.com/goosewobbler/releasekit/blob/10755a5df991a47a9a473d5b9d3f0dd3b0f38497/packages/release/src/standing-pr/standing-pr.ts#L596-L602)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Stale JSDoc now describes the wrong function**

   The original block comment (lines 596–601) described `extractOverrideLabels` — it mentions "present on a PR, sorted and de-duplicated" and "what the manifest records". After the refactor those words only apply to `extractOverrideLabels`, not to `relevantOverrideLabelNames` (which returns a `Set` of configured label names, takes no `prLabels` argument, and neither sorts nor de-duplicates live labels). Having two consecutive JSDoc comments on one function is also a TypeScript/editor antipattern: most tooling attaches only the immediately preceding comment. Moving the old block down to `extractOverrideLabels` and leaving the new single-line comment on `relevantOverrideLabelNames` would fix both problems.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Frelease%2Fsrc%2Fstanding-pr%2Fstanding-pr.ts%0ALine%3A%20596-602%0A%0AComment%3A%0A**Stale%20JSDoc%20now%20describes%20the%20wrong%20function**%0A%0AThe%20original%20block%20comment%20%28lines%20596%E2%80%93601%29%20described%20%60extractOverrideLabels%60%20%E2%80%94%20it%20mentions%20%22present%20on%20a%20PR%2C%20sorted%20and%20de-duplicated%22%20and%20%22what%20the%20manifest%20records%22.%20After%20the%20refactor%20those%20words%20only%20apply%20to%20%60extractOverrideLabels%60%2C%20not%20to%20%60relevantOverrideLabelNames%60%20%28which%20returns%20a%20%60Set%60%20of%20configured%20label%20names%2C%20takes%20no%20%60prLabels%60%20argument%2C%20and%20neither%20sorts%20nor%20de-duplicates%20live%20labels%29.%20Having%20two%20consecutive%20JSDoc%20comments%20on%20one%20function%20is%20also%20a%20TypeScript%2Feditor%20antipattern%3A%20most%20tooling%20attaches%20only%20the%20immediately%20preceding%20comment.%20Moving%20the%20old%20block%20down%20to%20%60extractOverrideLabels%60%20and%20leaving%20the%20new%20single-line%20comment%20on%20%60relevantOverrideLabelNames%60%20would%20fix%20both%20problems.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=goosewobbler%2Freleasekit&pr=412&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Frelease%2Fsrc%2Fstanding-pr%2Fstanding-pr.ts%0ALine%3A%20596-602%0A%0AComment%3A%0A**Stale%20JSDoc%20now%20describes%20the%20wrong%20function**%0A%0AThe%20original%20block%20comment%20%28lines%20596%E2%80%93601%29%20described%20%60extractOverrideLabels%60%20%E2%80%94%20it%20mentions%20%22present%20on%20a%20PR%2C%20sorted%20and%20de-duplicated%22%20and%20%22what%20the%20manifest%20records%22.%20After%20the%20refactor%20those%20words%20only%20apply%20to%20%60extractOverrideLabels%60%2C%20not%20to%20%60relevantOverrideLabelNames%60%20%28which%20returns%20a%20%60Set%60%20of%20configured%20label%20names%2C%20takes%20no%20%60prLabels%60%20argument%2C%20and%20neither%20sorts%20nor%20de-duplicates%20live%20labels%29.%20Having%20two%20consecutive%20JSDoc%20comments%20on%20one%20function%20is%20also%20a%20TypeScript%2Feditor%20antipattern%3A%20most%20tooling%20attaches%20only%20the%20immediately%20preceding%20comment.%20Moving%20the%20old%20block%20down%20to%20%60extractOverrideLabels%60%20and%20leaving%20the%20new%20single-line%20comment%20on%20%60relevantOverrideLabelNames%60%20would%20fix%20both%20problems.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=412&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (4): Last reviewed commit: ["test(release): cover the unlabeled (labe..."](https://github.com/goosewobbler/releasekit/commit/de8b19b62660d4a15d2ae04f18d6ae45848013b4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39173727)</sub>

<!-- /greptile_comment -->