### PR TITLE
feat(git): add the @releasekit/git execution seam (#357, PR 1)

### DIFF
--- a/packages/git/package.json
+++ b/packages/git/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@releasekit/git",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Git execution seam for releasekit",
+  "type": "module",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
+  },
+  "scripts": {
+    "build": "tsup src/index.ts --format esm --dts",
+    "dev": "tsup src/index.ts --format esm --watch --dts",
+    "clean": "rm -rf dist coverage .turbo",
+    "lint": "biome check .",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:unit": "vitest run --dir test/unit",
+    "test:coverage": "vitest run --coverage"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "catalog:",
+    "@types/node": "catalog:",
+    "@vitest/coverage-v8": "catalog:",
+    "tsup": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "engines": {
+    "node": ">=22"
+  }
+}

--- a/packages/git/src/errors.ts
+++ b/packages/git/src/errors.ts
@@ -1,0 +1,56 @@
+/**
+ * Raised when a `git` invocation fails unexpectedly. Carries the full argv that was run, the exit
+ * code, and stderr, so a caller (or a failure report) can show exactly what was attempted without the
+ * adapter having to log. The argv is the array passed to `execFile` — never a shell string — so there
+ * is nothing to un-escape and no shell interpolation to reconstruct.
+ */
+export class GitError extends Error {
+  /** The argv that failed, e.g. `['tag', '-a', 'v1.0.0', '-m', 'release']`. */
+  readonly args: string[];
+  /** The process exit code, or undefined when git could not be spawned at all. */
+  readonly exitCode: number | undefined;
+  /** Captured stderr, trimmed; empty when none. */
+  readonly stderr: string;
+
+  constructor(message: string, args: string[], exitCode: number | undefined, stderr: string) {
+    super(message);
+    this.name = 'GitError';
+    this.args = args;
+    this.exitCode = exitCode;
+    this.stderr = stderr;
+  }
+}
+
+/**
+ * The exit code carried by a Node `child_process` exec error, if any. `execFile`'s error sets `code`
+ * to the process exit status (a number) for a non-zero exit, or to a string (e.g. `'ENOENT'`) when
+ * the binary is missing — only the numeric form is a real exit code.
+ */
+export function gitExitCode(error: unknown): number | undefined {
+  if (error && typeof error === 'object' && 'code' in error) {
+    const { code } = error as { code?: unknown };
+    if (typeof code === 'number') return code;
+  }
+  return undefined;
+}
+
+/**
+ * Whether `error` means the `git` binary itself could not be found/spawned (ENOENT), as opposed to
+ * git running and exiting non-zero. A missing binary must always surface — even from a "soft" lookup
+ * that otherwise swallows a non-zero exit — because it is a configuration failure, not a "no" answer.
+ */
+export function isCommandNotFound(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+  const { code } = error as { code?: unknown };
+  return code === 'ENOENT';
+}
+
+/**
+ * Whether `error` is a timeout kill from `execFile`'s `timeout` option. Node kills the child with
+ * `killed === true` and surfaces the signal that did it, so the push wrapper can distinguish a hung
+ * push from an ordinary non-zero exit and report it as a timeout.
+ */
+export function isExecTimeout(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+  return (error as { killed?: unknown }).killed === true;
+}

