### PR TITLE
fix(version): keep linked/fixed groups on the prerelease line when created from a stable baseline

### DIFF
--- a/packages/version/src/core/groupStrategy.ts
+++ b/packages/version/src/core/groupStrategy.ts
@@ -21,6 +21,7 @@ import * as path from 'node:path';
 import type { Package } from '@manypkg/get-packages';
 import type { VersionChangelogEntry } from '@releasekit/core';
 import { shouldMatchPackageTargets, shouldProcessPackage as shouldProcessPackageUtil } from '@releasekit/core';
+import type { ReleaseType } from 'semver';
 import semver from 'semver';
 import { extractChangelogEntriesFromCommits } from '../changelog/commitParser.js';
 import { BaseVersionError } from '../errors/baseError.js';
@@ -171,17 +172,34 @@ function computeGroup(group: ResolvedGroup, plans: MemberPlan[], config: Config)
   const maxRank = Math.max(...changedPlans.map(memberBumpRank));
   const bumpType = RANK_TO_TYPE[maxRank] ?? 'patch';
 
+  // A member can be *creating* a prerelease from a stable baseline (premajor/preminor/prepatch —
+  // e.g. 0.0.1 -> 1.0.0-next.0). RANK_TO_TYPE collapses those to a stable major/minor/patch
+  // magnitude, so applying the aggregate directly would graduate the group to a stable release,
+  // and the never-regress guard below can't recover it (1.0.0-next.0 < 1.0.0 in semver). Detect
+  // that and apply the pre-variant + identifier so the group stays on the prerelease line.
+  const creatingPrerelease =
+    bumpType !== 'prerelease' &&
+    !semver.prerelease(maxBaseline) &&
+    (config.isPrerelease || changedPlans.some((p) => semver.valid(p.ownNext) && semver.prerelease(p.ownNext) !== null));
+
   // Apply the aggregate bump once to the highest baseline in the group. For prerelease rank
   // (all changed members are on a prerelease family), pass the identifier so semver.inc
   // increments within the prerelease instead of graduating to a stable release. Members whose
   // own bump already produced a higher version still pull the group version up via the
   // never-regress guard below.
-  let groupVersion =
-    bumpType === 'prerelease'
-      ? config.prereleaseIdentifier
-        ? (semver.inc(maxBaseline, 'prerelease', config.prereleaseIdentifier) ?? maxBaseline)
-        : maxBaseline
-      : (semver.inc(maxBaseline, bumpType) ?? maxBaseline);
+  let groupVersion: string;
+  if (bumpType === 'prerelease') {
+    groupVersion = config.prereleaseIdentifier
+      ? (semver.inc(maxBaseline, 'prerelease', config.prereleaseIdentifier) ?? maxBaseline)
+      : maxBaseline;
+  } else if (creatingPrerelease) {
+    const preBump = `pre${bumpType}` as ReleaseType;
+    groupVersion = config.prereleaseIdentifier
+      ? (semver.inc(maxBaseline, preBump, config.prereleaseIdentifier) ?? maxBaseline)
+      : (semver.inc(maxBaseline, preBump) ?? maxBaseline);
+  } else {
+    groupVersion = semver.inc(maxBaseline, bumpType) ?? maxBaseline;
+  }
 
   // Never let the group version regress below any member's independently-computed next version
   // (covers prerelease increments and members whose own bump already exceeded the aggregate).

--- a/packages/version/src/core/groupStrategy.ts
+++ b/packages/version/src/core/groupStrategy.ts
@@ -177,6 +177,11 @@ function computeGroup(group: ResolvedGroup, plans: MemberPlan[], config: Config)
   // magnitude, so applying the aggregate directly would graduate the group to a stable release,
   // and the never-regress guard below can't recover it (1.0.0-next.0 < 1.0.0 in semver). Detect
   // that and apply the pre-variant + identifier so the group stays on the prerelease line.
+  //
+  // Two signals, by design: `config.isPrerelease` is the explicit, authoritative request (the user
+  // passed --prerelease / the prerelease channel) — when set, the group belongs on the prerelease
+  // line regardless of per-member magnitudes. The member-scan is the inference fallback for when the
+  // flag isn't set globally but a member's own calculation already produced a prerelease.
   const creatingPrerelease =
     bumpType !== 'prerelease' &&
     !semver.prerelease(maxBaseline) &&

--- a/packages/version/test/unit/core/groupStrategy.spec.ts
+++ b/packages/version/test/unit/core/groupStrategy.spec.ts
@@ -261,6 +261,35 @@ describe('createGroupStrategy', () => {
         undefined,
       );
     });
