### PR TITLE
feat(version): surface the resolved version action in summary + --json (#420)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -42,6 +42,7 @@ export {
   wrapSelectionRegion,
 } from './selectionRegion.js';
 export type {
+  VersionAction,
   VersionChangelogEntry,
   VersionOutput,
   VersionPackageChangelog,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -30,6 +30,15 @@ export interface VersionPackageChangelog {
 }
 
 /**
+ * The resolved action a package's version landed on — purely additive observability (#420), it
+ * never changes which version resolves. `'graduated'` means a prerelease was promoted to stable and
+ * any requested bump was ignored; `'bumped'` is the ordinary commit/label-driven bump;
+ * `'first-release'` is a package with no prior tag. Defined as a string-literal union (core cannot
+ * import the version package, where the deriving logic lives).
+ */
+export type VersionAction = 'first-release' | 'graduated' | 'bumped';
+
+/**
  * The complete JSON output of @releasekit/version --json.
  * This is the primary interchange format between version and notes.
  */
@@ -100,4 +109,14 @@ export interface VersionPackageUpdate {
    * the dependency graph. Absent for targets.
    */
   prerequisiteOf?: string[];
+  /**
+   * The resolved version action for this update (#420): `'graduated'` (prerelease → stable, bump
+   * ignored), `'bumped'` (commit/label-driven), or `'first-release'`. Purely additive observability —
+   * it never affects which version resolved. Optional for backwards compatibility: standing-PR
+   * manifests produced before this field existed won't carry it, so every consumer must tolerate
+   * its absence (render nothing).
+   */
+  action?: VersionAction;
+  /** Short human-readable reason for {@link action} (e.g. `Graduated 1.0.0-next.1 → 1.0.0 (bump ignored).`). Optional, same back-compat rule as {@link action}. */
+  actionReason?: string;
 }

--- a/packages/release/src/preview/format.ts
+++ b/packages/release/src/preview/format.ts
@@ -295,11 +295,13 @@ export function formatPreviewComment(result: ReleaseOutput | null, options?: For
   let pkgSummary: string;
   if (isSync) {
     pkgSummary = syncVersionRange(versionOutput);
+  } else if (pkgCount === 1) {
+    const only = versionOutput.updates[0];
+    // Annotate the resolved version action (#420) when present; absent on pre-field manifests.
+    const annotation = only?.action ? ` (${only.action})` : '';
+    pkgSummary = `${only?.packageName} ${only?.newVersion}${annotation}`;
   } else {
-    pkgSummary =
-      pkgCount === 1
-        ? `${versionOutput.updates[0]?.packageName} ${versionOutput.updates[0]?.newVersion}`
-        : `${pkgCount} packages`;
+    pkgSummary = `${pkgCount} packages`;
   }
 
   lines.push('<details>', `<summary><b>Release Preview</b> — ${pkgSummary}</summary>`, '');

--- a/packages/release/src/release.ts
+++ b/packages/release/src/release.ts
@@ -290,7 +290,10 @@ export async function runRelease(inputOptions: ReleaseOptions): Promise<ReleaseO
 
   info(`Found ${versionOutput.updates.length} package update(s)`);
   for (const update of versionOutput.updates) {
-    info(`  ${update.packageName} → ${update.newVersion}`);
+    // Annotate the resolved version action when present (#420). Absent on manifests produced
+    // before the field existed — render nothing rather than an empty parenthetical.
+    const annotation = update.action ? ` (${update.action})` : '';
+    info(`  ${update.packageName} → ${update.newVersion}${annotation}`);
   }
 
   // --- Step 2: Notes ---

--- a/packages/release/test/unit/preview-format.spec.ts
+++ b/packages/release/test/unit/preview-format.spec.ts
@@ -112,6 +112,45 @@ describe('formatPreviewComment', () => {
     expect(result).toContain('<summary><b>Release Preview</b> — my-lib 1.0.0</summary>');
   });
 
+  it('should annotate the resolved version action in the single-package summary when present', () => {
+    const graduated: ReleaseOutput = {
+      versionOutput: {
+        dryRun: true,
+        updates: [
+          {
+            packageName: 'my-lib',
+            newVersion: '1.0.0',
+            filePath: 'package.json',
+            action: 'graduated',
+            actionReason: 'Graduated 1.0.0-next.1 → 1.0.0 (bump ignored).',
+          },
+        ],
+        changelogs: [],
+        tags: ['v1.0.0'],
+      },
+      notesGenerated: false,
+    };
+    const result = formatPreviewComment(graduated);
+    expect(result).toContain('<summary><b>Release Preview</b> — my-lib 1.0.0 (graduated)</summary>');
+  });
+
+  it('should render the single-package summary cleanly when the action field is absent (old manifest)', () => {
+    const noAction: ReleaseOutput = {
+      versionOutput: {
+        dryRun: true,
+        updates: [{ packageName: 'my-lib', newVersion: '1.0.0', filePath: 'package.json' }],
+        changelogs: [],
+        tags: ['v1.0.0'],
+      },
+      notesGenerated: false,
+    };
+    const result = formatPreviewComment(noAction);
+    // No empty parenthetical, no "undefined" leaking from the absent field.
+    expect(result).toContain('<summary><b>Release Preview</b> — my-lib 1.0.0</summary>');
+    expect(result).not.toContain('my-lib 1.0.0 ()');
+    expect(result).not.toContain('undefined');
+  });
+
   it('should not include package table', () => {
     const result = formatPreviewComment(releaseOutput);
     expect(result).not.toContain('### Packages');

--- a/packages/release/test/unit/preview-format.spec.ts
+++ b/packages/release/test/unit/preview-format.spec.ts
@@ -134,6 +134,50 @@ describe('formatPreviewComment', () => {
     expect(result).toContain('<summary><b>Release Preview</b> — my-lib 1.0.0 (graduated)</summary>');
   });
 
+  it('should annotate a bumped action in the single-package summary', () => {
+    const bumped: ReleaseOutput = {
+      versionOutput: {
+        dryRun: true,
+        updates: [
+          {
+            packageName: 'my-lib',
+            newVersion: '1.1.0',
+            filePath: 'package.json',
+            action: 'bumped',
+            actionReason: 'Bumped to 1.1.0.',
+          },
+        ],
+        changelogs: [],
+        tags: ['v1.1.0'],
+      },
+      notesGenerated: false,
+    };
+    const result = formatPreviewComment(bumped);
+    expect(result).toContain('<summary><b>Release Preview</b> — my-lib 1.1.0 (bumped)</summary>');
+  });
+
+  it('should annotate a first-release action in the single-package summary', () => {
+    const firstRelease: ReleaseOutput = {
+      versionOutput: {
+        dryRun: true,
+        updates: [
+          {
+            packageName: 'my-lib',
+            newVersion: '1.0.0',
+            filePath: 'package.json',
+            action: 'first-release',
+            actionReason: 'First release (no prior tag).',
+          },
+        ],
+        changelogs: [],
+        tags: ['v1.0.0'],
+      },
+      notesGenerated: false,
+    };
+    const result = formatPreviewComment(firstRelease);
+    expect(result).toContain('<summary><b>Release Preview</b> — my-lib 1.0.0 (first-release)</summary>');
+  });
+
   it('should render the single-package summary cleanly when the action field is absent (old manifest)', () => {
     const noAction: ReleaseOutput = {
       versionOutput: {

--- a/packages/version/src/core/groupStrategy.ts
+++ b/packages/version/src/core/groupStrategy.ts
@@ -35,11 +35,13 @@ import {
   addChangelogData,
   addTag,
   setCommitMessage,
+  setPackageUpdateAction,
   setPackageUpdateGroup,
   setPackageUpdateTag,
   setVersioningStrategy,
 } from '../utils/jsonOutput.js';
 import { log } from '../utils/logging.js';
+import { resolveVersionAction } from '../utils/versionAction.js';
 import { BaselineResolver } from './baselineResolver.js';
 import { expandTargetsForAtomicGroups, type ResolvedGroup, resolveGroups } from './groupResolution.js';
 import { calculateVersion } from './versionCalculator.js';
@@ -343,6 +345,14 @@ async function releaseGroup(
     addTag(tag);
     setPackageUpdateTag(name, tag);
     setPackageUpdateGroup(name, group.name);
+    // Resolved version action (#420), derived from the member's own tag facts and the version it
+    // actually resolved to (group version for fixed/linked, own line for independent).
+    const { action: memberAction, reason: memberReason } = resolveVersionAction({
+      hasNoTags: plan.latestTag === '',
+      latestTag: plan.latestTag,
+      nextVersion: version,
+    });
+    setPackageUpdateAction(name, memberAction, memberReason);
 
     const baselineTagPrefix = deriveBaselineTagPrefix(config.baselineTagTemplate, formattedPrefix, name);
     const { entries, revisionRange, previousVersion } = await extractEntries(baselineResolver, {
@@ -481,6 +491,13 @@ export function createGroupStrategy(config: Config): (packages: PackagesWithRoot
         const tag = formatTag(plan.ownNext, formattedPrefix, name, config.tagTemplate, config.packageSpecificTags);
         addTag(tag);
         setPackageUpdateTag(name, tag);
+        // Resolved version action (#420) for an independently-versioned ungrouped package.
+        const { action: ungroupedAction, reason: ungroupedReason } = resolveVersionAction({
+          hasNoTags: plan.latestTag === '',
+          latestTag: plan.latestTag,
+          nextVersion: plan.ownNext,
+        });
+        setPackageUpdateAction(name, ungroupedAction, ungroupedReason);
         const baselineTagPrefix = deriveBaselineTagPrefix(config.baselineTagTemplate, formattedPrefix, name);
         const { entries, revisionRange, previousVersion } = await extractEntries(baselineResolver, {
           pkgDir: pkg.dir,

--- a/packages/version/src/core/versionStrategies.ts
+++ b/packages/version/src/core/versionStrategies.ts
@@ -20,11 +20,14 @@ import {
   addBaselineTag,
   addChangelogData,
   addTag,
+  setAllPackageUpdateActions,
   setCommitMessage,
+  setPackageUpdateAction,
   setPackageUpdateTag,
   setVersioningStrategy,
 } from '../utils/jsonOutput.js';
 import { log } from '../utils/logging.js';
+import { resolveVersionAction } from '../utils/versionAction.js';
 import { BaselineResolver } from './baselineResolver.js';
 import { hasExplicitGroups } from './groupResolution.js';
 import { createGroupStrategy } from './groupStrategy.js';
@@ -442,6 +445,15 @@ export function createSyncStrategy(config: Config): StrategyFunction {
           if (pkgName && pkgTag) setPackageUpdateTag(pkgName, pkgTag);
         }
       }
+      // Resolved version action (#420). Every package moves in lockstep to the same nextVersion
+      // against the same latestTag, so the action is identical across the sync unit — record it on
+      // every update record (including the root lockstep bump).
+      const { action: syncAction, reason: syncReason } = resolveVersionAction({
+        hasNoTags: latestTag === '',
+        latestTag,
+        nextVersion,
+      });
+      setAllPackageUpdateActions(syncAction, syncReason);
       setCommitMessage(formattedCommitMessage);
 
       if (!dryRun) {
@@ -642,6 +654,14 @@ export function createSingleStrategy(config: Config): StrategyFunction {
 
       addTag(tagName);
       setPackageUpdateTag(packageName, tagName);
+      // Resolved version action (#420). In single mode an empty `latestTag` means no prior tag
+      // (no manifest-fallback synthetic tag here), matching the baseline resolve's `hasRealTag`.
+      const { action: singleAction, reason: singleReason } = resolveVersionAction({
+        hasNoTags: latestTag === '',
+        latestTag,
+        nextVersion,
+      });
+      setPackageUpdateAction(packageName, singleAction, singleReason);
       setCommitMessage(commitMsg);
 
       if (!dryRun) {

--- a/packages/version/src/index.ts
+++ b/packages/version/src/index.ts
@@ -14,3 +14,9 @@ export { PackageProcessor } from './package/packageProcessor.js';
 export type { Config, VersionConfigBase, VersionRunOptions } from './types.js';
 export type { JsonOutputData } from './utils/jsonOutput.js';
 export { enableJsonOutput, flushPendingWrites, getJsonData } from './utils/jsonOutput.js';
+export {
+  resolveVersionAction,
+  type VersionAction,
+  type VersionActionInput,
+  type VersionActionResult,
+} from './utils/versionAction.js';

--- a/packages/version/src/package/packageProcessor.ts
+++ b/packages/version/src/package/packageProcessor.ts
@@ -14,11 +14,13 @@ import {
   addChangelogData,
   addTag,
   setCommitMessage,
+  setPackageUpdateAction,
   setPackageUpdateTag,
   setSharedEntries,
 } from '../utils/jsonOutput.js';
 import { log } from '../utils/logging.js';
 import { getVersionFromManifests } from '../utils/manifestHelpers.js';
+import { resolveVersionAction } from '../utils/versionAction.js';
 import { updatePackageVersion } from './packageManagement.js';
 
 type ChangelogEntry = VersionChangelogEntry;
@@ -430,6 +432,10 @@ export class PackageProcessor {
       // Track tag for JSON output (git ops now handled by publish)
       addTag(packageTag);
       setPackageUpdateTag(name, packageTag);
+      // Resolved version action (#420) — derived from the same tag facts the calculator saw.
+      // `hasNoTags` is `!hasRealTag`: a manifest-fallback synthetic tag isn't a real prior tag.
+      const { action, reason } = resolveVersionAction({ hasNoTags: !hasRealTag, latestTag, nextVersion });
+      setPackageUpdateAction(name, action, reason);
       tags.push(packageTag);
 
       if (this.dryRun) {

--- a/packages/version/src/utils/jsonOutput.ts
+++ b/packages/version/src/utils/jsonOutput.ts
@@ -4,7 +4,7 @@
  */
 
 import fs from 'node:fs';
-import type { VersionChangelogEntry, VersionOutput, VersionPackageChangelog } from '@releasekit/core';
+import type { VersionAction, VersionChangelogEntry, VersionOutput, VersionPackageChangelog } from '@releasekit/core';
 
 /** @deprecated Use {@link VersionOutput} from `@releasekit/core` instead. */
 export type JsonOutputData = VersionOutput;
@@ -122,6 +122,35 @@ export function setPackageUpdateGroup(packageName: string, group: string): void 
   if (!_jsonOutputMode) return;
   const update = _jsonData.updates.find((u) => u.packageName === packageName);
   if (update) update.group = group;
+}
+
+/**
+ * Record the resolved version action (#420) on a package update — `graduated` / `bumped` /
+ * `first-release` plus a short human reason. Purely additive observability; never affects the
+ * resolved version. Called by each strategy after the update record exists. No-op when the update
+ * isn't found (mirrors the other setPackageUpdate* helpers).
+ */
+export function setPackageUpdateAction(packageName: string, action: VersionAction, reason: string): void {
+  if (!_jsonOutputMode) return;
+  const update = _jsonData.updates.find((u) => u.packageName === packageName);
+  if (update) {
+    update.action = action;
+    update.actionReason = reason;
+  }
+}
+
+/**
+ * Record the same resolved version action (#420) on every package update. Used by the sync strategy,
+ * where all packages move in lockstep to the same version against the same baseline, so the action
+ * is identical across the whole unit. Owns the iteration internally so callers don't read back the
+ * (otherwise-private) update list.
+ */
+export function setAllPackageUpdateActions(action: VersionAction, reason: string): void {
+  if (!_jsonOutputMode) return;
+  for (const update of _jsonData.updates) {
+    update.action = action;
+    update.actionReason = reason;
+  }
 }
 
 /**

--- a/packages/version/src/utils/versionAction.ts
+++ b/packages/version/src/utils/versionAction.ts
@@ -1,0 +1,73 @@
+/**
+ * Resolved version action: the *reason* a package's version landed where it did.
+ *
+ * This is purely additive observability (#420) — it never changes which version is resolved. It
+ * surfaces, in the human summary and `--json`, the graduate-vs-bump reasoning that previously lived
+ * only in DEBUG logs, so a dry run can explain *why* a version resolved as it did.
+ *
+ *  - `first-release`: no prior real tag — the package is releasing for the first time.
+ *  - `graduated`: the prior version was a prerelease and the next version is its stable form, so a
+ *    requested bump was ignored in favour of graduating the existing prerelease to stable.
+ *  - `bumped`: the ordinary commit/label-driven bump.
+ */
+
+import type { VersionAction } from '@releasekit/core';
+import semver from 'semver';
+import { isStableVersion } from './versionUtils.js';
+
+export type { VersionAction };
+
+export interface VersionActionResult {
+  action: VersionAction;
+  reason: string;
+}
+
+export interface VersionActionInput {
+  /** True when there is no prior real tag for this package (a manifest-fallback synthetic tag still counts as no tag). */
+  hasNoTags: boolean;
+  /** The package's discovered latest tag (consumer-facing or baseline form), or `''` when none. */
+  latestTag: string;
+  /** The version being released. */
+  nextVersion: string;
+}
+
+/**
+ * Strip any tag prefix/scope (e.g. `v`, `release/v`, `@scope/pkg@v`) off a tag and return the bare
+ * semver it embeds, or `null` when none can be parsed. Mirrors the version-extraction in
+ * {@link isStableTag} so graduation detection here lines up with the changelog floor's.
+ */
+function versionFromTag(tag: string): string | null {
+  // Bounded quantifiers (not `\d+`) guard against polynomial backtracking on uncontrolled tag input
+  // (CodeQL js/polynomial-redos) — real semver components never approach these lengths.
+  const match = tag.match(/\d{1,16}\.\d{1,16}\.\d{1,16}(?:-[0-9A-Za-z.-]{1,256})?/);
+  if (!match) return null;
+  return semver.valid(match[0]);
+}
+
+/**
+ * Derive the resolved version action from signals already in scope where the per-package update is
+ * built. Pure and defensive: any parse failure falls back to `bumped` rather than throwing, so this
+ * can never abort a version run.
+ */
+export function resolveVersionAction(input: VersionActionInput): VersionActionResult {
+  const { hasNoTags, latestTag, nextVersion } = input;
+
+  if (hasNoTags || !latestTag) {
+    return { action: 'first-release', reason: 'First release (no prior tag).' };
+  }
+
+  const prev = versionFromTag(latestTag);
+
+  // Graduation: the prior version was a prerelease and the next version is its stable form (same
+  // major.minor.patch base, prerelease segment dropped) — a requested bump was ignored to graduate
+  // the existing prerelease to stable. Fall back to `bumped` whenever the prior tag can't be parsed.
+  if (prev && semver.prerelease(prev) !== null && isStableVersion(nextVersion)) {
+    const prevBase = `${semver.major(prev)}.${semver.minor(prev)}.${semver.patch(prev)}`;
+    const nextValid = semver.valid(nextVersion);
+    if (nextValid && prevBase === nextValid) {
+      return { action: 'graduated', reason: `Graduated ${prev} → ${nextVersion} (bump ignored).` };
+    }
+  }
+
+  return { action: 'bumped', reason: `Bumped to ${nextVersion}.` };
+}

--- a/packages/version/test/unit/utils/jsonOutput.spec.ts
+++ b/packages/version/test/unit/utils/jsonOutput.spec.ts
@@ -11,6 +11,7 @@ import {
   printJsonOutput,
   recordPendingWrite,
   setCommitMessage,
+  setPackageUpdateAction,
   setPackageUpdateTag,
   setVersioningStrategy,
   tagPrerequisiteRoles,
@@ -330,6 +331,38 @@ describe('JSON Output Utilities', () => {
 
       freshDisabled.setPackageUpdateTag('pkg', 'pkg@v1.0.0');
       expect(freshDisabled.getJsonData().updates).toEqual([]);
+    });
+  });
+
+  describe('setPackageUpdateAction', () => {
+    it('should set the action and reason on a matching update', () => {
+      enableJsonOutput();
+      addPackageUpdate('my-package', '1.0.0', '/path/to/package.json');
+
+      setPackageUpdateAction('my-package', 'graduated', 'Graduated 1.0.0-next.1 → 1.0.0 (bump ignored).');
+
+      const data = getJsonData();
+      expect(data.updates[0]?.action).toBe('graduated');
+      expect(data.updates[0]?.actionReason).toBe('Graduated 1.0.0-next.1 → 1.0.0 (bump ignored).');
+    });
+
+    it('should leave action and reason undefined when never set (old-manifest tolerance)', () => {
+      enableJsonOutput();
+      addPackageUpdate('my-package', '1.0.0', '/path/to/package.json');
+
+      const data = getJsonData();
+      expect(data.updates[0]?.action).toBeUndefined();
+      expect(data.updates[0]?.actionReason).toBeUndefined();
+    });
+
+    it('should be a no-op for an unknown package name', () => {
+      enableJsonOutput();
+      addPackageUpdate('my-package', '1.0.0', '/path/to/package.json');
+
+      setPackageUpdateAction('other-package', 'bumped', 'Bumped to 1.0.0.');
+
+      const data = getJsonData();
+      expect(data.updates[0]?.action).toBeUndefined();
     });
   });
 

--- a/packages/version/test/unit/utils/versionAction.spec.ts
+++ b/packages/version/test/unit/utils/versionAction.spec.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveVersionAction } from '../../../src/utils/versionAction.js';
+
+describe('resolveVersionAction', () => {
+  it('should report first-release when hasNoTags is true', () => {
+    const result = resolveVersionAction({ hasNoTags: true, latestTag: '', nextVersion: '1.0.0' });
+    expect(result.action).toBe('first-release');
+    expect(result.reason).toMatch(/first release/i);
+  });
+
+  it('should report first-release when there is no latestTag even if hasNoTags is false', () => {
+    // Defensive: an empty latestTag with hasNoTags mistakenly false still means no prior release.
+    const result = resolveVersionAction({ hasNoTags: false, latestTag: '', nextVersion: '1.0.0' });
+    expect(result.action).toBe('first-release');
+  });
+
+  it('should report graduated when a prerelease tag resolves to its stable form', () => {
+    const result = resolveVersionAction({ hasNoTags: false, latestTag: 'v1.0.0-next.1', nextVersion: '1.0.0' });
+    expect(result.action).toBe('graduated');
+    expect(result.reason).toBe('Graduated 1.0.0-next.1 → 1.0.0 (bump ignored).');
+  });
+
+  it('should report graduated for a package-scoped prerelease tag', () => {
+    const result = resolveVersionAction({
+      hasNoTags: false,
+      latestTag: '@scope/pkg@v2.3.0-beta.4',
+      nextVersion: '2.3.0',
+    });
+    expect(result.action).toBe('graduated');
+    expect(result.reason).toBe('Graduated 2.3.0-beta.4 → 2.3.0 (bump ignored).');
+  });
+
+  it('should report bumped for a normal stable-to-stable bump', () => {
+    const result = resolveVersionAction({ hasNoTags: false, latestTag: 'v1.0.0', nextVersion: '1.1.0' });
+    expect(result.action).toBe('bumped');
+    expect(result.reason).toBe('Bumped to 1.1.0.');
+  });
+
+  it('should report bumped when a prerelease advances to a higher base (not graduation)', () => {
+    // 1.0.0-next.1 -> 1.1.0 is a real bump, not a graduation of the same base, so it stays bumped.
+    const result = resolveVersionAction({ hasNoTags: false, latestTag: 'v1.0.0-next.1', nextVersion: '1.1.0' });
+    expect(result.action).toBe('bumped');
+  });
+
+  it('should report bumped when a prerelease advances to another prerelease', () => {
+    const result = resolveVersionAction({
+      hasNoTags: false,
+      latestTag: 'v1.0.0-next.1',
+      nextVersion: '1.0.0-next.2',
+    });
+    expect(result.action).toBe('bumped');
+  });
+
+  it('should fall back to bumped when the prior tag cannot be parsed', () => {
+    const result = resolveVersionAction({ hasNoTags: false, latestTag: 'not-a-version', nextVersion: '1.0.0' });
+    expect(result.action).toBe('bumped');
+    expect(result.reason).toBe('Bumped to 1.0.0.');
+  });
+
+  it('should never throw on malformed input and default to bumped', () => {
+    expect(() =>
+      resolveVersionAction({ hasNoTags: false, latestTag: 'vvv...---', nextVersion: 'garbage' }),
+    ).not.toThrow();
+    const result = resolveVersionAction({ hasNoTags: false, latestTag: 'vvv...---', nextVersion: 'garbage' });
+    expect(result.action).toBe('bumped');
+  });
+});


### PR DESCRIPTION
Closes #420 — Part 2 of #388, the observability half. Last of the Tier-1 implementation work alongside the #361 refactor (#423).

## Why
The summary and `--json` showed only the final number and requested bump; whether a version **graduated** (prerelease → stable, bump ignored) or was **bumped** lived only in DEBUG. So a dry run couldn't reveal *why* a version resolved as it did. This surfaces it — **purely additive, no resolved version changes**.

## What
- **core** — `VersionAction = 'first-release' | 'graduated' | 'bumped'` + **optional** `action?` / `actionReason?` on `VersionPackageUpdate`. Optional per the architecture invariant (`VersionOutput` is the cross-stage contract **and** is persisted in standing-PR manifests — old manifests lack the field, and every read is guarded).
- **version** — `resolveVersionAction({hasNoTags, latestTag, nextVersion})`: a pure, exported, defensive helper. `graduated` only when the prior tag is a prerelease whose stable base equals `nextVersion`; **any parse failure falls back to `bumped`, never throws** (ReDoS-bounded regex). Derived at the 3 build sites (packageProcessor, single/sync strategy, group strategy) from signals already in scope — `calculateVersion`'s return type is untouched (no invasive rewrite of its many string returns).
- **release** — the human summary and the preview lead-line annotate `… (graduated)` / `(first-release)` etc., guarded for absence; `--json` carries the field automatically (no whitelist).

## Tests
`versionAction.spec` (9 — graduation w/ prefixed+scoped tags, first-release, normal bump, prerelease-that-bumps-base = bumped, unparseable fallback, never-throws), `jsonOutput.spec` (+3 incl. old-manifest absent-field tolerance), `preview-format.spec` (+2). Gate 27/27; `schema:check` green (no config change).

## Note
A prerelease that bumps its base (`1.0.0-next.1` → `1.1.0`) is intentionally `bumped`, not `graduated` — matching the changelog floor's own graduation condition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR surfaces the resolved version action (`first-release`, `graduated`, `bumped`) in the human summary and `--json` output, closing the observability gap where graduation vs. bump reasoning previously existed only in DEBUG logs. The change is purely additive — no existing version resolution logic is touched.

- **`packages/core/src/types.ts`** — adds the `VersionAction` string-literal union and optional `action`/`actionReason` fields to `VersionPackageUpdate`; optional for backward compatibility with standing-PR manifests that predate the field.
- **`packages/version/src/utils/versionAction.ts`** — new pure, exported `resolveVersionAction` helper with bounded-quantifier regex (ReDoS-safe), a well-defined graduation condition, and a defensive fallback to `bumped` on any parse failure.
- **Call sites** in all four strategies (single, sync, group member, ungrouped independent) derive the action from signals already in scope and persist it via `setPackageUpdateAction` / `setAllPackageUpdateActions`; the release summary and preview format annotate it with an absence guard.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — purely additive observability with no changes to version resolution logic and full backward compatibility for old manifests.

Every consumer of the new fields guards against their absence, existing strategies are not restructured, the graduation regex mirrors the already-vetted pattern in versionUtils.ts, and the fallback-to-bumped path means even malformed input cannot abort a version run. Tests cover all three action outcomes, the absent-field path, and the never-throws contract.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/version/src/utils/versionAction.ts | New pure helper deriving first-release/graduated/bumped from tag signals; defensively bounded regex, falls back to bumped on any parse failure, never throws. |
| packages/core/src/types.ts | Additive: VersionAction string-literal union and optional action/actionReason fields on VersionPackageUpdate, with back-compat docs for old manifests. |
| packages/version/src/utils/jsonOutput.ts | Two new helpers (setPackageUpdateAction / setAllPackageUpdateActions) mirror the existing setter pattern; both are no-ops when JSON mode is off or package not found. |
| packages/version/src/core/versionStrategies.ts | resolveVersionAction called after addPackageUpdate in both sync and single strategies; sync correctly uses setAllPackageUpdateActions to stamp every update with the shared action. |
| packages/version/src/core/groupStrategy.ts | resolveVersionAction wired at two call sites (group members and ungrouped independent packages), each pulling per-package latestTag and nextVersion already in scope. |
| packages/version/src/package/packageProcessor.ts | resolveVersionAction called after the tag is computed; hasNoTags correctly mapped from !hasRealTag to distinguish manifest-fallback synthetic tags from real prior tags. |
| packages/release/src/preview/format.ts | Single-package summary now appends the action annotation; absent field produces no empty parenthetical; multi-package path unchanged. |
| packages/release/src/release.ts | Per-package log line annotated with action when present; absent field check prevents empty parenthetical. |
| packages/version/test/unit/utils/versionAction.spec.ts | 9 cases covering first-release, graduation with prefix and scoped tags, normal bump, prerelease-to-higher-base, unparseable fallback, and never-throws on malformed input. |
| packages/release/test/unit/preview-format.spec.ts | 4 new cases cover graduated, bumped, first-release, and absent-field (old manifest) paths, including negative assertions for empty parenthetical and undefined leakage. |
| packages/version/test/unit/utils/jsonOutput.spec.ts | 3 new cases for setPackageUpdateAction: happy path, absent-field old-manifest tolerance, and no-op for unknown package name. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[resolveVersionAction called\nafter version is calculated] --> B{hasNoTags\nor latestTag empty?}
    B -->|Yes| C[action: 'first-release']
    B -->|No| D[versionFromTag latestTag\nbounded regex + semver.valid]
    D --> E{prev parseable AND\nprev is prerelease AND\nnextVersion is stable?}
    E -->|No| G[action: 'bumped']
    E -->|Yes| F{prevBase === semver.valid\nnextVersion?}
    F -->|No| G
    F -->|Yes| H[action: 'graduated']
    C --> I[setPackageUpdateAction\nor setAllPackageUpdateActions]
    G --> I
    H --> I
    I --> J[VersionPackageUpdate\naction + actionReason fields]
    J --> K[--json output\nautomatically carries field]
    J --> L[release.ts summary\nannotates each package log line]
    J --> M[format.ts preview\nannotates single-pkg summary]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[resolveVersionAction called\nafter version is calculated] --> B{hasNoTags\nor latestTag empty?}
    B -->|Yes| C[action: 'first-release']
    B -->|No| D[versionFromTag latestTag\nbounded regex + semver.valid]
    D --> E{prev parseable AND\nprev is prerelease AND\nnextVersion is stable?}
    E -->|No| G[action: 'bumped']
    E -->|Yes| F{prevBase === semver.valid\nnextVersion?}
    F -->|No| G
    F -->|Yes| H[action: 'graduated']
    C --> I[setPackageUpdateAction\nor setAllPackageUpdateActions]
    G --> I
    H --> I
    I --> J[VersionPackageUpdate\naction + actionReason fields]
    J --> K[--json output\nautomatically carries field]
    J --> L[release.ts summary\nannotates each package log line]
    J --> M[format.ts preview\nannotates single-pkg summary]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["test(release): cover bumped + first-rele..."](https://github.com/goosewobbler/releasekit/commit/e4ed3ff11694da749c2e575737ff6eb4a5332925) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39643987)</sub>

<!-- /greptile_comment -->