### PR TITLE
fix(release): skip the PR preview on the standing release PR (#424)

### DIFF
--- a/packages/release/src/preview/preview.ts
+++ b/packages/release/src/preview/preview.ts
@@ -38,11 +38,34 @@ interface LabelOverrideResult {
   labelContext: LabelContext;
 }
 
+/** The head ref of the PR this preview run targets, from the Actions event payload, or undefined. */
+function currentPrHeadRef(): string | undefined {
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (!eventPath || !fs.existsSync(eventPath)) return undefined;
+  try {
+    const event = JSON.parse(fs.readFileSync(eventPath, 'utf-8'));
+    return event.pull_request?.head?.ref as string | undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 export async function runPreview(options: PreviewOptions): Promise<void> {
   // Check if preview is enabled in config
   const ciConfig = loadCIConfig({ cwd: options.projectDir, configPath: options.config });
   if (ciConfig?.prPreview === false) {
     info('PR preview is disabled in config (ci.prPreview: false)');
+    return;
+  }
+
+  const strategy = ciConfig?.releaseStrategy ?? 'direct';
+
+  // Don't preview the standing PR itself — its head is the release branch, whose commits already
+  // carry the release-prep bump, so re-analysing double-counts the version (e.g. 0.32.1 → 0.32.2).
+  // The standing PR's manifest comment is authoritative for what it releases; a preview on it is
+  // noise (#424). Mirrors the inverse publish-side guard in standing-pr.ts.
+  if (strategy === 'standing-pr' && currentPrHeadRef() === (ciConfig?.standingPr?.branch ?? 'release/next')) {
+    info('Skipping preview: this PR is the standing release PR (its manifest comment is authoritative).');
     return;
   }
 
@@ -61,8 +84,6 @@ export async function runPreview(options: PreviewOptions): Promise<void> {
 
   // Apply label-driven overrides (pass the forge to avoid creating a second instance)
   const { options: effectiveOptions, labelContext } = await applyLabelOverrides(options, ciConfig, context, forge);
-
-  const strategy = ciConfig?.releaseStrategy ?? 'direct';
 
   // For standing-pr strategy, fetch a read-only snapshot of the current standing PR (link,
   // queued packages, minAge gate state) so the preview can render a true release preview.

--- a/packages/release/src/preview/preview.ts
+++ b/packages/release/src/preview/preview.ts
@@ -38,13 +38,16 @@ interface LabelOverrideResult {
   labelContext: LabelContext;
 }
 
-/** The head ref of the PR this preview run targets, from the Actions event payload, or undefined. */
-function currentPrHeadRef(): string | undefined {
+interface PullRequestEvent {
+  pull_request?: { head?: { ref?: string }; base?: { sha?: string } };
+}
+
+/** Read and parse the GitHub Actions event payload once, or undefined on any error. */
+function readEventPayload(): PullRequestEvent | undefined {
   const eventPath = process.env.GITHUB_EVENT_PATH;
   if (!eventPath || !fs.existsSync(eventPath)) return undefined;
   try {
-    const event = JSON.parse(fs.readFileSync(eventPath, 'utf-8'));
-    return event.pull_request?.head?.ref as string | undefined;
+    return JSON.parse(fs.readFileSync(eventPath, 'utf-8')) as PullRequestEvent;
   } catch {
     return undefined;
   }
@@ -59,12 +62,18 @@ export async function runPreview(options: PreviewOptions): Promise<void> {
   }
 
   const strategy = ciConfig?.releaseStrategy ?? 'direct';
+  // Read the Actions event payload once — reused for the standing-PR head-ref guard here and the
+  // advisory baseRef below.
+  const event = readEventPayload();
 
   // Don't preview the standing PR itself — its head is the release branch, whose commits already
   // carry the release-prep bump, so re-analysing double-counts the version (e.g. 0.32.1 → 0.32.2).
   // The standing PR's manifest comment is authoritative for what it releases; a preview on it is
   // noise (#424). Mirrors the inverse publish-side guard in standing-pr.ts.
-  if (strategy === 'standing-pr' && currentPrHeadRef() === (ciConfig?.standingPr?.branch ?? 'release/next')) {
+  if (
+    strategy === 'standing-pr' &&
+    event?.pull_request?.head?.ref === (ciConfig?.standingPr?.branch ?? 'release/next')
+  ) {
     info('Skipping preview: this PR is the standing release PR (its manifest comment is authoritative).');
     return;
   }
@@ -125,15 +134,7 @@ export async function runPreview(options: PreviewOptions): Promise<void> {
   // event payload (pull_request.base.sha) — non-fatal if unavailable.
   let prBaseSha: string | undefined;
   if (labelContext.advisoryInStandingPr) {
-    const eventPath = process.env.GITHUB_EVENT_PATH;
-    if (eventPath && fs.existsSync(eventPath)) {
-      try {
-        const event = JSON.parse(fs.readFileSync(eventPath, 'utf-8'));
-        prBaseSha = event.pull_request?.base?.sha as string | undefined;
-      } catch {
-        // Non-fatal: fall back to full commit history
-      }
-    }
+    prBaseSha = event?.pull_request?.base?.sha;
   }
 
   // Run version analysis unless release is skipped or in label mode with no bump label

--- a/packages/release/test/unit/preview.spec.ts
+++ b/packages/release/test/unit/preview.spec.ts
@@ -1130,7 +1130,8 @@ describe('runPreview', () => {
 
         await runPreview({ projectDir: '/test', dryRun: false, target: '@test/package' });
 
-        // fs.existsSync/readFileSync should not have been called because immediate mode is not advisory
+        // The event payload is read once (for the standing-PR guard), but immediate mode is not
+        // advisory, so prBaseSha is never extracted from it — baseRef stays undefined.
         const callArg = mockRunRelease.mock.calls[0]?.[0] as { baseRef?: string } | undefined;
         expect(callArg?.baseRef).toBeUndefined();
       });

--- a/packages/release/test/unit/preview.spec.ts
+++ b/packages/release/test/unit/preview.spec.ts
@@ -191,6 +191,61 @@ describe('runPreview', () => {
     });
   });
 
+  describe('standing release PR skip (#424)', () => {
+    afterEach(() => {
+      delete process.env.GITHUB_EVENT_PATH;
+    });
+
+    function withHeadRef(ref: string): void {
+      process.env.GITHUB_EVENT_PATH = '/tmp/event.json';
+      mockFsExistsSync.mockReturnValue(true);
+      mockFsReadFileSync.mockReturnValue(JSON.stringify({ pull_request: { head: { ref } } }));
+    }
+
+    it('should skip the preview when the PR is the standing release PR', async () => {
+      // The standing PR's head IS the release branch; its commits already carry the release-prep
+      // bump, so previewing it would double-count the version (#424).
+      mockLoadCIConfig.mockReturnValue({
+        releaseStrategy: 'standing-pr',
+        standingPr: { branch: 'release/next' },
+        releaseTrigger: 'commit',
+      });
+      withHeadRef('release/next');
+
+      await runPreview({ projectDir: '/test', dryRun: false, target: '@test/package' });
+
+      expect(mockRunRelease).not.toHaveBeenCalled();
+      expect(mockPostOrUpdateComment).not.toHaveBeenCalled();
+    });
+
+    it('should honour a custom standing branch name', async () => {
+      mockLoadCIConfig.mockReturnValue({
+        releaseStrategy: 'standing-pr',
+        standingPr: { branch: 'release/queue' },
+        releaseTrigger: 'commit',
+      });
+      withHeadRef('release/queue');
+
+      await runPreview({ projectDir: '/test', dryRun: false, target: '@test/package' });
+
+      expect(mockRunRelease).not.toHaveBeenCalled();
+    });
+
+    it('should still preview a feeder PR in standing-pr mode (head ref is not the release branch)', async () => {
+      mockLoadCIConfig.mockReturnValue({
+        releaseStrategy: 'standing-pr',
+        standingPr: { branch: 'release/next' },
+        releaseTrigger: 'commit',
+      });
+      withHeadRef('feature/login');
+
+      await runPreview({ projectDir: '/test', dryRun: false, target: '@test/package' });
+
+      expect(mockRunRelease).toHaveBeenCalled();
+      expect(mockPostOrUpdateComment).toHaveBeenCalled();
+    });
+  });
+
   describe('options', () => {
     it('should pass config and projectDir options through', async () => {
       await runPreview({ projectDir: '/test', config: '/custom/config.json', dryRun: false, target: '@test/package' });

--- a/packages/release/test/unit/preview.spec.ts
+++ b/packages/release/test/unit/preview.spec.ts
@@ -194,6 +194,10 @@ describe('runPreview', () => {
   describe('standing release PR skip (#424)', () => {
     afterEach(() => {
       delete process.env.GITHUB_EVENT_PATH;
+      // clearAllMocks() (in beforeEach) clears calls but not return-value impls, so reset the fs
+      // mocks explicitly — otherwise withHeadRef's `existsSync → true` leaks into later tests.
+      mockFsExistsSync.mockReturnValue(false);
+      mockFsReadFileSync.mockReset();
     });
 
     function withHeadRef(ref: string): void {


### PR DESCRIPTION
Closes #424. The double-bump preview you spotted on standing PR #422.

## Bug
The preview workflow fires on every `pull_request` event — including the standing release PR (head = `ci.standingPr.branch`). `runPreview` had no guard, so on the standing PR it re-analysed `release/next`'s commits (which already carry the release-prep bump) and the merge prediction merged the manifest (e.g. `0.32.1`) with that re-analysis → a stray preview comment showing `0.32.2`. The manifest comment (`0.32.1`) was correct; the preview was the artifact.

## Fix
Early guard in `runPreview`: in standing-pr mode, when the current PR's head ref (from the Actions `pull_request.head.ref` payload — same source already used for `base.sha`) equals the configured standing branch, skip the preview and return. There's nothing meaningful to preview on the standing PR — it *is* the release, and its manifest comment is authoritative.

- Config-aware (handles custom branch names) → authoritative, per the project's "workflow `if` guards can't read config" invariant.
- Mirrors the inverse publish-side head-ref guard in `standing-pr.ts`.
- Feeder PRs (any other head ref) and non-standing-pr strategies are unaffected.

## Tests
`preview.spec.ts` — standing-PR skip (no `runRelease`, no comment), custom branch name honoured, and a feeder PR still previewed. Full gate 27/27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds an early-return guard in `runPreview` to skip the preview step when the current PR is the standing release PR, fixing a double-bump artifact in preview comments (#424). As a secondary improvement, the event-payload file is now read once via a shared `readEventPayload()` helper and reused for both the new guard and the existing advisory `prBaseSha` extraction.

- **Guard logic** (`preview.ts` lines 73–79): when `strategy === 'standing-pr'` and the event's `pull_request.head.ref` equals the configured standing branch (or the default `release/next`), the function returns early with an informative log. This mirrors the inverse publish-side guard in `standing-pr.ts`.
- **Refactor** (`preview.ts` lines 46–53, 137): replaces the inline duplicated file-read with a single `readEventPayload()` call, addressing a previously noted double-read issue.
- **Tests** (`preview.spec.ts` lines 194–255): three new test cases cover the skip path, a custom branch name, and a feeder PR that must still proceed; the `afterEach` explicitly resets fs mock return values to prevent state leakage into later tests.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a well-scoped early return that only fires in standing-PR mode when the head ref exactly matches the configured release branch, leaving all other preview paths completely untouched.

The guard is gated behind two independent conditions (correct strategy and exact branch-name match), so false positives are ruled out. Optional chaining throughout means the function degrades gracefully when no event payload is available. The refactored single event-file read is strictly simpler than before. Three new tests cover the skip path, a custom branch name, and the feeder-PR pass-through, and the afterEach teardown prevents mock state from leaking into the wider suite.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/release/src/preview/preview.ts | Adds readEventPayload() helper and early-exit guard for the standing-PR head ref; refactors the advisory prBaseSha extraction to reuse the already-parsed event object. Logic is correct and safe. |
| packages/release/test/unit/preview.spec.ts | New standing release PR skip describe block with three focused test cases and a proper afterEach that resets fs mock return values to prevent state leakage. Comment on the existing immediate-mode test updated to reflect the new one-read behaviour. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[runPreview called] --> B[loadCIConfig]
    B --> C{prPreview === false?}
    C -->|yes| D[return early]
    C -->|no| E[readEventPayload once]
    E --> F{standing-pr strategy AND head.ref === standing branch?}
    F -->|yes NEW GUARD| G[return early skip preview]
    F -->|no| H[resolve forge + context]
    H --> I[applyLabelOverrides]
    I --> J[runRelease + postOrUpdateComment]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[runPreview called] --> B[loadCIConfig]
    B --> C{prPreview === false?}
    C -->|yes| D[return early]
    C -->|no| E[readEventPayload once]
    E --> F{standing-pr strategy AND head.ref === standing branch?}
    F -->|yes NEW GUARD| G[return early skip preview]
    F -->|no| H[resolve forge + context]
    H --> I[applyLabelOverrides]
    I --> J[runRelease + postOrUpdateComment]
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["test(release): correct a stale comment a..."](https://github.com/goosewobbler/releasekit/commit/8d10b694f8a905200e2829d989c766b4d1e019ea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39641455)</sub>

<!-- /greptile_comment -->