+
+    it('should stay on the prerelease line when a member creates a prerelease from a stable baseline', async () => {
+      // Regression: a linked group's first prerelease (premajor 0.0.1 -> 1.0.0-next.0). The
+      // aggregate magnitude is a stable `major`, so without the pre-variant the group graduates to
+      // 1.0.0, and the never-regress guard can't recover it (1.0.0-next.0 < 1.0.0 in semver).
+      const service = mkPackage('@wdio/flutter-service', '0.0.1');
+      const contract = mkPackage('wdio_flutter', '0.0.1');
+
+      // Only the service earned a change — a premajor prerelease.
+      vi.mocked(calculator.calculateVersion).mockImplementation(async (_cfg, opts) => {
+        if (opts.name === '@wdio/flutter-service') return '1.0.0-next.0';
+        return '';
+      });
+
+      const strategy = createGroupStrategy(
+        baseConfig({
+          prereleaseIdentifier: 'next',
+          groups: { flutter: { packages: ['@wdio/flutter-service', 'wdio_flutter'], sync: 'linked' } },
+        }),
+      );
+      await strategy(workspace([service, contract]));
+
+      expect(packageManagement.updatePackageVersion).toHaveBeenCalledTimes(1);
+      expect(packageManagement.updatePackageVersion).toHaveBeenCalledWith(
+        '/ws/packages/wdio-flutter-service/package.json',
+        '1.0.0-next.0',
+        undefined,
+      );
+    });
   });
 
   describe('group baseline = max(member baselines)', () => {

--- a/packages/version/test/unit/core/groupStrategy.spec.ts
+++ b/packages/version/test/unit/core/groupStrategy.spec.ts
@@ -290,6 +290,40 @@ describe('createGroupStrategy', () => {
         undefined,
       );
     });
+
+    it('should stay on the prerelease line for a fixed group creating a prerelease from a stable baseline', async () => {
+      // Same premajor-from-stable bug, fixed mode: the aggregate magnitude (stable major) would
+      // graduate to 1.0.0. sync only affects which members release (fixed releases ALL of them, even
+      // the unchanged contract), not the groupVersion computation — so the fix must hold here too.
+      const service = mkPackage('@wdio/flutter-service', '0.0.1');
+      const contract = mkPackage('wdio_flutter', '0.0.1');
+
+      vi.mocked(calculator.calculateVersion).mockImplementation(async (_cfg, opts) => {
+        if (opts.name === '@wdio/flutter-service') return '1.0.0-next.0';
+        return '';
+      });
+
+      const strategy = createGroupStrategy(
+        baseConfig({
+          prereleaseIdentifier: 'next',
+          groups: { flutter: { packages: ['@wdio/flutter-service', 'wdio_flutter'], sync: 'fixed' } },
+        }),
+      );
+      await strategy(workspace([service, contract]));
+
+      // Fixed → both members release at the shared prerelease version, none graduated to 1.0.0.
+      expect(packageManagement.updatePackageVersion).toHaveBeenCalledTimes(2);
+      expect(packageManagement.updatePackageVersion).toHaveBeenCalledWith(
+        '/ws/packages/wdio-flutter-service/package.json',
+        '1.0.0-next.0',
+        undefined,
+      );
+      expect(packageManagement.updatePackageVersion).toHaveBeenCalledWith(
+        '/ws/packages/wdio_flutter/package.json',
+        '1.0.0-next.0',
+        undefined,
+      );
+    });
   });
 
   describe('group baseline = max(member baselines)', () => {


### PR DESCRIPTION
## Bug

A `linked` or `fixed` version group's **first prerelease from a stable baseline** graduates to a **stable** release. Requesting `premajor` (e.g. `release_type=prerelease`, `bump=major`) on a group whose members are at a stable version like `0.0.1` produces `1.0.0` instead of `1.0.0-next.0`.

Observed driving a first flutter-service prerelease (linked group, baseline `0.0.1`). The per-package calculator computes the correct `1.0.0-next.0`, but the group aggregate overrides it:

```
[DEBUG] Specified type version: 1.0.0-next.0                 ← per-package calc: correct
Group "flutter" (linked): releasing 1 member(s) at 1.0.0.   ← group OVERRODE it
```

## Root cause

`computeGroup` aggregates member bump *magnitudes* through `BUMP_RANK` → `RANK_TO_TYPE`:

- `BUMP_RANK`: `premajor` and `major` are **both rank 3** (the "pre" is dropped).
- `RANK_TO_TYPE[3]` = `'major'` (stable) → `semver.inc('0.0.1', 'major')` = `1.0.0`.

Only rank 0 (`prerelease` = *incrementing within an existing* prerelease family) is prerelease-aware. A prerelease **created from a stable baseline** (premajor/preminor/prepatch) is graduated to stable. The never-regress guard can't recover it because the member's correct value is semver-less-than the graduated stable version (`1.0.0-next.0 < 1.0.0`).

The per-package strategy doesn't have this bug — it infers the prerelease from the `premajor` bump type directly; only the linked/fixed **aggregate** loses it.

## Fix

Detect when the aggregate represents a prerelease *created from a stable baseline* — `config.isPrerelease`, or a changed member whose own next version is a prerelease while the group's max baseline is stable — and apply the `pre`-variant + identifier instead of the stable aggregate:

```ts
} else if (creatingPrerelease) {
  const preBump = `pre${bumpType}` as ReleaseType;   // major → premajor, etc.
  groupVersion = config.prereleaseIdentifier
    ? (semver.inc(maxBaseline, preBump, config.prereleaseIdentifier) ?? maxBaseline)
    : (semver.inc(maxBaseline, preBump) ?? maxBaseline);
}
```

→ `semver.inc('0.0.1', 'premajor', 'next')` = `1.0.0-next.0`. The existing rank-0 prerelease-increment path and the stable path are unchanged. Covers `linked` and `fixed` groups and all three pre-variants, so it applies to every group's first prerelease from a stable baseline (not just the flutter case that surfaced it).

## Tests

- New regression test: a linked group at baseline `0.0.1` with a member earning a premajor prerelease now releases `1.0.0-next.0`, not `1.0.0`. Verified it **fails on `main`** (`expected '1.0.0-next.0', got '1.0.0'`) and **passes with the fix**.
- Full `@wdio/version` unit suite: **648/648 pass**. `tsc --noEmit` and `biome check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug in `computeGroup` where the first prerelease bump from a stable baseline (e.g. `premajor` on `0.0.1`) was collapsed to a stable release (`1.0.0`) because `BUMP_RANK` maps both `major` and `premajor` to rank 3, and `RANK_TO_TYPE[3]` is `'major'`. The fix adds a `creatingPrerelease` guard that detects this situation and applies the `pre${bumpType}` variant, keeping the group on the prerelease line.

- **`groupStrategy.ts`**: Introduces `creatingPrerelease` detection using two signals — `config.isPrerelease` (authoritative flag) or a member whose `ownNext` is already a prerelease — and routes into a new `else if` branch that calls `semver.inc` with `premajor`/`preminor`/`prepatch` instead of the stable variant.
- **`groupStrategy.spec.ts`**: Adds two regression tests (one for `linked`, one for `fixed` sync mode) that verify the group version stays on the prerelease line at `1.0.0-next.0` instead of graduating to `1.0.0`.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the fix is tightly scoped to the new `creatingPrerelease` branch, the existing stable and prerelease-increment paths are untouched, and the never-regress guard continues to act as a correctness backstop.

The change adds a well-guarded branch that only fires when the group's max baseline is stable, the bump magnitude is not already a prerelease-increment, and either the global prerelease flag is set or a member's own computed next is a prerelease. All 648 unit tests pass, and two new regression tests confirm the fix for both `linked` and `fixed` sync modes. The one open design question about `config.isPrerelease` acting as a blunt override was raised in the previous review cycle and is a pre-existing policy choice rather than a defect introduced here.

No files require special attention beyond what was already discussed in prior review threads.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/version/src/core/groupStrategy.ts | Adds `creatingPrerelease` detection and a new `else if` branch in `computeGroup` to apply `pre${bumpType}` when creating a prerelease from a stable baseline; the `config.isPrerelease` arm can fire even when per-member calculations produced no prerelease (flagged in previous thread). |
| packages/version/test/unit/core/groupStrategy.spec.ts | Adds two regression tests covering linked and fixed group modes for the premajor-from-stable bug; both scenarios are correctly asserted. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[computeGroup called] --> B{group.sync == independent?}
    B -- yes --> C[return each member's ownNext]
    B -- no --> D[maxBaseline = max of all member baselines]
    D --> E[maxRank = max memberBumpRank across changedPlans]
    E --> F[bumpType = RANK_TO_TYPE of maxRank]
    F --> G{bumpType == prerelease?}
    G -- yes --> H[semver.inc with 'prerelease' + identifier]
    G -- no --> I{creatingPrerelease?\nbumpType != prerelease\n&& !prerelease in maxBaseline\n&& isPrerelease config OR member ownNext is prerelease}
    I -- yes --> J["preBump = pre + bumpType\nsemver.inc(maxBaseline, preBump, identifier)"]
    I -- no --> K["semver.inc(maxBaseline, bumpType)"]
    H --> L[never-regress guard: take max of groupVersion and each member ownNext]
    J --> L
    K --> L
    L --> M[fixed: release ALL members\nlinked: release only changed members]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[computeGroup called] --> B{group.sync == independent?}
    B -- yes --> C[return each member's ownNext]
    B -- no --> D[maxBaseline = max of all member baselines]
    D --> E[maxRank = max memberBumpRank across changedPlans]
    E --> F[bumpType = RANK_TO_TYPE of maxRank]
    F --> G{bumpType == prerelease?}
    G -- yes --> H[semver.inc with 'prerelease' + identifier]
    G -- no --> I{creatingPrerelease?\nbumpType != prerelease\n&& !prerelease in maxBaseline\n&& isPrerelease config OR member ownNext is prerelease}
    I -- yes --> J["preBump = pre + bumpType\nsemver.inc(maxBaseline, preBump, identifier)"]
    I -- no --> K["semver.inc(maxBaseline, bumpType)"]
    H --> L[never-regress guard: take max of groupVersion and each member ownNext]
    J --> L
    K --> L
    L --> M[fixed: release ALL members\nlinked: release only changed members]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["test(version): cover fixed-group prerele..."](https://github.com/goosewobbler/releasekit/commit/ba1750b72672425d74475c52c65add8d9dd5456a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39629990)</sub>

<!-- /greptile_comment -->