### PR TITLE
feat(release): team-based allow-list (@org/team) for standing-PR authorization (#400)

### DIFF
--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -564,7 +564,15 @@ export const StandingPrConfigSchema = z.object({
           'Minimum repository permission an actor needs to steer the standing PR — tick/untick selection checkboxes, apply release labels, and (with branch protection) merge. Default: admin.',
         ),
       allowedActors: z
-        .array(z.string())
+        .array(
+          // A GitHub username (e.g. `octocat`) or a team as `@org/team-slug`. The `@…/…` form needs
+          // the slash — `@octocat` is neither a username nor a team and would silently match nobody,
+          // so reject it at config-load time. Round-trips into the JSON Schema as `pattern`.
+          z.string().regex(/^(?:[A-Za-z0-9-]+|@[A-Za-z0-9-]+\/[A-Za-z0-9._-]+)$/, {
+            message:
+              'allowedActors entries must be a GitHub username (e.g. "octocat") or a team as "@org/team-slug" (note the slash).',
+          }),
+        )
         .optional()
         .describe(
           'Extra actors authorized regardless of permission level: GitHub usernames, or "@org/team-slug" to authorize a whole team. Team-membership checks need a token with read:org scope (a PAT or GitHub App), not the default GITHUB_TOKEN; without it, team entries fail closed — the 403 is surfaced as a warning and the actor is not authorized.',

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -567,7 +567,7 @@ export const StandingPrConfigSchema = z.object({
         .array(z.string())
         .optional()
         .describe(
-          'Extra actors authorized regardless of permission level: GitHub usernames, or "@org/team-slug" to authorize a whole team. Team-membership checks need a token with org read:org scope (a PAT or GitHub App), not the default GITHUB_TOKEN; without it, team entries resolve to "not a member".',
+          'Extra actors authorized regardless of permission level: GitHub usernames, or "@org/team-slug" to authorize a whole team. Team-membership checks need a token with read:org scope (a PAT or GitHub App), not the default GITHUB_TOKEN; without it, team entries fail closed — the 403 is surfaced as a warning and the actor is not authorized.',
         ),
       enforceMergeAuthor: z
         .boolean()

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -567,7 +567,7 @@ export const StandingPrConfigSchema = z.object({
         .array(z.string())
         .optional()
         .describe(
-          'Extra actors authorized regardless of permission level: GitHub usernames. (Team support via "@org/team" entries is added separately and requires an org-read token, not the default GITHUB_TOKEN.)',
+          'Extra actors authorized regardless of permission level: GitHub usernames, or "@org/team-slug" to authorize a whole team. Team-membership checks need a token with org read:org scope (a PAT or GitHub App), not the default GITHUB_TOKEN; without it, team entries resolve to "not a member".',
         ),
       enforceMergeAuthor: z
         .boolean()

--- a/packages/config/test/unit/schema.spec.ts
+++ b/packages/config/test/unit/schema.spec.ts
@@ -546,6 +546,17 @@ describe('CIConfigSchema', () => {
     expect(() => CIConfigSchema.parse({ releaseStrategy: 'invalid' })).toThrow();
   });
 
+  it('should accept usernames and @org/team entries in standingPr.authorization.allowedActors', () => {
+    const result = CIConfigSchema.parse({
+      standingPr: { authorization: { allowedActors: ['octocat', 'release-bot', '@acme/releasers'] } },
+    });
+    expect(result.standingPr?.authorization?.allowedActors).toEqual(['octocat', 'release-bot', '@acme/releasers']);
+  });
+
+  it('should reject an allowedActors entry like "@octocat" (an @-prefix without the team slash)', () => {
+    expect(() => CIConfigSchema.parse({ standingPr: { authorization: { allowedActors: ['@octocat'] } } })).toThrow();
+  });
+
   it('should reject non-positive minChanges', () => {
     expect(() => CIConfigSchema.parse({ minChanges: 0 })).toThrow();
     expect(() => CIConfigSchema.parse({ minChanges: -1 })).toThrow();

--- a/packages/forge/src/fake.ts
+++ b/packages/forge/src/fake.ts
@@ -98,8 +98,11 @@ export class FakeForge implements Forge {
   }
 
   async isTeamMember(org: string, teamSlug: string, username: string): Promise<boolean> {
-    const lc = username.toLowerCase();
-    return (this.teamMemberships[`${org}/${teamSlug}`] ?? []).some((m) => m.toLowerCase() === lc);
+    // GitHub resolves org/team slugs AND usernames case-insensitively — match the real adapter.
+    const lcUser = username.toLowerCase();
+    const lcKey = `${org}/${teamSlug}`.toLowerCase();
+    const key = Object.keys(this.teamMemberships).find((k) => k.toLowerCase() === lcKey);
+    return (key ? this.teamMemberships[key] : []).some((m) => m.toLowerCase() === lcUser);
   }
 
   async getActorPermission(username: string): Promise<RepoPermission> {

--- a/packages/forge/src/fake.ts
+++ b/packages/forge/src/fake.ts
@@ -42,6 +42,8 @@ export interface FakeForgeSeed {
   releasesByTag?: Record<string, ReleaseRef>;
   /** Per-username repo permission. Unseeded usernames resolve to 'none'. */
   actorPermissions?: Record<string, RepoPermission>;
+  /** Team memberships, keyed by `org/team-slug` → member logins. Unseeded teams have no members. */
+  teamMemberships?: Record<string, string[]>;
 }
 
 /**
@@ -61,6 +63,7 @@ export class FakeForge implements Forge {
   private readonly releases: ReleaseSummary[];
   private readonly releasesByTag: Record<string, ReleaseRef>;
   private readonly actorPermissions: Record<string, RepoPermission>;
+  private readonly teamMemberships: Record<string, string[]>;
 
   // Recorded writes, for assertions.
   readonly createdComments: Array<{ prNumber: number; body: string }> = [];
@@ -90,7 +93,13 @@ export class FakeForge implements Forge {
     this.releases = seed.releases ?? [];
     this.releasesByTag = seed.releasesByTag ?? {};
     this.actorPermissions = seed.actorPermissions ?? {};
+    this.teamMemberships = seed.teamMemberships ?? {};
     this.nextCommentId = Math.max(0, ...this.comments.map((c) => c.id)) + 1;
+  }
+
+  async isTeamMember(org: string, teamSlug: string, username: string): Promise<boolean> {
+    const lc = username.toLowerCase();
+    return (this.teamMemberships[`${org}/${teamSlug}`] ?? []).some((m) => m.toLowerCase() === lc);
   }
 
   async getActorPermission(username: string): Promise<RepoPermission> {

--- a/packages/forge/src/github.ts
+++ b/packages/forge/src/github.ts
@@ -135,6 +135,20 @@ export class GitHubForge implements Forge {
     }
   }
 
+  async isTeamMember(org: string, teamSlug: string, username: string): Promise<boolean> {
+    try {
+      const { data } = await this.octokit.rest.teams.getMembershipForUserInOrg({ org, team_slug: teamSlug, username });
+      // A pending invite is not yet a member; only 'active' membership authorizes.
+      return data.state === 'active';
+    } catch (error) {
+      // 404 = not a member. Any other error (403 = the token lacks org-read scope, network, …) can't
+      // be answered — surface it (the caller's gate wrapper warns and fails closed) rather than
+      // silently reporting "not a member", which is indistinguishable from a real non-member.
+      if (forgeErrorStatus(error) === 404) return false;
+      throw error;
+    }
+  }
+
   async findComment(prNumber: number, marker: string): Promise<ForgeComment | null> {
     const iterator = this.octokit.paginate.iterator(this.octokit.rest.issues.listComments, {
       ...this.base,

--- a/packages/forge/src/types.ts
+++ b/packages/forge/src/types.ts
@@ -151,6 +151,9 @@ export interface Forge {
   /** The actor's permission level on the repo (for gating who may steer the standing PR). Returns
    *  'none' for an unknown/outside actor rather than throwing. */
   getActorPermission(username: string): Promise<RepoPermission>;
+  /** Whether `username` is an active member of `org`/`teamSlug`. Returns false when not a member;
+   *  throws on an access error (e.g. a token without org-read scope) so the caller can surface it. */
+  isTeamMember(org: string, teamSlug: string, username: string): Promise<boolean>;
 
   // — Commit status —
   setCommitStatus(status: CommitStatus): Promise<void>;

--- a/packages/forge/test/unit/fake.spec.ts
+++ b/packages/forge/test/unit/fake.spec.ts
@@ -124,4 +124,11 @@ describe('FakeForge', () => {
     expect(await forge.getActorPermission('BOB')).toBe('write');
     expect(await forge.getActorPermission('stranger')).toBe('none');
   });
+
+  it('should resolve seeded team membership case-insensitively', async () => {
+    const forge = createFakeForge({ teamMemberships: { 'acme/releasers': ['Alice'] } });
+    expect(await forge.isTeamMember('acme', 'releasers', 'alice')).toBe(true);
+    expect(await forge.isTeamMember('acme', 'releasers', 'bob')).toBe(false);
+    expect(await forge.isTeamMember('acme', 'other', 'alice')).toBe(false);
+  });
 });

--- a/packages/forge/test/unit/github.spec.ts
+++ b/packages/forge/test/unit/github.spec.ts
@@ -13,6 +13,7 @@ function makeOctokit() {
     updateRelease: vi.fn(),
     getReleaseByTag: vi.fn(),
     getCollaboratorPermissionLevel: vi.fn(),
+    getMembershipForUserInOrg: vi.fn(),
     pullsList: vi.fn(),
     pullsGet: vi.fn(),
     pullsCreate: vi.fn(),
@@ -35,6 +36,9 @@ function makeOctokit() {
         updateRelease: fns.updateRelease,
         getReleaseByTag: fns.getReleaseByTag,
         getCollaboratorPermissionLevel: fns.getCollaboratorPermissionLevel,
+      },
+      teams: {
+        getMembershipForUserInOrg: fns.getMembershipForUserInOrg,
       },
       pulls: {
         list: fns.pullsList,
@@ -401,6 +405,37 @@ describe('GitHubForge.getActorPermission', () => {
     const { octokit, fns } = makeOctokit();
     fns.getCollaboratorPermissionLevel.mockRejectedValue(Object.assign(new Error('403'), { status: 403 }));
     await expect(new GitHubForge(octokit, 'o', 'r').getActorPermission('alice')).rejects.toThrow('403');
+  });
+});
+
+describe('GitHubForge.isTeamMember', () => {
+  it('should return true for an active member', async () => {
+    const { octokit, fns } = makeOctokit();
+    fns.getMembershipForUserInOrg.mockResolvedValue({ data: { state: 'active' } });
+    expect(await new GitHubForge(octokit, 'o', 'r').isTeamMember('acme', 'releasers', 'alice')).toBe(true);
+    expect(fns.getMembershipForUserInOrg).toHaveBeenCalledWith({
+      org: 'acme',
+      team_slug: 'releasers',
+      username: 'alice',
+    });
+  });
+
+  it('should return false for a pending (not yet active) invite', async () => {
+    const { octokit, fns } = makeOctokit();
+    fns.getMembershipForUserInOrg.mockResolvedValue({ data: { state: 'pending' } });
+    expect(await new GitHubForge(octokit, 'o', 'r').isTeamMember('acme', 'releasers', 'bob')).toBe(false);
+  });
+
+  it('should return false when not a member (404)', async () => {
+    const { octokit, fns } = makeOctokit();
+    fns.getMembershipForUserInOrg.mockRejectedValue(Object.assign(new Error('404'), { status: 404 }));
+    expect(await new GitHubForge(octokit, 'o', 'r').isTeamMember('acme', 'releasers', 'stranger')).toBe(false);
+  });
+
+  it('should rethrow a non-404 (e.g. 403 missing org-read scope) so the caller can surface it', async () => {
+    const { octokit, fns } = makeOctokit();
+    fns.getMembershipForUserInOrg.mockRejectedValue(Object.assign(new Error('403'), { status: 403 }));
+    await expect(new GitHubForge(octokit, 'o', 'r').isTeamMember('acme', 'releasers', 'alice')).rejects.toThrow('403');
   });
 });
 

--- a/packages/release/src/standing-pr/authorization.ts
+++ b/packages/release/src/standing-pr/authorization.ts
@@ -61,10 +61,21 @@ function isBot(login: string | undefined, type: string | undefined): boolean {
   return type === 'Bot' || (login !== undefined && login.endsWith('[bot]'));
 }
 
+/** An `allowedActors` entry naming a GitHub team, e.g. `@acme/releasers` → `{ org, team }`. */
+function parseTeamRef(entry: string): { org: string; team: string } | undefined {
+  if (!entry.startsWith('@') || !entry.includes('/')) return undefined;
+  const [org, team] = entry.slice(1).split('/');
+  return org && team ? { org, team } : undefined;
+}
+
 /**
  * Whether `login` may steer the standing PR under `authz`. Bots are always authorized (the tool runs
- * as one). Otherwise the actor passes if explicitly allow-listed, or if their repository permission
- * meets the configured threshold. An unknown actor (no login, or no repo access) is not authorized.
+ * as one). Otherwise the actor passes if explicitly allow-listed by username, if their repository
+ * permission meets the configured threshold, or if they're a member of an allow-listed `@org/team`.
+ * An unknown actor (no login, or no repo access / team membership) is not authorized.
+ *
+ * Checks are ordered cheapest-first — username, then the single permission API call, then team
+ * membership (one API call per `@org/team`, only reached for an actor not already authorized).
  */
 export async function isAuthorizedActor(
   forge: Forge,
@@ -74,10 +85,23 @@ export async function isAuthorizedActor(
 ): Promise<boolean> {
   if (isBot(login, type)) return true;
   if (!login) return false;
-  // GitHub usernames are case-insensitive, so compare case-folded — a `allowedActors: ['Alice']`
-  // entry must still match an event delivering `login: 'alice'`.
+  const entries = authz.allowedActors ?? [];
+
+  // 1. Username allow-list. GitHub usernames are case-insensitive, so compare case-folded — an
+  //    `allowedActors: ['Alice']` entry must still match an event delivering `login: 'alice'`.
   const lc = login.toLowerCase();
-  if (authz.allowedActors?.some((a) => a.toLowerCase() === lc)) return true;
+  if (entries.some((e) => !parseTeamRef(e) && e.toLowerCase() === lc)) return true;
+
+  // 2. Repository permission threshold.
   const permission = await forge.getActorPermission(login);
-  return PERMISSION_RANK[permission] >= PERMISSION_RANK[authz.requiredPermission];
+  if (PERMISSION_RANK[permission] >= PERMISSION_RANK[authz.requiredPermission]) return true;
+
+  // 3. Team membership — last, since it costs an API call per team and a 403 (no org-read scope)
+  //    propagates to the caller's gate wrapper. An `@org/team` member is authorized regardless of
+  //    repo permission.
+  for (const entry of entries) {
+    const ref = parseTeamRef(entry);
+    if (ref && (await forge.isTeamMember(ref.org, ref.team, login))) return true;
+  }
+  return false;
 }

--- a/packages/release/test/unit/authorization.spec.ts
+++ b/packages/release/test/unit/authorization.spec.ts
@@ -1,6 +1,6 @@
 import * as fs from 'node:fs';
 import { createFakeForge } from '@releasekit/forge';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { getEventActor, isAuthorizedActor, type StandingPrAuthorization } from '../../src/standing-pr/authorization.js';
 
 const authz = (overrides: Partial<StandingPrAuthorization> = {}): StandingPrAuthorization => ({
@@ -43,6 +43,20 @@ describe('isAuthorizedActor', () => {
     const forge = createFakeForge();
     expect(await isAuthorizedActor(forge, undefined, 'User', authz())).toBe(false);
     expect(await isAuthorizedActor(forge, 'stranger', 'User', authz())).toBe(false); // unseeded → 'none'
+  });
+
+  it('should authorize a member of an allow-listed @org/team', async () => {
+    const forge = createFakeForge({ teamMemberships: { 'acme/releasers': ['carol'] } });
+    expect(await isAuthorizedActor(forge, 'carol', 'User', authz({ allowedActors: ['@acme/releasers'] }))).toBe(true);
+    // A non-member with no threshold permission is rejected.
+    expect(await isAuthorizedActor(forge, 'dave', 'User', authz({ allowedActors: ['@acme/releasers'] }))).toBe(false);
+  });
+
+  it('should check team membership only after username + threshold (no team call for an admin)', async () => {
+    const forge = createFakeForge({ actorPermissions: { alice: 'admin' } });
+    const teamSpy = vi.spyOn(forge, 'isTeamMember');
+    expect(await isAuthorizedActor(forge, 'alice', 'User', authz({ allowedActors: ['@acme/releasers'] }))).toBe(true);
+    expect(teamSpy).not.toHaveBeenCalled(); // admin passed the threshold; team membership never queried
   });
 });
 

--- a/releasekit.schema.json
+++ b/releasekit.schema.json
@@ -1241,7 +1241,7 @@
                   "items": {
                     "type": "string"
                   },
-                  "description": "Extra actors authorized regardless of permission level: GitHub usernames. (Team support via \"@org/team\" entries is added separately and requires an org-read token, not the default GITHUB_TOKEN.)"
+                  "description": "Extra actors authorized regardless of permission level: GitHub usernames, or \"@org/team-slug\" to authorize a whole team. Team-membership checks need a token with org read:org scope (a PAT or GitHub App), not the default GITHUB_TOKEN; without it, team entries resolve to \"not a member\"."
                 },
                 "enforceMergeAuthor": {
                   "type": "boolean",

--- a/releasekit.schema.json
+++ b/releasekit.schema.json
@@ -1241,7 +1241,7 @@
                   "items": {
                     "type": "string"
                   },
-                  "description": "Extra actors authorized regardless of permission level: GitHub usernames, or \"@org/team-slug\" to authorize a whole team. Team-membership checks need a token with org read:org scope (a PAT or GitHub App), not the default GITHUB_TOKEN; without it, team entries resolve to \"not a member\"."
+                  "description": "Extra actors authorized regardless of permission level: GitHub usernames, or \"@org/team-slug\" to authorize a whole team. Team-membership checks need a token with read:org scope (a PAT or GitHub App), not the default GITHUB_TOKEN; without it, team entries fail closed — the 403 is surfaced as a warning and the actor is not authorized."
                 },
                 "enforceMergeAuthor": {
                   "type": "boolean",

--- a/releasekit.schema.json
+++ b/releasekit.schema.json
@@ -1239,7 +1239,8 @@
                 "allowedActors": {
                   "type": "array",
                   "items": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^(?:[A-Za-z0-9-]+|@[A-Za-z0-9-]+\\/[A-Za-z0-9._-]+)$"
                   },
                   "description": "Extra actors authorized regardless of permission level: GitHub usernames, or \"@org/team-slug\" to authorize a whole team. Team-membership checks need a token with read:org scope (a PAT or GitHub App), not the default GITHUB_TOKEN; without it, team entries fail closed — the 403 is surfaced as a warning and the actor is not authorized."
                 },


### PR DESCRIPTION
Closes #400. Extends the authorization allow-list to groups, per your "specific groups" requirement. Only needs the #399 foundation (merged), so it's off `main`.

## What this adds

`ci.standingPr.authorization.allowedActors` now accepts **`@org/team-slug`** entries in addition to usernames — any **active** member of that GitHub team is authorized regardless of their repo permission.

- **Forge** gains `isTeamMember(org, teamSlug, username)` over `teams.getMembershipForUserInOrg` (active membership only; a pending invite doesn't count). 404 → not a member; **any other error (e.g. 403 from a token without `read:org` scope) is rethrown** so the caller's gate wrapper (`authorizedOrWarn`) warns and fails closed — consistent with `getActorPermission`. `FakeForge` seeds `teamMemberships`.
- **`isAuthorizedActor`** checks **username → permission threshold → team membership**, cheapest-first: the team API call only fires for an actor not already authorized (e.g. an admin never triggers a team lookup).

## Token caveat (documented)

Team-membership checks need a token with **`read:org`** scope — a PAT or GitHub App, **not** the default `GITHUB_TOKEN`. Without it, `@org/team` entries resolve to "not a member" (and the 403 surfaces as a warning via the gate). The config description says so; the #405 docs will expand on it.

## Acceptance

- [x] `@org/team` entries authorize members of that team
- [x] Plain username entries still work; bot + threshold unchanged
- [x] Missing org-read scope degrades gracefully (warn + fail-closed via the gate), never crashes
- [x] Unit tests for the team path (faked membership + adapter) and the ordering
- [x] Docs note the org-read-token requirement

Schema + `docs/configuration.md` regenerated (`schema:check` green). Full gate: **27/27**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extends `ci.standingPr.authorization.allowedActors` to accept GitHub team references (`@org/team-slug`) alongside plain usernames, enabling any active member of a named team to be authorized for standing-PR steering regardless of their individual repository permission.

- **Forge interface** gains `isTeamMember(org, teamSlug, username)`: `GitHubForge` calls `teams.getMembershipForUserInOrg`, returns `false` on 404 (not a member), and rethrows anything else (notably 403 on a token without `read:org`) so the existing gate wrapper fails closed; `FakeForge` implements the same interface with seeded data and correct case-insensitive key lookup.
- **`isAuthorizedActor`** follows a cheapest-first ordering — username allow-list → permission threshold → team membership API call — ensuring the expensive team lookup only fires for actors not already authorized by cheaper checks.
- **Schema + JSON Schema** adds a validation regex that rejects `@username` (missing slash) at config-load time while accepting bare usernames and well-formed `@org/team-slug` entries, and updates the `description` to document the `read:org` token requirement and fail-closed behaviour.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the authorization logic is additive, strictly fail-closed on missing scope, and backed by comprehensive unit tests across all three layers (schema, forge adapter, standing-PR gate).

The three-step check in `isAuthorizedActor` is correctly ordered and short-circuits safely. The forge adapter's 404/rethrow contract matches the existing `getActorPermission` pattern. The schema regex closes the `@username` (no slash) foot-gun at config-load time. The previous case-sensitivity issue in `FakeForge` has been addressed. No authorization bypass or silent-failure paths were found.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/release/src/standing-pr/authorization.ts | Adds `parseTeamRef` helper and a three-step cheapest-first check in `isAuthorizedActor`; logic is correct, error propagation matches documented fail-closed contract. |
| packages/forge/src/github.ts | Adds `isTeamMember` to `GitHubForge`: active-only membership, 404 → false, other errors rethrown — consistent with `getActorPermission` error-handling pattern. |
| packages/forge/src/fake.ts | Adds `teamMemberships` seed and case-insensitive `isTeamMember` to `FakeForge`, correctly mirroring the real adapter's case-insensitive GitHub behaviour. |
| packages/config/src/schema.ts | Adds a validation regex to `allowedActors` items rejecting bare `@username` at config-load time; description updated to document fail-closed behaviour on missing scope. |
| packages/forge/src/types.ts | Adds `isTeamMember` to the `Forge` interface with clear doc-comment covering the 404/throw contract. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller
    participant isAuthorizedActor
    participant Forge

    Caller->>isAuthorizedActor: login, type, authz
    isAuthorizedActor->>isAuthorizedActor: isBot? → return true
    isAuthorizedActor->>isAuthorizedActor: no login? → return false
    isAuthorizedActor->>isAuthorizedActor: 1. username allow-list check (no API call)
    alt username matched
        isAuthorizedActor-->>Caller: true
    else
        isAuthorizedActor->>Forge: getActorPermission(login)
        Forge-->>isAuthorizedActor: RepoPermission
        alt "permission >= threshold"
            isAuthorizedActor-->>Caller: true
        else
            loop "each @org/team entry"
                isAuthorizedActor->>Forge: isTeamMember(org, team, login)
                alt active member (200 active)
                    Forge-->>isAuthorizedActor: true
                    isAuthorizedActor-->>Caller: true
                else not a member (404)
                    Forge-->>isAuthorizedActor: false
                else access error (403 / other)
                    Forge-->>isAuthorizedActor: throws
                    isAuthorizedActor-->>Caller: throws - gate wrapper warns + fails closed
                end
            end
            isAuthorizedActor-->>Caller: false
        end
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller
    participant isAuthorizedActor
    participant Forge

    Caller->>isAuthorizedActor: login, type, authz
    isAuthorizedActor->>isAuthorizedActor: isBot? → return true
    isAuthorizedActor->>isAuthorizedActor: no login? → return false
    isAuthorizedActor->>isAuthorizedActor: 1. username allow-list check (no API call)
    alt username matched
        isAuthorizedActor-->>Caller: true
    else
        isAuthorizedActor->>Forge: getActorPermission(login)
        Forge-->>isAuthorizedActor: RepoPermission
        alt "permission >= threshold"
            isAuthorizedActor-->>Caller: true
        else
            loop "each @org/team entry"
                isAuthorizedActor->>Forge: isTeamMember(org, team, login)
                alt active member (200 active)
                    Forge-->>isAuthorizedActor: true
                    isAuthorizedActor-->>Caller: true
                else not a member (404)
                    Forge-->>isAuthorizedActor: false
                else access error (403 / other)
                    Forge-->>isAuthorizedActor: throws
                    isAuthorizedActor-->>Caller: throws - gate wrapper warns + fails closed
                end
            end
            isAuthorizedActor-->>Caller: false
        end
    end
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["feat(config): validate allowedActors ent..."](https://github.com/goosewobbler/releasekit/commit/ef015815f836e931a9f9dc308c4e2b8dd311767f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39178509)</sub>

<!-- /greptile_comment -->