### PR TITLE
fix(publish): label a post-publish push failure git-push, not unknown (#429)

### DIFF
--- a/packages/publish/src/stages/git-push.ts
+++ b/packages/publish/src/stages/git-push.ts
@@ -95,24 +95,32 @@ export async function pushPackageTag(tag: string, ctx: PipelineContext, setup?: 
 
   const { remote, pushRemote, branch } = resolvedSetup;
 
-  // Push the specific tag ref (carries the underlying commit with it)
-  await execCommand('git', ['push', pushRemote, `refs/tags/${tag}`], {
-    cwd,
-    dryRun,
-    label: `git push ${remote} refs/tags/${tag}`,
-  });
-  output.git.tags.push(tag);
-
-  // Push the branch (idempotent — no-op if remote is already up-to-date)
-  if (output.git.committed && branch) {
-    await execCommand('git', ['push', pushRemote, branch], {
+  // Wrap raw exec failures as GIT_PUSH_ERROR so the failure report labels the stage `git-push`
+  // rather than `unknown` — mirrors runGitPushStage. Without this, a branch push rejected by a
+  // branch ruleset surfaced as "Stage unknown" (#429).
+  try {
+    // Push the specific tag ref (carries the underlying commit with it)
+    await execCommand('git', ['push', pushRemote, `refs/tags/${tag}`], {
       cwd,
       dryRun,
-      label: `git push ${remote} ${branch}`,
+      label: `git push ${remote} refs/tags/${tag}`,
     });
-  }
+    output.git.tags.push(tag);
 
-  output.git.pushed = true;
+    // Push the branch (idempotent — no-op if remote is already up-to-date)
+    if (output.git.committed && branch) {
+      await execCommand('git', ['push', pushRemote, branch], {
+        cwd,
+        dryRun,
+        label: `git push ${remote} ${branch}`,
+      });
+    }
+
+    output.git.pushed = true;
+  } catch (error) {
+    if (error instanceof PublishError) throw error;
+    throw createPublishError(PublishErrorCode.GIT_PUSH_ERROR, error instanceof Error ? error.message : String(error));
+  }
 }
 
 /** Error strategy: THROWS. Push after publish. */

--- a/packages/publish/test/unit/stages/git-push.spec.ts
+++ b/packages/publish/test/unit/stages/git-push.spec.ts
@@ -223,6 +223,31 @@ describe('git-push stage', () => {
     expect(calls.every((c) => !(c[1] as string[]).includes('rev-parse'))).toBe(true);
   });
 
+  it('should wrap a pushPackageTag branch-push failure as GIT_PUSH_ERROR, not unknown (#429)', async () => {
+    const { execCommand } = await import('../../../src/utils/exec.js');
+    vi.mocked(execCommand).mockImplementation(async (_file, args) => {
+      if (Array.isArray(args) && args[0] === 'rev-parse') return { stdout: 'main\n', stderr: '', exitCode: 0 };
+      // The branch push is rejected by a branch ruleset — a raw exec failure.
+      if (Array.isArray(args) && args[0] === 'push' && args[2] === 'main') {
+        throw new Error('Command failed: git push origin main\nremote: error: GH013: rule violations');
+      }
+      return { stdout: '', stderr: '', exitCode: 0 };
+    });
+
+    let thrown: unknown;
+    try {
+      await pushPackageTag('@scope/pkg@v1.0.0', createContext());
+    } catch (err) {
+      thrown = err;
+    }
+
+    // Must be a GIT_PUSH_ERROR so inferStageName labels the report `git-push` (not `unknown`),
+    // and the remote's message is preserved.
+    expect(thrown).toBeInstanceOf(PublishError);
+    expect((thrown as PublishError).code).toBe('GIT_PUSH_ERROR');
+    expect((thrown as PublishError).message).toContain('git push origin main');
+  });
+
   it('should skip when push disabled in config', async () => {
     const { execCommand } = await import('../../../src/utils/exec.js');
     const config = getDefaultConfig();

--- a/packages/publish/test/unit/stages/git-push.spec.ts
+++ b/packages/publish/test/unit/stages/git-push.spec.ts
@@ -223,31 +223,6 @@ describe('git-push stage', () => {
     expect(calls.every((c) => !(c[1] as string[]).includes('rev-parse'))).toBe(true);
   });
 
-  it('should wrap a pushPackageTag branch-push failure as GIT_PUSH_ERROR, not unknown (#429)', async () => {
-    const { execCommand } = await import('../../../src/utils/exec.js');
-    vi.mocked(execCommand).mockImplementation(async (_file, args) => {
-      if (Array.isArray(args) && args[0] === 'rev-parse') return { stdout: 'main\n', stderr: '', exitCode: 0 };
-      // The branch push is rejected by a branch ruleset — a raw exec failure.
-      if (Array.isArray(args) && args[0] === 'push' && args[2] === 'main') {
-        throw new Error('Command failed: git push origin main\nremote: error: GH013: rule violations');
-      }
-      return { stdout: '', stderr: '', exitCode: 0 };
-    });
-
-    let thrown: unknown;
-    try {
-      await pushPackageTag('@scope/pkg@v1.0.0', createContext());
-    } catch (err) {
-      thrown = err;
-    }
-
-    // Must be a GIT_PUSH_ERROR so inferStageName labels the report `git-push` (not `unknown`),
-    // and the remote's message is preserved.
-    expect(thrown).toBeInstanceOf(PublishError);
-    expect((thrown as PublishError).code).toBe('GIT_PUSH_ERROR');
-    expect((thrown as PublishError).message).toContain('git push origin main');
-  });
-
   it('should skip when push disabled in config', async () => {
     const { execCommand } = await import('../../../src/utils/exec.js');
     const config = getDefaultConfig();
@@ -351,6 +326,31 @@ describe('pushPackageTag', () => {
     expect(calls[2]?.[1]).toEqual(['push', 'origin', 'main']);
     expect(ctx.output.git.tags).toContain('pkg-a@v1.0.0');
     expect(ctx.output.git.pushed).toBe(true);
+  });
+
+  it('should wrap a branch-push failure as GIT_PUSH_ERROR, not unknown (#429)', async () => {
+    const { execCommand } = await import('../../../src/utils/exec.js');
+    vi.mocked(execCommand).mockImplementation(async (_file, args) => {
+      if (Array.isArray(args) && args[0] === 'rev-parse') return { stdout: 'main\n', stderr: '', exitCode: 0 };
+      // The branch push is rejected by a branch ruleset — a raw exec failure.
+      if (Array.isArray(args) && args[0] === 'push' && args[2] === 'main') {
+        throw new Error('Command failed: git push origin main\nremote: error: GH013: rule violations');
+      }
+      return { stdout: '', stderr: '', exitCode: 0 };
+    });
+
+    let thrown: unknown;
+    try {
+      await pushPackageTag('@scope/pkg@v1.0.0', createContext());
+    } catch (err) {
+      thrown = err;
+    }
+
+    // Must be a GIT_PUSH_ERROR so inferStageName labels the report `git-push` (not `unknown`),
+    // and the remote's message is preserved.
+    expect(thrown).toBeInstanceOf(PublishError);
+    expect((thrown as PublishError).code).toBe('GIT_PUSH_ERROR');
+    expect((thrown as PublishError).message).toContain('git push origin main');
   });
 
   it('should skip branch push when not committed', async () => {


### PR DESCRIPTION
Closes #429. The second inaccuracy in the desktop-mobile failure report (the headline was #428/#431).

## Bug
The report showed **"Stage `unknown` failed: Command failed: git push origin main"**. The stage map already has `GIT_PUSH_ERROR → 'git-push'`, so the push error reached the report **unwrapped**.

Root cause: in `packageSpecificTags` mode the per-package `pushPackageTag()` (pipeline path) pushed the tag and branch **without** the `GIT_PUSH_ERROR` try/catch that `runGitPushStage` has. So a branch push rejected by a ruleset threw a raw `execCommand` `"Command failed: git push origin main"` (note: no `"Failed to push to remote:"` prefix — the tell that it bypassed the wrap), and `inferStageName` — which only maps `BasePublishError` codes — fell through to `'unknown'`.

## Fix
Wrap `pushPackageTag`'s pushes in the same `GIT_PUSH_ERROR` try/catch as `runGitPushStage` (preserving the remote's message as the detail; a detached-HEAD `PublishError` still passes through without double-wrapping). The report now labels it **`git-push`**.

## Test
`git-push.spec.ts` — a `pushPackageTag` branch-push failure now throws a `PublishError` with `code: GIT_PUSH_ERROR` and the remote's message preserved. Gate 27/27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Wraps the `pushPackageTag` function's git push calls in the same `GIT_PUSH_ERROR` try/catch pattern already used by `runGitPushStage`, so that branch push rejections in `packageSpecificTags` mode are labelled `git-push` in failure reports instead of `unknown`.

- **`git-push.ts`**: The tag and branch `execCommand` calls are now wrapped in a try/catch; raw errors are re-thrown as `PublishError(GIT_PUSH_ERROR)`, while existing `PublishError` instances (e.g. detached-HEAD from `preparePushSetup`, which runs *before* the try block) pass through untouched.
- **`git-push.spec.ts`**: A new test in the `pushPackageTag` describe block verifies that a branch push failure produces a `PublishError` with `code: GIT_PUSH_ERROR` and preserves the remote's error message.
</details>

<h3>Confidence Score: 5/5</h3>

Targeted, surgical fix: adds a try/catch around two execCommand calls in pushPackageTag, exactly mirroring the pattern already proven in runGitPushStage.

The change is minimal and well-scoped. The PublishError pass-through guard prevents double-wrapping. The preparePushSetup call sits outside the try block so the detached-HEAD path is unaffected. The new test exercises the exact failure scenario described in the bug report and passes.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/publish/src/stages/git-push.ts | Adds a try/catch around pushPackageTag's execCommand calls, mirroring the existing runGitPushStage pattern; logic is correct and avoids double-wrapping PublishError. |
| packages/publish/test/unit/stages/git-push.spec.ts | New test is correctly placed inside describe('pushPackageTag') and validates the error type, code, and message for a branch-push rejection. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[pushPackageTag called] --> B{setup provided?}
    B -- No --> C[preparePushSetup]
    C -- throws PublishError --> D[Propagates up unchanged]
    C -- returns setup --> E[Resolve remote / branch]
    B -- Yes --> E
    E --> F[try block]
    F --> G[execCommand: git push tag]
    G -- success --> H[output.git.tags.push tag]
    H --> I{committed && branch?}
    I -- Yes --> J[execCommand: git push branch]
    I -- No --> K[output.git.pushed = true]
    J -- success --> K
    K --> L[return]
    G -- throws Error --> M{catch}
    J -- throws Error --> M
    M -- instanceof PublishError --> N[re-throw as-is]
    M -- raw Error --> O[createPublishError GIT_PUSH_ERROR]
    O --> P[throw — report labels stage git-push]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[pushPackageTag called] --> B{setup provided?}
    B -- No --> C[preparePushSetup]
    C -- throws PublishError --> D[Propagates up unchanged]
    C -- returns setup --> E[Resolve remote / branch]
    B -- Yes --> E
    E --> F[try block]
    F --> G[execCommand: git push tag]
    G -- success --> H[output.git.tags.push tag]
    H --> I{committed && branch?}
    I -- Yes --> J[execCommand: git push branch]
    I -- No --> K[output.git.pushed = true]
    J -- success --> K
    K --> L[return]
    G -- throws Error --> M{catch}
    J -- throws Error --> M
    M -- instanceof PublishError --> N[re-throw as-is]
    M -- raw Error --> O[createPublishError GIT_PUSH_ERROR]
    O --> P[throw — report labels stage git-push]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["test(publish): move the #429 wrap test i..."](https://github.com/goosewobbler/releasekit/commit/50de4433aafc1c846ef23908ff7477b7fcd6a463) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39679638)</sub>

<!-- /greptile_comment -->