### PR TITLE
feat(release): refuse to publish a standing PR merged by an unauthorized actor (#403)

### DIFF
--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -569,6 +569,12 @@ export const StandingPrConfigSchema = z.object({
         .describe(
           'Extra actors authorized regardless of permission level: GitHub usernames. (Team support via "@org/team" entries is added separately and requires an org-read token, not the default GITHUB_TOKEN.)',
         ),
+      enforceMergeAuthor: z
+        .boolean()
+        .default(true)
+        .describe(
+          'Refuse to publish the standing PR when the actor who merged it is not authorized (defense-in-depth behind a branch-protection ruleset, which is the primary merge gate). Set false to rely on branch protection alone.',
+        ),
     })
     .optional()
     .describe(

--- a/packages/release/src/standing-pr/authorization.ts
+++ b/packages/release/src/standing-pr/authorization.ts
@@ -30,6 +30,8 @@ export interface EventActor {
   type?: string;
   /** Who merged the PR (`event.pull_request.merged_by.login`), for the publish-author gate. */
   mergedBy?: string;
+  /** The merger's GitHub type (`event.pull_request.merged_by.type`) — `'Bot'` for app/bot actors. */
+  mergedByType?: string;
 }
 
 /** Read the triggering actor (and the merger, for publish) from the GitHub Actions event payload. */
@@ -40,13 +42,14 @@ export function getEventActor(): EventActor {
     const event = JSON.parse(fs.readFileSync(eventPath, 'utf-8')) as {
       action?: string;
       sender?: { login?: string; type?: string };
-      pull_request?: { merged_by?: { login?: string } | null };
+      pull_request?: { merged_by?: { login?: string; type?: string } | null };
     };
     return {
       action: event.action,
       login: event.sender?.login,
       type: event.sender?.type,
       mergedBy: event.pull_request?.merged_by?.login,
+      mergedByType: event.pull_request?.merged_by?.type,
     };
   } catch {
     return {};

--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -1234,19 +1234,25 @@ export async function publishFromManifest(prNumber: number, options: StandingPRO
   // the #337 staleness refusal: a publish that shouldn't happen is stopped here, not retried.
   const authz = standingPrConfig?.authorization;
   if (authz?.enforceMergeAuthor) {
-    const merger = getEventActor().mergedBy;
-    if (merger) {
+    const actor = getEventActor();
+    if (!actor.mergedBy) {
+      // No merger in the event (e.g. a manual/dispatch publish, or an inferred PR with no event) —
+      // the gate can't run. Log it so an enforcement gap is visible rather than a silent skip.
+      warn(
+        `enforceMergeAuthor is set but the merging actor is unknown (no merged_by in the event) — skipping the publish-author check for PR #${prNumber}.`,
+      );
+    } else {
       let authorized = true;
       try {
-        authorized = await isAuthorizedActor(forge, merger, undefined, authz);
+        authorized = await isAuthorizedActor(forge, actor.mergedBy, actor.mergedByType, authz);
       } catch (err) {
         warn(
-          `Could not verify merger '${merger}' permission — proceeding, since branch protection is the primary gate: ${err instanceof Error ? err.message : String(err)}`,
+          `Could not verify merger '${actor.mergedBy}' permission — proceeding, since branch protection is the primary gate: ${err instanceof Error ? err.message : String(err)}`,
         );
       }
       if (!authorized) {
         throw new Error(
-          `Refusing to publish PR #${prNumber}: it was merged by '${merger}', who lacks the required '${authz.requiredPermission}' permission (ci.standingPr.authorization). Restrict who can merge the release branch with a branch-protection ruleset, or set ci.standingPr.authorization.enforceMergeAuthor: false.`,
+          `Refusing to publish PR #${prNumber}: it was merged by '${actor.mergedBy}', who lacks the required '${authz.requiredPermission}' permission (ci.standingPr.authorization). Restrict who can merge the release branch with a branch-protection ruleset, or set ci.standingPr.authorization.enforceMergeAuthor: false.`,
         );
       }
     }

--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -1227,6 +1227,31 @@ export async function publishFromManifest(prNumber: number, options: StandingPRO
     );
   }
 
+  // Publish-author gate (#403): defense-in-depth behind a branch-protection ruleset (the primary
+  // merge gate). Refuse to publish when the actor who merged the PR isn't authorized to steer
+  // releases — catching a missing/misconfigured ruleset. On an unverifiable permission check we
+  // proceed rather than block a legitimate release (the ruleset already gated the merge). Mirrors
+  // the #337 staleness refusal: a publish that shouldn't happen is stopped here, not retried.
+  const authz = standingPrConfig?.authorization;
+  if (authz?.enforceMergeAuthor) {
+    const merger = getEventActor().mergedBy;
+    if (merger) {
+      let authorized = true;
+      try {
+        authorized = await isAuthorizedActor(forge, merger, undefined, authz);
+      } catch (err) {
+        warn(
+          `Could not verify merger '${merger}' permission — proceeding, since branch protection is the primary gate: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+      if (!authorized) {
+        throw new Error(
+          `Refusing to publish PR #${prNumber}: it was merged by '${merger}', who lacks the required '${authz.requiredPermission}' permission (ci.standingPr.authorization). Restrict who can merge the release branch with a branch-protection ruleset, or set ci.standingPr.authorization.enforceMergeAuthor: false.`,
+        );
+      }
+    }
+  }
+
   // Warn if manifest base is no longer an ancestor of current HEAD (history may be rewritten)
   const currentSha = getHeadSha(cwd);
   try {

--- a/packages/release/test/unit/standing-pr.spec.ts
+++ b/packages/release/test/unit/standing-pr.spec.ts
@@ -1726,6 +1726,77 @@ describe('runStandingPRPublish', () => {
     expect(vi.mocked(runPublishStep)).not.toHaveBeenCalled();
   });
 
+  const publishConfigWithAuthz = async (authorization: Record<string, unknown>) => {
+    const { loadConfig } = await import('@releasekit/config');
+    vi.mocked(loadConfig).mockReturnValue({
+      ci: { standingPr: { branch: 'release/next', deleteBranchOnMerge: true, authorization } },
+      git: { branch: 'main' },
+    } as unknown as ReturnType<typeof loadConfig>);
+  };
+
+  const mergedByEvent = async (login: string) => {
+    const { readFileSync } = await import('node:fs');
+    vi.mocked(readFileSync).mockReturnValue(
+      JSON.stringify({
+        pull_request: { head: { ref: 'release/next' }, number: 42, merged: true, merged_by: { login } },
+      }),
+    );
+  };
+
+  it('should refuse to publish when the merger is not authorized (#403)', async () => {
+    await publishConfigWithAuthz({ requiredPermission: 'admin', enforceMergeAuthor: true });
+    await mergedByEvent('rando');
+    await mockForge({
+      comments: [{ id: 1, body: serializeManifest(baseManifest) }],
+      actorPermissions: { rando: 'write' }, // below admin
+    });
+
+    await expect(
+      runStandingPRPublish({ projectDir: '/test', verbose: false, quiet: false, json: false }),
+    ).rejects.toThrow(/Refusing to publish/);
+
+    const { runPublishStep } = await import('../../src/steps.js');
+    expect(vi.mocked(runPublishStep)).not.toHaveBeenCalled();
+  });
+
+  it('should publish when the merger is authorized (#403)', async () => {
+    await publishConfigWithAuthz({ requiredPermission: 'admin', enforceMergeAuthor: true });
+    await mergedByEvent('admin-user');
+    await mockForge({
+      comments: [{ id: 1, body: serializeManifest(baseManifest) }],
+      actorPermissions: { 'admin-user': 'admin' },
+    });
+    const { runNotesStep, runPublishStep } = await import('../../src/steps.js');
+    vi.mocked(runNotesStep).mockResolvedValue({ packageNotes: {}, releaseNotes: {}, files: [] });
+    vi.mocked(runPublishStep).mockResolvedValue({ publishSucceeded: true } as unknown as Awaited<
+      ReturnType<typeof runPublishStep>
+    >);
+
+    const result = await runStandingPRPublish({ projectDir: '/test', verbose: false, quiet: false, json: false });
+
+    expect(result).not.toBeNull();
+    expect(vi.mocked(runPublishStep)).toHaveBeenCalled();
+  });
+
+  it('should not check the merger when enforceMergeAuthor is false (#403)', async () => {
+    await publishConfigWithAuthz({ requiredPermission: 'admin', enforceMergeAuthor: false });
+    await mergedByEvent('rando'); // unauthorized, but the check is disabled
+    await mockForge({
+      comments: [{ id: 1, body: serializeManifest(baseManifest) }],
+      actorPermissions: { rando: 'write' },
+    });
+    const { runNotesStep, runPublishStep } = await import('../../src/steps.js');
+    vi.mocked(runNotesStep).mockResolvedValue({ packageNotes: {}, releaseNotes: {}, files: [] });
+    vi.mocked(runPublishStep).mockResolvedValue({ publishSucceeded: true } as unknown as Awaited<
+      ReturnType<typeof runPublishStep>
+    >);
+
+    const result = await runStandingPRPublish({ projectDir: '/test', verbose: false, quiet: false, json: false });
+
+    expect(result).not.toBeNull();
+    expect(vi.mocked(runPublishStep)).toHaveBeenCalled();
+  });
+
   it('should publish when override labels match the manifest, ignoring non-override labels (#337)', async () => {
     const { readFileSync } = await import('node:fs');
     vi.mocked(readFileSync).mockReturnValue(

--- a/packages/release/test/unit/standing-pr.spec.ts
+++ b/packages/release/test/unit/standing-pr.spec.ts
@@ -1797,6 +1797,53 @@ describe('runStandingPRPublish', () => {
     expect(vi.mocked(runPublishStep)).toHaveBeenCalled();
   });
 
+  it('should publish (fail open) when the merger permission check is unverifiable (#403)', async () => {
+    await publishConfigWithAuthz({ requiredPermission: 'admin', enforceMergeAuthor: true });
+    await mergedByEvent('someone');
+    const forge = await mockForge({ comments: [{ id: 1, body: serializeManifest(baseManifest) }] });
+    // A transient permission-check failure must not block the publish — the merge ruleset is primary.
+    vi.spyOn(forge, 'getActorPermission').mockRejectedValue(Object.assign(new Error('500'), { status: 500 }));
+    const { runNotesStep, runPublishStep } = await import('../../src/steps.js');
+    vi.mocked(runNotesStep).mockResolvedValue({ packageNotes: {}, releaseNotes: {}, files: [] });
+    vi.mocked(runPublishStep).mockResolvedValue({ publishSucceeded: true } as unknown as Awaited<
+      ReturnType<typeof runPublishStep>
+    >);
+
+    const result = await runStandingPRPublish({ projectDir: '/test', verbose: false, quiet: false, json: false });
+
+    expect(result).not.toBeNull();
+    expect(vi.mocked(runPublishStep)).toHaveBeenCalled(); // failed open
+  });
+
+  it('should treat a Bot merger as authorized via merged_by.type, without a permission call (#403)', async () => {
+    await publishConfigWithAuthz({ requiredPermission: 'admin', enforceMergeAuthor: true });
+    const { readFileSync } = await import('node:fs');
+    // A GitHub App whose login does NOT end in [bot] — recognised by type, not the login suffix.
+    vi.mocked(readFileSync).mockReturnValue(
+      JSON.stringify({
+        pull_request: {
+          head: { ref: 'release/next' },
+          number: 42,
+          merged: true,
+          merged_by: { login: 'release-bot', type: 'Bot' },
+        },
+      }),
+    );
+    const forge = await mockForge({ comments: [{ id: 1, body: serializeManifest(baseManifest) }] });
+    const permSpy = vi.spyOn(forge, 'getActorPermission');
+    const { runNotesStep, runPublishStep } = await import('../../src/steps.js');
+    vi.mocked(runNotesStep).mockResolvedValue({ packageNotes: {}, releaseNotes: {}, files: [] });
+    vi.mocked(runPublishStep).mockResolvedValue({ publishSucceeded: true } as unknown as Awaited<
+      ReturnType<typeof runPublishStep>
+    >);
+
+    const result = await runStandingPRPublish({ projectDir: '/test', verbose: false, quiet: false, json: false });
+
+    expect(result).not.toBeNull();
+    expect(vi.mocked(runPublishStep)).toHaveBeenCalled();
+    expect(permSpy).not.toHaveBeenCalled(); // recognised as a bot by type — no permission lookup
+  });
+
   it('should publish when override labels match the manifest, ignoring non-override labels (#337)', async () => {
     const { readFileSync } = await import('node:fs');
     vi.mocked(readFileSync).mockReturnValue(

--- a/releasekit.schema.json
+++ b/releasekit.schema.json
@@ -1242,6 +1242,11 @@
                     "type": "string"
                   },
                   "description": "Extra actors authorized regardless of permission level: GitHub usernames. (Team support via \"@org/team\" entries is added separately and requires an org-read token, not the default GITHUB_TOKEN.)"
+                },
+                "enforceMergeAuthor": {
+                  "type": "boolean",
+                  "default": true,
+                  "description": "Refuse to publish the standing PR when the actor who merged it is not authorized (defense-in-depth behind a branch-protection ruleset, which is the primary merge gate). Set false to rely on branch protection alone."
                 }
               },
               "description": "Restrict who can steer the standing PR — its selection checkboxes, release labels, and merge. Omit to allow anyone with the GitHub permission GitHub itself requires for each action (today’s behavior)."


### PR DESCRIPTION
Closes #403. The publish-side enforcement slice — defense-in-depth behind the GitHub merge ruleset. Only needs the #399 foundation (merged), so it's off `main` (independent of the #401/#402 update-path gates).

## What this does

`standing-pr publish` refuses to publish when the actor who **merged** the PR isn't authorized to steer releases. A branch-protection ruleset on the release branch is the *primary* gate (who can merge = who can publish); this catches a missing or misconfigured ruleset.

- After parsing the manifest and before the publish step, the merger (`merged_by` from the event payload) is checked against `ci.standingPr.authorization`.
- An **unauthorized** merger → throws with a clear message, no tags/publish — mirroring the #337 staleness refusal ("a publish that shouldn't happen is stopped here").
- On an **unverifiable** permission check (transient API/token error) → proceed, since the ruleset already gated the merge — rather than block a legitimate release.
- New **`ci.standingPr.authorization.enforceMergeAuthor`** (default `true`) toggles it; `false` relies on branch protection alone.

## Acceptance

- [x] Publish refuses when the merger lacks the required permission, with a clear message
- [x] Publish proceeds for an authorized merger
- [x] No check when authorization is unconfigured or `enforceMergeAuthor: false`
- [x] Unit tests for refused vs allowed vs disabled

Schema + `docs/configuration.md` regenerated (`schema:check` green). Full gate: `pnpm turbo run lint typecheck test:coverage` → **27/27**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a publish-side enforcement gate that refuses to complete a `standing-pr publish` when the actor who merged the PR is not authorized under `ci.standingPr.authorization`. It is designed as defense-in-depth behind a branch-protection ruleset, catching misconfigured rulesets without blocking legitimate releases when the permission check is unverifiable (fail-open).

- Adds `enforceMergeAuthor` (default `true`) to the `authorization` sub-schema; when `authorization` is configured the gate is on by default and can be disabled with `enforceMergeAuthor: false`.
- Reads `merged_by.type` from the event payload alongside `merged_by.login`, so bot/GitHub App actors whose login doesn't end in `[bot]` are correctly short-circuited without a permission API call.
- Five new tests cover all acceptance criteria: unauthorized refusal, authorized pass, disabled gate, fail-open on transient API error, and bot-type bypass.
</details>

<h3>Confidence Score: 5/5</h3>

The change adds a new enforcement gate that is safely fail-open on transient errors, correctly handles bot actors, and warns rather than silently skips when the merger is unknown. All previous review concerns have been addressed.

The gate logic is straightforward and well-bounded: it only fires when `authorization` is explicitly configured, short-circuits for bots, fails open on API errors, and throws with a clear actionable message on unauthorized mergers. All four acceptance criteria have dedicated tests, including the previously-missing fail-open and bot-type paths. The schema change is backward-compatible (new optional field inside an already-optional block, with a sensible default), and the generated JSON schema matches.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/release/src/standing-pr/standing-pr.ts | Inserts the publish-author gate after manifest parsing: warns on missing merger, fails open on transient permission errors, and throws a clear error when an unauthorized merger is detected. |
| packages/release/src/standing-pr/authorization.ts | Adds `mergedByType` field to `EventActor` and reads `merged_by.type` from the event payload, fixing bot-detection for merge authors whose login doesn't end with `[bot]`. |
| packages/config/src/schema.ts | Adds `enforceMergeAuthor` boolean (default `true`) to the `authorization` sub-schema; defaults to enforcement-on when `authorization` is configured, opt-out via `false`. |
| packages/release/test/unit/standing-pr.spec.ts | Adds five new tests covering refused, authorized, disabled, fail-open (unverifiable), and bot-type-bypass paths — all four acceptance criteria are now exercised. |
| releasekit.schema.json | Auto-generated JSON schema updated to reflect the new `enforceMergeAuthor` property; matches the Zod schema changes exactly. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[publishFromManifest called] --> B{authorization configured\nand enforceMergeAuthor true?}
    B -- No --> G[Continue to publish]
    B -- Yes --> C[getEventActor — read merged_by]
    C --> D{mergedBy present?}
    D -- No --> E[warn: enforcement gap\nskip gate] --> G
    D -- Yes --> F[isAuthorizedActor\nmergedBy + mergedByType]
    F --> H{isBot?\ntype===Bot or login ends in bot}
    H -- Yes --> G
    H -- No --> I{in allowedActors?}
    I -- Yes --> G
    I -- No --> J[forge.getActorPermission]
    J -- throws --> K[warn: unverifiable\nfail open] --> G
    J -- returns --> L{PERMISSION_RANK >=\nrequiredPermission?}
    L -- Yes --> G
    L -- No --> M[throw: Refusing to publish]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[publishFromManifest called] --> B{authorization configured\nand enforceMergeAuthor true?}
    B -- No --> G[Continue to publish]
    B -- Yes --> C[getEventActor — read merged_by]
    C --> D{mergedBy present?}
    D -- No --> E[warn: enforcement gap\nskip gate] --> G
    D -- Yes --> F[isAuthorizedActor\nmergedBy + mergedByType]
    F --> H{isBot?\ntype===Bot or login ends in bot}
    H -- Yes --> G
    H -- No --> I{in allowedActors?}
    I -- Yes --> G
    I -- No --> J[forge.getActorPermission]
    J -- throws --> K[warn: unverifiable\nfail open] --> G
    J -- returns --> L{PERMISSION_RANK >=\nrequiredPermission?}
    L -- Yes --> G
    L -- No --> M[throw: Refusing to publish]
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(release): publish-author gate — read..."](https://github.com/goosewobbler/releasekit/commit/e334c3f04f705992fd50fe9a2e9f92a4a9c55be4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39176418)</sub>

<!-- /greptile_comment -->