### PR TITLE
fix(version): guard the first-release stable-manifest bump overshoot (#388)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -50,6 +50,7 @@ Run the full release pipeline: version, changelog, publish, git, and GitHub Rele
 | `-b, --bump <type>` | `patch` \| `minor` \| `major` \| `prerelease` | auto | Force bump type |
 | `-p, --prerelease [identifier]` | boolean \| string | - | Create prerelease version |
 | `--stable` | boolean | `false` | Graduate prerelease packages to stable without bumping |
+| `--allow-first-bump` | boolean | `false` | Acknowledge applying a bump on a first release with an already-stable manifest (silences the overshoot warning; see [`version.allowFirstBump`](./configuration.md#version)) |
 | `-s, --sync` | boolean | `false` | Use synchronized versioning across all packages |
 | `-t, --target <packages>` | string | all | Target specific packages (comma-separated) |
 | `--include-prerequisites` | boolean | `false` | Also release the changed internal dependencies of `--target` packages (and the rest of their groups) |
@@ -188,6 +189,7 @@ Version a package or packages based on configuration and conventional commits. A
 | `-b, --bump <type>` | `patch` \| `minor` \| `major` \| `prerelease` | auto | Specify bump type |
 | `-p, --prerelease [identifier]` | boolean \| string | - | Create prerelease version |
 | `--stable` | boolean | `false` | Graduate prerelease packages to stable without bumping |
+| `--allow-first-bump` | boolean | `false` | Acknowledge applying a bump on a first release with an already-stable manifest (silences the overshoot warning; see [`version.allowFirstBump`](./configuration.md#version)) |
 | `-s, --sync` | boolean | config | Use synchronized versioning across all packages |
 | `-j, --json` | boolean | `false` | Output results as JSON |
 | `-t, --target <packages>` | string | all | Comma-delimited list of package names to target |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -75,6 +75,7 @@ Versioning configuration.
 | `mismatchStrategy` | `"error"` \| `"warn"` \| `"ignore"` \| `"prefer-package"` \| `"prefer-git"` | `"warn"` | How to handle version mismatches |
 | `versionPrefix` | string | `""` | Prefix for version tags |
 | `prereleaseIdentifier` | string | — | Identifier for prerelease versions (e.g., 'alpha', 'beta') |
+| `allowFirstBump` | boolean | `false` | Acknowledge applying a bump on a first release with an already-stable manifest. On a first release (no prior tag), `--stable --bump <type>` applies the bump (e.g. 1.0.0 → 2.0.0) rather than graduating, which can silently overshoot the staged first version. By default this is flagged per `mismatchStrategy` (warn, or abort under "error"); set true (or pass --allow-first-bump) to apply the bump silently — legitimate when importing a package with prior external version history. |
 | `strictReachable` | boolean | `false` | Only use reachable tags |
 | `zeroMajor` | `"spec"` \| `"strict"` | `"spec"` | Pre-1.0 handling of commit-inferred breaking changes. 'spec' (default): bump the 0.x minor (0.24.0 → 0.25.0), per semver §4. 'strict': bump the next major (→ 1.0.0). Inferred path only — explicit overrides (--bump major, bump:major) always graduate to 1.0.0. |
 | `pub` | object | — | Dart/Flutter pub configuration |

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -121,6 +121,12 @@ export const VersionConfigSchema = z.object({
     .describe('How to handle version mismatches'),
   versionPrefix: z.string().default('').describe('Prefix for version tags'),
   prereleaseIdentifier: z.string().optional().describe("Identifier for prerelease versions (e.g., 'alpha', 'beta')"),
+  allowFirstBump: z
+    .boolean()
+    .default(false)
+    .describe(
+      'Acknowledge applying a bump on a first release with an already-stable manifest. On a first release (no prior tag), `--stable --bump <type>` applies the bump (e.g. 1.0.0 → 2.0.0) rather than graduating, which can silently overshoot the staged first version. By default this is flagged per `mismatchStrategy` (warn, or abort under "error"); set true (or pass --allow-first-bump) to apply the bump silently — legitimate when importing a package with prior external version history.',
+    ),
   strictReachable: z.boolean().default(false).describe('Only use reachable tags'),
   zeroMajor: z
     .enum(['spec', 'strict'])

--- a/packages/release/src/commands/release-command.ts
+++ b/packages/release/src/commands/release-command.ts
@@ -11,6 +11,11 @@ export function createReleaseCommand(): Command {
     .option('-b, --bump <type>', 'Force bump type (patch|minor|major|prerelease)')
     .option('-p, --prerelease [identifier]', 'Create prerelease version')
     .option('--stable', 'Graduate prerelease packages to stable without bumping', false)
+    .option(
+      '--allow-first-bump',
+      'Acknowledge applying a bump on a first release with an already-stable manifest (silences the overshoot warning)',
+      false,
+    )
     .option('-s, --sync', 'Use synchronized versioning across all packages', false)
     .option('-t, --target <packages>', 'Target specific packages (comma-separated)')
     .option(
@@ -42,6 +47,7 @@ export function createReleaseCommand(): Command {
         bump: opts.bump,
         prerelease: opts.prerelease,
         stable: opts.stable,
+        allowFirstBump: opts.allowFirstBump,
         sync: opts.sync,
         target: opts.target,
         includePrerequisites: opts.includePrerequisites,

--- a/packages/release/src/steps.ts
+++ b/packages/release/src/steps.ts
@@ -20,6 +20,7 @@ export async function runVersionStep(options: ReleaseOptions): Promise<VersionOu
     bump: options.bump as import('semver').ReleaseType | undefined,
     prerelease: options.prerelease,
     stable: options.stable,
+    allowFirstBump: options.allowFirstBump,
     dryRun: options.dryRun,
     sync: options.sync,
     targets,

--- a/packages/release/src/types.ts
+++ b/packages/release/src/types.ts
@@ -7,6 +7,8 @@ export interface ReleaseOptions {
   bump?: string;
   prerelease?: string | boolean;
   stable?: boolean;
+  /** Acknowledge a first-release bump on an already-stable manifest (silences the #388 overshoot guard). */
+  allowFirstBump?: boolean;
   sync: boolean;
   target?: string;
   /** Also release the changed internal dependencies of `target` packages (and the rest of their groups). */

--- a/packages/version/src/command.ts
+++ b/packages/version/src/command.ts
@@ -14,6 +14,11 @@ export function createVersionCommand(): Command {
     .option('-b, --bump <type>', 'Specify bump type (patch|minor|major|prerelease)')
     .option('-p, --prerelease [identifier]', 'Create prerelease version')
     .option('--stable', 'Graduate prerelease packages to stable without bumping', false)
+    .option(
+      '--allow-first-bump',
+      'Acknowledge applying a bump on a first release with an already-stable manifest (silences the overshoot warning)',
+      false,
+    )
     .option('-s, --sync', 'Use synchronized versioning across all packages')
     .option('-j, --json', 'Output results as JSON', false)
     .option('-t, --target <packages>', 'Comma-delimited list of package names to target')
@@ -59,6 +64,7 @@ export function createVersionCommand(): Command {
           bump: options.bump,
           prerelease: options.prerelease,
           stable: options.stable,
+          allowFirstBump: options.allowFirstBump,
           dryRun: options.dryRun,
           sync: options.sync,
           targets: cliTargets.length > 0 ? cliTargets : undefined,

--- a/packages/version/src/core/versionCalculator.ts
+++ b/packages/version/src/core/versionCalculator.ts
@@ -46,9 +46,6 @@ export function applyOverrideScope(
 }
 
 /**
- * Calculates the next version number based on the current version and options
- */
-/**
  * First-release overshoot guard (#388): on a first release (no prior tag) with an already-stable
  * manifest, `--stable --bump <type>` APPLIES the bump (1.0.0 → 2.0.0) rather than graduating, which
  * silently overshoots the staged first version. The resolved version is deliberately left unchanged
@@ -73,6 +70,9 @@ function guardFirstReleaseBump(config: Config, name: string | undefined, current
   log(message, 'warning');
 }
 
+/**
+ * Calculates the next version number based on the current version and options
+ */
 export async function calculateVersion(config: Config, options: VersionOptions): Promise<string> {
   const scoped = applyOverrideScope(config, options);
   return calculateVersionInner(scoped.config, scoped.options);

--- a/packages/version/src/core/versionCalculator.ts
+++ b/packages/version/src/core/versionCalculator.ts
@@ -48,6 +48,31 @@ export function applyOverrideScope(
 /**
  * Calculates the next version number based on the current version and options
  */
+/**
+ * First-release overshoot guard (#388): on a first release (no prior tag) with an already-stable
+ * manifest, `--stable --bump <type>` APPLIES the bump (1.0.0 → 2.0.0) rather than graduating, which
+ * silently overshoots the staged first version. The resolved version is deliberately left unchanged
+ * — a bump is sometimes legitimate (importing a package with prior external history) — so this only
+ * makes the case visible/escapable per `mismatchStrategy`: `error` aborts, `ignore` is silent,
+ * everything else (default `warn`) warns. `version.allowFirstBump` (or `--allow-first-bump`)
+ * acknowledges it and stays silent. (prefer-package/prefer-git have no distinct meaning on the
+ * no-tag axis, so they warn like the default — see #388.)
+ */
+function guardFirstReleaseBump(config: Config, name: string | undefined, currentVer: string, type: ReleaseType): void {
+  if (config.allowFirstBump) return;
+  const pkg = name || 'package';
+  const bumped = bumpVersion(currentVer, type);
+  const message =
+    `${pkg} has no prior tag and a stable manifest (${currentVer}); --bump ${type} will publish ${bumped}, not ${currentVer}. ` +
+    `To release ${currentVer}, stage the manifest at a prerelease (e.g. ${currentVer}-next.0, which graduates), ` +
+    `or set version.allowFirstBump (or pass --allow-first-bump) to apply the bump.`;
+  if ((config.mismatchStrategy ?? 'warn') === 'error') {
+    throw new Error(`First-release version overshoot: ${message}`);
+  }
+  if (config.mismatchStrategy === 'ignore') return;
+  log(message, 'warning');
+}
+
 export async function calculateVersion(config: Config, options: VersionOptions): Promise<string> {
   const scoped = applyOverrideScope(config, options);
   return calculateVersionInner(scoped.config, scoped.options);
@@ -213,6 +238,11 @@ async function calculateVersionInner(config: Config, options: VersionOptions): P
         // No explicit bump label: skip already-stable packages
         log(`Skipping ${name || 'package'}: already at stable version ${currentVer}`, 'info');
         return '';
+      } else if (hasNoTags) {
+        // Stable manifest + explicit bump on a FIRST release: the bump is APPLIED (e.g. 1.0.0 +
+        // major = 2.0.0), not graduated, silently overshooting the staged first version (#388).
+        // Make it visible/escapable per mismatchStrategy; the resolved version is unchanged.
+        guardFirstReleaseBump(config, name, currentVer, type);
       }
       log(`Stable package with explicit bump label, falling through to normal logic`, 'debug');
       // Stable package with explicit bump label: fall through to normal bump logic

--- a/packages/version/src/core/versionEngine.ts
+++ b/packages/version/src/core/versionEngine.ts
@@ -58,6 +58,7 @@ export class VersionEngine {
         effective.isPrerelease = true;
       }
       if (runOptions.stable) effective.stableOnly = true;
+      if (runOptions.allowFirstBump) effective.allowFirstBump = true;
       if (runOptions.targets?.length) this.runtimeTargets = runOptions.targets;
       if (runOptions.baseRef) effective.baseRef = runOptions.baseRef;
       if (runOptions.overrideScope) effective.overrideScope = runOptions.overrideScope;

--- a/packages/version/src/types.ts
+++ b/packages/version/src/types.ts
@@ -23,6 +23,8 @@ export interface VersionRunOptions {
   /** Graduate prerelease packages to stable; skip already-stable packages
    *  unless bump is also set, in which case bump applies to stable packages. */
   stable?: boolean;
+  /** Acknowledge a first-release bump on a stable manifest, silencing the #388 overshoot guard. */
+  allowFirstBump?: boolean;
   dryRun?: boolean;
   sync?: boolean;
   /** Limit release to these package name patterns (comma-split targets from CLI). */
@@ -120,6 +122,9 @@ export interface Config extends VersionConfigBase {
    *  leaked into "Project-wide changes" (#397). Not user config. */
   allWorkspacePackages?: Array<{ name: string; dir: string }>;
   mismatchStrategy?: 'error' | 'warn' | 'ignore' | 'prefer-package' | 'prefer-git';
+  /** Acknowledge a first-release bump on an already-stable manifest, silencing the #388 overshoot
+   *  guard (which otherwise warns, or aborts under mismatchStrategy 'error'). See VersionConfig.allowFirstBump. */
+  allowFirstBump?: boolean;
   strictReachable?: boolean;
   /** Pre-1.0 inferred-breaking bump policy ('spec' | 'strict'). See docs/configuration.md#versionzeromajor. */
   zeroMajor?: 'spec' | 'strict';
@@ -212,6 +217,7 @@ export function toVersionConfig(config: VersionConfig | undefined, gitConfig?: G
     })),
     defaultReleaseType: config.defaultReleaseType as ReleaseType | undefined,
     mismatchStrategy: config.mismatchStrategy,
+    allowFirstBump: config.allowFirstBump,
     zeroMajor: config.zeroMajor,
     versionPrefix: config.versionPrefix ?? '',
     prereleaseIdentifier: config.prereleaseIdentifier,

--- a/packages/version/test/unit/core/versionCalculator.spec.ts
+++ b/packages/version/test/unit/core/versionCalculator.spec.ts
@@ -373,6 +373,57 @@ describe('Version Calculator', () => {
       expect(versionUtils.bumpVersion).toHaveBeenCalledWith('0.0.0', 'major', 'next');
       expect(version).toBe('1.0.0-next.0');
     });
+
+    // #388: a stable manifest on a first release with --stable applies the bump (1.0.0 → 2.0.0)
+    // rather than graduating, silently overshooting. The guard makes it visible/escapable without
+    // changing the resolved version.
+    function stableFirstReleaseMocks() {
+      vi.spyOn(versionUtils, 'getBestVersionSource').mockResolvedValue({
+        source: 'package',
+        version: '1.0.0',
+        reason: 'No git tag provided',
+      });
+      vi.spyOn(manifestHelpers, 'getVersionFromManifests').mockReturnValue({
+        version: '1.0.0',
+        manifestFound: true,
+        manifestPath: '/repo/packages/pkg/package.json',
+        manifestType: 'package.json',
+      });
+      vi.spyOn(semver, 'prerelease').mockReturnValue(null); // stable manifest
+      vi.spyOn(versionUtils, 'bumpVersion').mockReturnValue('2.0.0');
+    }
+    const stableFirstReleaseOptions: VersionOptions = {
+      latestTag: '',
+      hasRealTag: false,
+      type: 'major',
+      versionPrefix: 'v',
+      path: '/repo/packages/pkg',
+      name: 'my-pkg',
+    };
+
+    it('should warn but still apply the bump on a first-release stable manifest (#388)', async () => {
+      stableFirstReleaseMocks();
+      const config = { ...defaultConfig, stableOnly: true, type: 'major' as const };
+      const version = await calculateVersion(config as Config, stableFirstReleaseOptions);
+      expect(version).toBe('2.0.0'); // resolved version is unchanged — only made visible
+      expect(logging.log).toHaveBeenCalledWith(expect.stringContaining('will publish 2.0.0, not 1.0.0'), 'warning');
+    });
+
+    it('should abort a first-release stable-manifest bump under mismatchStrategy "error" (#388)', async () => {
+      stableFirstReleaseMocks();
+      const config = { ...defaultConfig, stableOnly: true, type: 'major' as const, mismatchStrategy: 'error' as const };
+      await expect(calculateVersion(config as Config, stableFirstReleaseOptions)).rejects.toThrow(
+        /First-release version overshoot/,
+      );
+    });
+
+    it('should apply the bump silently when allowFirstBump acknowledges it (#388)', async () => {
+      stableFirstReleaseMocks();
+      const config = { ...defaultConfig, stableOnly: true, type: 'major' as const, allowFirstBump: true };
+      const version = await calculateVersion(config as Config, stableFirstReleaseOptions);
+      expect(version).toBe('2.0.0');
+      expect(logging.log).not.toHaveBeenCalledWith(expect.stringContaining('will publish 2.0.0, not 1.0.0'), 'warning');
+    });
   });
 
   describe('Specified version type (explicit bump)', () => {

--- a/packages/version/test/unit/core/versionCalculator.spec.ts
+++ b/packages/version/test/unit/core/versionCalculator.spec.ts
@@ -424,6 +424,19 @@ describe('Version Calculator', () => {
       expect(version).toBe('2.0.0');
       expect(logging.log).not.toHaveBeenCalledWith(expect.stringContaining('will publish 2.0.0, not 1.0.0'), 'warning');
     });
+
+    it('should apply the bump silently under mismatchStrategy "ignore" (#388)', async () => {
+      stableFirstReleaseMocks();
+      const config = {
+        ...defaultConfig,
+        stableOnly: true,
+        type: 'major' as const,
+        mismatchStrategy: 'ignore' as const,
+      };
+      const version = await calculateVersion(config as Config, stableFirstReleaseOptions);
+      expect(version).toBe('2.0.0');
+      expect(logging.log).not.toHaveBeenCalledWith(expect.stringContaining('will publish 2.0.0, not 1.0.0'), 'warning');
+    });
   });
 
   describe('Specified version type (explicit bump)', () => {

--- a/releasekit.schema.json
+++ b/releasekit.schema.json
@@ -248,6 +248,11 @@
           "type": "string",
           "description": "Identifier for prerelease versions (e.g., 'alpha', 'beta')"
         },
+        "allowFirstBump": {
+          "type": "boolean",
+          "default": false,
+          "description": "Acknowledge applying a bump on a first release with an already-stable manifest. On a first release (no prior tag), `--stable --bump <type>` applies the bump (e.g. 1.0.0 → 2.0.0) rather than graduating, which can silently overshoot the staged first version. By default this is flagged per `mismatchStrategy` (warn, or abort under \"error\"); set true (or pass --allow-first-bump) to apply the bump silently — legitimate when importing a package with prior external version history."
+        },
         "strictReachable": {
           "type": "boolean",
           "default": false,


### PR DESCRIPTION
Part 1 of #388 (the remaining Part 2 is split into a follow-up — see below). Third of the 0.33.0 correctness cluster.

## Problem

On a first release (no prior tag), `--stable --bump <type>` behaves in opposite ways depending only on the manifest:
- **prerelease** manifest (`1.0.0-next.0`) → graduates to `1.0.0`, bump ignored ✅
- **already-stable** manifest (`1.0.0`) → nothing to graduate, so the bump is **applied** → `2.0.0`, silently overshooting the staged first version ⚠️

Staging a new package at its intended `1.0.0` therefore publishes `2.0.0`, and the dry-run summary shows only the final number.

## Fix (Part 1 — make it visible/escapable)

Per the issue and the agreed scope, the resolved version is **deliberately left unchanged** — applying a bump is sometimes legitimate (importing a package with prior external history). Instead:

- **Detect** first-release + stable manifest + explicit bump in the `stableOnly` path.
- **Surface per `mismatchStrategy`**: `error` aborts, `ignore` is silent, everything else (default `warn`) warns: *"@scope/pkg has no prior tag and a stable manifest (1.0.0); --bump major will publish 2.0.0, not 1.0.0. To release 1.0.0, stage the manifest at a prerelease, or set version.allowFirstBump / pass --allow-first-bump."*
- **Escape**: new `version.allowFirstBump` config + `--allow-first-bump` flag (release + version CLIs) acknowledges it and stays silent.

`prefer-package`/`prefer-git` have no distinct meaning on the no-tag axis, so they warn like the default (decision per the issue discussion: loud/abort axis only — don't invent pin semantics).

## Scope / follow-up

This is **Part 1**. The issue's **Part 2** — surfacing the resolved *action* (graduated vs bumped) + reason in the summary and `--json`, a cross-package `VersionOutput` contract change — is tracked as a separate follow-up issue (the issue itself calls them independent).

## Tests / generated

Guard unit tests (warn / error-aborts / allowFirstBump-silent), schema + `docs/configuration.md` + `docs/cli.md` updated. Full gate 27/27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a guard for a first-release overshoot bug (#388): when `--stable --bump <type>` is used on a package with no prior tag and an already-stable manifest (e.g. `1.0.0`), the bump is applied rather than graduated, silently publishing `2.0.0` instead of the staged `1.0.0`. The fix surfaces the situation via `mismatchStrategy` without changing the resolved version, and adds `version.allowFirstBump` / `--allow-first-bump` as an explicit opt-out.

- Adds `guardFirstReleaseBump` in `versionCalculator.ts` that fires only when `stableOnly` is true, the manifest is stable, an explicit bump type is present, and `hasNoTags` is true; behaviour varies by `mismatchStrategy` (warn/error/ignore/prefer-*) and is silenced by `allowFirstBump`.
- Threads the new flag through the CLI (`createVersionCommand`, `createReleaseCommand`), `VersionRunOptions`, `ReleaseOptions`, `Config`/`VersionConfig`, Zod schema, and JSON schema, with corresponding documentation updates.
- Adds four guard unit tests covering warn, error-aborts, `allowFirstBump`-silent, and `ignore`-silent paths.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the guard is narrowly scoped to the first-release / stable-manifest / explicit-bump intersection inside the stableOnly path, and the resolved version is deliberately left unchanged.

The new guard is correctly positioned after the `!type` early-return so `type` is always defined when `guardFirstReleaseBump` is called. The `allowFirstBump` flag is threaded consistently through CLI → engine → config, and all four mismatch-strategy branches (warn, error, ignore, prefer-*) are now covered by unit tests. The change is purely additive on the warning/error side — the actual computed version is never altered.

No files require special attention; the implementation is self-contained in `versionCalculator.ts` and its test file.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/version/src/core/versionCalculator.ts | Adds `guardFirstReleaseBump` and wires it into the `stableOnly` branch; placement is correct and all four mismatch-strategy paths are handled. |
| packages/version/src/core/versionEngine.ts | Propagates `runOptions.allowFirstBump` into the shallow-copied `effective` config; pattern is consistent with the existing flag-forwarding convention. |
| packages/version/src/types.ts | Adds `allowFirstBump` to both `VersionRunOptions` and `Config`, and maps it through `toVersionConfig`; all three touch-points are consistent. |
| packages/version/test/unit/core/versionCalculator.spec.ts | Adds all four guard branches (warn, error, allowFirstBump-silent, ignore-silent); mock setup is shared via `stableFirstReleaseMocks` helper for clarity. |
| packages/config/src/schema.ts | Adds `allowFirstBump` to `VersionConfigSchema` with correct Zod type, default, and description. |
| packages/release/src/commands/release-command.ts | Adds `--allow-first-bump` CLI option and forwards it to `ReleaseOptions`; consistent with the version command. |
| packages/version/src/command.ts | Adds `--allow-first-bump` to the version CLI and maps it to `allowFirstBump` in `VersionRunOptions`. |
| releasekit.schema.json | Adds `allowFirstBump` boolean property to the JSON schema with default false and accurate description. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["calculateVersionInner\n(stableOnly = true)"] --> B{semver.prerelease\ncurrentVer?}
    B -- yes --> C["Graduate to stable base\nreturn stableVersion"]
    B -- no --> D{type defined?}
    D -- no --> E["Skip package\nreturn ''"]
    D -- yes --> F{hasNoTags?}
    F -- no --> G["Fall through\nto normal bump logic"]
    F -- yes --> H["guardFirstReleaseBump\nconfig, name, currentVer, type"]
    H --> I{allowFirstBump?}
    I -- true --> G
    I -- false --> J{mismatchStrategy}
    J -- error --> K["throw Error\n'First-release version overshoot'"]
    J -- ignore --> G
    J -- warn / prefer-* / default --> L["log warning\n'will publish X, not Y'"]
    L --> G
    G --> M["bumpVersion\nreturn bumped version"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["calculateVersionInner\n(stableOnly = true)"] --> B{semver.prerelease\ncurrentVer?}
    B -- yes --> C["Graduate to stable base\nreturn stableVersion"]
    B -- no --> D{type defined?}
    D -- no --> E["Skip package\nreturn ''"]
    D -- yes --> F{hasNoTags?}
    F -- no --> G["Fall through\nto normal bump logic"]
    F -- yes --> H["guardFirstReleaseBump\nconfig, name, currentVer, type"]
    H --> I{allowFirstBump?}
    I -- true --> G
    I -- false --> J{mismatchStrategy}
    J -- error --> K["throw Error\n'First-release version overshoot'"]
    J -- ignore --> G
    J -- warn / prefer-* / default --> L["log warning\n'will publish X, not Y'"]
    L --> G
    G --> M["bumpVersion\nreturn bumped version"]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(version): un-orphan the calculateVer..."](https://github.com/goosewobbler/releasekit/commit/0edae7120addac32d8c3fa03e850dbdbdac8d697) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39620098)</sub>

<!-- /greptile_comment -->