--- a/packages/git/src/fake.ts
+++ b/packages/git/src/fake.ts
@@ -110,7 +110,9 @@ export class FakeGit implements Git {
   readonly committed: FakeCommitRecord[] = [];
   readonly tagged: FakeTagRecord[] = [];
   readonly fetched: string[] = [];
-  readonly checkedOut: string[] = [];
+  /** Each `checkout` call: the ref and whether `-B` (create) was requested — so consumer tests can
+   *  assert the create flag, not just the ref. */
+  readonly checkedOut: Array<{ ref: string; create: boolean }> = [];
   readonly resetTo: string[] = [];
   readonly pushed: FakePushRecord[] = [];
 
@@ -215,8 +217,8 @@ export class FakeGit implements Git {
     this.fetched.push(remote);
   }
 
-  async checkout(ref: string, _opts: GitCheckoutOptions = {}): Promise<void> {
-    this.checkedOut.push(ref);
+  async checkout(ref: string, opts: GitCheckoutOptions = {}): Promise<void> {
+    this.checkedOut.push({ ref, create: opts.create ?? false });
   }
 
   async resetHard(ref: string, _cwd?: string): Promise<void> {

--- a/packages/git/src/fake.ts
+++ b/packages/git/src/fake.ts
@@ -1,0 +1,231 @@
+import type {
+  Git,
+  GitCheckoutOptions,
+  GitCommitOptions,
+  GitCountCommitsOptions,
+  GitFetchOptions,
+  GitForEachRefOptions,
+  GitListTagsOptions,
+  GitLogOptions,
+  GitPushOptions,
+  GitStatusOptions,
+  GitTagOptions,
+} from './types.js';
+
+/** A recorded commit. */
+export interface FakeCommitRecord {
+  message: string;
+  paths?: string[];
+  skipHooks?: boolean;
+}
+
+/** A recorded tag. */
+export interface FakeTagRecord {
+  name: string;
+  message?: string;
+}
+
+/** A recorded push. */
+export interface FakePushRecord {
+  remote: string;
+  ref?: string;
+  force?: boolean;
+  forceWithLease?: boolean;
+  tags?: boolean;
+}
+
+/** A seeded `git log` response, matched against the requested range (or `'*'` as a catch-all). */
+export type FakeLog = Record<string, string>;
+
+/**
+ * Seed state for a {@link FakeGit}. Everything is optional; unseeded reads return empty/false/null so
+ * a consumer can be driven end-to-end without spawning git.
+ */
+export interface FakeGitSeed {
+  /** Whether the directory is a git repo (`isRepository`). Defaults to true. */
+  isRepo?: boolean;
+  /** Tag names returned by `listTags` (in seeded order). */
+  tags?: string[];
+  /** The "nearest reachable tag" returned by `describeTags`. `null` (or omitted) → no tag. */
+  nearestTag?: string | null;
+  /** The SHA returned by `headSha`. */
+  headSha?: string;
+  /** The branch returned by `currentBranch`. */
+  currentBranch?: string;
+  /** Remote URLs by remote name (`remoteUrl`). Unseeded remotes resolve to null. */
+  remoteUrls?: Record<string, string>;
+  /** Refs that `refExists` reports present. */
+  existingRefs?: string[];
+  /**
+   * Ancestry for `isAncestor`. A record maps a `ref` to the list of refs it has as ancestors, OR a
+   * predicate `(ancestor, ref) => boolean` for finer control. Unseeded → false.
+   */
+  ancestors?: Record<string, string[]> | ((ancestor: string, ref: string) => boolean);
+  /** Branches present on each remote (`remoteBranchExists`), keyed by remote name. */
+  remoteBranches?: Record<string, string[]>;
+  /** `git log` responses keyed by range; `'*'` is a catch-all when no range matches. */
+  commits?: FakeLog;
+  /** Changed paths per commit SHA (`diffTreeNames`). Unseeded SHAs return empty. */
+  diffNames?: Record<string, string[]>;
+  /** Lines returned by `forEachRef` (the seam is format-agnostic, so callers seed final lines). */
+  refLines?: string[];
+  /** Commit counts per range (`countCommits`). Unseeded ranges return 0. */
+  commitCounts?: Record<string, number>;
+  /** Working-tree status text returned by `status`. Defaults to empty (clean). */
+  status?: string;
+}
+
+function ancestryHas(ancestors: FakeGitSeed['ancestors'], ancestor: string, ref: string): boolean {
+  if (!ancestors) return false;
+  if (typeof ancestors === 'function') return ancestors(ancestor, ref);
+  return (ancestors[ref] ?? []).includes(ancestor);
+}
+
+/**
+ * In-memory {@link Git} for tests — the second adapter that justifies the seam. Queries return seeded
+ * data; mutations record their calls on public readonly arrays for assertions (and keep the in-memory
+ * view consistent enough to re-query, e.g. a tagged name shows up in `listTags`).
+ */
+export class FakeGit implements Git {
+  private readonly isRepo: boolean;
+  private readonly tagsList: string[];
+  private readonly nearestTag: string | null;
+  private readonly head: string;
+  private readonly branch: string;
+  private readonly remoteUrls: Record<string, string>;
+  private readonly existingRefs: Set<string>;
+  private readonly ancestors: FakeGitSeed['ancestors'];
+  private readonly remoteBranches: Record<string, string[]>;
+  private readonly commits: FakeLog;
+  private readonly diffNames: Record<string, string[]>;
+  private readonly refLines: string[];
+  private readonly commitCounts: Record<string, number>;
+  private statusText: string;
+
+  // Recorded mutations, for assertions.
+  readonly added: string[][] = [];
+  readonly committed: FakeCommitRecord[] = [];
+  readonly tagged: FakeTagRecord[] = [];
+  readonly fetched: string[] = [];
+  readonly checkedOut: string[] = [];
+  readonly resetTo: string[] = [];
+  readonly pushed: FakePushRecord[] = [];
+
+  constructor(seed: FakeGitSeed = {}) {
+    this.isRepo = seed.isRepo ?? true;
+    this.tagsList = [...(seed.tags ?? [])];
+    this.nearestTag = seed.nearestTag ?? null;
+    this.head = seed.headSha ?? '0000000000000000000000000000000000000000';
+    this.branch = seed.currentBranch ?? 'main';
+    this.remoteUrls = seed.remoteUrls ?? {};
+    this.existingRefs = new Set(seed.existingRefs ?? []);
+    this.ancestors = seed.ancestors;
+    this.remoteBranches = seed.remoteBranches ?? {};
+    this.commits = seed.commits ?? {};
+    this.diffNames = seed.diffNames ?? {};
+    this.refLines = [...(seed.refLines ?? [])];
+    this.commitCounts = seed.commitCounts ?? {};
+    this.statusText = seed.status ?? '';
+  }
+
+  // — Queries —
+
+  async isRepository(_cwd?: string): Promise<boolean> {
+    return this.isRepo;
+  }
+
+  async currentBranch(_cwd?: string): Promise<string> {
+    return this.branch;
+  }
+
+  async headSha(_cwd?: string): Promise<string> {
+    return this.head;
+  }
+
+  async remoteUrl(remote: string, _cwd?: string): Promise<string | null> {
+    return this.remoteUrls[remote] ?? null;
+  }
+
+  async listTags(_opts: GitListTagsOptions = {}): Promise<string[]> {
+    return [...this.tagsList];
+  }
+
+  async describeTags(_cwd?: string): Promise<string | null> {
+    return this.nearestTag;
+  }
+
+  async refExists(ref: string, _cwd?: string): Promise<boolean> {
+    return this.existingRefs.has(ref);
+  }
+
+  async isAncestor(ancestor: string, ref: string, _cwd?: string): Promise<boolean> {
+    return ancestryHas(this.ancestors, ancestor, ref);
+  }
+
+  async countCommits(range: string, _opts: GitCountCommitsOptions = {}): Promise<number> {
+    return this.commitCounts[range] ?? 0;
+  }
+
+  async log(opts: GitLogOptions): Promise<string> {
+    const key = opts.range ?? '*';
+    return this.commits[key] ?? this.commits['*'] ?? '';
+  }
+
+  async diffTreeNames(commitSha: string, _cwd?: string): Promise<string[]> {
+    return [...(this.diffNames[commitSha] ?? [])];
+  }
+
+  async forEachRef(_opts: GitForEachRefOptions): Promise<string[]> {
+    return [...this.refLines];
+  }
+
+  async remoteBranchExists(remote: string, branch: string, _cwd?: string): Promise<boolean> {
+    return (this.remoteBranches[remote] ?? []).includes(branch);
+  }
+
+  // — Mutations —
+
+  async add(paths: string[], _cwd?: string): Promise<void> {
+    this.added.push([...paths]);
+  }
+
+  async commit(message: string, opts: GitCommitOptions = {}): Promise<void> {
+    this.committed.push({ message, paths: opts.paths, skipHooks: opts.skipHooks });
+  }
+
+  async tag(name: string, opts: GitTagOptions = {}): Promise<void> {
+    this.tagged.push({ name, message: opts.message });
+    if (!this.tagsList.includes(name)) this.tagsList.push(name);
+  }
+
+  async fetch(remote: string, _opts: GitFetchOptions = {}): Promise<void> {
+    this.fetched.push(remote);
+  }
+
+  async checkout(ref: string, _opts: GitCheckoutOptions = {}): Promise<void> {
+    this.checkedOut.push(ref);
+  }
+
+  async resetHard(ref: string, _cwd?: string): Promise<void> {
+    this.resetTo.push(ref);
+  }
+
+  async status(_opts: GitStatusOptions = {}): Promise<string> {
+    return this.statusText;
+  }
+
+  async push(opts: GitPushOptions): Promise<void> {
+    this.pushed.push({
+      remote: opts.remote,
+      ref: opts.ref,
+      force: opts.force,
+      forceWithLease: opts.forceWithLease,
+      tags: opts.tags,
+    });
+  }
+}
+
+/** Convenience factory mirroring {@link createGitCli}. */
+export function createFakeGit(seed: FakeGitSeed = {}): FakeGit {
+  return new FakeGit(seed);
+}

--- a/packages/git/src/fake.ts
+++ b/packages/git/src/fake.ts
@@ -153,6 +153,12 @@ export class FakeGit implements Git {
     return [...this.tagsList];
   }
 
+  /**
+   * Returns the seeded `nearestTag`. Note the asymmetry with {@link FakeGit.listTags}: `tag()`
+   * appends to the tag list (so `listTags()` reflects newly-created tags) but does NOT update
+   * `nearestTag` — "nearest reachable tag" is a reachability fact the fake can't derive, so seed it
+   * explicitly. A test expecting `describeTags()` to see a tag created via `tag()` must re-seed.
+   */
   async describeTags(_cwd?: string): Promise<string | null> {
     return this.nearestTag;
   }

--- a/packages/git/src/fake.ts
+++ b/packages/git/src/fake.ts
@@ -88,7 +88,8 @@ function ancestryHas(ancestors: FakeGitSeed['ancestors'], ancestor: string, ref:
  */
 export class FakeGit implements Git {
   private readonly isRepo: boolean;
-  private readonly tagsList: string[];
+  // Not readonly: tag() mutates this via push(); the other readonly fields are genuinely immutable.
+  private tagsList: string[];
   private readonly nearestTag: string | null;
   private readonly head: string;
   private readonly branch: string;
@@ -104,6 +105,8 @@ export class FakeGit implements Git {
 
   // Recorded mutations, for assertions.
   readonly added: string[][] = [];
+  /** How many times `addAll()` ("stage everything") was called. */
+  addedAll = 0;
   readonly committed: FakeCommitRecord[] = [];
   readonly tagged: FakeTagRecord[] = [];
   readonly fetched: string[] = [];
@@ -184,6 +187,10 @@ export class FakeGit implements Git {
   }
 
   // — Mutations —
+
+  async addAll(_cwd?: string): Promise<void> {
+    this.addedAll += 1;
+  }
 
   async add(paths: string[], _cwd?: string): Promise<void> {
     this.added.push([...paths]);

--- a/packages/git/src/git.ts
+++ b/packages/git/src/git.ts
@@ -1,0 +1,284 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { GitError, gitExitCode, isCommandNotFound, isExecTimeout } from './errors.js';
+import type {
+  Git,
+  GitCheckoutOptions,
+  GitCommitOptions,
+  GitCountCommitsOptions,
+  GitFetchOptions,
+  GitForEachRefOptions,
+  GitListTagsOptions,
+  GitLogOptions,
+  GitPushOptions,
+  GitStatusOptions,
+  GitTagOptions,
+} from './types.js';
+
+/** Default ceiling for a push, mirroring the safety the publish package's exec wrapper provided. */
+const DEFAULT_PUSH_TIMEOUT_MS = 120_000;
+
+/** Git can emit a lot on a big `log`; match the publish exec wrapper's generous buffer. */
+const MAX_BUFFER = 1024 * 1024 * 10;
+
+/** Result of a single git invocation. */
+interface RunResult {
+  stdout: string;
+  stderr: string;
+}
+
+/** Per-invocation options threaded to the underlying runner. */
+interface RunOptions {
+  cwd: string;
+  /** Discard stdio when the output is irrelevant (the "soft" exit-code lookups). */
+  ignoreOutput?: boolean;
+  /** Hard timeout in milliseconds; on expiry the child is killed and the run rejects. */
+  timeout?: number;
+}
+
+/**
+ * The subprocess primitive the adapter depends on: run `git` with an **argument array** and resolve
+ * its stdout/stderr, or reject with the spawn/exit error. Injectable so tests can supply a stand-in
+ * without spawning a real process; the default is `execFile` bound to the `git` binary.
+ */
+export type GitRunner = (args: string[], options: RunOptions) => Promise<RunResult>;
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * The default {@link GitRunner}: `execFile('git', args)` — an argv array, so no shell, no
+ * interpolation. `ignoreOutput` is part of the runner contract (it lets a custom runner discard
+ * stdio for the soft exit-code lookups), but the promisified `execFile` always buffers stdout/stderr
+ * — bounded by `maxBuffer` — so here we simply ignore the captured output by not reading it.
+ */
+const defaultRunner: GitRunner = async (args, options) => {
+  const { stdout, stderr } = await execFileAsync('git', args, {
+    cwd: options.cwd,
+    maxBuffer: MAX_BUFFER,
+    timeout: options.timeout,
+  });
+  return { stdout: stdout.toString(), stderr: stderr.toString() };
+};
+
+/**
+ * Subprocess-backed {@link Git}. Every method builds an argv array and hands it to the runner — a git
+ * argument is therefore a literal argv slot, never text spliced into a shell command, so a malicious
+ * tag/branch/message can't break out into shell execution (the security smell this seam removes).
+ *
+ * The runner is injected (default: `execFile('git', …)`), so tests assert on the exact argv without
+ * spawning git.
+ */
+export class GitCli implements Git {
+  constructor(private readonly run: GitRunner = defaultRunner) {}
+
+  private cwd(cwd?: string): string {
+    return cwd ?? process.cwd();
+  }
+
+  /** Run git, wrapping any failure in a {@link GitError} that carries the argv, exit code, and stderr. */
+  private async exec(args: string[], options: RunOptions): Promise<RunResult> {
+    try {
+      return await this.run(args, options);
+    } catch (error) {
+      if (isExecTimeout(error)) {
+        throw new GitError(`git ${args.join(' ')} timed out after ${options.timeout}ms`, args, undefined, '');
+      }
+      const stderr = (error as { stderr?: unknown }).stderr;
+      const stderrText = typeof stderr === 'string' ? stderr.trim() : (stderr?.toString().trim() ?? '');
+      const detail = stderrText || (error instanceof Error ? error.message : String(error));
+      throw new GitError(`git ${args.join(' ')} failed: ${detail}`, args, gitExitCode(error), stderrText);
+    }
+  }
+
+  /**
+   * Run a "soft" lookup whose non-zero exit is an expected answer (false/absent), not an error.
+   * Returns true on a clean exit, false on a non-zero exit — but a missing `git` binary (ENOENT)
+   * still throws, because that's a configuration failure, not a "no".
+   */
+  private async execSoft(args: string[], options: RunOptions): Promise<boolean> {
+    try {
+      await this.run(args, options);
+      return true;
+    } catch (error) {
+      if (isCommandNotFound(error)) {
+        throw new GitError(`git binary not found (running: git ${args.join(' ')})`, args, undefined, '');
+      }
+      return false;
+    }
+  }
+
+  // — Queries —
+
+  async isRepository(cwd?: string): Promise<boolean> {
+    return this.execSoft(['rev-parse', '--is-inside-work-tree'], { cwd: this.cwd(cwd), ignoreOutput: true });
+  }
+
+  async currentBranch(cwd?: string): Promise<string> {
+    const { stdout } = await this.exec(['rev-parse', '--abbrev-ref', 'HEAD'], { cwd: this.cwd(cwd) });
+    return stdout.trim();
+  }
+
+  async headSha(cwd?: string): Promise<string> {
+    const { stdout } = await this.exec(['rev-parse', 'HEAD'], { cwd: this.cwd(cwd) });
+    return stdout.trim();
+  }
+
+  async remoteUrl(remote: string, cwd?: string): Promise<string | null> {
+    try {
+      const { stdout } = await this.run(['remote', 'get-url', remote], { cwd: this.cwd(cwd) });
+      return stdout.trim();
+    } catch (error) {
+      if (isCommandNotFound(error)) {
+        throw new GitError(
+          'git binary not found (running: git remote get-url)',
+          ['remote', 'get-url', remote],
+          undefined,
+          '',
+        );
+      }
+      // Non-zero exit (e.g. "No such remote") → the remote is simply absent.
+      return null;
+    }
+  }
+
+  async listTags(opts: GitListTagsOptions = {}): Promise<string[]> {
+    const args = ['tag'];
+    if (opts.sort) args.push(`--sort=${opts.sort}`);
+    const { stdout } = await this.exec(args, { cwd: this.cwd(opts.cwd) });
+    return splitLines(stdout);
+  }
+
+  async describeTags(cwd?: string): Promise<string | null> {
+    try {
+      const { stdout } = await this.run(['describe', '--tags', '--abbrev=0'], { cwd: this.cwd(cwd) });
+      return stdout.trim();
+    } catch (error) {
+      if (isCommandNotFound(error)) {
+        throw new GitError(
+          'git binary not found (running: git describe)',
+          ['describe', '--tags', '--abbrev=0'],
+          undefined,
+          '',
+        );
+      }
+      // Non-zero exit means "no names found, cannot describe anything" → no reachable tag.
+      return null;
+    }
+  }
+
+  async refExists(ref: string, cwd?: string): Promise<boolean> {
+    return this.execSoft(['rev-parse', '--verify', '--quiet', `${ref}^{commit}`], {
+      cwd: this.cwd(cwd),
+      ignoreOutput: true,
+    });
+  }
+
+  async isAncestor(ancestor: string, ref: string, cwd?: string): Promise<boolean> {
+    return this.execSoft(['merge-base', '--is-ancestor', ancestor, ref], { cwd: this.cwd(cwd), ignoreOutput: true });
+  }
+
+  async countCommits(range: string, opts: GitCountCommitsOptions = {}): Promise<number> {
+    const args = ['rev-list', '--count', range];
+    if (opts.path) args.push('--', opts.path);
+    const { stdout } = await this.exec(args, { cwd: this.cwd(opts.cwd) });
+    return Number.parseInt(stdout.trim(), 10) || 0;
+  }
+
+  async log(opts: GitLogOptions): Promise<string> {
+    const args = ['log'];
+    if (opts.format !== undefined) args.push(`--format=${opts.format}`);
+    if (opts.extraArgs) args.push(...opts.extraArgs);
+    if (opts.range !== undefined) args.push(opts.range);
+    if (opts.paths && opts.paths.length > 0) args.push('--', ...opts.paths);
+    const { stdout } = await this.exec(args, { cwd: this.cwd(opts.cwd) });
+    return stdout;
+  }
+
+  async diffTreeNames(commitSha: string, cwd?: string): Promise<string[]> {
+    const { stdout } = await this.exec(['diff-tree', '--no-commit-id', '--name-only', '-r', commitSha], {
+      cwd: this.cwd(cwd),
+    });
+    return splitLines(stdout);
+  }
+
+  async forEachRef(opts: GitForEachRefOptions): Promise<string[]> {
+    const args = ['for-each-ref', `--format=${opts.format}`];
+    if (opts.sort) args.push(`--sort=${opts.sort}`);
+    if (opts.pattern) args.push(opts.pattern);
+    const { stdout } = await this.exec(args, { cwd: this.cwd(opts.cwd) });
+    return splitLines(stdout);
+  }
+
+  async remoteBranchExists(remote: string, branch: string, cwd?: string): Promise<boolean> {
+    return this.execSoft(['ls-remote', '--exit-code', '--heads', remote, branch], {
+      cwd: this.cwd(cwd),
+      ignoreOutput: true,
+    });
+  }
+
+  // — Mutations —
+
+  async add(paths: string[], cwd?: string): Promise<void> {
+    // `add -A` is its own flag form; everything else is an explicit pathspec list after `--`.
+    const args = paths.length === 1 && paths[0] === '-A' ? ['add', '-A'] : ['add', '--', ...paths];
+    await this.exec(args, { cwd: this.cwd(cwd) });
+  }
+
+  async commit(message: string, opts: GitCommitOptions = {}): Promise<void> {
+    const args = ['commit', '-m', message];
+    if (opts.skipHooks) args.push('--no-verify');
+    if (opts.paths && opts.paths.length > 0) args.push('--', ...opts.paths);
+    await this.exec(args, { cwd: this.cwd(opts.cwd) });
+  }
+
+  async tag(name: string, opts: GitTagOptions = {}): Promise<void> {
+    const args = opts.message !== undefined ? ['tag', '-a', name, '-m', opts.message] : ['tag', name];
+    await this.exec(args, { cwd: this.cwd(opts.cwd) });
+  }
+
+  async fetch(remote: string, opts: GitFetchOptions = {}): Promise<void> {
+    await this.exec(['fetch', remote], { cwd: this.cwd(opts.cwd) });
+  }
+
+  async checkout(ref: string, opts: GitCheckoutOptions = {}): Promise<void> {
+    const args = opts.create ? ['checkout', '-B', ref] : ['checkout', ref];
+    await this.exec(args, { cwd: this.cwd(opts.cwd) });
+  }
+
+  async resetHard(ref: string, cwd?: string): Promise<void> {
+    await this.exec(['reset', '--hard', ref], { cwd: this.cwd(cwd) });
+  }
+
+  async status(opts: GitStatusOptions = {}): Promise<string> {
+    const args = ['status'];
+    if (opts.porcelain) args.push('--porcelain');
+    if (opts.paths && opts.paths.length > 0) args.push('--', ...opts.paths);
+    const { stdout } = await this.exec(args, { cwd: this.cwd(opts.cwd) });
+    return stdout;
+  }
+
+  async push(opts: GitPushOptions): Promise<void> {
+    const args = ['push'];
+    if (opts.forceWithLease) args.push('--force-with-lease');
+    else if (opts.force) args.push('--force');
+    if (opts.tags) args.push('--tags');
+    args.push(opts.remote);
+    if (opts.ref !== undefined) args.push(opts.ref);
+    // A push can hang on a stalled network forever; a hard timeout preserves the safety the publish
+    // package previously got from its async exec wrapper. execFile kills the child on expiry.
+    await this.exec(args, { cwd: this.cwd(opts.cwd), timeout: opts.timeoutMs ?? DEFAULT_PUSH_TIMEOUT_MS });
+  }
+}
+
+/** Trim, split on newlines, and drop empties — the shape git's multi-line list outputs need. */
+function splitLines(output: string): string[] {
+  return output
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}
+
+/** Construct a subprocess-backed {@link Git}. Pass a custom runner to redirect away from `execFile`. */
+export function createGitCli(run?: GitRunner): Git {
+  return new GitCli(run);
+}

--- a/packages/git/src/git.ts
+++ b/packages/git/src/git.ts
@@ -46,6 +46,25 @@ export type GitRunner = (args: string[], options: RunOptions) => Promise<RunResu
 const execFileAsync = promisify(execFile);
 
 /**
+ * Reject a value that git would parse as an option. `execFile('git', argv)` uses no shell, so there is
+ * no shell-injection, but git itself still parses a leading-`-` positional as a flag — so a remote of
+ * `--upload-pack=evil`, or a ref/branch/tag of `--output=…`, becomes argument injection (arbitrary
+ * command execution via `--upload-pack`/`--receive-pack`). A ref/remote/branch/tag name can never
+ * legitimately start with `-`, so we refuse it on the data-flow path *before* it reaches the argv —
+ * this is the barrier that severs the injection (and clears CodeQL's second-order alert).
+ */
+function assertNotOption(value: string, kind: string): void {
+  if (value.startsWith('-')) {
+    throw new GitError(
+      `Refusing to run git: ${kind} '${value}' looks like an option (starts with '-')`,
+      [],
+      undefined,
+      '',
+    );
+  }
+}
+
+/**
  * The default {@link GitRunner}: `execFile('git', args)` — an argv array, so no shell, no
  * interpolation. `ignoreOutput` is part of the runner contract (it lets a custom runner discard
  * stdio for the soft exit-code lookups), but the promisified `execFile` always buffers stdout/stderr
@@ -124,6 +143,7 @@ export class GitCli implements Git {
   }
 
   async remoteUrl(remote: string, cwd?: string): Promise<string | null> {
+    assertNotOption(remote, 'remote');
     try {
       const { stdout } = await this.run(['remote', 'get-url', remote], { cwd: this.cwd(cwd) });
       return stdout.trim();
@@ -167,6 +187,7 @@ export class GitCli implements Git {
   }
 
   async refExists(ref: string, cwd?: string): Promise<boolean> {
+    assertNotOption(ref, 'ref');
     return this.execSoft(['rev-parse', '--verify', '--quiet', `${ref}^{commit}`], {
       cwd: this.cwd(cwd),
       ignoreOutput: true,
@@ -174,10 +195,13 @@ export class GitCli implements Git {
   }
 
   async isAncestor(ancestor: string, ref: string, cwd?: string): Promise<boolean> {
+    assertNotOption(ancestor, 'ancestor');
+    assertNotOption(ref, 'ref');
     return this.execSoft(['merge-base', '--is-ancestor', ancestor, ref], { cwd: this.cwd(cwd), ignoreOutput: true });
   }
 
   async countCommits(range: string, opts: GitCountCommitsOptions = {}): Promise<number> {
+    assertNotOption(range, 'range');
     const args = ['rev-list', '--count', range];
     if (opts.path) args.push('--', opts.path);
     const { stdout } = await this.exec(args, { cwd: this.cwd(opts.cwd) });
@@ -185,6 +209,7 @@ export class GitCli implements Git {
   }
 
   async log(opts: GitLogOptions): Promise<string> {
+    if (opts.range !== undefined) assertNotOption(opts.range, 'range');
     const args = ['log'];
     if (opts.format !== undefined) args.push(`--format=${opts.format}`);
     if (opts.extraArgs) args.push(...opts.extraArgs);
@@ -210,6 +235,8 @@ export class GitCli implements Git {
   }
 
   async remoteBranchExists(remote: string, branch: string, cwd?: string): Promise<boolean> {
+    assertNotOption(remote, 'remote');
+    assertNotOption(branch, 'branch');
     return this.execSoft(['ls-remote', '--exit-code', '--heads', remote, branch], {
       cwd: this.cwd(cwd),
       ignoreOutput: true,
@@ -218,10 +245,13 @@ export class GitCli implements Git {
 
   // — Mutations —
 
+  async addAll(cwd?: string): Promise<void> {
+    await this.exec(['add', '-A'], { cwd: this.cwd(cwd) });
+  }
+
   async add(paths: string[], cwd?: string): Promise<void> {
-    // `add -A` is its own flag form; everything else is an explicit pathspec list after `--`.
-    const args = paths.length === 1 && paths[0] === '-A' ? ['add', '-A'] : ['add', '--', ...paths];
-    await this.exec(args, { cwd: this.cwd(cwd) });
+    // Always an explicit pathspec list after `--`; "stage everything" is the dedicated addAll().
+    await this.exec(['add', '--', ...paths], { cwd: this.cwd(cwd) });
   }
 
   async commit(message: string, opts: GitCommitOptions = {}): Promise<void> {
@@ -232,20 +262,24 @@ export class GitCli implements Git {
   }
 
   async tag(name: string, opts: GitTagOptions = {}): Promise<void> {
+    assertNotOption(name, 'tag name');
     const args = opts.message !== undefined ? ['tag', '-a', name, '-m', opts.message] : ['tag', name];
     await this.exec(args, { cwd: this.cwd(opts.cwd) });
   }
 
   async fetch(remote: string, opts: GitFetchOptions = {}): Promise<void> {
+    assertNotOption(remote, 'remote');
     await this.exec(['fetch', remote], { cwd: this.cwd(opts.cwd) });
   }
 
   async checkout(ref: string, opts: GitCheckoutOptions = {}): Promise<void> {
+    assertNotOption(ref, 'ref');
     const args = opts.create ? ['checkout', '-B', ref] : ['checkout', ref];
     await this.exec(args, { cwd: this.cwd(opts.cwd) });
   }
 
   async resetHard(ref: string, cwd?: string): Promise<void> {
+    assertNotOption(ref, 'ref');
     await this.exec(['reset', '--hard', ref], { cwd: this.cwd(cwd) });
   }
 
@@ -258,6 +292,8 @@ export class GitCli implements Git {
   }
 
   async push(opts: GitPushOptions): Promise<void> {
+    assertNotOption(opts.remote, 'remote');
+    if (opts.ref !== undefined) assertNotOption(opts.ref, 'ref');
     const args = ['push'];
     if (opts.forceWithLease) args.push('--force-with-lease');
     else if (opts.force) args.push('--force');

--- a/packages/git/src/git.ts
+++ b/packages/git/src/git.ts
@@ -237,7 +237,9 @@ export class GitCli implements Git {
   async remoteBranchExists(remote: string, branch: string, cwd?: string): Promise<boolean> {
     assertNotOption(remote, 'remote');
     assertNotOption(branch, 'branch');
-    return this.execSoft(['ls-remote', '--exit-code', '--heads', remote, branch], {
+    // `--end-of-options` terminates option parsing so a remote/branch can never be read as a git
+    // option (e.g. a malicious `--upload-pack=…` → RCE). Belt-and-suspenders with assertNotOption.
+    return this.execSoft(['ls-remote', '--exit-code', '--heads', '--end-of-options', remote, branch], {
       cwd: this.cwd(cwd),
       ignoreOutput: true,
     });
@@ -269,7 +271,8 @@ export class GitCli implements Git {
 
   async fetch(remote: string, opts: GitFetchOptions = {}): Promise<void> {
     assertNotOption(remote, 'remote');
-    await this.exec(['fetch', remote], { cwd: this.cwd(opts.cwd) });
+    // `--end-of-options`: a remote can never be parsed as a git option (`--upload-pack=…` → RCE).
+    await this.exec(['fetch', '--end-of-options', remote], { cwd: this.cwd(opts.cwd) });
   }
 
   async checkout(ref: string, opts: GitCheckoutOptions = {}): Promise<void> {
@@ -298,7 +301,8 @@ export class GitCli implements Git {
     if (opts.forceWithLease) args.push('--force-with-lease');
     else if (opts.force) args.push('--force');
     if (opts.tags) args.push('--tags');
-    args.push(opts.remote);
+    // `--end-of-options`: remote/ref can never be parsed as git options (`--receive-pack=…` → RCE).
+    args.push('--end-of-options', opts.remote);
     if (opts.ref !== undefined) args.push(opts.ref);
     // A push can hang on a stalled network forever; a hard timeout preserves the safety the publish
     // package previously got from its async exec wrapper. execFile kills the child on expiry.

--- a/packages/git/src/git.ts
+++ b/packages/git/src/git.ts
@@ -220,6 +220,7 @@ export class GitCli implements Git {
   }
 
   async diffTreeNames(commitSha: string, cwd?: string): Promise<string[]> {
+    assertNotOption(commitSha, 'commit');
     const { stdout } = await this.exec(['diff-tree', '--no-commit-id', '--name-only', '-r', commitSha], {
       cwd: this.cwd(cwd),
     });
@@ -227,6 +228,9 @@ export class GitCli implements Git {
   }
 
   async forEachRef(opts: GitForEachRefOptions): Promise<string[]> {
+    // `format`/`sort` are flag values by design; `pattern` is a positional ref, so guard it like
+    // every other user-controlled positional (a leading-`-` pattern would be read as an option).
+    if (opts.pattern !== undefined) assertNotOption(opts.pattern, 'pattern');
     const args = ['for-each-ref', `--format=${opts.format}`];
     if (opts.sort) args.push(`--sort=${opts.sort}`);
     if (opts.pattern) args.push(opts.pattern);

--- a/packages/git/src/index.ts
+++ b/packages/git/src/index.ts
@@ -1,0 +1,24 @@
+export { GitError, gitExitCode, isCommandNotFound, isExecTimeout } from './errors.js';
+export {
+  createFakeGit,
+  type FakeCommitRecord,
+  FakeGit,
+  type FakeGitSeed,
+  type FakeLog,
+  type FakePushRecord,
+  type FakeTagRecord,
+} from './fake.js';
+export { createGitCli, GitCli, type GitRunner } from './git.js';
+export type {
+  Git,
+  GitCheckoutOptions,
+  GitCommitOptions,
+  GitCountCommitsOptions,
+  GitFetchOptions,
+  GitForEachRefOptions,
+  GitListTagsOptions,
+  GitLogOptions,
+  GitPushOptions,
+  GitStatusOptions,
+  GitTagOptions,
+} from './types.js';

--- a/packages/git/src/types.ts
+++ b/packages/git/src/types.ts
@@ -1,0 +1,156 @@
+/**
+ * `Git` — the local repository's git operations (queries over history/refs, and mutations like
+ * commit/tag/push), behind one execution seam.
+ *
+ * The single real adapter (`GitCli`) shells out to the `git` binary via `node:child_process`'s
+ * `execFile` with an **argument array** — never a shell-interpolated string — so a tag name, branch,
+ * or message containing shell metacharacters can never be re-interpreted by a shell. The in-memory
+ * fake (`FakeGit`) stands in for the binary in tests so consumers can be exercised end-to-end without
+ * spawning git. Methods take/return plain data — they never leak `child_process` types — so the seam
+ * stays swappable.
+ *
+ * Conventions:
+ * - Every method is async and takes an optional `cwd` (default `process.cwd()`).
+ * - "Soft" lookups (`isRepository`, `remoteUrl`, `describeTags`, `refExists`, `isAncestor`,
+ *   `remoteBranchExists`) treat a non-zero git exit as the answer (false/null), not an error; they
+ *   only throw a {@link GitError} when git itself is missing or fails unexpectedly.
+ * - Everything else throws a {@link GitError} on failure, carrying the failed argv, exit code, and
+ *   stderr.
+ */
+
+/** Options for {@link Git.log}. */
+export interface GitLogOptions {
+  /** A commit range, e.g. `v1.0.0..HEAD`. Omit for the full history. */
+  range?: string;
+  /** A `--format=<format>` / `--pretty=format:` string. */
+  format?: string;
+  /** Restrict to commits touching these paths (passed after `--`). */
+  paths?: string[];
+  /** Extra raw arguments inserted before the range (e.g. `--no-merges`, `-n`, `20`). */
+  extraArgs?: string[];
+  cwd?: string;
+}
+
+/** Options for {@link Git.push}. */
+export interface GitPushOptions {
+  remote: string;
+  /** The ref(spec) to push, e.g. `HEAD:release/next` or a tag name. */
+  ref?: string;
+  force?: boolean;
+  forceWithLease?: boolean;
+  /** Push tags (`--tags`). */
+  tags?: boolean;
+  cwd?: string;
+  /** Hard ceiling for the push in milliseconds; a hung push is killed and surfaced as a timeout. */
+  timeoutMs?: number;
+}
+
+/** Options for {@link Git.commit}. */
+export interface GitCommitOptions {
+  cwd?: string;
+  /** Limit the commit to these pathspecs (passed after `--`). */
+  paths?: string[];
+  /** Pass `--no-verify` to skip pre-commit / commit-msg hooks. */
+  skipHooks?: boolean;
+}
+
+/** Options for {@link Git.tag}. */
+export interface GitTagOptions {
+  /** When set, create an annotated tag (`-a -m <message>`); otherwise a lightweight tag. */
+  message?: string;
+  cwd?: string;
+}
+
+/** Options for {@link Git.fetch}. */
+export interface GitFetchOptions {
+  cwd?: string;
+}
+
+/** Options for {@link Git.checkout}. */
+export interface GitCheckoutOptions {
+  /** Create (or reset) the branch with `-B`. */
+  create?: boolean;
+  cwd?: string;
+}
+
+/** Options for {@link Git.listTags}. */
+export interface GitListTagsOptions {
+  /** A `--sort=<key>` value, e.g. `-creatordate` or `version:refname`. */
+  sort?: string;
+  cwd?: string;
+}
+
+/** Options for {@link Git.countCommits}. */
+export interface GitCountCommitsOptions {
+  /** Restrict the count to commits touching this path (passed after `--`). */
+  path?: string;
+  cwd?: string;
+}
+
+/** Options for {@link Git.forEachRef}. */
+export interface GitForEachRefOptions {
+  /** A `--format=<format>` string. */
+  format: string;
+  /** A `--sort=<key>` value. */
+  sort?: string;
+  /** A ref pattern to match, e.g. `refs/tags/v*`. */
+  pattern?: string;
+  cwd?: string;
+}
+
+/** Options for {@link Git.status}. */
+export interface GitStatusOptions {
+  /** Use `--porcelain` machine-readable output. */
+  porcelain?: boolean;
+  /** Restrict to these pathspecs (passed after `--`). */
+  paths?: string[];
+  cwd?: string;
+}
+
+export interface Git {
+  // — Queries —
+  /** Whether `cwd` is inside a git work tree (`rev-parse --is-inside-work-tree`); false on failure. */
+  isRepository(cwd?: string): Promise<boolean>;
+  /** The current branch name (`rev-parse --abbrev-ref HEAD`). */
+  currentBranch(cwd?: string): Promise<string>;
+  /** The full SHA of `HEAD` (`rev-parse HEAD`). */
+  headSha(cwd?: string): Promise<string>;
+  /** The configured URL of `remote` (`remote get-url`), or null when the remote is absent. */
+  remoteUrl(remote: string, cwd?: string): Promise<string | null>;
+  /** All tag names (`tag`), optionally sorted by `sort` (`--sort=<sort>`). */
+  listTags(opts?: GitListTagsOptions): Promise<string[]>;
+  /** The most recent reachable tag (`describe --tags --abbrev=0`), or null when there is none. */
+  describeTags(cwd?: string): Promise<string | null>;
+  /** Whether `ref` resolves to a commit (`rev-parse --verify --quiet <ref>^{commit}`). */
+  refExists(ref: string, cwd?: string): Promise<boolean>;
+  /** Whether `ancestor` is an ancestor of `ref` (`merge-base --is-ancestor`). */
+  isAncestor(ancestor: string, ref: string, cwd?: string): Promise<boolean>;
+  /** Number of commits in `range` (`rev-list --count`), optionally restricted to a path. */
+  countCommits(range: string, opts?: GitCountCommitsOptions): Promise<number>;
+  /** Raw `git log` output for the given range/format/paths. */
+  log(opts: GitLogOptions): Promise<string>;
+  /** File paths changed by `commitSha` (`diff-tree --no-commit-id --name-only -r`). */
+  diffTreeNames(commitSha: string, cwd?: string): Promise<string[]>;
+  /** One formatted line per matching ref (`for-each-ref`), empties dropped. */
+  forEachRef(opts: GitForEachRefOptions): Promise<string[]>;
+  /** Whether `branch` exists on `remote` (`ls-remote --exit-code --heads`). */
+  remoteBranchExists(remote: string, branch: string, cwd?: string): Promise<boolean>;
+
+  // — Mutations —
+  /** Stage paths (`add -- <paths>`); pass `['-A']` to stage everything (`add -A`). */
+  add(paths: string[], cwd?: string): Promise<void>;
+  /** Create a commit with `message` (`commit -m`), optionally scoped to paths / skipping hooks. */
+  commit(message: string, opts?: GitCommitOptions): Promise<void>;
+  /** Create a tag `name` — annotated when `message` is given (`tag -a -m`), else lightweight. */
+  tag(name: string, opts?: GitTagOptions): Promise<void>;
+  /** Fetch from `remote` (`fetch`). */
+  fetch(remote: string, opts?: GitFetchOptions): Promise<void>;
+  /** Check out `ref` (`checkout`); with `create`, create/reset the branch (`checkout -B`). */
+  checkout(ref: string, opts?: GitCheckoutOptions): Promise<void>;
+  /** Hard-reset the work tree to `ref` (`reset --hard`). */
+  resetHard(ref: string, cwd?: string): Promise<void>;
+  /** Working-tree status (`status`), optionally porcelain and/or scoped to paths. */
+  status(opts?: GitStatusOptions): Promise<string>;
+  /** Push to a remote (`push`); supports force / force-with-lease / tags and a hard timeout. */
+  push(opts: GitPushOptions): Promise<void>;
+}

--- a/packages/git/src/types.ts
+++ b/packages/git/src/types.ts
@@ -137,8 +137,10 @@ export interface Git {
   remoteBranchExists(remote: string, branch: string, cwd?: string): Promise<boolean>;
 
   // — Mutations —
-  /** Stage paths (`add -- <paths>`); pass `['-A']` to stage everything (`add -A`). */
+  /** Stage the given pathspecs (`add -- <paths>`). To stage everything, use {@link Git.addAll}. */
   add(paths: string[], cwd?: string): Promise<void>;
+  /** Stage every change in the work tree (`add -A`). */
+  addAll(cwd?: string): Promise<void>;
   /** Create a commit with `message` (`commit -m`), optionally scoped to paths / skipping hooks. */
   commit(message: string, opts?: GitCommitOptions): Promise<void>;
   /** Create a tag `name` — annotated when `message` is given (`tag -a -m`), else lightweight. */

--- a/packages/git/test/unit/fake.spec.ts
+++ b/packages/git/test/unit/fake.spec.ts
@@ -99,13 +99,18 @@ describe('FakeGit mutations', () => {
     await git.commit('chore: release', { paths: ['CHANGELOG.md'], skipHooks: true });
     await git.fetch('origin');
     await git.checkout('release/next', { create: true });
+    await git.checkout('main');
     await git.resetHard('origin/main');
 
     expect(git.added).toEqual([['a.ts', 'b.ts']]);
     expect(git.addedAll).toBe(2);
     expect(git.committed).toEqual([{ message: 'chore: release', paths: ['CHANGELOG.md'], skipHooks: true }]);
     expect(git.fetched).toEqual(['origin']);
-    expect(git.checkedOut).toEqual(['release/next']);
+    // Records the create flag, not just the ref.
+    expect(git.checkedOut).toEqual([
+      { ref: 'release/next', create: true },
+      { ref: 'main', create: false },
+    ]);
     expect(git.resetTo).toEqual(['origin/main']);
   });
 

--- a/packages/git/test/unit/fake.spec.ts
+++ b/packages/git/test/unit/fake.spec.ts
@@ -91,16 +91,18 @@ describe('FakeGit queries', () => {
 });
 
 describe('FakeGit mutations', () => {
-  it('should record adds, commits, fetches, checkouts, and resets', async () => {
+  it('should record adds, addAll, commits, fetches, checkouts, and resets', async () => {
     const git = createFakeGit();
     await git.add(['a.ts', 'b.ts']);
-    await git.add(['-A']);
+    await git.addAll();
+    await git.addAll();
     await git.commit('chore: release', { paths: ['CHANGELOG.md'], skipHooks: true });
     await git.fetch('origin');
     await git.checkout('release/next', { create: true });
     await git.resetHard('origin/main');
 
-    expect(git.added).toEqual([['a.ts', 'b.ts'], ['-A']]);
+    expect(git.added).toEqual([['a.ts', 'b.ts']]);
+    expect(git.addedAll).toBe(2);
     expect(git.committed).toEqual([{ message: 'chore: release', paths: ['CHANGELOG.md'], skipHooks: true }]);
     expect(git.fetched).toEqual(['origin']);
     expect(git.checkedOut).toEqual(['release/next']);

--- a/packages/git/test/unit/fake.spec.ts
+++ b/packages/git/test/unit/fake.spec.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from 'vitest';
+import { createFakeGit } from '../../src/fake.js';
+
+describe('FakeGit queries', () => {
+  it('should return seeded reads and sensible defaults for unseeded ones', async () => {
+    const git = createFakeGit({
+      tags: ['v1.0.0', 'v1.1.0'],
+      nearestTag: 'v1.1.0',
+      headSha: 'deadbeef',
+      currentBranch: 'release/next',
+      remoteUrls: { origin: 'git@github.com:o/r.git' },
+      commitCounts: { 'v1..HEAD': 3 },
+      status: ' M a.ts\n',
+    });
+
+    expect(await git.isRepository()).toBe(true);
+    expect(await git.listTags()).toEqual(['v1.0.0', 'v1.1.0']);
+    expect(await git.describeTags()).toBe('v1.1.0');
+    expect(await git.headSha()).toBe('deadbeef');
+    expect(await git.currentBranch()).toBe('release/next');
+    expect(await git.remoteUrl('origin')).toBe('git@github.com:o/r.git');
+    expect(await git.remoteUrl('upstream')).toBeNull();
+    expect(await git.countCommits('v1..HEAD')).toBe(3);
+    expect(await git.countCommits('absent..HEAD')).toBe(0);
+    expect(await git.status({ porcelain: true })).toBe(' M a.ts\n');
+  });
+
+  it('should default to a repo with main/zeroed-sha and empty/null reads when unseeded', async () => {
+    const git = createFakeGit();
+    expect(await git.isRepository()).toBe(true);
+    expect(await git.currentBranch()).toBe('main');
+    expect(await git.headSha()).toMatch(/^0+$/);
+    expect(await git.describeTags()).toBeNull();
+    expect(await git.listTags()).toEqual([]);
+    expect(await git.status()).toBe('');
+  });
+
+  it('should honour an isRepo: false seed', async () => {
+    expect(await createFakeGit({ isRepo: false }).isRepository()).toBe(false);
+  });
+
+  it('should report seeded existing refs', async () => {
+    const git = createFakeGit({ existingRefs: ['v1.0.0', 'refs/heads/main'] });
+    expect(await git.refExists('v1.0.0')).toBe(true);
+    expect(await git.refExists('refs/heads/main')).toBe(true);
+    expect(await git.refExists('missing')).toBe(false);
+  });
+
+  it('should resolve isAncestor from a record of descendant -> ancestors', async () => {
+    const git = createFakeGit({ ancestors: { HEAD: ['v1.0.0', 'main'] } });
+    expect(await git.isAncestor('v1.0.0', 'HEAD')).toBe(true);
+    expect(await git.isAncestor('main', 'HEAD')).toBe(true);
+    expect(await git.isAncestor('v2.0.0', 'HEAD')).toBe(false);
+    expect(await git.isAncestor('v1.0.0', 'other')).toBe(false);
+  });
+
+  it('should resolve isAncestor from a predicate seed', async () => {
+    const git = createFakeGit({ ancestors: (ancestor, ref) => ancestor === 'base' && ref === 'tip' });
+    expect(await git.isAncestor('base', 'tip')).toBe(true);
+    expect(await git.isAncestor('base', 'other')).toBe(false);
+  });
+
+  it('should match log by range, falling back to the * catch-all', async () => {
+    const git = createFakeGit({ commits: { 'v1..HEAD': 'ranged log', '*': 'all log' } });
+    expect(await git.log({ range: 'v1..HEAD' })).toBe('ranged log');
+    expect(await git.log({ range: 'other..HEAD' })).toBe('all log');
+    expect(await git.log({})).toBe('all log');
+  });
+
+  it('should return empty log when neither the range nor a catch-all is seeded', async () => {
+    expect(await createFakeGit().log({ range: 'v1..HEAD' })).toBe('');
+  });
+
+  it('should return seeded changed paths per commit', async () => {
+    const git = createFakeGit({ diffNames: { sha1: ['a.ts', 'b.ts'] } });
+    expect(await git.diffTreeNames('sha1')).toEqual(['a.ts', 'b.ts']);
+    expect(await git.diffTreeNames('sha2')).toEqual([]);
+  });
+
+  it('should return seeded for-each-ref lines', async () => {
+    const git = createFakeGit({ refLines: ['v1 sha1', 'v2 sha2'] });
+    expect(await git.forEachRef({ format: '%(refname)' })).toEqual(['v1 sha1', 'v2 sha2']);
+  });
+
+  it('should report seeded remote branches per remote', async () => {
+    const git = createFakeGit({ remoteBranches: { origin: ['release/next'] } });
+    expect(await git.remoteBranchExists('origin', 'release/next')).toBe(true);
+    expect(await git.remoteBranchExists('origin', 'main')).toBe(false);
+    expect(await git.remoteBranchExists('upstream', 'release/next')).toBe(false);
+  });
+});
+
+describe('FakeGit mutations', () => {
+  it('should record adds, commits, fetches, checkouts, and resets', async () => {
+    const git = createFakeGit();
+    await git.add(['a.ts', 'b.ts']);
+    await git.add(['-A']);
+    await git.commit('chore: release', { paths: ['CHANGELOG.md'], skipHooks: true });
+    await git.fetch('origin');
+    await git.checkout('release/next', { create: true });
+    await git.resetHard('origin/main');
+
+    expect(git.added).toEqual([['a.ts', 'b.ts'], ['-A']]);
+    expect(git.committed).toEqual([{ message: 'chore: release', paths: ['CHANGELOG.md'], skipHooks: true }]);
+    expect(git.fetched).toEqual(['origin']);
+    expect(git.checkedOut).toEqual(['release/next']);
+    expect(git.resetTo).toEqual(['origin/main']);
+  });
+
+  it('should record tags and surface a new tag in listTags', async () => {
+    const git = createFakeGit({ tags: ['v1.0.0'] });
+    await git.tag('v1.1.0', { message: 'release v1.1.0' });
+    await git.tag('v1.0.0'); // already present — not duplicated
+
+    expect(git.tagged).toEqual([
+      { name: 'v1.1.0', message: 'release v1.1.0' },
+      { name: 'v1.0.0', message: undefined },
+    ]);
+    expect(await git.listTags()).toEqual(['v1.0.0', 'v1.1.0']);
+  });
+
+  it('should record pushes with their flags', async () => {
+    const git = createFakeGit();
+    await git.push({ remote: 'origin', ref: 'HEAD:release/next', forceWithLease: true, tags: true });
+    await git.push({ remote: 'origin', force: true });
+
+    expect(git.pushed).toEqual([
+      { remote: 'origin', ref: 'HEAD:release/next', force: undefined, forceWithLease: true, tags: true },
+      { remote: 'origin', ref: undefined, force: true, forceWithLease: undefined, tags: undefined },
+    ]);
+  });
+});
+
+describe('createFakeGit', () => {
+  it('should not share recorded-call arrays between instances', async () => {
+    const a = createFakeGit();
+    await a.commit('one');
+    const b = createFakeGit();
+    expect(b.committed).toEqual([]);
+    expect(a.committed).toHaveLength(1);
+  });
+});

--- a/packages/git/test/unit/git.spec.ts
+++ b/packages/git/test/unit/git.spec.ts
@@ -183,7 +183,14 @@ describe('GitCli queries', () => {
   it('should answer remoteBranchExists via ls-remote --exit-code exit code', async () => {
     const yes = makeRunner();
     expect(await new GitCli(yes.run).remoteBranchExists('origin', 'release/next', '/r')).toBe(true);
-    expect(yes.calls[0].args).toEqual(['ls-remote', '--exit-code', '--heads', 'origin', 'release/next']);
+    expect(yes.calls[0].args).toEqual([
+      'ls-remote',
+      '--exit-code',
+      '--heads',
+      '--end-of-options',
+      'origin',
+      'release/next',
+    ]);
 
     const no = makeRunner({ reject: exitError(2) });
     expect(await new GitCli(no.run).remoteBranchExists('origin', 'absent')).toBe(false);
@@ -236,7 +243,7 @@ describe('GitCli mutations', () => {
   it('should fetch from the named remote', async () => {
     const { run, calls } = makeRunner();
     await new GitCli(run).fetch('origin', { cwd: '/r' });
-    expect(calls[0].args).toEqual(['fetch', 'origin']);
+    expect(calls[0].args).toEqual(['fetch', '--end-of-options', 'origin']);
   });
 
   it('should checkout a ref, using -B when create is set', async () => {
@@ -272,7 +279,7 @@ describe('GitCli.push', () => {
   it('should push the remote and ref and pass the default timeout to execFile', async () => {
     const { run, calls } = makeRunner();
     await new GitCli(run).push({ remote: 'origin', ref: 'HEAD:release/next', cwd: '/r' });
-    expect(calls[0].args).toEqual(['push', 'origin', 'HEAD:release/next']);
+    expect(calls[0].args).toEqual(['push', '--end-of-options', 'origin', 'HEAD:release/next']);
     expect(calls[0].options.timeout).toBe(120_000);
   });
 
@@ -285,13 +292,13 @@ describe('GitCli.push', () => {
   it('should prefer --force-with-lease over --force and include --tags', async () => {
     const { run, calls } = makeRunner();
     await new GitCli(run).push({ remote: 'origin', force: true, forceWithLease: true, tags: true });
-    expect(calls[0].args).toEqual(['push', '--force-with-lease', '--tags', 'origin']);
+    expect(calls[0].args).toEqual(['push', '--force-with-lease', '--tags', '--end-of-options', 'origin']);
   });
 
   it('should use --force when only force is set', async () => {
     const { run, calls } = makeRunner();
     await new GitCli(run).push({ remote: 'origin', force: true, ref: 'main' });
-    expect(calls[0].args).toEqual(['push', '--force', 'origin', 'main']);
+    expect(calls[0].args).toEqual(['push', '--force', '--end-of-options', 'origin', 'main']);
   });
 
   it('should throw a GitError noting the timeout when the push is killed', async () => {
@@ -334,7 +341,7 @@ describe('GitCli option-injection guard', () => {
   it('should still run a normal value through the guard unharmed', async () => {
     const { run, calls } = makeRunner();
     await new GitCli(run).fetch('origin');
-    expect(calls[0].args).toEqual(['fetch', 'origin']);
+    expect(calls[0].args).toEqual(['fetch', '--end-of-options', 'origin']);
   });
 });
 

--- a/packages/git/test/unit/git.spec.ts
+++ b/packages/git/test/unit/git.spec.ts
@@ -197,9 +197,15 @@ describe('GitCli mutations', () => {
     expect(calls[0].args).toEqual(['add', '--', 'a.ts', 'b.ts']);
   });
 
-  it('should stage everything with add -A when paths is ["-A"]', async () => {
+  it('should stage a literal "-A" path after -- rather than treating it as a flag', async () => {
     const { run, calls } = makeRunner();
     await new GitCli(run).add(['-A']);
+    expect(calls[0].args).toEqual(['add', '--', '-A']);
+  });
+
+  it('should stage everything with add -A via addAll', async () => {
+    const { run, calls } = makeRunner();
+    await new GitCli(run).addAll('/r');
     expect(calls[0].args).toEqual(['add', '-A']);
   });
 
@@ -291,6 +297,44 @@ describe('GitCli.push', () => {
   it('should throw a GitError noting the timeout when the push is killed', async () => {
     const { run } = makeRunner({ reject: timeoutKill() });
     await expect(new GitCli(run).push({ remote: 'origin', timeoutMs: 10 })).rejects.toThrow(/timed out after 10ms/);
+  });
+});
+
+describe('GitCli option-injection guard', () => {
+  it('should refuse a leading-dash remote in fetch and never call the runner', async () => {
+    const { run } = makeRunner();
+    await expect(new GitCli(run).fetch('--upload-pack=evil')).rejects.toBeInstanceOf(GitError);
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it('should refuse a leading-dash ref in checkout and never call the runner', async () => {
+    const { run } = makeRunner();
+    await expect(new GitCli(run).checkout('-malicious')).rejects.toThrow(/looks like an option/);
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it('should refuse a leading-dash tag name and never call the runner', async () => {
+    const { run } = makeRunner();
+    await expect(new GitCli(run).tag('--force')).rejects.toBeInstanceOf(GitError);
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it('should refuse a leading-dash branch in remoteBranchExists and never call the runner', async () => {
+    const { run } = makeRunner();
+    await expect(new GitCli(run).remoteBranchExists('origin', '--output=evil')).rejects.toBeInstanceOf(GitError);
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it('should refuse a leading-dash remote in push and never call the runner', async () => {
+    const { run } = makeRunner();
+    await expect(new GitCli(run).push({ remote: '--receive-pack=evil' })).rejects.toBeInstanceOf(GitError);
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it('should still run a normal value through the guard unharmed', async () => {
+    const { run, calls } = makeRunner();
+    await new GitCli(run).fetch('origin');
+    expect(calls[0].args).toEqual(['fetch', 'origin']);
   });
 });
 

--- a/packages/git/test/unit/git.spec.ts
+++ b/packages/git/test/unit/git.spec.ts
@@ -1,0 +1,345 @@
+import { describe, expect, it, vi } from 'vitest';
+import { GitError, gitExitCode, isCommandNotFound, isExecTimeout } from '../../src/errors.js';
+import { createGitCli, GitCli, type GitRunner } from '../../src/git.js';
+
+interface RunOptions {
+  cwd: string;
+  ignoreOutput?: boolean;
+  timeout?: number;
+}
+
+/** A recorded invocation: the argv git would have run, plus the per-call options. */
+interface Call {
+  args: string[];
+  options: RunOptions;
+}
+
+/**
+ * A hand-built {@link GitRunner} stand-in (the analogue of forge's `makeOctokit`). It records every
+ * argv array, returns canned stdout/stderr, and can be told to reject — so a test asserts on the exact
+ * arguments without spawning a real `git`.
+ */
+function makeRunner(responses: { stdout?: string; stderr?: string; reject?: unknown } = {}) {
+  const calls: Call[] = [];
+  const run: GitRunner = vi.fn(async (args, options) => {
+    calls.push({ args, options });
+    if (responses.reject !== undefined) throw responses.reject;
+    return { stdout: responses.stdout ?? '', stderr: responses.stderr ?? '' };
+  });
+  return { run, calls };
+}
+
+/** A Node exec-style error: numeric `code` is an exit status; `stderr` carries git's message. */
+const exitError = (code: number, stderr = '') => Object.assign(new Error(`exit ${code}`), { code, stderr });
+/** A missing-binary spawn error. */
+const enoent = () => Object.assign(new Error('spawn git ENOENT'), { code: 'ENOENT' });
+/** A timeout kill from execFile's `timeout` option. */
+const timeoutKill = () => Object.assign(new Error('killed'), { killed: true, signal: 'SIGTERM' });
+
+describe('GitCli queries', () => {
+  it('should shell out for isRepository with an argv array and ignored stdio, true on clean exit', async () => {
+    const { run, calls } = makeRunner();
+    expect(await new GitCli(run).isRepository('/repo')).toBe(true);
+    expect(calls[0].args).toEqual(['rev-parse', '--is-inside-work-tree']);
+    expect(calls[0].options).toEqual({ cwd: '/repo', ignoreOutput: true });
+  });
+
+  it('should return false from isRepository when git exits non-zero', async () => {
+    const { run } = makeRunner({ reject: exitError(128, 'not a git repository') });
+    expect(await new GitCli(run).isRepository('/tmp')).toBe(false);
+  });
+
+  it('should throw from isRepository when the git binary is missing', async () => {
+    const { run } = makeRunner({ reject: enoent() });
+    await expect(new GitCli(run).isRepository()).rejects.toBeInstanceOf(GitError);
+  });
+
+  it('should trim the branch name from rev-parse --abbrev-ref HEAD', async () => {
+    const { run, calls } = makeRunner({ stdout: 'release/next\n' });
+    expect(await new GitCli(run).currentBranch('/r')).toBe('release/next');
+    expect(calls[0].args).toEqual(['rev-parse', '--abbrev-ref', 'HEAD']);
+  });
+
+  it('should trim the head sha from rev-parse HEAD', async () => {
+    const { run, calls } = makeRunner({ stdout: 'abc123\n' });
+    expect(await new GitCli(run).headSha()).toBe('abc123');
+    expect(calls[0].args).toEqual(['rev-parse', 'HEAD']);
+  });
+
+  it('should return the remote url, trimmed', async () => {
+    const { run, calls } = makeRunner({ stdout: 'git@github.com:o/r.git\n' });
+    expect(await new GitCli(run).remoteUrl('origin', '/r')).toBe('git@github.com:o/r.git');
+    expect(calls[0].args).toEqual(['remote', 'get-url', 'origin']);
+  });
+
+  it('should return null from remoteUrl when the remote is absent (non-zero exit)', async () => {
+    const { run } = makeRunner({ reject: exitError(2, 'No such remote') });
+    expect(await new GitCli(run).remoteUrl('upstream')).toBeNull();
+  });
+
+  it('should throw from remoteUrl when the git binary is missing', async () => {
+    const { run } = makeRunner({ reject: enoent() });
+    await expect(new GitCli(run).remoteUrl('origin')).rejects.toBeInstanceOf(GitError);
+  });
+
+  it('should list tags and pass --sort when given, splitting and dropping empties', async () => {
+    const { run, calls } = makeRunner({ stdout: 'v1.0.0\nv1.1.0\n\n' });
+    expect(await new GitCli(run).listTags({ sort: '-creatordate' })).toEqual(['v1.0.0', 'v1.1.0']);
+    expect(calls[0].args).toEqual(['tag', '--sort=-creatordate']);
+  });
+
+  it('should list tags without --sort when none is given', async () => {
+    const { run, calls } = makeRunner({ stdout: 'v1\n' });
+    await new GitCli(run).listTags();
+    expect(calls[0].args).toEqual(['tag']);
+  });
+
+  it('should return the nearest tag from describe, trimmed', async () => {
+    const { run, calls } = makeRunner({ stdout: 'v2.0.0\n' });
+    expect(await new GitCli(run).describeTags('/r')).toBe('v2.0.0');
+    expect(calls[0].args).toEqual(['describe', '--tags', '--abbrev=0']);
+  });
+
+  it('should return null from describeTags when there is no reachable tag (non-zero exit)', async () => {
+    const { run } = makeRunner({ reject: exitError(128, 'No names found') });
+    expect(await new GitCli(run).describeTags()).toBeNull();
+  });
+
+  it('should verify a ref with the ^{commit} peel and ignored stdio, true on clean exit', async () => {
+    const { run, calls } = makeRunner();
+    expect(await new GitCli(run).refExists('v1.0.0', '/r')).toBe(true);
+    expect(calls[0].args).toEqual(['rev-parse', '--verify', '--quiet', 'v1.0.0^{commit}']);
+    expect(calls[0].options.ignoreOutput).toBe(true);
+  });
+
+  it('should return false from refExists when the ref does not resolve', async () => {
+    const { run } = makeRunner({ reject: exitError(1) });
+    expect(await new GitCli(run).refExists('missing')).toBe(false);
+  });
+
+  it('should answer isAncestor via merge-base --is-ancestor exit code', async () => {
+    const ok = makeRunner();
+    expect(await new GitCli(ok.run).isAncestor('a', 'b', '/r')).toBe(true);
+    expect(ok.calls[0].args).toEqual(['merge-base', '--is-ancestor', 'a', 'b']);
+
+    const no = makeRunner({ reject: exitError(1) });
+    expect(await new GitCli(no.run).isAncestor('a', 'b')).toBe(false);
+  });
+
+  it('should count commits, appending the path after -- when given', async () => {
+    const { run, calls } = makeRunner({ stdout: '7\n' });
+    expect(await new GitCli(run).countCommits('v1..HEAD', { path: 'packages/git' })).toBe(7);
+    expect(calls[0].args).toEqual(['rev-list', '--count', 'v1..HEAD', '--', 'packages/git']);
+  });
+
+  it('should count commits without a path and default unparseable output to 0', async () => {
+    const { run, calls } = makeRunner({ stdout: '\n' });
+    expect(await new GitCli(run).countCommits('v1..HEAD')).toBe(0);
+    expect(calls[0].args).toEqual(['rev-list', '--count', 'v1..HEAD']);
+  });
+
+  it('should build a git log argv with format, extraArgs, range, and paths in order', async () => {
+    const { run, calls } = makeRunner({ stdout: 'raw log\n' });
+    const out = await new GitCli(run).log({
+      format: '%H %s',
+      extraArgs: ['--no-merges'],
+      range: 'v1..HEAD',
+      paths: ['a.ts', 'b.ts'],
+      cwd: '/r',
+    });
+    expect(out).toBe('raw log\n');
+    expect(calls[0].args).toEqual(['log', '--format=%H %s', '--no-merges', 'v1..HEAD', '--', 'a.ts', 'b.ts']);
+  });
+
+  it('should omit format/range/paths from git log when not provided', async () => {
+    const { run, calls } = makeRunner({ stdout: '' });
+    await new GitCli(run).log({});
+    expect(calls[0].args).toEqual(['log']);
+  });
+
+  it('should list changed paths from diff-tree, splitting and dropping empties', async () => {
+    const { run, calls } = makeRunner({ stdout: 'a.ts\nb.ts\n\n' });
+    expect(await new GitCli(run).diffTreeNames('sha1', '/r')).toEqual(['a.ts', 'b.ts']);
+    expect(calls[0].args).toEqual(['diff-tree', '--no-commit-id', '--name-only', '-r', 'sha1']);
+  });
+
+  it('should run for-each-ref with format, and append sort/pattern when given', async () => {
+    const { run, calls } = makeRunner({ stdout: 'v1 sha1\nv2 sha2\n' });
+    expect(
+      await new GitCli(run).forEachRef({
+        format: '%(refname) %(objectname)',
+        sort: '-creatordate',
+        pattern: 'refs/tags/v*',
+      }),
+    ).toEqual(['v1 sha1', 'v2 sha2']);
+    expect(calls[0].args).toEqual([
+      'for-each-ref',
+      '--format=%(refname) %(objectname)',
+      '--sort=-creatordate',
+      'refs/tags/v*',
+    ]);
+  });
+
+  it('should answer remoteBranchExists via ls-remote --exit-code exit code', async () => {
+    const yes = makeRunner();
+    expect(await new GitCli(yes.run).remoteBranchExists('origin', 'release/next', '/r')).toBe(true);
+    expect(yes.calls[0].args).toEqual(['ls-remote', '--exit-code', '--heads', 'origin', 'release/next']);
+
+    const no = makeRunner({ reject: exitError(2) });
+    expect(await new GitCli(no.run).remoteBranchExists('origin', 'absent')).toBe(false);
+  });
+});
+
+describe('GitCli mutations', () => {
+  it('should stage explicit paths after --', async () => {
+    const { run, calls } = makeRunner();
+    await new GitCli(run).add(['a.ts', 'b.ts'], '/r');
+    expect(calls[0].args).toEqual(['add', '--', 'a.ts', 'b.ts']);
+  });
+
+  it('should stage everything with add -A when paths is ["-A"]', async () => {
+    const { run, calls } = makeRunner();
+    await new GitCli(run).add(['-A']);
+    expect(calls[0].args).toEqual(['add', '-A']);
+  });
+
+  it('should commit with -m and append --no-verify and pathspecs when requested', async () => {
+    const { run, calls } = makeRunner();
+    await new GitCli(run).commit('chore: release', { skipHooks: true, paths: ['CHANGELOG.md'], cwd: '/r' });
+    expect(calls[0].args).toEqual(['commit', '-m', 'chore: release', '--no-verify', '--', 'CHANGELOG.md']);
+  });
+
+  it('should commit with a bare -m when no options are given', async () => {
+    const { run, calls } = makeRunner();
+    await new GitCli(run).commit('feat: x');
+    expect(calls[0].args).toEqual(['commit', '-m', 'feat: x']);
+  });
+
+  it('should create an annotated tag when a message is given', async () => {
+    const { run, calls } = makeRunner();
+    await new GitCli(run).tag('v1.0.0', { message: 'release v1.0.0', cwd: '/r' });
+    expect(calls[0].args).toEqual(['tag', '-a', 'v1.0.0', '-m', 'release v1.0.0']);
+  });
+
+  it('should create a lightweight tag when no message is given', async () => {
+    const { run, calls } = makeRunner();
+    await new GitCli(run).tag('v1.0.0');
+    expect(calls[0].args).toEqual(['tag', 'v1.0.0']);
+  });
+
+  it('should fetch from the named remote', async () => {
+    const { run, calls } = makeRunner();
+    await new GitCli(run).fetch('origin', { cwd: '/r' });
+    expect(calls[0].args).toEqual(['fetch', 'origin']);
+  });
+
+  it('should checkout a ref, using -B when create is set', async () => {
+    const plain = makeRunner();
+    await new GitCli(plain.run).checkout('main');
+    expect(plain.calls[0].args).toEqual(['checkout', 'main']);
+
+    const create = makeRunner();
+    await new GitCli(create.run).checkout('release/next', { create: true });
+    expect(create.calls[0].args).toEqual(['checkout', '-B', 'release/next']);
+  });
+
+  it('should hard-reset to a ref', async () => {
+    const { run, calls } = makeRunner();
+    await new GitCli(run).resetHard('origin/main', '/r');
+    expect(calls[0].args).toEqual(['reset', '--hard', 'origin/main']);
+  });
+
+  it('should run status, adding --porcelain and pathspecs when requested', async () => {
+    const { run, calls } = makeRunner({ stdout: ' M a.ts\n' });
+    expect(await new GitCli(run).status({ porcelain: true, paths: ['a.ts'] })).toBe(' M a.ts\n');
+    expect(calls[0].args).toEqual(['status', '--porcelain', '--', 'a.ts']);
+  });
+
+  it('should run a bare status when no options are given', async () => {
+    const { run, calls } = makeRunner({ stdout: 'clean\n' });
+    await new GitCli(run).status();
+    expect(calls[0].args).toEqual(['status']);
+  });
+});
+
+describe('GitCli.push', () => {
+  it('should push the remote and ref and pass the default timeout to execFile', async () => {
+    const { run, calls } = makeRunner();
+    await new GitCli(run).push({ remote: 'origin', ref: 'HEAD:release/next', cwd: '/r' });
+    expect(calls[0].args).toEqual(['push', 'origin', 'HEAD:release/next']);
+    expect(calls[0].options.timeout).toBe(120_000);
+  });
+
+  it('should pass an explicit timeoutMs through to the runner timeout option', async () => {
+    const { run, calls } = makeRunner();
+    await new GitCli(run).push({ remote: 'origin', timeoutMs: 5_000 });
+    expect(calls[0].options.timeout).toBe(5_000);
+  });
+
+  it('should prefer --force-with-lease over --force and include --tags', async () => {
+    const { run, calls } = makeRunner();
+    await new GitCli(run).push({ remote: 'origin', force: true, forceWithLease: true, tags: true });
+    expect(calls[0].args).toEqual(['push', '--force-with-lease', '--tags', 'origin']);
+  });
+
+  it('should use --force when only force is set', async () => {
+    const { run, calls } = makeRunner();
+    await new GitCli(run).push({ remote: 'origin', force: true, ref: 'main' });
+    expect(calls[0].args).toEqual(['push', '--force', 'origin', 'main']);
+  });
+
+  it('should throw a GitError noting the timeout when the push is killed', async () => {
+    const { run } = makeRunner({ reject: timeoutKill() });
+    await expect(new GitCli(run).push({ remote: 'origin', timeoutMs: 10 })).rejects.toThrow(/timed out after 10ms/);
+  });
+});
+
+describe('GitError mapping', () => {
+  it('should wrap an unexpected failure in a GitError carrying argv, exit code, and stderr', async () => {
+    const { run } = makeRunner({ reject: exitError(128, 'fatal: bad object\n') });
+    const error = await new GitCli(run).headSha().catch((e) => e as GitError);
+    expect(error).toBeInstanceOf(GitError);
+    expect(error.args).toEqual(['rev-parse', 'HEAD']);
+    expect(error.exitCode).toBe(128);
+    expect(error.stderr).toBe('fatal: bad object');
+    expect(error.message).toContain('fatal: bad object');
+  });
+});
+
+describe('createGitCli', () => {
+  it('should build a GitCli', () => {
+    expect(createGitCli()).toBeInstanceOf(GitCli);
+  });
+
+  it('should route through an injected runner', async () => {
+    const { run, calls } = makeRunner({ stdout: 'main\n' });
+    expect(await createGitCli(run).currentBranch()).toBe('main');
+    expect(calls).toHaveLength(1);
+  });
+
+  it('should default cwd to process.cwd() when none is given', async () => {
+    const { run, calls } = makeRunner({ stdout: 'sha\n' });
+    await createGitCli(run).headSha();
+    expect(calls[0].options.cwd).toBe(process.cwd());
+  });
+});
+
+describe('error helpers', () => {
+  it('should read a numeric exit code and ignore a string code (ENOENT)', () => {
+    expect(gitExitCode(exitError(128))).toBe(128);
+    expect(gitExitCode(enoent())).toBeUndefined();
+    expect(gitExitCode(new Error('plain'))).toBeUndefined();
+  });
+
+  it('should detect a missing binary via ENOENT only', () => {
+    expect(isCommandNotFound(enoent())).toBe(true);
+    expect(isCommandNotFound(exitError(1))).toBe(false);
+    expect(isCommandNotFound(undefined)).toBe(false);
+  });
+
+  it('should detect a timeout via killed', () => {
+    expect(isExecTimeout(timeoutKill())).toBe(true);
+    expect(isExecTimeout(exitError(1))).toBe(false);
+    expect(isExecTimeout(null)).toBe(false);
+  });
+});

--- a/packages/git/test/unit/git.spec.ts
+++ b/packages/git/test/unit/git.spec.ts
@@ -338,6 +338,20 @@ describe('GitCli option-injection guard', () => {
     expect(run).not.toHaveBeenCalled();
   });
 
+  it('should refuse a leading-dash commit in diffTreeNames and never call the runner', async () => {
+    const { run } = makeRunner();
+    await expect(new GitCli(run).diffTreeNames('--output=evil')).rejects.toBeInstanceOf(GitError);
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it('should refuse a leading-dash pattern in forEachRef and never call the runner', async () => {
+    const { run } = makeRunner();
+    await expect(new GitCli(run).forEachRef({ format: '%(refname)', pattern: '--evil' })).rejects.toBeInstanceOf(
+      GitError,
+    );
+    expect(run).not.toHaveBeenCalled();
+  });
+
   it('should still run a normal value through the guard unharmed', async () => {
     const { run, calls } = makeRunner();
     await new GitCli(run).fetch('origin');

--- a/packages/git/tsconfig.json
+++ b/packages/git/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/packages/git/vitest.config.ts
+++ b/packages/git/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig, mergeConfig } from 'vitest/config';
+import baseConfig from '../../vitest.config.base.js';
+
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    test: {
+      include: ['test/**/*.spec.ts'],
+    },
+  }),
+);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -204,6 +204,27 @@ importers:
         specifier: 'catalog:'
         version: 4.1.9(@types/node@22.20.0)(@vitest/coverage-v8@4.1.9)(vite@7.3.1(@types/node@22.20.0)(tsx@4.22.4)(yaml@2.9.0))
 
+  packages/git:
+    devDependencies:
+      '@biomejs/biome':
+        specifier: 'catalog:'
+        version: 2.5.0
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.20.0
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 4.1.9(vitest@4.1.9)
+      tsup:
+        specifier: 'catalog:'
+        version: 8.5.1(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.9(@types/node@22.20.0)(@vitest/coverage-v8@4.1.9)(vite@7.3.1(@types/node@22.20.0)(tsx@4.22.4)(yaml@2.9.0))
+
   packages/notes:
     dependencies:
       '@anthropic-ai/sdk':
@@ -646,12 +667,6 @@ packages:
       conventional-commits-parser:
         optional: true
 
-  '@esbuild/aix-ppc64@0.27.3':
-    resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [aix]
-
   '@esbuild/aix-ppc64@0.27.7':
     resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
     engines: {node: '>=18'}
@@ -664,12 +679,6 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.27.3':
-    resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [android]
-
   '@esbuild/android-arm64@0.27.7':
     resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
     engines: {node: '>=18'}
@@ -680,12 +689,6 @@ packages:
     resolution: {integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [android]
-
-  '@esbuild/android-arm@0.27.3':
-    resolution: {integrity: sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==}
-    engines: {node: '>=18'}
-    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.27.7':
@@ -700,12 +703,6 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.27.3':
-    resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [android]
-
   '@esbuild/android-x64@0.27.7':
     resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
     engines: {node: '>=18'}
@@ -718,12 +715,6 @@ packages:
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.27.3':
-    resolution: {integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [darwin]
-
   '@esbuild/darwin-arm64@0.27.7':
     resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
     engines: {node: '>=18'}
@@ -734,12 +725,6 @@ packages:
     resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [darwin]
-
-  '@esbuild/darwin-x64@0.27.3':
-    resolution: {integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.27.7':
@@ -754,12 +739,6 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.27.3':
-    resolution: {integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [freebsd]
-
   '@esbuild/freebsd-arm64@0.27.7':
     resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
     engines: {node: '>=18'}
@@ -770,12 +749,6 @@ packages:
     resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-x64@0.27.3':
-    resolution: {integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.27.7':
@@ -790,12 +763,6 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.27.3':
-    resolution: {integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [linux]
-
   '@esbuild/linux-arm64@0.27.7':
     resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
     engines: {node: '>=18'}
@@ -806,12 +773,6 @@ packages:
     resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [linux]
-
-  '@esbuild/linux-arm@0.27.3':
-    resolution: {integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==}
-    engines: {node: '>=18'}
-    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.27.7':
@@ -826,12 +787,6 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.27.3':
-    resolution: {integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [linux]
-
   '@esbuild/linux-ia32@0.27.7':
     resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
     engines: {node: '>=18'}
@@ -842,12 +797,6 @@ packages:
     resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
-    os: [linux]
-
-  '@esbuild/linux-loong64@0.27.3':
-    resolution: {integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==}
-    engines: {node: '>=18'}
-    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.27.7':
@@ -862,12 +811,6 @@ packages:
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.27.3':
-    resolution: {integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==}
-    engines: {node: '>=18'}
-    cpu: [mips64el]
-    os: [linux]
-
   '@esbuild/linux-mips64el@0.27.7':
     resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
     engines: {node: '>=18'}
@@ -878,12 +821,6 @@ packages:
     resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
     engines: {node: '>=18'}
     cpu: [mips64el]
-    os: [linux]
-
-  '@esbuild/linux-ppc64@0.27.3':
-    resolution: {integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.27.7':
@@ -898,12 +835,6 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.27.3':
-    resolution: {integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==}
-    engines: {node: '>=18'}
-    cpu: [riscv64]
-    os: [linux]
-
   '@esbuild/linux-riscv64@0.27.7':
     resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
     engines: {node: '>=18'}
@@ -914,12 +845,6 @@ packages:
     resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
-    os: [linux]
-
-  '@esbuild/linux-s390x@0.27.3':
-    resolution: {integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==}
-    engines: {node: '>=18'}
-    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.27.7':
@@ -934,12 +859,6 @@ packages:
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.27.3':
-    resolution: {integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [linux]
-
   '@esbuild/linux-x64@0.27.7':
     resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
     engines: {node: '>=18'}
@@ -952,12 +871,6 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.27.3':
-    resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [netbsd]
-
   '@esbuild/netbsd-arm64@0.27.7':
     resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
     engines: {node: '>=18'}
@@ -968,12 +881,6 @@ packages:
     resolution: {integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [netbsd]
-
-  '@esbuild/netbsd-x64@0.27.3':
-    resolution: {integrity: sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.27.7':
@@ -988,12 +895,6 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.27.3':
-    resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openbsd]
-
   '@esbuild/openbsd-arm64@0.27.7':
     resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
     engines: {node: '>=18'}
@@ -1004,12 +905,6 @@ packages:
     resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [openbsd]
-
-  '@esbuild/openbsd-x64@0.27.3':
-    resolution: {integrity: sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.27.7':
@@ -1024,12 +919,6 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openharmony-arm64@0.27.3':
-    resolution: {integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openharmony]
-
   '@esbuild/openharmony-arm64@0.27.7':
     resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
     engines: {node: '>=18'}
@@ -1041,12 +930,6 @@ packages:
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
-
-  '@esbuild/sunos-x64@0.27.3':
-    resolution: {integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [sunos]
 
   '@esbuild/sunos-x64@0.27.7':
     resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
@@ -1060,12 +943,6 @@ packages:
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.27.3':
-    resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [win32]
-
   '@esbuild/win32-arm64@0.27.7':
     resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
     engines: {node: '>=18'}
@@ -1078,12 +955,6 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.27.3':
-    resolution: {integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [win32]
-
   '@esbuild/win32-ia32@0.27.7':
     resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
     engines: {node: '>=18'}
@@ -1094,12 +965,6 @@ packages:
     resolution: {integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==}
     engines: {node: '>=18'}
     cpu: [ia32]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.27.3':
-    resolution: {integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.27.7':
@@ -1241,19 +1106,9 @@ packages:
   '@octokit/types@16.0.0':
     resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
 
-  '@rollup/rollup-android-arm-eabi@4.58.0':
-    resolution: {integrity: sha512-mr0tmS/4FoVk1cnaeN244A/wjvGDNItZKR8hRhnmCzygyRXYtKF5jVDSIILR1U97CTzAYmbgIj/Dukg62ggG5w==}
-    cpu: [arm]
-    os: [android]
-
   '@rollup/rollup-android-arm-eabi@4.62.2':
     resolution: {integrity: sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==}
     cpu: [arm]
-    os: [android]
-
-  '@rollup/rollup-android-arm64@4.58.0':
-    resolution: {integrity: sha512-+s++dbp+/RTte62mQD9wLSbiMTV+xr/PeRJEc/sFZFSBRlHPNPVaf5FXlzAL77Mr8FtSfQqCN+I598M8U41ccQ==}
-    cpu: [arm64]
     os: [android]
 
   '@rollup/rollup-android-arm64@4.62.2':
@@ -1261,19 +1116,9 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.58.0':
-    resolution: {integrity: sha512-MFWBwTcYs0jZbINQBXHfSrpSQJq3IUOakcKPzfeSznONop14Pxuqa0Kg19GD0rNBMPQI2tFtu3UzapZpH0Uc1Q==}
-    cpu: [arm64]
-    os: [darwin]
-
   '@rollup/rollup-darwin-arm64@4.62.2':
     resolution: {integrity: sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==}
     cpu: [arm64]
-    os: [darwin]
-
-  '@rollup/rollup-darwin-x64@4.58.0':
-    resolution: {integrity: sha512-yiKJY7pj9c9JwzuKYLFaDZw5gma3fI9bkPEIyofvVfsPqjCWPglSHdpdwXpKGvDeYDms3Qal8qGMEHZ1M/4Udg==}
-    cpu: [x64]
     os: [darwin]
 
   '@rollup/rollup-darwin-x64@4.62.2':
@@ -1281,19 +1126,9 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.58.0':
-    resolution: {integrity: sha512-x97kCoBh5MOevpn/CNK9W1x8BEzO238541BGWBc315uOlN0AD/ifZ1msg+ZQB05Ux+VF6EcYqpiagfLJ8U3LvQ==}
-    cpu: [arm64]
-    os: [freebsd]
-
   '@rollup/rollup-freebsd-arm64@4.62.2':
     resolution: {integrity: sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==}
     cpu: [arm64]
-    os: [freebsd]
-
-  '@rollup/rollup-freebsd-x64@4.58.0':
-    resolution: {integrity: sha512-Aa8jPoZ6IQAG2eIrcXPpjRcMjROMFxCt1UYPZZtCxRV68WkuSigYtQ/7Zwrcr2IvtNJo7T2JfDXyMLxq5L4Jlg==}
-    cpu: [x64]
     os: [freebsd]
 
   '@rollup/rollup-freebsd-x64@4.62.2':
@@ -1301,18 +1136,8 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.58.0':
-    resolution: {integrity: sha512-Ob8YgT5kD/lSIYW2Rcngs5kNB/44Q2RzBSPz9brf2WEtcGR7/f/E9HeHn1wYaAwKBni+bdXEwgHvUd0x12lQSA==}
-    cpu: [arm]
-    os: [linux]
-
   '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
     resolution: {integrity: sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==}
-    cpu: [arm]
-    os: [linux]
-
-  '@rollup/rollup-linux-arm-musleabihf@4.58.0':
-    resolution: {integrity: sha512-K+RI5oP1ceqoadvNt1FecL17Qtw/n9BgRSzxif3rTL2QlIu88ccvY+Y9nnHe/cmT5zbH9+bpiJuG1mGHRVwF4Q==}
     cpu: [arm]
     os: [linux]
 
@@ -1321,18 +1146,8 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-gnu@4.58.0':
-    resolution: {integrity: sha512-T+17JAsCKUjmbopcKepJjHWHXSjeW7O5PL7lEFaeQmiVyw4kkc5/lyYKzrv6ElWRX/MrEWfPiJWqbTvfIvjM1Q==}
-    cpu: [arm64]
-    os: [linux]
-
   '@rollup/rollup-linux-arm64-gnu@4.62.2':
     resolution: {integrity: sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@rollup/rollup-linux-arm64-musl@4.58.0':
-    resolution: {integrity: sha512-cCePktb9+6R9itIJdeCFF9txPU7pQeEHB5AbHu/MKsfH/k70ZtOeq1k4YAtBv9Z7mmKI5/wOLYjQ+B9QdxR6LA==}
     cpu: [arm64]
     os: [linux]
 
@@ -1341,18 +1156,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-loong64-gnu@4.58.0':
-    resolution: {integrity: sha512-iekUaLkfliAsDl4/xSdoCJ1gnnIXvoNz85C8U8+ZxknM5pBStfZjeXgB8lXobDQvvPRCN8FPmmuTtH+z95HTmg==}
-    cpu: [loong64]
-    os: [linux]
-
   '@rollup/rollup-linux-loong64-gnu@4.62.2':
     resolution: {integrity: sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==}
-    cpu: [loong64]
-    os: [linux]
-
-  '@rollup/rollup-linux-loong64-musl@4.58.0':
-    resolution: {integrity: sha512-68ofRgJNl/jYJbxFjCKE7IwhbfxOl1muPN4KbIqAIe32lm22KmU7E8OPvyy68HTNkI2iV/c8y2kSPSm2mW/Q9Q==}
     cpu: [loong64]
     os: [linux]
 
@@ -1361,18 +1166,8 @@ packages:
     cpu: [loong64]
     os: [linux]
 
-  '@rollup/rollup-linux-ppc64-gnu@4.58.0':
-    resolution: {integrity: sha512-dpz8vT0i+JqUKuSNPCP5SYyIV2Lh0sNL1+FhM7eLC457d5B9/BC3kDPp5BBftMmTNsBarcPcoz5UGSsnCiw4XQ==}
-    cpu: [ppc64]
-    os: [linux]
-
   '@rollup/rollup-linux-ppc64-gnu@4.62.2':
     resolution: {integrity: sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==}
-    cpu: [ppc64]
-    os: [linux]
-
-  '@rollup/rollup-linux-ppc64-musl@4.58.0':
-    resolution: {integrity: sha512-4gdkkf9UJ7tafnweBCR/mk4jf3Jfl0cKX9Np80t5i78kjIH0ZdezUv/JDI2VtruE5lunfACqftJ8dIMGN4oHew==}
     cpu: [ppc64]
     os: [linux]
 
@@ -1381,18 +1176,8 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.58.0':
-    resolution: {integrity: sha512-YFS4vPnOkDTD/JriUeeZurFYoJhPf9GQQEF/v4lltp3mVcBmnsAdjEWhr2cjUCZzZNzxCG0HZOvJU44UGHSdzw==}
-    cpu: [riscv64]
-    os: [linux]
-
   '@rollup/rollup-linux-riscv64-gnu@4.62.2':
     resolution: {integrity: sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@rollup/rollup-linux-riscv64-musl@4.58.0':
-    resolution: {integrity: sha512-x2xgZlFne+QVNKV8b4wwaCS8pwq3y14zedZ5DqLzjdRITvreBk//4Knbcvm7+lWmms9V9qFp60MtUd0/t/PXPw==}
     cpu: [riscv64]
     os: [linux]
 
@@ -1401,28 +1186,13 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-s390x-gnu@4.58.0':
-    resolution: {integrity: sha512-jIhrujyn4UnWF8S+DHSkAkDEO3hLX0cjzxJZPLF80xFyzyUIYgSMRcYQ3+uqEoyDD2beGq7Dj7edi8OnJcS/hg==}
-    cpu: [s390x]
-    os: [linux]
-
   '@rollup/rollup-linux-s390x-gnu@4.62.2':
     resolution: {integrity: sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==}
     cpu: [s390x]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-gnu@4.58.0':
-    resolution: {integrity: sha512-+410Srdoh78MKSJxTQ+hZ/Mx+ajd6RjjPwBPNd0R3J9FtL6ZA0GqiiyNjCO9In0IzZkCNrpGymSfn+kgyPQocg==}
-    cpu: [x64]
-    os: [linux]
-
   '@rollup/rollup-linux-x64-gnu@4.62.2':
     resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
-    cpu: [x64]
-    os: [linux]
-
-  '@rollup/rollup-linux-x64-musl@4.58.0':
-    resolution: {integrity: sha512-ZjMyby5SICi227y1MTR3VYBpFTdZs823Rs/hpakufleBoufoOIB6jtm9FEoxn/cgO7l6PM2rCEl5Kre5vX0QrQ==}
     cpu: [x64]
     os: [linux]
 
@@ -1431,39 +1201,19 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-openbsd-x64@4.58.0':
-    resolution: {integrity: sha512-ds4iwfYkSQ0k1nb8LTcyXw//ToHOnNTJtceySpL3fa7tc/AsE+UpUFphW126A6fKBGJD5dhRvg8zw1rvoGFxmw==}
-    cpu: [x64]
-    os: [openbsd]
-
   '@rollup/rollup-openbsd-x64@4.62.2':
     resolution: {integrity: sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==}
     cpu: [x64]
     os: [openbsd]
-
-  '@rollup/rollup-openharmony-arm64@4.58.0':
-    resolution: {integrity: sha512-fd/zpJniln4ICdPkjWFhZYeY/bpnaN9pGa6ko+5WD38I0tTqk9lXMgXZg09MNdhpARngmxiCg0B0XUamNw/5BQ==}
-    cpu: [arm64]
-    os: [openharmony]
 
   '@rollup/rollup-openharmony-arm64@4.62.2':
     resolution: {integrity: sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rollup/rollup-win32-arm64-msvc@4.58.0':
-    resolution: {integrity: sha512-YpG8dUOip7DCz3nr/JUfPbIUo+2d/dy++5bFzgi4ugOGBIox+qMbbqt/JoORwvI/C9Kn2tz6+Bieoqd5+B1CjA==}
-    cpu: [arm64]
-    os: [win32]
-
   '@rollup/rollup-win32-arm64-msvc@4.62.2':
     resolution: {integrity: sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==}
     cpu: [arm64]
-    os: [win32]
-
-  '@rollup/rollup-win32-ia32-msvc@4.58.0':
-    resolution: {integrity: sha512-b9DI8jpFQVh4hIXFr0/+N/TzLdpBIoPzjt0Rt4xJbW3mzguV3mduR9cNgiuFcuL/TeORejJhCWiAXe3E/6PxWA==}
-    cpu: [ia32]
     os: [win32]
 
   '@rollup/rollup-win32-ia32-msvc@4.62.2':
@@ -1471,18 +1221,8 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-gnu@4.58.0':
-    resolution: {integrity: sha512-CSrVpmoRJFN06LL9xhkitkwUcTZtIotYAF5p6XOR2zW0Zz5mzb3IPpcoPhB02frzMHFNo1reQ9xSF5fFm3hUsQ==}
-    cpu: [x64]
-    os: [win32]
-
   '@rollup/rollup-win32-x64-gnu@4.62.2':
     resolution: {integrity: sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==}
-    cpu: [x64]
-    os: [win32]
-
-  '@rollup/rollup-win32-x64-msvc@4.58.0':
-    resolution: {integrity: sha512-QFsBgQNTnh5K0t/sBsjJLq24YVqEIVkGpfN2VHsnN90soZyhaiA9UUHufcctVNL4ypJY0wrwad0wslx2KJQ1/w==}
     cpu: [x64]
     os: [win32]
 
@@ -1554,9 +1294,6 @@ packages:
 
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
-
-  '@types/estree@1.0.8':
-    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
@@ -1887,11 +1624,6 @@ packages:
 
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
-
-  esbuild@0.27.3:
-    resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
-    engines: {node: '>=18'}
-    hasBin: true
 
   esbuild@0.27.7:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
@@ -2327,11 +2059,6 @@ packages:
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
-  rollup@4.58.0:
-    resolution: {integrity: sha512-wbT0mBmWbIvvq8NeEYWWvevvxnOyhKChir47S66WCxw1SXqhw7ssIYejnQEVt7XYQpsj2y8F9PM+Cr3SNEa0gw==}
-    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
-    hasBin: true
-
   rollup@4.62.2:
     resolution: {integrity: sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -2431,10 +2158,6 @@ packages:
   tinyexec@1.0.4:
     resolution: {integrity: sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==}
     engines: {node: '>=18'}
-
-  tinyglobby@0.2.15:
-    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
-    engines: {node: '>=12.0.0'}
 
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
@@ -2711,16 +2434,10 @@ snapshots:
       conventional-commits-filter: 5.0.0
       conventional-commits-parser: 6.2.1
 
-  '@esbuild/aix-ppc64@0.27.3':
-    optional: true
-
   '@esbuild/aix-ppc64@0.27.7':
     optional: true
 
   '@esbuild/aix-ppc64@0.28.0':
-    optional: true
-
-  '@esbuild/android-arm64@0.27.3':
     optional: true
 
   '@esbuild/android-arm64@0.27.7':
@@ -2729,16 +2446,10 @@ snapshots:
   '@esbuild/android-arm64@0.28.0':
     optional: true
 
-  '@esbuild/android-arm@0.27.3':
-    optional: true
-
   '@esbuild/android-arm@0.27.7':
     optional: true
 
   '@esbuild/android-arm@0.28.0':
-    optional: true
-
-  '@esbuild/android-x64@0.27.3':
     optional: true
 
   '@esbuild/android-x64@0.27.7':
@@ -2747,16 +2458,10 @@ snapshots:
   '@esbuild/android-x64@0.28.0':
     optional: true
 
-  '@esbuild/darwin-arm64@0.27.3':
-    optional: true
-
   '@esbuild/darwin-arm64@0.27.7':
     optional: true
 
   '@esbuild/darwin-arm64@0.28.0':
-    optional: true
-
-  '@esbuild/darwin-x64@0.27.3':
     optional: true
 
   '@esbuild/darwin-x64@0.27.7':
@@ -2765,16 +2470,10 @@ snapshots:
   '@esbuild/darwin-x64@0.28.0':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.27.3':
-    optional: true
-
   '@esbuild/freebsd-arm64@0.27.7':
     optional: true
 
   '@esbuild/freebsd-arm64@0.28.0':
-    optional: true
-
-  '@esbuild/freebsd-x64@0.27.3':
     optional: true
 
   '@esbuild/freebsd-x64@0.27.7':
@@ -2783,16 +2482,10 @@ snapshots:
   '@esbuild/freebsd-x64@0.28.0':
     optional: true
 
-  '@esbuild/linux-arm64@0.27.3':
-    optional: true
-
   '@esbuild/linux-arm64@0.27.7':
     optional: true
 
   '@esbuild/linux-arm64@0.28.0':
-    optional: true
-
-  '@esbuild/linux-arm@0.27.3':
     optional: true
 
   '@esbuild/linux-arm@0.27.7':
@@ -2801,16 +2494,10 @@ snapshots:
   '@esbuild/linux-arm@0.28.0':
     optional: true
 
-  '@esbuild/linux-ia32@0.27.3':
-    optional: true
-
   '@esbuild/linux-ia32@0.27.7':
     optional: true
 
   '@esbuild/linux-ia32@0.28.0':
-    optional: true
-
-  '@esbuild/linux-loong64@0.27.3':
     optional: true
 
   '@esbuild/linux-loong64@0.27.7':
@@ -2819,16 +2506,10 @@ snapshots:
   '@esbuild/linux-loong64@0.28.0':
     optional: true
 
-  '@esbuild/linux-mips64el@0.27.3':
-    optional: true
-
   '@esbuild/linux-mips64el@0.27.7':
     optional: true
 
   '@esbuild/linux-mips64el@0.28.0':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.27.3':
     optional: true
 
   '@esbuild/linux-ppc64@0.27.7':
@@ -2837,16 +2518,10 @@ snapshots:
   '@esbuild/linux-ppc64@0.28.0':
     optional: true
 
-  '@esbuild/linux-riscv64@0.27.3':
-    optional: true
-
   '@esbuild/linux-riscv64@0.27.7':
     optional: true
 
   '@esbuild/linux-riscv64@0.28.0':
-    optional: true
-
-  '@esbuild/linux-s390x@0.27.3':
     optional: true
 
   '@esbuild/linux-s390x@0.27.7':
@@ -2855,16 +2530,10 @@ snapshots:
   '@esbuild/linux-s390x@0.28.0':
     optional: true
 
-  '@esbuild/linux-x64@0.27.3':
-    optional: true
-
   '@esbuild/linux-x64@0.27.7':
     optional: true
 
   '@esbuild/linux-x64@0.28.0':
-    optional: true
-
-  '@esbuild/netbsd-arm64@0.27.3':
     optional: true
 
   '@esbuild/netbsd-arm64@0.27.7':
@@ -2873,16 +2542,10 @@ snapshots:
   '@esbuild/netbsd-arm64@0.28.0':
     optional: true
 
-  '@esbuild/netbsd-x64@0.27.3':
-    optional: true
-
   '@esbuild/netbsd-x64@0.27.7':
     optional: true
 
   '@esbuild/netbsd-x64@0.28.0':
-    optional: true
-
-  '@esbuild/openbsd-arm64@0.27.3':
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.7':
@@ -2891,16 +2554,10 @@ snapshots:
   '@esbuild/openbsd-arm64@0.28.0':
     optional: true
 
-  '@esbuild/openbsd-x64@0.27.3':
-    optional: true
-
   '@esbuild/openbsd-x64@0.27.7':
     optional: true
 
   '@esbuild/openbsd-x64@0.28.0':
-    optional: true
-
-  '@esbuild/openharmony-arm64@0.27.3':
     optional: true
 
   '@esbuild/openharmony-arm64@0.27.7':
@@ -2909,16 +2566,10 @@ snapshots:
   '@esbuild/openharmony-arm64@0.28.0':
     optional: true
 
-  '@esbuild/sunos-x64@0.27.3':
-    optional: true
-
   '@esbuild/sunos-x64@0.27.7':
     optional: true
 
   '@esbuild/sunos-x64@0.28.0':
-    optional: true
-
-  '@esbuild/win32-arm64@0.27.3':
     optional: true
 
   '@esbuild/win32-arm64@0.27.7':
@@ -2927,16 +2578,10 @@ snapshots:
   '@esbuild/win32-arm64@0.28.0':
     optional: true
 
-  '@esbuild/win32-ia32@0.27.3':
-    optional: true
-
   '@esbuild/win32-ia32@0.27.7':
     optional: true
 
   '@esbuild/win32-ia32@0.28.0':
-    optional: true
-
-  '@esbuild/win32-x64@0.27.3':
     optional: true
 
   '@esbuild/win32-x64@0.27.7':
@@ -3083,151 +2728,76 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 27.0.0
 
-  '@rollup/rollup-android-arm-eabi@4.58.0':
-    optional: true
-
   '@rollup/rollup-android-arm-eabi@4.62.2':
-    optional: true
-
-  '@rollup/rollup-android-arm64@4.58.0':
     optional: true
 
   '@rollup/rollup-android-arm64@4.62.2':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.58.0':
-    optional: true
-
   '@rollup/rollup-darwin-arm64@4.62.2':
-    optional: true
-
-  '@rollup/rollup-darwin-x64@4.58.0':
     optional: true
 
   '@rollup/rollup-darwin-x64@4.62.2':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.58.0':
-    optional: true
-
   '@rollup/rollup-freebsd-arm64@4.62.2':
-    optional: true
-
-  '@rollup/rollup-freebsd-x64@4.58.0':
     optional: true
 
   '@rollup/rollup-freebsd-x64@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.58.0':
-    optional: true
-
   '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
-    optional: true
-
-  '@rollup/rollup-linux-arm-musleabihf@4.58.0':
     optional: true
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.58.0':
-    optional: true
-
   '@rollup/rollup-linux-arm64-gnu@4.62.2':
-    optional: true
-
-  '@rollup/rollup-linux-arm64-musl@4.58.0':
     optional: true
 
   '@rollup/rollup-linux-arm64-musl@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-loong64-gnu@4.58.0':
-    optional: true
-
   '@rollup/rollup-linux-loong64-gnu@4.62.2':
-    optional: true
-
-  '@rollup/rollup-linux-loong64-musl@4.58.0':
     optional: true
 
   '@rollup/rollup-linux-loong64-musl@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-gnu@4.58.0':
-    optional: true
-
   '@rollup/rollup-linux-ppc64-gnu@4.62.2':
-    optional: true
-
-  '@rollup/rollup-linux-ppc64-musl@4.58.0':
     optional: true
 
   '@rollup/rollup-linux-ppc64-musl@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.58.0':
-    optional: true
-
   '@rollup/rollup-linux-riscv64-gnu@4.62.2':
-    optional: true
-
-  '@rollup/rollup-linux-riscv64-musl@4.58.0':
     optional: true
 
   '@rollup/rollup-linux-riscv64-musl@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.58.0':
-    optional: true
-
   '@rollup/rollup-linux-s390x-gnu@4.62.2':
-    optional: true
-
-  '@rollup/rollup-linux-x64-gnu@4.58.0':
     optional: true
 
   '@rollup/rollup-linux-x64-gnu@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.58.0':
-    optional: true
-
   '@rollup/rollup-linux-x64-musl@4.62.2':
-    optional: true
-
-  '@rollup/rollup-openbsd-x64@4.58.0':
     optional: true
 
   '@rollup/rollup-openbsd-x64@4.62.2':
     optional: true
 
-  '@rollup/rollup-openharmony-arm64@4.58.0':
-    optional: true
-
   '@rollup/rollup-openharmony-arm64@4.62.2':
-    optional: true
-
-  '@rollup/rollup-win32-arm64-msvc@4.58.0':
     optional: true
 
   '@rollup/rollup-win32-arm64-msvc@4.62.2':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.58.0':
-    optional: true
-
   '@rollup/rollup-win32-ia32-msvc@4.62.2':
     optional: true
 
-  '@rollup/rollup-win32-x64-gnu@4.58.0':
-    optional: true
-
   '@rollup/rollup-win32-x64-gnu@4.62.2':
-    optional: true
-
-  '@rollup/rollup-win32-x64-msvc@4.58.0':
     optional: true
 
   '@rollup/rollup-win32-x64-msvc@4.62.2':
@@ -3280,8 +2850,6 @@ snapshots:
   '@types/ejs@3.1.5': {}
 
   '@types/esrecurse@4.3.1': {}
-
-  '@types/estree@1.0.8': {}
 
   '@types/estree@1.0.9': {}
 
@@ -3517,9 +3085,9 @@ snapshots:
     dependencies:
       balanced-match: 4.0.4
 
-  bundle-require@5.1.0(esbuild@0.27.3):
+  bundle-require@5.1.0(esbuild@0.27.7):
     dependencies:
-      esbuild: 0.27.3
+      esbuild: 0.27.7
       load-tsconfig: 0.2.5
 
   cac@6.7.14: {}
@@ -3613,35 +3181,6 @@ snapshots:
   environment@1.1.0: {}
 
   es-module-lexer@2.0.0: {}
-
-  esbuild@0.27.3:
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.27.3
-      '@esbuild/android-arm': 0.27.3
-      '@esbuild/android-arm64': 0.27.3
-      '@esbuild/android-x64': 0.27.3
-      '@esbuild/darwin-arm64': 0.27.3
-      '@esbuild/darwin-x64': 0.27.3
-      '@esbuild/freebsd-arm64': 0.27.3
-      '@esbuild/freebsd-x64': 0.27.3
-      '@esbuild/linux-arm': 0.27.3
-      '@esbuild/linux-arm64': 0.27.3
-      '@esbuild/linux-ia32': 0.27.3
-      '@esbuild/linux-loong64': 0.27.3
-      '@esbuild/linux-mips64el': 0.27.3
-      '@esbuild/linux-ppc64': 0.27.3
-      '@esbuild/linux-riscv64': 0.27.3
-      '@esbuild/linux-s390x': 0.27.3
-      '@esbuild/linux-x64': 0.27.3
-      '@esbuild/netbsd-arm64': 0.27.3
-      '@esbuild/netbsd-x64': 0.27.3
-      '@esbuild/openbsd-arm64': 0.27.3
-      '@esbuild/openbsd-x64': 0.27.3
-      '@esbuild/openharmony-arm64': 0.27.3
-      '@esbuild/sunos-x64': 0.27.3
-      '@esbuild/win32-arm64': 0.27.3
-      '@esbuild/win32-ia32': 0.27.3
-      '@esbuild/win32-x64': 0.27.3
 
   esbuild@0.27.7:
     optionalDependencies:
@@ -3810,7 +3349,7 @@ snapshots:
     dependencies:
       magic-string: 0.30.21
       mlly: 1.8.0
-      rollup: 4.58.0
+      rollup: 4.62.2
 
   flat-cache@4.0.1:
     dependencies:
@@ -4098,37 +3637,6 @@ snapshots:
 
   rfdc@1.4.1: {}
 
-  rollup@4.58.0:
-    dependencies:
-      '@types/estree': 1.0.8
-    optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.58.0
-      '@rollup/rollup-android-arm64': 4.58.0
-      '@rollup/rollup-darwin-arm64': 4.58.0
-      '@rollup/rollup-darwin-x64': 4.58.0
-      '@rollup/rollup-freebsd-arm64': 4.58.0
-      '@rollup/rollup-freebsd-x64': 4.58.0
-      '@rollup/rollup-linux-arm-gnueabihf': 4.58.0
-      '@rollup/rollup-linux-arm-musleabihf': 4.58.0
-      '@rollup/rollup-linux-arm64-gnu': 4.58.0
-      '@rollup/rollup-linux-arm64-musl': 4.58.0
-      '@rollup/rollup-linux-loong64-gnu': 4.58.0
-      '@rollup/rollup-linux-loong64-musl': 4.58.0
-      '@rollup/rollup-linux-ppc64-gnu': 4.58.0
-      '@rollup/rollup-linux-ppc64-musl': 4.58.0
-      '@rollup/rollup-linux-riscv64-gnu': 4.58.0
-      '@rollup/rollup-linux-riscv64-musl': 4.58.0
-      '@rollup/rollup-linux-s390x-gnu': 4.58.0
-      '@rollup/rollup-linux-x64-gnu': 4.58.0
-      '@rollup/rollup-linux-x64-musl': 4.58.0
-      '@rollup/rollup-openbsd-x64': 4.58.0
-      '@rollup/rollup-openharmony-arm64': 4.58.0
-      '@rollup/rollup-win32-arm64-msvc': 4.58.0
-      '@rollup/rollup-win32-ia32-msvc': 4.58.0
-      '@rollup/rollup-win32-x64-gnu': 4.58.0
-      '@rollup/rollup-win32-x64-msvc': 4.58.0
-      fsevents: 2.3.3
-
   rollup@4.62.2:
     dependencies:
       '@types/estree': 1.0.9
@@ -4223,7 +3731,7 @@ snapshots:
       lines-and-columns: 1.2.4
       mz: 2.7.0
       pirates: 4.0.7
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
       ts-interface-checker: 0.1.13
 
   supports-color@7.2.0:
@@ -4243,11 +3751,6 @@ snapshots:
   tinyexec@0.3.2: {}
 
   tinyexec@1.0.4: {}
-
-  tinyglobby@0.2.15:
-    dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
 
   tinyglobby@0.2.16:
     dependencies:
@@ -4273,22 +3776,22 @@ snapshots:
 
   tsup@8.5.1(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0):
     dependencies:
-      bundle-require: 5.1.0(esbuild@0.27.3)
+      bundle-require: 5.1.0(esbuild@0.27.7)
       cac: 6.7.14
       chokidar: 4.0.3
       consola: 3.4.2
       debug: 4.4.3
-      esbuild: 0.27.3
+      esbuild: 0.27.7
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
       postcss-load-config: 6.0.1(postcss@8.5.15)(tsx@4.22.4)(yaml@2.9.0)
       resolve-from: 5.0.0
-      rollup: 4.58.0
+      rollup: 4.62.2
       source-map: 0.7.6
       sucrase: 3.35.1
       tinyexec: 0.3.2
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
       tree-kill: 1.2.2
     optionalDependencies:
       postcss: 8.5.15


### PR DESCRIPTION
First of the **phased #357** migration (epic #369). Adds a single git-execution seam — **no existing package is migrated in this PR**; consumers move over one PR at a time after, `main` green at each step.

## What
A new `@releasekit/git` package mirroring the `@releasekit/forge` seam:
- **`types.ts`** — the `Git` interface, 28 async operations. Queries: `isRepository`, `currentBranch`, `headSha`, `remoteUrl`, `listTags`, `describeTags`, `refExists`, `isAncestor`, `countCommits`, `log`, `diffTreeNames`, `forEachRef`, `remoteBranchExists`. Mutations: `add`, `commit`, `tag`, `fetch`, `checkout`, `resetHard`, `status`, `push`.
- **`git.ts`** — `GitCli` over an **injectable runner** (default `execFile('git', argv)`). Every method builds an **argv array** — never a shell-interpolated string — so a tag/branch/message with shell metacharacters lands in a literal slot and can't break out. This is the security smell #357 removes (notes/`git-log.ts` + release/`standing-pr.ts` shell strings, migrated in later PRs).
- **`fake.ts`** — `FakeGit` with a seedable in-memory state + recorded-call arrays (`committed`, `tagged`, `pushed`, …) so consumers can be tested end-to-end without spawning git.
- **`errors.ts`** — `GitError` (argv + exit code + stderr) and `gitExitCode`/`isCommandNotFound`/`isExecTimeout` helpers.

## Design notes
- **`push` has a timeout** (default 120s) → a hung push can't block forever, preserving the safety publish's async exec wrapper provided.
- **Soft lookups** (`refExists`, `isAncestor`, `remoteUrl`, `describeTags`, `remoteBranchExists`, `isRepository`) return `false`/`null` on an expected non-zero exit and only throw on a missing/erroring binary.
- Zero runtime deps (shells out via `node:child_process`). Auto-wired via the `packages/*` workspace glob; lockfile gains only the new package + its catalog devDeps.

## Tests
60 tests — `git.spec.ts` (45: argv assertions per method, `add -A` vs `--`, annotated vs lightweight tag, force-with-lease precedence, soft-lookup null/false on non-zero exit, ENOENT throws, push timeout passed + timeout→`GitError`), `fake.spec.ts` (15). Gate **30/30** (the prior 27 + 3 new package tasks).

## Next
PR 2–5 migrate one consumer each (version → publish → release → notes) onto this seam; epic #369 closes when notes lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces `@releasekit/git`, a new monorepo package that wraps git operations behind a typed execution seam, replacing future ad-hoc shell-string invocations with an `execFile`-based argv-array adapter (`GitCli`) and an in-memory test double (`FakeGit`).

- **`GitCli`** builds all git invocations as argv arrays (never shell strings), adds `assertNotOption` guards on every user-supplied positional to block argument injection, and applies a hard timeout to `push` to prevent hung network calls from blocking indefinitely.
- **`FakeGit`** provides a seedable, mutation-recording in-memory adapter so consumers can be tested end-to-end without spawning a real git process; previously-flagged issues (`-A` sentinel, `tagsList readonly`, `describeTags` asymmetry) are all resolved or documented.
- **60 tests** cover argv construction, soft-lookup semantics (false/null on non-zero exit, throw on ENOENT), option-injection guards, push timeout propagation, and `FakeGit` isolation.
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge — this is a net-new package with no existing consumers yet, all argv injection guards are in place, and previously-flagged issues are resolved.

The change adds a well-isolated new package that touches no existing code. All git invocations go through argv arrays (no shell interpolation), option-injection guards cover every user-supplied positional, 60 tests validate the full surface, and the previously-flagged `-A` sentinel, `readonly tagsList`, and `describeTags` asymmetry are all addressed. The only finding is a latent asymmetry in `execSoft` that has no current call path triggering it.

No files require special attention for merging; `packages/git/src/git.ts` has a minor inconsistency in `execSoft` worth addressing before timeout options are added to any soft-lookup method.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/git/src/git.ts | Core `GitCli` adapter — argv-array construction, `assertNotOption` guards, `exec`/`execSoft` split, and push timeout. A latent gap: `execSoft` doesn't re-throw on timeout kills the way `exec` does, so a future caller that passes a timeout would get silent `false` instead of an error. |
| packages/git/src/fake.ts | In-memory `FakeGit` — seed-based queries, mutation recording, `describeTags` asymmetry now clearly documented in JSDoc, `tagsList` `readonly` removed (it is mutated via `push()` in `tag()`). Clean. |
| packages/git/src/errors.ts | Defines `GitError` (argv + exit code + stderr) and three narrow type-guards (`gitExitCode`, `isCommandNotFound`, `isExecTimeout`). Well-scoped and tested. |
| packages/git/src/types.ts | Defines the `Git` interface and all option types. Well-documented conventions (soft lookups, async, optional cwd). No issues. |
| packages/git/test/unit/git.spec.ts | 45 tests covering all GitCli methods, argv ordering, option-injection guards, soft-lookup null/false semantics, push timeout propagation, and GitError mapping. Thorough. |
| packages/git/test/unit/fake.spec.ts | 15 tests for `FakeGit` covering seeded queries, defaults, mutations, tag list consistency, and instance isolation. No issues. |
| packages/git/src/index.ts | Re-exports all public symbols from errors, fake, git, and types. Complete and matches the interface surface. |
| packages/git/package.json | New package manifest — zero runtime deps, catalog-pinned devDeps, ESM-only build, Node ≥22 engine constraint. Consistent with the rest of the monorepo. |

</details>


<details><summary><h3>Class Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
classDiagram
    class Git {
        +isRepository() Promise
        +currentBranch() Promise
        +headSha() Promise
        +remoteUrl() Promise
        +listTags() Promise
        +describeTags() Promise
        +refExists() Promise
        +isAncestor() Promise
        +countCommits() Promise
        +log() Promise
        +diffTreeNames() Promise
        +forEachRef() Promise
        +remoteBranchExists() Promise
        +add() Promise
        +addAll() Promise
        +commit() Promise
        +tag() Promise
        +fetch() Promise
        +checkout() Promise
        +resetHard() Promise
        +status() Promise
        +push() Promise
    }
    class GitCli {
        -run GitRunner
        -exec() Promise
        -execSoft() Promise
    }
    class FakeGit {
        -tagsList string[]
        +added string[][]
        +committed FakeCommitRecord[]
        +tagged FakeTagRecord[]
        +pushed FakePushRecord[]
    }
    class GitError {
        +args string[]
        +exitCode number
        +stderr string
    }
    Git <|.. GitCli
    Git <|.. FakeGit
    GitCli ..> GitError
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
classDiagram
    class Git {
        +isRepository() Promise
        +currentBranch() Promise
        +headSha() Promise
        +remoteUrl() Promise
        +listTags() Promise
        +describeTags() Promise
        +refExists() Promise
        +isAncestor() Promise
        +countCommits() Promise
        +log() Promise
        +diffTreeNames() Promise
        +forEachRef() Promise
        +remoteBranchExists() Promise
        +add() Promise
        +addAll() Promise
        +commit() Promise
        +tag() Promise
        +fetch() Promise
        +checkout() Promise
        +resetHard() Promise
        +status() Promise
        +push() Promise
    }
    class GitCli {
        -run GitRunner
        -exec() Promise
        -execSoft() Promise
    }
    class FakeGit {
        -tagsList string[]
        +added string[][]
        +committed FakeCommitRecord[]
        +tagged FakeTagRecord[]
        +pushed FakePushRecord[]
    }
    class GitError {
        +args string[]
        +exitCode number
        +stderr string
    }
    Git <|.. GitCli
    Git <|.. FakeGit
    GitCli ..> GitError
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/git/src/fake.ts`, line 308-311 ([link](https://github.com/goosewobbler/releasekit/blob/ac76c5a194b8f7fc8a280a86fe0d90dd4ec1208a/packages/git/src/fake.ts#L308-L311)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> `FakeGit.describeTags()` asymmetry after mutations — `tag()` updates `tagsList` so that `listTags()` reflects newly created tags, but `nearestTag` is `private readonly` and never updated. A test that seeds `nearestTag: null`, calls `tag('v1.0.0')`, then asserts `describeTags()` returns `'v1.0.0'` will fail — but the equivalent with `listTags()` would pass. Noting this discrepancy in a JSDoc comment on `describeTags()` (or on `FakeGitSeed.nearestTag`) would help future test authors avoid the surprise.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fgit%2Fsrc%2Ffake.ts%0ALine%3A%20308-311%0A%0AComment%3A%0A%60FakeGit.describeTags%28%29%60%20asymmetry%20after%20mutations%20%E2%80%94%20%60tag%28%29%60%20updates%20%60tagsList%60%20so%20that%20%60listTags%28%29%60%20reflects%20newly%20created%20tags%2C%20but%20%60nearestTag%60%20is%20%60private%20readonly%60%20and%20never%20updated.%20A%20test%20that%20seeds%20%60nearestTag%3A%20null%60%2C%20calls%20%60tag%28'v1.0.0'%29%60%2C%20then%20asserts%20%60describeTags%28%29%60%20returns%20%60'v1.0.0'%60%20will%20fail%20%E2%80%94%20but%20the%20equivalent%20with%20%60listTags%28%29%60%20would%20pass.%20Noting%20this%20discrepancy%20in%20a%20JSDoc%20comment%20on%20%60describeTags%28%29%60%20%28or%20on%20%60FakeGitSeed.nearestTag%60%29%20would%20help%20future%20test%20authors%20avoid%20the%20surprise.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=goosewobbler%2Freleasekit&pr=427&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fgit%2Fsrc%2Ffake.ts%0ALine%3A%20308-311%0A%0AComment%3A%0A%60FakeGit.describeTags%28%29%60%20asymmetry%20after%20mutations%20%E2%80%94%20%60tag%28%29%60%20updates%20%60tagsList%60%20so%20that%20%60listTags%28%29%60%20reflects%20newly%20created%20tags%2C%20but%20%60nearestTag%60%20is%20%60private%20readonly%60%20and%20never%20updated.%20A%20test%20that%20seeds%20%60nearestTag%3A%20null%60%2C%20calls%20%60tag%28'v1.0.0'%29%60%2C%20then%20asserts%20%60describeTags%28%29%60%20returns%20%60'v1.0.0'%60%20will%20fail%20%E2%80%94%20but%20the%20equivalent%20with%20%60listTags%28%29%60%20would%20pass.%20Noting%20this%20discrepancy%20in%20a%20JSDoc%20comment%20on%20%60describeTags%28%29%60%20%28or%20on%20%60FakeGitSeed.nearestTag%60%29%20would%20help%20future%20test%20authors%20avoid%20the%20surprise.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=427&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (7): Last reviewed commit: ["fix(git): FakeGit.checkout records the c..."](https://github.com/goosewobbler/releasekit/commit/29dfeacacc5df1149a4480791433a0063f4ad6f8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39648266)</sub>

<!-- /greptile_comment -->