### PR TITLE
refactor(notes): deepen the shared LLM-task module (#361)

### DIFF
--- a/packages/notes/src/llm/tasks/categorize.ts
+++ b/packages/notes/src/llm/tasks/categorize.ts
@@ -1,38 +1,33 @@
 import { warn } from '@releasekit/core';
 import type { ChangelogEntry, LLMCategory } from '../../core/types.js';
 import { LLMError } from '../../errors/index.js';
-import { extractJsonFromResponse } from '../../utils/json.js';
-import type { ValidationResult } from '../correctiveRetry.js';
-import { withCorrectiveRetry } from '../correctiveRetry.js';
 import type { CategorizeContext, CategorizedEntries, LLMProvider } from '../index.js';
-import type { CompleteResult, LLMMessage } from '../messages.js';
+import type { LLMMessage } from '../messages.js';
 import { resolveSystemPrompt } from '../prompts.js';
 import { buildCategorizeSchema, CategorizeOutputSchema } from '../schemas.js';
 import { getAllowedScopesFromCategories, validateEntryScopes } from '../scopes.js';
-import { groupByCategory } from './shared.js';
+import {
+  buildCategorySection,
+  checkCategoryNames,
+  groupByCategory,
+  parseLLMResult,
+  renderScopeInstruction,
+  runCorrectiveTask,
+  type TaskValidator,
+} from './shared.js';
 
 function buildSystemPrompt(categories: LLMCategory[] | undefined): string {
-  const categorySection =
-    categories && categories.length > 0
-      ? `Categories (use ONLY these exact names):\n${categories
-          .map((c) => {
-            const scopeInfo = c.scopes?.length ? ` Allowed scopes: ${c.scopes.join(', ')}.` : '';
-            return `- "${c.name}": ${c.description}${scopeInfo}`;
-          })
-          .join('\n')}`
-      : `Categories: Group into meaningful categories (e.g., "Core", "UI", "API", "Performance", "Bug Fixes", "Documentation").`;
+  const categorySection = buildCategorySection(
+    categories,
+    `Categories: Group into meaningful categories (e.g., "Core", "UI", "API", "Performance", "Bug Fixes", "Documentation").`,
+  );
 
-  let scopeInstruction = '';
-  if (categories && categories.length > 0) {
-    const scopeMap = getAllowedScopesFromCategories(categories);
-    if (scopeMap.size > 0) {
-      const parts: string[] = [];
-      for (const [catName, scopes] of scopeMap) {
-        parts.push(`For "${catName}", use a scope from: ${scopes.join(', ')}.`);
-      }
-      scopeInstruction = `\n${parts.join('\n')}\nOnly use scopes from these predefined lists. Set scope to null if no scope applies.`;
-    }
-  }
+  // Scope source: explicit category `scopes` arrays via getAllowedScopesFromCategories.
+  const pairs =
+    categories && categories.length > 0
+      ? [...getAllowedScopesFromCategories(categories)].map(([name, scopes]) => ({ name, scopes }))
+      : [];
+  const scopeInstruction = renderScopeInstruction(pairs, '');
 
   return `You are categorizing changelog entries for a software release.
 
@@ -48,36 +43,18 @@ function buildUserPrompt(entries: ChangelogEntry[]): string {
   return `Entries:\n${text}`;
 }
 
-function buildCorrectionMessages(_badContent: string, error: string): LLMMessage[] {
-  return [
-    {
-      role: 'user',
-      content: `Your previous response had an error: ${error}
-
-Please fix the issue and output only valid JSON matching the required schema.`,
-    },
-  ];
-}
-
-function makeValidator(
+export function createCategorizeValidator(
   entries: ChangelogEntry[],
   context: CategorizeContext,
-): (result: CompleteResult) => ValidationResult<CategorizedEntries[]> {
+): TaskValidator<CategorizedEntries[]> {
   // Work with a copy that has scopes cleared (LLM assigns them fresh)
   const cleanEntries = entries.map((e) => ({ ...e, scope: undefined }));
 
   return (result) => {
-    let parsed: unknown;
-    try {
-      parsed =
-        typeof result.structured !== 'undefined'
-          ? result.structured
-          : JSON.parse(extractJsonFromResponse(result.content));
-    } catch (e) {
-      return { valid: false, error: `Invalid JSON: ${e instanceof Error ? e.message : String(e)}` };
-    }
+    const parsed = parseLLMResult(result);
+    if (!parsed.ok) return { valid: false, error: parsed.error };
 
-    const zodResult = CategorizeOutputSchema.safeParse(parsed);
+    const zodResult = CategorizeOutputSchema.safeParse(parsed.data);
     if (!zodResult.success) {
       return { valid: false, error: `Schema error: ${zodResult.error.message}` };
     }
@@ -90,17 +67,11 @@ function makeValidator(
     }
 
     // Validate category names when categories are configured
-    const categoryNames = context.categories?.map((c) => c.name);
-    if (categoryNames?.length) {
-      const invalid = zodResult.data.entries.filter((e) => !categoryNames.includes(e.category)).map((e) => e.category);
-      if (invalid.length > 0) {
-        const unique = [...new Set(invalid)];
-        return {
-          valid: false,
-          error: `Unknown categories: ${unique.join(', ')}. Valid categories: ${categoryNames.join(', ')}`,
-        };
-      }
-    }
+    const categoryError = checkCategoryNames(
+      zodResult.data.entries,
+      context.categories?.map((c) => c.name),
+    );
+    if (categoryError) return { valid: false, error: categoryError };
 
     // Apply scopes from LLM response
     const withScopes: ChangelogEntry[] = cleanEntries.map((entry, i) => {
@@ -140,22 +111,14 @@ export async function categorizeEntries(
     { role: 'user', content: buildUserPrompt(entries) },
   ];
 
-  const schema = buildCategorizeSchema(context.categories ?? []);
-  const validate = makeValidator(entries, context);
-
   try {
-    return await withCorrectiveRetry(
-      (messages, isFirstAttempt) =>
-        provider.complete(
-          messages,
-          isFirstAttempt && provider.capabilities.structuredOutputs
-            ? { schema, toolName: 'categorize_entries' }
-            : undefined,
-        ),
-      validate,
-      buildCorrectionMessages,
+    return await runCorrectiveTask({
+      provider,
       initialMessages,
-    );
+      schema: buildCategorizeSchema(context.categories ?? []),
+      toolName: 'categorize_entries',
+      validate: createCategorizeValidator(entries, context),
+    });
   } catch (error) {
     if (error instanceof LLMError) {
       warn(`categorizeEntries failed after all attempts: ${error.message}. Returning entries under General.`);

--- a/packages/notes/src/llm/tasks/enhance-and-categorize.ts
+++ b/packages/notes/src/llm/tasks/enhance-and-categorize.ts
@@ -1,18 +1,24 @@
 import { warn } from '@releasekit/core';
 import type { ChangelogEntry, LLMCategory } from '../../core/types.js';
 import { LLMError } from '../../errors/index.js';
-import { extractJsonFromResponse } from '../../utils/json.js';
-import type { ValidationResult } from '../correctiveRetry.js';
-import { withCorrectiveRetry } from '../correctiveRetry.js';
 import { renderExamplesBlock } from '../examples/parser.js';
 import type { CategorizeContext, CategorizedEntries, EnhanceContext, LLMProvider } from '../index.js';
-import type { CompleteResult, LLMMessage } from '../messages.js';
+import type { LLMMessage } from '../messages.js';
 import { resolveSystemPrompt } from '../prompts.js';
 import { buildEnhanceAndCategorizeSchema, EnhanceAndCategorizeOutputSchema } from '../schemas.js';
 import { validateEntryScopes } from '../scopes.js';
-import { groupByCategory, renderPRBlocks } from './shared.js';
+import {
+  buildCategorySection,
+  checkCategoryNames,
+  groupByCategory,
+  parseLLMResult,
+  renderPRBlocks,
+  renderScopeInstruction,
+  runCorrectiveTask,
+  type TaskValidator,
+} from './shared.js';
 
-interface CombinedResult {
+export interface CombinedResult {
   enhancedEntries: ChangelogEntry[];
   categories: CategorizedEntries[];
 }
@@ -20,24 +26,17 @@ interface CombinedResult {
 function buildSystemPrompt(categories: LLMCategory[] | undefined, style: string | undefined): string {
   const styleText = style || 'Use past tense ("Added feature" not "Add feature"). Be concise.';
 
-  const categorySection =
-    categories && categories.length > 0
-      ? `Categories (use ONLY these exact names):\n${categories
-          .map((c) => {
-            const scopeInfo = c.scopes?.length ? ` Allowed scopes: ${c.scopes.join(', ')}.` : '';
-            return `- "${c.name}": ${c.description}${scopeInfo}`;
-          })
-          .join('\n')}`
-      : `Categories: Group into meaningful categories (e.g., "New", "Fixed", "Changed", "Removed").`;
+  const categorySection = buildCategorySection(
+    categories,
+    `Categories: Group into meaningful categories (e.g., "New", "Fixed", "Changed", "Removed").`,
+  );
 
-  let scopeInstruction = '';
-  if (categories && categories.length > 0) {
-    const withScopes = categories.filter((c) => c.scopes?.length);
-    if (withScopes.length > 0) {
-      const parts = withScopes.map((c) => `For "${c.name}" entries, use a scope from: ${c.scopes?.join(', ')}.`);
-      scopeInstruction = `\n${parts.join('\n')}\nOnly use scopes from these predefined lists. Set scope to null if no scope applies.`;
-    }
-  }
+  // Scope source: categories whose own `scopes` array is non-empty.
+  const pairs =
+    categories && categories.length > 0
+      ? categories.filter((c) => c.scopes?.length).map((c) => ({ name: c.name, scopes: c.scopes! }))
+      : [];
+  const scopeInstruction = renderScopeInstruction(pairs, ' entries');
 
   return `You are generating release notes for a software project. Given changelog entries, rewrite each as a clear user-friendly description and categorize it.
 
@@ -71,35 +70,17 @@ function buildUserPrompt(entries: ChangelogEntry[]): string {
   return `Entries:\n${entriesText}`;
 }
 
-function buildCorrectionMessages(_badContent: string, error: string): LLMMessage[] {
-  return [
-    {
-      role: 'user',
-      content: `Your previous response had an error: ${error}
-
-Please fix the issue and output only valid JSON matching the required schema.`,
-    },
-  ];
-}
-
-function makeValidator(
+export function createEnhanceAndCategorizeValidator(
   entries: ChangelogEntry[],
   context: EnhanceContext & CategorizeContext,
-): (result: CompleteResult) => ValidationResult<CombinedResult> {
+): TaskValidator<CombinedResult> {
   return (result) => {
     // Parse JSON (structured output or text fallback)
-    let parsed: unknown;
-    try {
-      parsed =
-        typeof result.structured !== 'undefined'
-          ? result.structured
-          : JSON.parse(extractJsonFromResponse(result.content));
-    } catch (e) {
-      return { valid: false, error: `Invalid JSON: ${e instanceof Error ? e.message : String(e)}` };
-    }
+    const parsed = parseLLMResult(result);
+    if (!parsed.ok) return { valid: false, error: parsed.error };
 
     // Validate structure
-    const zodResult = EnhanceAndCategorizeOutputSchema.safeParse(parsed);
+    const zodResult = EnhanceAndCategorizeOutputSchema.safeParse(parsed.data);
     if (!zodResult.success) {
       return { valid: false, error: `Schema error: ${zodResult.error.message}` };
     }
@@ -117,17 +98,11 @@ function makeValidator(
     }
 
     // Validate category names when categories are configured
-    const categoryNames = context.categories?.map((c) => c.name);
-    if (categoryNames?.length) {
-      const invalid = zodResult.data.entries.filter((e) => !categoryNames.includes(e.category)).map((e) => e.category);
-      if (invalid.length > 0) {
-        const unique = [...new Set(invalid)];
-        return {
-          valid: false,
-          error: `Unknown categories: ${unique.join(', ')}. Valid categories: ${categoryNames.join(', ')}`,
-        };
-      }
-    }
+    const categoryError = checkCategoryNames(
+      zodResult.data.entries,
+      context.categories?.map((c) => c.name),
+    );
+    if (categoryError) return { valid: false, error: categoryError };
 
     // Build enhanced entries
     const enhancedEntries: ChangelogEntry[] = entries.map((original, i) => {
@@ -185,22 +160,14 @@ export async function enhanceAndCategorize(
     { role: 'user', content: buildUserPrompt(entries) },
   ];
 
-  const schema = buildEnhanceAndCategorizeSchema(context.categories ?? []);
-  const validate = makeValidator(entries, context);
-
   try {
-    return await withCorrectiveRetry(
-      (messages, isFirstAttempt) =>
-        provider.complete(
-          messages,
-          isFirstAttempt && provider.capabilities.structuredOutputs
-            ? { schema, toolName: 'emit_release_notes' }
-            : undefined,
-        ),
-      validate,
-      buildCorrectionMessages,
+    return await runCorrectiveTask({
+      provider,
       initialMessages,
-    );
+      schema: buildEnhanceAndCategorizeSchema(context.categories ?? []),
+      toolName: 'emit_release_notes',
+      validate: createEnhanceAndCategorizeValidator(entries, context),
+    });
   } catch (error) {
     if (error instanceof LLMError) {
       warn(`enhanceAndCategorize failed after all attempts: ${error.message}. Returning entries ungrouped.`);

--- a/packages/notes/src/llm/tasks/shared.ts
+++ b/packages/notes/src/llm/tasks/shared.ts
@@ -1,5 +1,10 @@
-import type { ChangelogEntry } from '../../core/types.js';
+import type { ChangelogEntry, JSONSchema, LLMCategory } from '../../core/types.js';
+import { extractJsonFromResponse } from '../../utils/json.js';
+import type { ValidationResult } from '../correctiveRetry.js';
+import { withCorrectiveRetry } from '../correctiveRetry.js';
 import type { CategorizedEntries } from '../index.js';
+import type { CompleteResult, LLMMessage } from '../messages.js';
+import type { LLMProvider } from '../provider.js';
 
 export function escAttr(s: string): string {
   return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/"/g, '&quot;');
@@ -39,4 +44,100 @@ export function groupByCategory(
     result.push({ category, entries: catEntries });
   }
   return result;
+}
+
+/**
+ * Renders the "Categories" section of a task system prompt. When categories are
+ * configured it lists each name/description (plus any allowed scopes); otherwise
+ * it returns the task-specific free-form `fallback` instruction.
+ */
+export function buildCategorySection(categories: LLMCategory[] | undefined, fallback: string): string {
+  if (!categories || categories.length === 0) return fallback;
+  const lines = categories.map((c) => {
+    const scopeInfo = c.scopes?.length ? ` Allowed scopes: ${c.scopes.join(', ')}.` : '';
+    return `- "${c.name}": ${c.description}${scopeInfo}`;
+  });
+  return `Categories (use ONLY these exact names):\n${lines.join('\n')}`;
+}
+
+/**
+ * Renders the per-category scope instruction block. `entrySuffix` distinguishes
+ * the two callers' wording (categorize: `For "X", …`; enhance: `For "X" entries, …`).
+ * The scope-source resolution stays in each task — only the final rendering is shared.
+ */
+export function renderScopeInstruction(pairs: Array<{ name: string; scopes: string[] }>, entrySuffix: string): string {
+  if (pairs.length === 0) return '';
+  const parts = pairs.map((p) => `For "${p.name}"${entrySuffix}, use a scope from: ${p.scopes.join(', ')}.`);
+  return `\n${parts.join('\n')}\nOnly use scopes from these predefined lists. Set scope to null if no scope applies.`;
+}
+
+export function buildCorrectionMessages(_badContent: string, error: string): LLMMessage[] {
+  return [
+    {
+      role: 'user',
+      content: `Your previous response had an error: ${error}
+
+Please fix the issue and output only valid JSON matching the required schema.`,
+    },
+  ];
+}
+
+/**
+ * Parses an LLM completion into a value, preferring structured output and
+ * falling back to JSON extracted from the text content. Returns a discriminated
+ * result so callers can surface the exact `Invalid JSON: …` error on failure.
+ */
+export function parseLLMResult(result: CompleteResult): { ok: true; data: unknown } | { ok: false; error: string } {
+  try {
+    const data =
+      typeof result.structured !== 'undefined'
+        ? result.structured
+        : JSON.parse(extractJsonFromResponse(result.content));
+    return { ok: true, data };
+  } catch (e) {
+    return { ok: false, error: `Invalid JSON: ${e instanceof Error ? e.message : String(e)}` };
+  }
+}
+
+/**
+ * Validates that every entry's category is one of the configured `categoryNames`.
+ * Returns the error string (with the deduped offenders) or `null` when all are
+ * valid or no categories are configured.
+ */
+export function checkCategoryNames(
+  llmEntries: Array<{ category: string }>,
+  categoryNames: string[] | undefined,
+): string | null {
+  if (!categoryNames?.length) return null;
+  const invalid = llmEntries.filter((e) => !categoryNames.includes(e.category)).map((e) => e.category);
+  if (invalid.length === 0) return null;
+  const unique = [...new Set(invalid)];
+  return `Unknown categories: ${unique.join(', ')}. Valid categories: ${categoryNames.join(', ')}`;
+}
+
+export type TaskValidator<T> = (result: CompleteResult) => ValidationResult<T>;
+
+/**
+ * Drives a structured-output task through `withCorrectiveRetry`: builds the
+ * completion closure (passing schema/toolName only on the first attempt when the
+ * provider supports structured outputs) and applies the per-task `validate`.
+ */
+export async function runCorrectiveTask<T>(opts: {
+  provider: LLMProvider;
+  initialMessages: LLMMessage[];
+  schema: JSONSchema;
+  toolName: string;
+  validate: TaskValidator<T>;
+}): Promise<T> {
+  const { provider, initialMessages, schema, toolName, validate } = opts;
+  return withCorrectiveRetry(
+    (messages, isFirstAttempt) =>
+      provider.complete(
+        messages,
+        isFirstAttempt && provider.capabilities.structuredOutputs ? { schema, toolName } : undefined,
+      ),
+    validate,
+    buildCorrectionMessages,
+    initialMessages,
+  );
 }

--- a/packages/notes/test/unit/llm/tasks.spec.ts
+++ b/packages/notes/test/unit/llm/tasks.spec.ts
@@ -1,0 +1,260 @@
+import { describe, expect, it } from 'vitest';
+import type { ChangelogEntry } from '../../../src/core/types.js';
+import type { CompleteResult } from '../../../src/llm/messages.js';
+import { createCategorizeValidator } from '../../../src/llm/tasks/categorize.js';
+import { createEnhanceAndCategorizeValidator } from '../../../src/llm/tasks/enhance-and-categorize.js';
+import { buildCategorySection, renderScopeInstruction } from '../../../src/llm/tasks/shared.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const entries: ChangelogEntry[] = [
+  { type: 'added', description: 'Add streaming support' },
+  { type: 'fixed', description: 'Fix null pointer in parser' },
+  { type: 'changed', description: 'Refactor config loading' },
+];
+
+const ctx = { packageName: 'my-lib', version: '2.0.0', previousVersion: '1.0.0' };
+
+/** Wraps a structured payload as a CompleteResult (structured-output path). */
+function structured(value: unknown): CompleteResult {
+  return { content: JSON.stringify(value), structured: value };
+}
+
+// ---------------------------------------------------------------------------
+// createCategorizeValidator
+// ---------------------------------------------------------------------------
+
+describe('createCategorizeValidator()', () => {
+  it('should validate a well-formed response and group entries by category', () => {
+    const validate = createCategorizeValidator(entries, ctx);
+    const result = validate(
+      structured({
+        entries: [
+          { category: 'New Features', scope: null },
+          { category: 'Bug Fixes', scope: null },
+          { category: 'Bug Fixes', scope: null },
+        ],
+      }),
+    );
+
+    expect(result.valid).toBe(true);
+    if (!result.valid) return;
+    expect(result.value).toHaveLength(2);
+    expect(result.value.find((c) => c.category === 'New Features')?.entries).toHaveLength(1);
+    expect(result.value.find((c) => c.category === 'Bug Fixes')?.entries).toHaveLength(2);
+  });
+
+  it('should reject malformed JSON with an Invalid JSON error', () => {
+    const validate = createCategorizeValidator(entries, ctx);
+    const result = validate({ content: 'not json', structured: undefined });
+
+    expect(result.valid).toBe(false);
+    if (result.valid) return;
+    expect(result.error).toContain('Invalid JSON');
+  });
+
+  it('should reject a response whose entry count does not match the input', () => {
+    const validate = createCategorizeValidator(entries, ctx);
+    const result = validate(structured({ entries: [{ category: 'New', scope: null }] }));
+
+    expect(result.valid).toBe(false);
+    if (result.valid) return;
+    expect(result.error).toBe('Expected 3 entries, got 1');
+  });
+
+  it('should reject categories outside the configured list', () => {
+    const validate = createCategorizeValidator(entries, {
+      ...ctx,
+      categories: [
+        { name: 'New Features', description: 'New things' },
+        { name: 'Bug Fixes', description: 'Fixes' },
+      ],
+    });
+    const result = validate(
+      structured({
+        entries: [
+          { category: 'New Features', scope: null },
+          { category: 'Mystery', scope: null },
+          { category: 'Bug Fixes', scope: null },
+        ],
+      }),
+    );
+
+    expect(result.valid).toBe(false);
+    if (result.valid) return;
+    expect(result.error).toBe('Unknown categories: Mystery. Valid categories: New Features, Bug Fixes');
+  });
+
+  it('should apply scopes from the LLM response', () => {
+    const validate = createCategorizeValidator(
+      [
+        { type: 'added', description: 'Update deps' },
+        { type: 'fixed', description: 'Fix bug' },
+      ],
+      {
+        ...ctx,
+        categories: [{ name: 'Developer', description: 'Internal', scopes: ['Dependencies', 'CI'] }],
+      },
+    );
+    const result = validate(
+      structured({
+        entries: [
+          { category: 'Developer', scope: 'Dependencies' },
+          { category: 'Developer', scope: null },
+        ],
+      }),
+    );
+
+    expect(result.valid).toBe(true);
+    if (!result.valid) return;
+    const dev = result.value.find((c) => c.category === 'Developer');
+    expect(dev?.entries[0]?.scope).toBe('Dependencies');
+    expect(dev?.entries[1]?.scope).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createEnhanceAndCategorizeValidator
+// ---------------------------------------------------------------------------
+
+describe('createEnhanceAndCategorizeValidator()', () => {
+  function fullEntry(description: string, category: string, scope: string | null = null) {
+    return { description, category, scope, breaking: null, leadIn: null };
+  }
+
+  it('should validate a well-formed response into enhanced entries and categories', () => {
+    const validate = createEnhanceAndCategorizeValidator(entries, ctx);
+    const result = validate(
+      structured({
+        entries: [
+          fullEntry('Added real-time streaming to the API', 'New'),
+          fullEntry('Fixed null pointer in parser', 'Fixed'),
+          {
+            description: 'Refactored config loading',
+            category: 'Developer',
+            scope: 'Code Quality',
+            breaking: null,
+            leadIn: null,
+          },
+        ],
+      }),
+    );
+
+    expect(result.valid).toBe(true);
+    if (!result.valid) return;
+    expect(result.value.enhancedEntries).toHaveLength(3);
+    expect(result.value.enhancedEntries[0]?.description).toBe('Added real-time streaming to the API');
+    expect(result.value.enhancedEntries[2]?.scope).toBe('Code Quality');
+    expect(result.value.categories).toHaveLength(3);
+  });
+
+  it('should reject malformed JSON with an Invalid JSON error', () => {
+    const validate = createEnhanceAndCategorizeValidator(entries, ctx);
+    const result = validate({ content: 'not json', structured: undefined });
+
+    expect(result.valid).toBe(false);
+    if (result.valid) return;
+    expect(result.error).toContain('Invalid JSON');
+  });
+
+  it('should reject a response with fewer entries than the input', () => {
+    const validate = createEnhanceAndCategorizeValidator(entries, ctx);
+    const result = validate(structured({ entries: [fullEntry('Only first', 'New')] }));
+
+    expect(result.valid).toBe(false);
+    if (result.valid) return;
+    expect(result.error).toBe('Expected 3 entries, got 1 (entries missing — cannot proceed)');
+  });
+
+  it('should truncate and still validate when the response has more entries than the input', () => {
+    const validate = createEnhanceAndCategorizeValidator(entries, ctx);
+    const result = validate(
+      structured({
+        entries: [
+          fullEntry('Enhanced A', 'New'),
+          fullEntry('Enhanced B', 'Fixed'),
+          fullEntry('Enhanced C', 'Changed'),
+          fullEntry('Spurious extra', 'New'),
+          fullEntry('Another extra', 'Fixed'),
+        ],
+      }),
+    );
+
+    expect(result.valid).toBe(true);
+    if (!result.valid) return;
+    expect(result.value.enhancedEntries).toHaveLength(3);
+    expect(result.value.enhancedEntries[2]?.description).toBe('Enhanced C');
+  });
+
+  it('should reject categories outside the configured list', () => {
+    const validate = createEnhanceAndCategorizeValidator(entries, {
+      ...ctx,
+      categories: [
+        { name: 'New', description: 'New things' },
+        { name: 'Fixed', description: 'Fixes' },
+        { name: 'Changed', description: 'Changes' },
+      ],
+    });
+    const result = validate(
+      structured({
+        entries: [fullEntry('a', 'New'), fullEntry('b', 'Mystery'), fullEntry('c', 'Changed')],
+      }),
+    );
+
+    expect(result.valid).toBe(false);
+    if (result.valid) return;
+    expect(result.error).toBe('Unknown categories: Mystery. Valid categories: New, Fixed, Changed');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildCategorySection
+// ---------------------------------------------------------------------------
+
+describe('buildCategorySection()', () => {
+  it('should return the fallback when no categories are configured', () => {
+    expect(buildCategorySection(undefined, 'FALLBACK')).toBe('FALLBACK');
+    expect(buildCategorySection([], 'FALLBACK')).toBe('FALLBACK');
+  });
+
+  it('should render the exact category list with allowed scopes', () => {
+    const section = buildCategorySection(
+      [
+        { name: 'New', description: 'New features' },
+        { name: 'Developer', description: 'Internal changes', scopes: ['CI', 'Deps'] },
+      ],
+      'FALLBACK',
+    );
+
+    expect(section).toBe(
+      'Categories (use ONLY these exact names):\n- "New": New features\n- "Developer": Internal changes Allowed scopes: CI, Deps.',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renderScopeInstruction
+// ---------------------------------------------------------------------------
+
+describe('renderScopeInstruction()', () => {
+  it('should return an empty string when there are no pairs', () => {
+    expect(renderScopeInstruction([], '')).toBe('');
+    expect(renderScopeInstruction([], ' entries')).toBe('');
+  });
+
+  it('should render the categorize wording (no entrySuffix)', () => {
+    const out = renderScopeInstruction([{ name: 'Developer', scopes: ['CI', 'Deps'] }], '');
+    expect(out).toBe(
+      '\nFor "Developer", use a scope from: CI, Deps.\nOnly use scopes from these predefined lists. Set scope to null if no scope applies.',
+    );
+  });
+
+  it('should render the enhance wording with the " entries" suffix', () => {
+    const out = renderScopeInstruction([{ name: 'Developer', scopes: ['CI', 'Deps'] }], ' entries');
+    expect(out).toBe(
+      '\nFor "Developer" entries, use a scope from: CI, Deps.\nOnly use scopes from these predefined lists. Set scope to null if no scope applies.',
+    );
+  });
+});


### PR DESCRIPTION
Closes #361. One of the two remaining backlog refactors of epic #369 (the other is #357).

## What & why

`categorize.ts` and `enhance-and-categorize.ts` carried ~50 lines of copy-pasted prompt-building + validation, and their validators were private closures no test could reach. This extracts the shared parts and makes the validators a named, directly testable surface — **behaviour-preserving**.

## Shared (`tasks/shared.ts`)
- `buildCategorySection(categories, fallback)` — the category-list block / per-task fallback
- `renderScopeInstruction(pairs, entrySuffix)` — the scope block; `entrySuffix` is `''` (categorize) vs `' entries'` (enhance), the only wording difference. Each task still resolves its **own** scope source (`getAllowedScopesFromCategories` vs `filter`), so nothing changes there.
- `buildCorrectionMessages` — was duplicated verbatim
- `parseLLMResult` + `checkCategoryNames` — the parse/validate skeleton
- `TaskValidator<T>` type + `runCorrectiveTask` — the `withCorrectiveRetry` driver

## Per-task
- `makeValidator` → exported `createCategorizeValidator` / `createEnhanceAndCategorizeValidator`. Each keeps its own count rule (categorize: exact; enhance: `<` reject / `>` truncate-with-warn) and entry-building. The LLMError fallbacks stay verbatim.

## Behaviour-unchanged proof
Every emitted prompt string is **byte-identical** — verified by `git diff` (each removed literal reappears verbatim), a reconstruction harness comparing OLD vs NEW prompt assembly across category/style permutations, and grep confirming the exact phrases (`use a scope from:`, `Unknown categories:`, `Allowed scopes:`, …) now live only in `shared.ts`.

## Tests
New `tasks.spec.ts` (15 tests): both validators exercised directly (valid grouping/enhancement, malformed JSON, count mismatch, enhance truncate-on-more, unknown-category rejection, scope application) + exact-string locks for the two prompt builders.

Full gate 27/27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extracts ~50 lines of duplicated prompt-building and validation logic from `categorize.ts` and `enhance-and-categorize.ts` into a shared `tasks/shared.ts` module, while also promoting the previously private `makeValidator` closures to exported `createCategorizeValidator` / `createEnhanceAndCategorizeValidator` functions. The refactoring is behaviour-preserving — prompt strings and validation semantics are unchanged — and the new `tasks.spec.ts` directly exercises both validators and the two prompt builders.

- **`shared.ts`** gains six new exports: `buildCategorySection`, `renderScopeInstruction`, `buildCorrectionMessages`, `parseLLMResult`, `checkCategoryNames`, and `runCorrectiveTask`, plus the `TaskValidator<T>` type.
- **`categorize.ts`** and **`enhance-and-categorize.ts`** are slimmed down to their task-specific logic (scope-source resolution, count rules, entry assembly), delegating all shared concerns to `shared.ts`; `CombinedResult` is newly exported from `enhance-and-categorize.ts` as a side effect of the restructure.
</details>

<h3>Confidence Score: 5/5</h3>

This is a clean, behaviour-preserving extraction with no functional changes to prompt strings or validation logic.

All prompt assembly paths produce byte-identical output to the originals. The validators carry over every count, schema, category-name, and scope check unchanged. The new runCorrectiveTask wrapper is a direct mechanical translation of the original withCorrectiveRetry call sites. New tests directly exercise both validators and both prompt builders with exact-string assertions, and the full 27-test gate passes.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/notes/src/llm/tasks/shared.ts | New shared module exposing six utility functions and a type; implementations match the originals verbatim where they replace duplication, and all new functions are well-typed and documented. |
| packages/notes/src/llm/tasks/categorize.ts | Reduced by ~50 lines; scope-pair construction (via getAllowedScopesFromCategories spread) and corrective-retry call are cleanly delegated to shared helpers with no behavioural change. |
| packages/notes/src/llm/tasks/enhance-and-categorize.ts | Equivalent simplification to categorize.ts; CombinedResult is now exported, and the validator is promoted from a private closure to a named export with identical logic. |
| packages/notes/test/unit/llm/tasks.spec.ts | New 260-line test file covering both validators (valid, malformed JSON, count mismatch, truncation, unknown category, scope assignment) and both prompt builders with exact-string assertions. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph tasks/shared.ts
        BCS["buildCategorySection(categories, fallback)"]
        RSI["renderScopeInstruction(pairs, entrySuffix)"]
        PLR["parseLLMResult(result)"]
        CCN["checkCategoryNames(entries, names)"]
        BCM["buildCorrectionMessages(_bad, error)"]
        RCT["runCorrectiveTask(opts)"]
        WCR["withCorrectiveRetry(...)"]
    end

    subgraph categorize.ts
        BSP1["buildSystemPrompt(categories)"]
        CSV["createCategorizeValidator(entries, ctx)"]
        CE["categorizeEntries(provider, entries, ctx)"]
        GASC["getAllowedScopesFromCategories(categories)"]
    end

    subgraph enhance-and-categorize.ts
        BSP2["buildSystemPrompt(categories, style)"]
        EACV["createEnhanceAndCategorizeValidator(entries, ctx)"]
        EAC["enhanceAndCategorize(provider, entries, ctx)"]
    end

    BSP1 --> BCS
    BSP1 --> GASC
    GASC --> RSI
    CSV --> PLR
    CSV --> CCN
    CE --> RCT

    BSP2 --> BCS
    BSP2 --> RSI
    EACV --> PLR
    EACV --> CCN
    EAC --> RCT

    RCT --> WCR
    WCR --> BCM
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    subgraph tasks/shared.ts
        BCS["buildCategorySection(categories, fallback)"]
        RSI["renderScopeInstruction(pairs, entrySuffix)"]
        PLR["parseLLMResult(result)"]
        CCN["checkCategoryNames(entries, names)"]
        BCM["buildCorrectionMessages(_bad, error)"]
        RCT["runCorrectiveTask(opts)"]
        WCR["withCorrectiveRetry(...)"]
    end

    subgraph categorize.ts
        BSP1["buildSystemPrompt(categories)"]
        CSV["createCategorizeValidator(entries, ctx)"]
        CE["categorizeEntries(provider, entries, ctx)"]
        GASC["getAllowedScopesFromCategories(categories)"]
    end

    subgraph enhance-and-categorize.ts
        BSP2["buildSystemPrompt(categories, style)"]
        EACV["createEnhanceAndCategorizeValidator(entries, ctx)"]
        EAC["enhanceAndCategorize(provider, entries, ctx)"]
    end

    BSP1 --> BCS
    BSP1 --> GASC
    GASC --> RSI
    CSV --> PLR
    CSV --> CCN
    CE --> RCT

    BSP2 --> BCS
    BSP2 --> RSI
    EACV --> PLR
    EACV --> CCN
    EAC --> RCT

    RCT --> WCR
    WCR --> BCM
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(notes): deepen the shared LLM-t..."](https://github.com/goosewobbler/releasekit/commit/9328a5cb8697da338293f89dc19c3b2188472dda) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39638465)</sub>

<!-- /greptile_comment -->