### PR TITLE
docs: securing the standing PR (authorization + rulesets) (#405)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,5 +95,5 @@ Fresh worktrees need `pnpm install` first. If you change dependencies, run `pnpm
 | [docs/configuration.md](./docs/configuration.md) | Full config reference (**generated**) |
 | [docs/cli.md](./docs/cli.md) | Every command and flag |
 | [docs/troubleshooting.md](./docs/troubleshooting.md) | Symptom-indexed errors, failed-publish recovery |
-| [packages/release/docs/ci-setup.md](./packages/release/docs/ci-setup.md) | Consumer workflow templates, standing-PR mode |
+| [packages/release/docs/ci-setup.md](./packages/release/docs/ci-setup.md) | Consumer workflow templates, standing-PR mode, securing the standing PR |
 | [docs/action.md](./docs/action.md) | GitHub Action inputs/outputs |

--- a/docs/release-taxonomy.md
+++ b/docs/release-taxonomy.md
@@ -77,6 +77,11 @@ prerequisites. Unticking a package that is a prerequisite of a still-ticked targ
 `independent` group, surfaces a ⚠️ warning — you can do it, but you're told what you're splitting.
 Members of a lockstep (`fixed`/`linked`) group can't be held back individually.
 
+In standing-PR mode the checkboxes and scope labels are a **release-control surface** — they decide
+what publishes, and merging the PR is the publish. To restrict who can change them (e.g. let triagers
+label but not steer releases), see
+[Securing the standing PR](../packages/release/docs/ci-setup.md#securing-the-standing-pr).
+
 ## Choosing between them
 
 - The packages are **always** coupled → **group** (and pick the mode by whether they share a version

--- a/packages/release/docs/ci-setup.md
+++ b/packages/release/docs/ci-setup.md
@@ -331,7 +331,7 @@ All `ci.standingPr.*` options:
 
 ### Securing the standing PR
 
-The standing PR is a **release-control surface**, not just a PR. Its release labels (`bump:*`, `scope:*`, `channel:*`) and selection checkboxes decide *what* publishes, and **merging it is the publish**. But GitHub maps all of that onto coarse repo roles: anyone with **Triage** can apply labels, anyone with **Write** can merge. GitHub itself can't express "Triage, but not release-steering," can't restrict labels per-label, can't hide the PR from some actors, and can't gate checkbox edits.
+The standing PR is a **release-control surface**, not just a PR. Its release labels (`bump:*`, `scope:*`, `channel:*`, `release:with-prerequisites`) and selection checkboxes decide *what* publishes, and **merging it is the publish**. But GitHub maps all of that onto coarse repo roles: anyone with **Triage** can apply labels, anyone with **Write** can merge. GitHub itself can't express "Triage, but not release-steering," can't restrict labels per-label, can't hide the PR from some actors, and can't gate checkbox edits.
 
 So control is enforced in two places:
 
@@ -369,7 +369,7 @@ With `authorization` configured (threshold `admin` shown):
 | Action | GitHub requires | With `authorization` configured |
 |---|---|---|
 | Tick/untick a selection checkbox | Triage (edit PR body) | Honored only if the editor is authorized; otherwise reverted to the manifest, with a notice. |
-| Add/remove a release label (`bump:*`, `scope:*`, `channel:*`) | Triage | Same — unauthorized changes are reverted and a notice posted. |
+| Add/remove a release label (`bump:*`, `scope:*`, `channel:*`, `release:with-prerequisites`) | Triage | Same — unauthorized changes are reverted and a notice posted. |
 | Add/remove a non-release label (`area:*`, …) | Triage | Unaffected — ReleaseKit only reconciles release-control labels. |
 | Merge the standing PR (**= publish**) | Write | Refused at publish if the merger isn't authorized (`enforceMergeAuthor`); the branch ruleset below is the primary gate. |
 

--- a/packages/release/docs/ci-setup.md
+++ b/packages/release/docs/ci-setup.md
@@ -327,6 +327,68 @@ All `ci.standingPr.*` options:
 | `mergeMethod` | `merge` | `merge` \| `squash` \| `rebase`. Squash recommended — produces a single `chore: release …` commit on main that the skip-pattern guard recognises. |
 | `minAge` | (unset) | Duration string (`6h`, `30m`, `1d`). Until elapsed, the `releasekit/standing-pr` status check reports `pending` with a countdown. Combined with branch protection on the status check, blocks early merges. Time baseline is `firstUpdatedAt` — the PR's first creation timestamp, preserved across updates. |
 | `minPackages` | (unset) | Minimum distinct packages with releasable changes before a standing PR is created. Below the threshold, an open PR is closed with an explanatory comment and no new PR is created until the threshold is met. |
+| `authorization` | (unset) | Restrict who can steer the standing PR — selection checkboxes, release labels, and merge. See [Securing the standing PR](#securing-the-standing-pr). Omit for today's behavior (anyone with the GitHub permission GitHub itself requires for each action). |
+
+### Securing the standing PR
+
+The standing PR is a **release-control surface**, not just a PR. Its release labels (`bump:*`, `scope:*`, `channel:*`) and selection checkboxes decide *what* publishes, and **merging it is the publish**. But GitHub maps all of that onto coarse repo roles: anyone with **Triage** can apply labels, anyone with **Write** can merge. GitHub itself can't express "Triage, but not release-steering," can't restrict labels per-label, can't hide the PR from some actors, and can't gate checkbox edits.
+
+So control is enforced in two places:
+
+- **Selection + release labels** — enforced *in code* by ReleaseKit, because GitHub can't. The manifest comment is authoritative; an unauthorized edit to the checkboxes or release labels is ignored and reconciled back to the manifest on the next update (the box re-ticks, the rogue label is removed, a notice is posted). This is opt-in hardening for teams that delegate triage.
+- **Merge (= publish)** — enforced by a **GitHub branch ruleset** (the primary gate, since merge is the privileged action) plus a publish-time **author check** (`enforceMergeAuthor`, defense-in-depth behind the ruleset).
+
+#### The `authorization` config
+
+```json
+{
+  "ci": {
+    "standingPr": {
+      "authorization": {
+        "requiredPermission": "admin",
+        "allowedActors": ["release-bot", "@acme/releasers"],
+        "enforceMergeAuthor": true
+      }
+    }
+  }
+}
+```
+
+| Field | Default | Purpose |
+|---|---|---|
+| `requiredPermission` | `admin` | Minimum repo permission to steer the standing PR. `admin` \| `maintain` \| `write`. |
+| `allowedActors` | (unset) | Extra actors authorized regardless of permission: GitHub usernames, or `@org/team-slug` to authorize a whole team. |
+| `enforceMergeAuthor` | `true` | Refuse to publish when the merger isn't authorized. Set `false` to rely on the branch ruleset alone. |
+
+Omit `authorization` entirely and ReleaseKit behaves as it always has — anyone with the GitHub permission GitHub requires for each action can perform it.
+
+#### Who can do what
+
+With `authorization` configured (threshold `admin` shown):
+
+| Action | GitHub requires | With `authorization` configured |
+|---|---|---|
+| Tick/untick a selection checkbox | Triage (edit PR body) | Honored only if the editor is authorized; otherwise reverted to the manifest, with a notice. |
+| Add/remove a release label (`bump:*`, `scope:*`, `channel:*`) | Triage | Same — unauthorized changes are reverted and a notice posted. |
+| Add/remove a non-release label (`area:*`, …) | Triage | Unaffected — ReleaseKit only reconciles release-control labels. |
+| Merge the standing PR (**= publish**) | Write | Refused at publish if the merger isn't authorized (`enforceMergeAuthor`); the branch ruleset below is the primary gate. |
+
+#### Branch rulesets (the merge gate)
+
+The in-code gates keep the *manifest* clean, but the merge itself is a GitHub action — gate it with two **repository rulesets** (Settings → Rules → Rulesets). Create them once, by hand or via your IaC/Terraform; they're repo policy and want an admin to apply deliberately.
+
+**1. Lock the release branch** — target `release/next` (your `ci.standingPr.branch`). Enable **Restrict creations**, **Restrict updates**, and **Restrict deletions** so only bypass actors can write the branch — no one can inject a commit that would then be published.
+
+> ⚠️ The release bot pushes this branch, so it **must** be a bypass actor or releases break. ReleaseKit can't infer the bot's identity for you. Create this ruleset in **evaluate** (dry-run) mode first, confirm in the repo's rule insights that the bot isn't tripped, then switch to **active**.
+
+**2. Require review on the default branch** — target `main` (or `~DEFAULT_BRANCH`). Enable **Require a pull request before merging** (≥ 1 approval), **Block force pushes**, and **Restrict deletions**. Since merging the standing PR is the publish, this gates the publish behind review.
+
+**Mapping `allowedActors` to ruleset bypass actors:** a `@org/team-slug` entry maps to a **Team** bypass actor (add the team in the ruleset's *Bypass list*). A plain **username can't** be a ruleset bypass actor — GitHub only exempts roles, teams, and apps — so usernames stay enforced by the in-code gates only. Always keep org/repo admins on the bypass list so you can't lock yourself out.
+
+#### Token caveats
+
+- **`@org/team` allow-lists** (the in-code gates) need a token with **`read:org`** scope — a PAT or GitHub App, **not** the default `GITHUB_TOKEN`. Without it, team-membership checks fail closed: the actor isn't authorized and a warning is logged. Username and permission-threshold entries work with the default token.
+- **Creating rulesets** needs an **admin-scoped** token (or just do it in the GitHub UI as an admin).
 
 ### Workflow
 

--- a/packages/release/docs/ci-setup.md
+++ b/packages/release/docs/ci-setup.md
@@ -387,7 +387,7 @@ The in-code gates keep the *manifest* clean, but the merge itself is a GitHub ac
 
 #### Token caveats
 
-- **`@org/team` allow-lists** (the in-code gates) need a token with **`read:org`** scope — a PAT or GitHub App, **not** the default `GITHUB_TOKEN`. Without it, team-membership checks fail closed: the actor isn't authorized and a warning is logged. Username and permission-threshold entries work with the default token.
+- **`@org/team` allow-lists** need a token with **`read:org`** scope — a PAT or GitHub App, **not** the default `GITHUB_TOKEN`. Without it, the team-membership check can't be answered, and the two gate types resolve it differently: the **selection and release-label gates fail _closed_** (the actor isn't treated as authorized; their edit is reverted, with a warning), while the **publish-author gate (`enforceMergeAuthor`) fails _open_** (it warns and proceeds, because the branch ruleset is the primary merge gate — a token misconfiguration shouldn't block a legitimate release). So **don't rely on `enforceMergeAuthor` alone for team-based merge control** — set up the branch ruleset. Username and permission-threshold entries work with the default token.
 - **Creating rulesets** needs an **admin-scoped** token (or just do it in the GitHub UI as an admin).
 
 ### Workflow


### PR DESCRIPTION
Closes #405. The last slice of the 0.32.0 standing-PR authorization feature — documentation.

## What's here

A new **"Securing the standing PR"** section in `packages/release/docs/ci-setup.md`:

- **Threat model** — the standing PR is a release-control surface (labels/checkboxes decide *what* publishes; merging it *is* the publish), and GitHub maps that onto coarse Triage/Write roles with no way to say "Triage but not release-steering."
- **The `ci.standingPr.authorization` config** — `requiredPermission`, `allowedActors`, `enforceMergeAuthor`, and the opt-in note.
- **Who-can-do-what table** — selection / release labels / merge, GitHub-required vs. enforced-with-authorization.
- **The split** — selection + release labels enforced in code (manifest is authoritative; unauthorized edits reconcile back); the merge gated by a branch ruleset + the publish-author check.
- **Branch rulesets as a manual/IaC spec** — the two rulesets (lock `release/next`, require review on `main`) mapped to GitHub's UI rule names, the `allowedActors` → bypass-actor mapping (teams → Team bypass; usernames can't be ruleset bypass actors), and the **evaluate-first** caveat so an active push-lock doesn't lock the release bot out.
- **Token caveats** — `read:org` for `@org/team` allow-lists; admin token to create rulesets.

Cross-links from the release-taxonomy selection section and the AGENTS.md doc table.

## Note on scope

This absorbs what **#404** (the dropped `standing-pr protect` command) would have automated — documented as a spec rather than a config-derived writer. Rationale on #404: a version-sensitive ruleset writer/checker doesn't earn its maintenance for two rarely-changing rulesets, and the audience that most needs merge protection manages rulesets via IaC and wants a spec, not a tool. The in-code gates (#401/#402/#403) remain the primary enforcement.

`docs/configuration.md` already carries the generated `authorization` config (from #399) and is untouched (never hand-edited). Docs-only; gate green (lint/typecheck/test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This is a docs-only PR adding a "Securing the standing PR" section to `packages/release/docs/ci-setup.md`, covering the threat model, `authorization` config fields, a who-can-do-what table, branch ruleset setup, and token caveats. It closes the documentation gap left by the dropped `standing-pr protect` command (#404).

- **`ci-setup.md`** gains the full authorization guide — config reference, two-ruleset setup walkthrough, bypass-actor mapping, and explicit fail-closed vs. fail-open distinctions for the two gate types (label gates vs. `enforceMergeAuthor`).
- **`docs/release-taxonomy.md`** and **`AGENTS.md`** receive cross-links to the new section.
</details>

<h3>Confidence Score: 5/5</h3>

Docs-only change with no runtime code modified; safe to merge.

All three changed files are Markdown documentation. The new section accurately describes the authorization model, includes `release:with-prerequisites` in both the prose and the who-can-do-what table (addressing previous review feedback), and explicitly differentiates the fail-closed behavior of label/checkbox gates from the fail-open behavior of `enforceMergeAuthor` (also previously flagged). Cross-links and relative paths are correct. No code paths are touched.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/release/docs/ci-setup.md | Adds 68-line 'Securing the standing PR' section and an `authorization` row to the config table; addresses prior review feedback by including `release:with-prerequisites` in both the opening paragraph and the who-can-do-what table, and by explicitly distinguishing fail-closed (label gates) from fail-open (enforceMergeAuthor) behavior. |
| docs/release-taxonomy.md | Adds a 5-line cross-link paragraph pointing readers to the new 'Securing the standing PR' section; relative path is correct. |
| AGENTS.md | One-line update to the doc-table entry for ci-setup.md to include 'securing the standing PR'; no issues. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([Actor performs action on standing PR]) --> B{Action type}

    B -->|Edit checkbox / add label| C{authorization\nconfigured?}
    B -->|Merge PR = publish| G{authorization\nconfigured?}

    C -->|No| D[Allow — standard GitHub permissions]
    C -->|Yes| E{Actor authorized?\nrequiredPermission\nor allowedActors}

    E -->|Yes| F[Allow — manifest updated]
    E -->|No| F2[Revert to manifest\npost notice]

    E -- team check, token lacks read:org --> E2[Fail closed\nrevert + warn]

    G -->|No| H[Allow — standard GitHub merge]
    G -->|Yes| I{Branch ruleset\npassed?}

    I -->|No — ruleset active| J[GitHub blocks merge]
    I -->|Yes — bypass actor\nor approved PR| K{enforceMergeAuthor\nchecks actor}

    K -->|Authorized| L[Publish proceeds]
    K -->|Not authorized| M[Publish refused]

    K -- team check, token lacks read:org --> K2[Fail open\nwarn + proceed\nbranch ruleset\nis primary gate]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A([Actor performs action on standing PR]) --> B{Action type}

    B -->|Edit checkbox / add label| C{authorization\nconfigured?}
    B -->|Merge PR = publish| G{authorization\nconfigured?}

    C -->|No| D[Allow — standard GitHub permissions]
    C -->|Yes| E{Actor authorized?\nrequiredPermission\nor allowedActors}

    E -->|Yes| F[Allow — manifest updated]
    E -->|No| F2[Revert to manifest\npost notice]

    E -- team check, token lacks read:org --> E2[Fail closed\nrevert + warn]

    G -->|No| H[Allow — standard GitHub merge]
    G -->|Yes| I{Branch ruleset\npassed?}

    I -->|No — ruleset active| J[GitHub blocks merge]
    I -->|Yes — bypass actor\nor approved PR| K{enforceMergeAuthor\nchecks actor}

    K -->|Authorized| L[Publish proceeds]
    K -->|Not authorized| M[Publish refused]

    K -- team check, token lacks read:org --> K2[Fail open\nwarn + proceed\nbranch ruleset\nis primary gate]
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["docs: correct the fail-open/closed asymm..."](https://github.com/goosewobbler/releasekit/commit/80250b9450aa8d9bd16624ab30673f653bdd6331) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39188530)</sub>

<!-- /greptile_comment -->