### PR TITLE
refactor(notes): migrate git access to the @releasekit/git seam (#357, PR 2)

### DIFF
--- a/packages/notes/package.json
+++ b/packages/notes/package.json
@@ -58,6 +58,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.105.0",
+    "@releasekit/git": "workspace:*",
     "@octokit/rest": "catalog:",
     "chalk": "catalog:",
     "commander": "catalog:",

--- a/packages/notes/package.json
+++ b/packages/notes/package.json
@@ -58,7 +58,6 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.105.0",
-    "@releasekit/git": "workspace:*",
     "@octokit/rest": "catalog:",
     "chalk": "catalog:",
     "commander": "catalog:",
@@ -77,6 +76,7 @@
     "@releasekit/config": "workspace:*",
     "@releasekit/core": "workspace:*",
     "@releasekit/forge": "workspace:*",
+    "@releasekit/git": "workspace:*",
     "@types/ejs": "^3.1.5",
     "@types/node": "catalog:",
     "@vitest/coverage-v8": "catalog:",

--- a/packages/notes/src/input/git-log.ts
+++ b/packages/notes/src/input/git-log.ts
@@ -1,6 +1,6 @@
-import { execSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { createGitCli, type Git } from '@releasekit/git';
 import type { ChangelogEntry, ChangelogInput, PackageChangelog } from '../core/types.js';
 import { InputParseError } from '../errors/index.js';
 
@@ -11,13 +11,13 @@ interface GitLogCommit {
   date: string;
 }
 
-function parseGitLog(fromRef?: string, toRef = 'HEAD'): GitLogCommit[] {
+async function parseGitLog(git: Git, fromRef?: string, toRef = 'HEAD'): Promise<GitLogCommit[]> {
   const range = fromRef ? `${fromRef}..${toRef}` : toRef;
 
   try {
-    const output = execSync(`git log ${range} --pretty=format:"%H|||%s|||%an|||%ad" --date=short`, {
-      encoding: 'utf-8',
-    });
+    // `--format=` (tformat) vs the old `--pretty=format:` differ only by a trailing newline, which
+    // the trim()/split() below absorbs — the parsed result is identical, minus the shell string.
+    const output = await git.log({ range, format: '%H|||%s|||%an|||%ad', extraArgs: ['--date=short'] });
 
     if (!output.trim()) {
       return [];
@@ -79,22 +79,13 @@ function parseConventionalCommit(message: string): ChangelogEntry | null {
   };
 }
 
-function getGitRemoteUrl(): string | null {
-  try {
-    const output = execSync('git remote get-url origin', { encoding: 'utf-8' });
-    return output.trim();
-  } catch {
-    return null;
-  }
+function getGitRemoteUrl(git: Git): Promise<string | null> {
+  return git.remoteUrl('origin');
 }
 
-function getCurrentVersion(): string {
-  try {
-    const output = execSync('git describe --tags --abbrev=0', { encoding: 'utf-8' });
-    return output.trim().replace(/^v/, '');
-  } catch {
-    return '0.0.0';
-  }
+async function getCurrentVersion(git: Git): Promise<string> {
+  const tag = await git.describeTags();
+  return tag ? tag.replace(/^v/, '') : '0.0.0';
 }
 
 function getPackageName(): string {
@@ -111,8 +102,12 @@ function getPackageName(): string {
   return 'package';
 }
 
-export function parseGitLogInput(fromRef?: string, toRef = 'HEAD'): ChangelogInput {
-  const commits = parseGitLog(fromRef, toRef);
+export async function parseGitLogInput(
+  fromRef?: string,
+  toRef = 'HEAD',
+  git: Git = createGitCli(),
+): Promise<ChangelogInput> {
+  const commits = await parseGitLog(git, fromRef, toRef);
 
   const entries: ChangelogEntry[] = [];
 
@@ -129,9 +124,9 @@ export function parseGitLogInput(fromRef?: string, toRef = 'HEAD'): ChangelogInp
     }
   }
 
-  const version = getCurrentVersion();
+  const version = await getCurrentVersion(git);
   const packageName = getPackageName();
-  const repoUrl = getGitRemoteUrl();
+  const repoUrl = await getGitRemoteUrl(git);
 
   const pkg: PackageChangelog = {
     packageName,

--- a/packages/notes/test/unit/input/git-log.spec.ts
+++ b/packages/notes/test/unit/input/git-log.spec.ts
@@ -1,0 +1,52 @@
+import { createFakeGit } from '@releasekit/git';
+import { describe, expect, it } from 'vitest';
+import { parseGitLogInput } from '../../../src/input/git-log.js';
+
+// `%H|||%s|||%an|||%ad` lines, as the seam's `log` would return them.
+const rawLog = [
+  'abc123|||feat(cli): add dry-run flag|||Alice|||2026-06-01',
+  'def456|||fix: prerelease sorting #42|||Bob|||2026-06-02',
+  'ghi789|||Merge pull request #5|||Bot|||2026-06-03',
+].join('\n');
+
+describe('parseGitLogInput', () => {
+  it('should parse conventional commits from the log range into changelog entries', async () => {
+    const git = createFakeGit({
+      commits: { 'v1.0.0..HEAD': rawLog },
+      remoteUrls: { origin: 'https://github.com/o/r.git' },
+      nearestTag: 'v1.2.0',
+    });
+
+    const input = await parseGitLogInput('v1.0.0', 'HEAD', git);
+
+    expect(input.source).toBe('git-log');
+    const pkg = input.packages[0];
+    expect(pkg?.version).toBe('1.2.0'); // describeTags 'v1.2.0' → 'v' stripped
+    expect(pkg?.repoUrl).toBe('https://github.com/o/r.git');
+    expect(pkg?.revisionRange).toBe('v1.0.0..HEAD');
+    expect(pkg?.previousVersion).toBe('1.0.0');
+    // feat → added, fix → fixed; the Merge commit is dropped.
+    expect(pkg?.entries).toEqual([
+      expect.objectContaining({ type: 'added', description: 'add dry-run flag', scope: 'cli' }),
+      expect.objectContaining({ type: 'fixed', description: 'prerelease sorting #42', issueIds: ['#42'] }),
+    ]);
+  });
+
+  it('should default version to 0.0.0 and repoUrl to null when there is no tag or remote', async () => {
+    const git = createFakeGit({ commits: { '*': '' } });
+    const input = await parseGitLogInput(undefined, 'HEAD', git);
+    expect(input.packages[0]?.version).toBe('0.0.0');
+    expect(input.packages[0]?.repoUrl).toBeNull();
+    expect(input.packages[0]?.entries).toEqual([]);
+  });
+
+  it('should query over toRef alone (no range) when no fromRef is given', async () => {
+    const git = createFakeGit({ commits: { HEAD: 'aaa|||chore: bump deps|||Sam|||2026-06-04' } });
+    const input = await parseGitLogInput(undefined, 'HEAD', git);
+    expect(input.packages[0]?.revisionRange).toBe('HEAD');
+    expect(input.packages[0]?.previousVersion).toBeNull();
+    expect(input.packages[0]?.entries).toEqual([
+      expect.objectContaining({ type: 'changed', description: 'bump deps' }),
+    ]);
+  });
+});

--- a/packages/notes/tsup.config.ts
+++ b/packages/notes/tsup.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'tsup';
 export default defineConfig({
   entry: ['src/index.ts', 'src/cli.ts'],
   format: ['esm'],
-  dts: { resolve: ['@releasekit/core', '@releasekit/config', '@releasekit/forge'] },
-  noExternal: ['@releasekit/core', '@releasekit/config', '@releasekit/forge'],
+  dts: { resolve: ['@releasekit/core', '@releasekit/config', '@releasekit/forge', '@releasekit/git'] },
+  noExternal: ['@releasekit/core', '@releasekit/config', '@releasekit/forge', '@releasekit/git'],
   external: [/^[^.]/],
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -233,9 +233,6 @@ importers:
       '@octokit/rest':
         specifier: 'catalog:'
         version: 22.0.1
-      '@releasekit/git':
-        specifier: workspace:*
-        version: link:../git
       chalk:
         specifier: 'catalog:'
         version: 5.6.2
@@ -282,6 +279,9 @@ importers:
       '@releasekit/forge':
         specifier: workspace:*
         version: link:../forge
+      '@releasekit/git':
+        specifier: workspace:*
+        version: link:../git
       '@types/ejs':
         specifier: ^3.1.5
         version: 3.1.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -233,6 +233,9 @@ importers:
       '@octokit/rest':
         specifier: 'catalog:'
         version: 22.0.1
+      '@releasekit/git':
+        specifier: workspace:*
+        version: link:../git
       chalk:
         specifier: 'catalog:'
         version: 5.6.2


### PR DESCRIPTION
PR 2 of #357 — the first consumer migration onto the `@releasekit/git` seam (PR 1 = #427, merged). Smallest consumer, and it kills the security smell.

## What
`packages/notes/src/input/git-log.ts` had **three shell-interpolated `execSync('git …')` calls** — exactly the injection risk #357 exists to remove. Migrated to the seam (`execFile` argv arrays, no shell):
- `git log ${range} --pretty=format:"…" --date=short` → `git.log({ range, format: '%H|||%s|||%an|||%ad', extraArgs: ['--date=short'] })`
- `git remote get-url origin` → `git.remoteUrl('origin')`
- `git describe --tags --abbrev=0` → `git.describeTags()` (strip `v`, default `0.0.0`)

`--format=` (tformat) vs the old `--pretty=format:` differ only by a trailing newline, which the existing `trim()`/`split('\n')` absorbs — **parsed output identical**.

## Async ripple: none
`parseGitLog`/`getGitRemoteUrl`/`getCurrentVersion` and the public `parseGitLogInput` become async (the seam is async). `parseGitLogInput` gains an injectable `git: Git = createGitCli()` for tests. It has **no internal callers** (only re-exported), so nothing else changes.

## Tests
`git-log.ts` was untested. Added `input/git-log.spec.ts` (3 tests) driving it entirely through `FakeGit` (seeded `commits`/`remoteUrls`/`nearestTag`) — no real `git` spawned, which is the seam's payoff for tests. Gate 31/31.

## Next
PRs 3–5: publish → release → version (the biggest). Epic #369 closes when version lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Migrates `packages/notes/src/input/git-log.ts` off three shell-interpolated `execSync` calls onto the `@releasekit/git` seam, removing the command-injection surface. All three helper functions (`parseGitLog`, `getGitRemoteUrl`, `getCurrentVersion`) and the public `parseGitLogInput` become async to match the seam's async contract.

- `git log … --pretty=format:\"…\"` → `git.log({ range, format, extraArgs })` using `execFile` argument arrays; `--format=` vs `--pretty=format:` trailing-newline difference is absorbed by the existing `trim()/split('\
')` chain.
- `git remote get-url origin` → `git.remoteUrl('origin')` (soft lookup; returns null on non-zero exit rather than throwing).
- `git describe --tags --abbrev=0` → `git.describeTags()` (soft lookup; null maps to the existing `'0.0.0'` default).
- New `git-log.spec.ts` tests the public API end-to-end via `FakeGit` — no real git process spawned.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a contained refactor within a single file, the seam contract is well-defined, and tests cover the main paths with no real git process.

All three git calls are correctly migrated to the seam's argument-array API. The async ripple is fully contained: parseGitLogInput has no internal callers and its signature change is backward-compatible. The soft-lookup semantics of remoteUrl and describeTags faithfully replicate the old try/catch-returning-null pattern. Tests are new (the file was previously untested) and exercise the key branches through FakeGit.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/notes/src/input/git-log.ts | Core migration: removes three shell-interpolated execSync calls, replaces with git seam methods (log/remoteUrl/describeTags). All functions made async; error handling correctly inherits the seam's soft-lookup semantics. |
| packages/notes/test/unit/input/git-log.spec.ts | New test file: 3 tests covering main path (commit parsing, version/URL resolution), no-tag/no-remote defaults, and no-fromRef range. Driven entirely through FakeGit with no real git spawned. |
| packages/notes/tsup.config.ts | @releasekit/git correctly added to both dts.resolve and noExternal arrays so the new seam import is bundled into the DTS output. |
| packages/notes/package.json | @releasekit/git added as a workspace dependency; consistent with the other in-repo package references. |
| pnpm-lock.yaml | Lock file updated to link @releasekit/git as a workspace: reference for the notes importer; generated change, no manual edits required. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller
    participant parseGitLogInput
    participant Git as Git seam

    Caller->>parseGitLogInput: parseGitLogInput(fromRef, toRef, git)
    parseGitLogInput->>Git: "git.log({ range, format, extraArgs })"
    Git-->>parseGitLogInput: raw log string
    parseGitLogInput->>parseGitLogInput: split + parseConventionalCommit
    parseGitLogInput->>Git: git.describeTags()
    Git-->>parseGitLogInput: tag or null
    parseGitLogInput->>Git: git.remoteUrl(origin)
    Git-->>parseGitLogInput: url or null
    parseGitLogInput-->>Caller: ChangelogInput
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller
    participant parseGitLogInput
    participant Git as Git seam

    Caller->>parseGitLogInput: parseGitLogInput(fromRef, toRef, git)
    parseGitLogInput->>Git: "git.log({ range, format, extraArgs })"
    Git-->>parseGitLogInput: raw log string
    parseGitLogInput->>parseGitLogInput: split + parseConventionalCommit
    parseGitLogInput->>Git: git.describeTags()
    Git-->>parseGitLogInput: tag or null
    parseGitLogInput->>Git: git.remoteUrl(origin)
    Git-->>parseGitLogInput: url or null
    parseGitLogInput-->>Caller: ChangelogInput
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(notes): bundle @releasekit/git inste..."](https://github.com/goosewobbler/releasekit/commit/317c279f6d4cbb217c310fc52c08679c590ea8bd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39692346)</sub>

<!-- /greptile_comment -->