### PR TITLE
feat(release): refresh stale PR state after a release (refresh-after-release)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -134,6 +134,30 @@ releasekit standing-pr merge --publish
 
 ---
 
+## `releasekit refresh-after-release`
+
+Run as the final step of a release/publish job to refresh state that goes stale when a release moves
+`main`. Two parts, with different criticality:
+
+- **Standing-PR reconcile** (standing-pr mode only) — re-runs the standing-PR update with
+  `--reconcile` so a manual/direct release that bypassed the standing PR doesn't leave its manifest
+  stating already-published versions. A failure here fails the job.
+- **Feeder-PR preview refresh** (opt-in via `ci.prPreview.refreshAfterRelease`) — replays the
+  preview comment on still-open PRs that already have one, so their prediction reflects the
+  post-release baseline. Best-effort: skips drafts, the standing PR, and PRs without a preview;
+  bounded to 50 PRs; per-PR failures only warn.
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `-c, --config <path>` | string | auto-discovered | Path to config file |
+| `--project-dir <path>` | string | `cwd` | Project directory |
+
+```bash
+releasekit refresh-after-release
+```
+
+---
+
 ## `releasekit labels`
 
 Create and reconcile the GitHub labels ReleaseKit relies on (`bump:*`, `channel:*`, `release:*`, configured `scope:*`, and the standing-PR labels). The label names honour `ci.labels` renames and `ci.scopeLabels`; descriptions and colours are canonical.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -388,11 +388,22 @@ CI automation configuration for release triggers, PR previews, and label managem
 |-----|------|---------|-------------|
 | `releaseStrategy` | `"manual"` \| `"direct"` \| `"standing-pr"` | `"direct"` | How releases are delivered. 'direct': release on merge to main. 'manual': releases triggered manually (e.g. workflow_dispatch). 'standing-pr': changes accumulate in a release PR; gate mode acts as the immediate-release evaluator, firing only for merges labelled with the immediate label. |
 | `releaseTrigger` | `"commit"` \| `"label"` | `"label"` | What triggers a release. 'label': a PR bump label (bump:patch/minor/major) is required. 'commit': conventional commits drive the bump automatically; every merge can trigger a release. |
-| `prPreview` | boolean | `true` | Enable PR preview comments showing what would be released if the PR is merged. Set to false to disable. |
 | `autoRelease` | boolean | `false` | Automatically trigger a release when CI conditions are met, without manual intervention. |
 | `skipPatterns` | `string[]` | `["chore: release "]` | Commit message prefixes that suppress a release. The default matches the release commit template to prevent release loops. |
 | `minChanges` | integer | `1` | Minimum number of packages with releasable changes required to trigger a release. |
 | `scopeLabels` | object | — | Map of scope labels to package patterns. When a PR has a label matching a key, only packages matching the corresponding pattern are released. |
+
+### `ci.prPreview`
+
+PR preview comments showing what would be released if the PR is merged. `true`/`false` toggles them; the object form additionally enables `refreshAfterRelease` to refresh feeder-PR previews after a release.
+
+Set to `false` to disable.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | boolean | `true` | Whether PR preview comments are posted. |
+| `refreshAfterRelease` | boolean | `false` | After a release completes, replay the preview comment on still-open feeder PRs so their "what would release" estimate is not left stale against the moved baseline. Cosmetic and best-effort — a failure here never fails the release. Requires the refresh-after-release step in your release workflow. |
+
 
 ### `ci.labels`
 

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -616,10 +616,28 @@ export const CIConfigSchema = z.object({
       "What triggers a release. 'label': a PR bump label (bump:patch/minor/major) is required. 'commit': conventional commits drive the bump automatically; every merge can trigger a release.",
     ),
   prPreview: z
-    .boolean()
+    .union([
+      z.boolean(),
+      z.object({
+        enabled: z.boolean().default(true).describe('Whether PR preview comments are posted.'),
+        refreshAfterRelease: z
+          .boolean()
+          .default(false)
+          .describe(
+            'After a release completes, replay the preview comment on still-open feeder PRs so their "what would release" estimate is not left stale against the moved baseline. Cosmetic and best-effort — a failure here never fails the release. Requires the refresh-after-release step in your release workflow.',
+          ),
+      }),
+    ])
     .default(true)
+    // Normalize the boolean shorthand and the object form to one canonical shape so every consumer
+    // reads `prPreview.enabled` / `prPreview.refreshAfterRelease` without re-checking the input type.
+    .transform((v) =>
+      typeof v === 'boolean'
+        ? { enabled: v, refreshAfterRelease: false }
+        : { enabled: v.enabled ?? true, refreshAfterRelease: v.refreshAfterRelease ?? false },
+    )
     .describe(
-      'Enable PR preview comments showing what would be released if the PR is merged. Set to false to disable.',
+      'PR preview comments showing what would be released if the PR is merged. `true`/`false` toggles them; the object form additionally enables `refreshAfterRelease` to refresh feeder-PR previews after a release.',
     ),
   autoRelease: z
     .boolean()

--- a/packages/config/test/unit/load.spec.ts
+++ b/packages/config/test/unit/load.spec.ts
@@ -332,7 +332,7 @@ describe('loadCIConfig', () => {
     );
 
     const result = loadCIConfig();
-    expect(result?.prPreview).toBe(false);
+    expect(result?.prPreview).toEqual({ enabled: false, refreshAfterRelease: false });
     expect(result?.autoRelease).toBe(true);
   });
 

--- a/packages/config/test/unit/schema.spec.ts
+++ b/packages/config/test/unit/schema.spec.ts
@@ -503,7 +503,7 @@ describe('CIConfigSchema', () => {
     const result = CIConfigSchema.parse({});
     expect(result.releaseStrategy).toBe('direct');
     expect(result.releaseTrigger).toBe('label');
-    expect(result.prPreview).toBe(true);
+    expect(result.prPreview).toEqual({ enabled: true, refreshAfterRelease: false });
     expect(result.autoRelease).toBe(false);
     expect(result.skipPatterns).toEqual(['chore: release ']);
     expect(result.minChanges).toBe(1);
@@ -530,7 +530,7 @@ describe('CIConfigSchema', () => {
       minChanges: 3,
     });
     expect(result.releaseStrategy).toBe('direct');
-    expect(result.prPreview).toBe(false);
+    expect(result.prPreview).toEqual({ enabled: false, refreshAfterRelease: false });
     expect(result.autoRelease).toBe(true);
     expect(result.skipPatterns).toEqual(['chore(deps):', 'ci:']);
     expect(result.minChanges).toBe(3);
@@ -540,6 +540,41 @@ describe('CIConfigSchema', () => {
     for (const strategy of ['manual', 'direct', 'standing-pr'] as const) {
       expect(CIConfigSchema.parse({ releaseStrategy: strategy }).releaseStrategy).toBe(strategy);
     }
+  });
+
+  it('should normalize prPreview: true to the canonical object', () => {
+    expect(CIConfigSchema.parse({ prPreview: true }).prPreview).toEqual({
+      enabled: true,
+      refreshAfterRelease: false,
+    });
+  });
+
+  it('should normalize prPreview: false to the canonical object (shorthand kept)', () => {
+    expect(CIConfigSchema.parse({ prPreview: false }).prPreview).toEqual({
+      enabled: false,
+      refreshAfterRelease: false,
+    });
+  });
+
+  it('should default an empty prPreview object to enabled with refresh off', () => {
+    expect(CIConfigSchema.parse({ prPreview: {} }).prPreview).toEqual({
+      enabled: true,
+      refreshAfterRelease: false,
+    });
+  });
+
+  it('should honor prPreview.refreshAfterRelease in the object form', () => {
+    expect(CIConfigSchema.parse({ prPreview: { refreshAfterRelease: true } }).prPreview).toEqual({
+      enabled: true,
+      refreshAfterRelease: true,
+    });
+  });
+
+  it('should allow disabling previews while the object form is used', () => {
+    expect(CIConfigSchema.parse({ prPreview: { enabled: false } }).prPreview).toEqual({
+      enabled: false,
+      refreshAfterRelease: false,
+    });
   });
 
   it('should reject invalid releaseStrategy', () => {
@@ -689,7 +724,7 @@ describe('ReleaseKitConfigSchema', () => {
     expect(result.version?.preset).toBe('conventional');
     expect(result.publish?.npm.enabled).toBe(true);
     expect(result.notes?.changelog).toMatchObject({ mode: 'packages' });
-    expect(result.ci?.prPreview).toBe(true);
+    expect(result.ci?.prPreview).toEqual({ enabled: true, refreshAfterRelease: false });
     expect(result.ci?.autoRelease).toBe(false);
   });
 

--- a/packages/forge/src/fake.ts
+++ b/packages/forge/src/fake.ts
@@ -8,6 +8,7 @@ import type {
   NewLabel,
   NewPullRequest,
   NewRelease,
+  OpenPullRequest,
   PullRequestChanges,
   PullRequestDetails,
   PullRequestRef,
@@ -33,6 +34,7 @@ interface FakeComment {
 export interface FakeForgeSeed {
   standingPR?: StandingPullRequest | null;
   recentlyClosedPRs?: AssociatedPullRequest[];
+  openPullRequests?: OpenPullRequest[];
   pullRequestsForCommit?: Record<string, AssociatedPullRequest[]>;
   issues?: Record<number, IssueDetails>;
   pullRequests?: Record<number, PullRequestDetails>;
@@ -55,6 +57,7 @@ export interface FakeForgeSeed {
 export class FakeForge implements Forge {
   standingPR: StandingPullRequest | null;
   private readonly recentlyClosedPRs: AssociatedPullRequest[];
+  private readonly openPullRequests: OpenPullRequest[];
   private readonly pullRequestsForCommit: Record<string, AssociatedPullRequest[]>;
   private readonly issues: Record<number, IssueDetails>;
   private readonly pullRequestDetails: Record<number, PullRequestDetails>;
@@ -85,6 +88,7 @@ export class FakeForge implements Forge {
   constructor(seed: FakeForgeSeed = {}) {
     this.standingPR = seed.standingPR ?? null;
     this.recentlyClosedPRs = seed.recentlyClosedPRs ?? [];
+    this.openPullRequests = seed.openPullRequests ?? [];
     this.pullRequestsForCommit = seed.pullRequestsForCommit ?? {};
     this.issues = seed.issues ?? {};
     this.pullRequestDetails = seed.pullRequests ?? {};
@@ -123,6 +127,10 @@ export class FakeForge implements Forge {
 
   async listRecentlyClosedPullRequests(_branch: string, limit: number): Promise<AssociatedPullRequest[]> {
     return this.recentlyClosedPRs.slice(0, limit);
+  }
+
+  async listOpenPullRequests(): Promise<OpenPullRequest[]> {
+    return [...this.openPullRequests];
   }
 
   async getIssue(issueNumber: number): Promise<IssueDetails> {

--- a/packages/forge/src/github.ts
+++ b/packages/forge/src/github.ts
@@ -11,6 +11,7 @@ import type {
   NewLabel,
   NewPullRequest,
   NewRelease,
+  OpenPullRequest,
   PullRequestChanges,
   PullRequestDetails,
   PullRequestRef,
@@ -25,6 +26,9 @@ const REPO_PERMISSIONS: readonly RepoPermission[] = ['admin', 'maintain', 'write
 
 /** Releases are listed at most this many pages deep (100/page) — bounds the examples fetch. */
 const MAX_RELEASE_PAGES = 3;
+
+/** Open PRs are listed at most this many pages deep (100/page) — bounds the post-release refresh. */
+const MAX_OPEN_PR_PAGES = 5;
 
 type LabelLike = string | { name?: string | null };
 
@@ -87,6 +91,25 @@ export class GitHubForge implements Forge {
       per_page: limit,
     });
     return data.map((pr) => ({ number: pr.number, mergedAt: pr.merged_at }));
+  }
+
+  async listOpenPullRequests(): Promise<OpenPullRequest[]> {
+    const prs: OpenPullRequest[] = [];
+    for (let page = 1; page <= MAX_OPEN_PR_PAGES; page++) {
+      const { data } = await this.octokit.rest.pulls.list({
+        ...this.base,
+        state: 'open',
+        sort: 'updated',
+        direction: 'desc',
+        per_page: 100,
+        page,
+      });
+      for (const pr of data) {
+        prs.push({ number: pr.number, headRef: pr.head.ref, draft: pr.draft ?? false, baseSha: pr.base.sha });
+      }
+      if (data.length < 100) break;
+    }
+    return prs;
   }
 
   async getIssue(issueNumber: number): Promise<IssueDetails> {

--- a/packages/forge/src/index.ts
+++ b/packages/forge/src/index.ts
@@ -13,6 +13,7 @@ export type {
   NewLabel,
   NewPullRequest,
   NewRelease,
+  OpenPullRequest,
   PullRequestChanges,
   PullRequestDetails,
   PullRequestRef,

--- a/packages/forge/src/types.ts
+++ b/packages/forge/src/types.ts
@@ -29,6 +29,15 @@ export interface AssociatedPullRequest {
   mergedAt: string | null;
 }
 
+/** An open PR, enough to decide whether to refresh its preview (skip drafts/the standing PR) and to
+ *  scope that preview's analysis (`baseSha`) without an event payload. */
+export interface OpenPullRequest {
+  number: number;
+  headRef: string;
+  draft: boolean;
+  baseSha: string;
+}
+
 /** An issue as returned by the issues endpoint (a PR is also an issue). */
 export interface IssueDetails {
   body: string;
@@ -123,6 +132,8 @@ export interface Forge {
   findStandingPR(branch: string): Promise<StandingPullRequest | null>;
   /** Recently-closed PRs whose head is `branch`, most-recently-updated first. */
   listRecentlyClosedPullRequests(branch: string, limit: number): Promise<AssociatedPullRequest[]>;
+  /** All open PRs (number, head ref, draft flag, base SHA), most-recently-updated first, page-capped. */
+  listOpenPullRequests(): Promise<OpenPullRequest[]>;
   /** Issue view of a PR (body, title, labels, and whether it is a PR). */
   getIssue(issueNumber: number): Promise<IssueDetails>;
   /** PR view (body + labels). */

--- a/packages/forge/test/unit/fake.spec.ts
+++ b/packages/forge/test/unit/fake.spec.ts
@@ -16,6 +16,14 @@ describe('FakeForge', () => {
     expect(await forge.getReleaseByTag('absent')).toBeNull();
   });
 
+  it('should return seeded open pull requests', async () => {
+    const open = [{ number: 7, headRef: 'feat/x', draft: false, baseSha: 'abc123' }];
+    const forge = createFakeForge({ openPullRequests: open });
+
+    expect(await forge.listOpenPullRequests()).toEqual(open);
+    expect(await createFakeForge().listOpenPullRequests()).toEqual([]);
+  });
+
   it('should record writes for assertions', async () => {
     const forge = createFakeForge();
     const ref = await forge.createPullRequest({ title: 't', body: 'b', head: 'h', base: 'm' });

--- a/packages/release/docs/ci-setup.md
+++ b/packages/release/docs/ci-setup.md
@@ -26,7 +26,8 @@ on:
 
 permissions:
   contents: write
-  id-token: write   # for npm OIDC trusted publishing
+  id-token: write       # for npm OIDC trusted publishing
+  pull-requests: write  # only needed if you enable ci.prPreview.refreshAfterRelease (below)
 
 jobs:
   release:
@@ -51,6 +52,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # For OIDC trusted publishing (recommended) — no NPM_TOKEN needed.
           # For token-based publishing: NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # Optional: after the release moves `main`, refresh the "what would release" preview on still-open
+      # PRs (they otherwise stay frozen at the pre-release baseline). No-op unless you enable
+      # `ci.prPreview.refreshAfterRelease`. See "PR Preview Comments" below.
+      - run: pnpm exec releasekit refresh-after-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 > **Using npm?** Drop the `pnpm/action-setup` step, set `cache: npm` on `setup-node`, and replace `pnpm install --frozen-lockfile` with `npm ci` and `pnpm exec` with `npx`.
@@ -130,7 +138,7 @@ on:
 permissions:
   contents: write
   id-token: write
-  pull-requests: read
+  pull-requests: write  # `read` is enough for release alone; `write` is needed to refresh previews after release
 
 jobs:
   release:
@@ -151,6 +159,12 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - run: pnpm exec releasekit release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Optional: refresh open-PR previews against the post-release baseline.
+      # No-op unless ci.prPreview.refreshAfterRelease is enabled.
+      - run: pnpm exec releasekit refresh-after-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
@@ -253,6 +267,26 @@ jobs:
 > **Using npm?** Drop the `pnpm/action-setup` step, set `cache: npm` on `setup-node`, and replace `pnpm install --frozen-lockfile` with `npm ci` and `pnpm exec` with `npx`.
 
 A ready-to-use template is available at [`templates/workflows/release-preview.yml`](../../../templates/workflows/release-preview.yml).
+
+### Keeping previews fresh after a release
+
+A preview is computed on `pull_request` events. When a release moves `main`, GitHub does **not**
+re-fire those events on other open PRs, so each one's prediction stays frozen at the *pre-release*
+baseline until it's pushed again. Enable a post-release refresh to fix this:
+
+```jsonc
+{
+  "ci": {
+    "prPreview": { "enabled": true, "refreshAfterRelease": true }
+  }
+}
+```
+
+With `refreshAfterRelease` on, add a `refresh-after-release` step to your release job (see the
+[Minimal](#minimal-setup-push-to-main) and [Label-Based](#label-based-trigger) examples). After each
+release it replays the preview on still-open PRs that already have one — skipping drafts, the standing
+PR, and PRs without a preview, and bounded to 50 PRs per run. It's best-effort: a per-PR failure only
+warns. (`ci.prPreview: true` remains valid shorthand for `{ "enabled": true }`.)
 
 ---
 

--- a/packages/release/src/cli.ts
+++ b/packages/release/src/cli.ts
@@ -6,6 +6,7 @@ import { Command } from 'commander';
 import { createBackfillCommand } from './commands/backfill-command.js';
 import { createGateCommand } from './commands/gate-command.js';
 import { createPreviewCommand } from './commands/preview-command.js';
+import { createRefreshAfterReleaseCommand } from './commands/refresh-after-release-command.js';
 import { createReleaseCommand } from './commands/release-command.js';
 import { createStandingPRCommand } from './commands/standing-pr-command.js';
 
@@ -18,6 +19,7 @@ export function createReleaseProgram(): Command {
     .addCommand(createReleaseCommand())
     .addCommand(createGateCommand())
     .addCommand(createStandingPRCommand())
+    .addCommand(createRefreshAfterReleaseCommand())
     .addCommand(createBackfillCommand());
 }
 

--- a/packages/release/src/commands/refresh-after-release-command.ts
+++ b/packages/release/src/commands/refresh-after-release-command.ts
@@ -1,0 +1,20 @@
+import { EXIT_CODES } from '@releasekit/core';
+import { Command } from 'commander';
+import { runRefreshAfterRelease } from '../preview/refresh.js';
+
+export function createRefreshAfterReleaseCommand(): Command {
+  return new Command('refresh-after-release')
+    .description('After a release, reconcile the standing PR (if any) and refresh stale feeder-PR previews')
+    .option('-c, --config <path>', 'Path to config file')
+    .option('--project-dir <path>', 'Project directory', process.cwd())
+    .action(async (opts) => {
+      try {
+        await runRefreshAfterRelease({ config: opts.config, projectDir: opts.projectDir });
+      } catch (error) {
+        // Reaching here means the release-critical standing-PR reconcile failed (the feeder-preview
+        // refresh swallows its own errors). Surface it and fail the job.
+        console.error(error instanceof Error ? error.message : String(error));
+        process.exit(EXIT_CODES.GENERAL_ERROR);
+      }
+    });
+}

--- a/packages/release/src/preview/preview.ts
+++ b/packages/release/src/preview/preview.ts
@@ -31,6 +31,13 @@ export interface PreviewOptions {
   stable?: boolean;
   bump?: string;
   target?: string;
+  /**
+   * Explicit base SHA for the advisory standing-pr commit-range scoping. The single-PR preview path
+   * reads this from the GitHub Actions `pull_request` event payload, but a post-release refresh runs
+   * on a push/dispatch event with no such payload — so the refresh runner supplies it per PR. Takes
+   * precedence over the event payload when set.
+   */
+  baseSha?: string;
 }
 
 interface LabelOverrideResult {
@@ -56,7 +63,7 @@ function readEventPayload(): PullRequestEvent | undefined {
 export async function runPreview(options: PreviewOptions): Promise<void> {
   // Check if preview is enabled in config
   const ciConfig = loadCIConfig({ cwd: options.projectDir, configPath: options.config });
-  if (ciConfig?.prPreview === false) {
+  if (ciConfig?.prPreview?.enabled === false) {
     info('PR preview is disabled in config (ci.prPreview: false)');
     return;
   }
@@ -134,7 +141,7 @@ export async function runPreview(options: PreviewOptions): Promise<void> {
   // event payload (pull_request.base.sha) — non-fatal if unavailable.
   let prBaseSha: string | undefined;
   if (labelContext.advisoryInStandingPr) {
-    prBaseSha = event?.pull_request?.base?.sha;
+    prBaseSha = options.baseSha ?? event?.pull_request?.base?.sha;
   }
 
   // Run version analysis unless release is skipped or in label mode with no bump label

--- a/packages/release/src/preview/preview.ts
+++ b/packages/release/src/preview/preview.ts
@@ -64,7 +64,7 @@ export async function runPreview(options: PreviewOptions): Promise<void> {
   // Check if preview is enabled in config
   const ciConfig = loadCIConfig({ cwd: options.projectDir, configPath: options.config });
   if (ciConfig?.prPreview?.enabled === false) {
-    info('PR preview is disabled in config (ci.prPreview: false)');
+    info('PR preview is disabled in config (ci.prPreview.enabled: false)');
     return;
   }
 

--- a/packages/release/src/preview/refresh.ts
+++ b/packages/release/src/preview/refresh.ts
@@ -70,12 +70,16 @@ export async function runRefreshAfterRelease(options: RefreshAfterReleaseOptions
       // Only refresh PRs that already have a preview — never manufacture one on a PR that opted out.
       if (!(await forge.findComment(pr.number, MARKER))) continue;
       eligible.push(pr);
+      // Open PRs come back most-recently-updated first, so the first MAX_FEEDER_PR_REFRESH are exactly
+      // the set we refresh. Stop probing once one past the cap is in hand — bounds the per-PR
+      // findComment calls instead of fetching comments for every open PR on a busy repo.
+      if (eligible.length > MAX_FEEDER_PR_REFRESH) break;
     }
 
     let toRefresh = eligible;
     if (eligible.length > MAX_FEEDER_PR_REFRESH) {
       warn(
-        `${eligible.length} open PRs have a preview; refreshing the ${MAX_FEEDER_PR_REFRESH} most recently updated and skipping the rest.`,
+        `More than ${MAX_FEEDER_PR_REFRESH} open PRs have a preview; refreshing the ${MAX_FEEDER_PR_REFRESH} most recently updated and skipping the rest.`,
       );
       toRefresh = eligible.slice(0, MAX_FEEDER_PR_REFRESH);
     }

--- a/packages/release/src/preview/refresh.ts
+++ b/packages/release/src/preview/refresh.ts
@@ -1,0 +1,110 @@
+import { loadCIConfig } from '@releasekit/config';
+import { info, warn } from '@releasekit/core';
+import type { OpenPullRequest } from '@releasekit/forge';
+import { getGitHubContext } from '../git.js';
+import { forgeFor, MARKER } from '../github.js';
+import { runStandingPRUpdate } from '../standing-pr/standing-pr.js';
+import { runPreview } from './preview.js';
+
+export interface RefreshAfterReleaseOptions {
+  config?: string;
+  projectDir: string;
+}
+
+/** Hard cap on feeder-PR previews refreshed in one run — keeps the cost bounded on busy repos. */
+const MAX_FEEDER_PR_REFRESH = 50;
+
+/**
+ * Post-release cleanup of state that goes stale when a release moves `main`. Run as the final step of
+ * a release/publish job. Two halves with deliberately different failure semantics:
+ *
+ * 1. **Standing-PR reconcile (release-critical).** A direct/manual/immediate release that bypasses
+ *    the standing PR leaves its manifest computed against the old baseline — and the `chore: release `
+ *    commit suppresses the normal push-triggered update. Reusing the existing `--reconcile` path
+ *    re-syncs it. A failure here propagates: a stale standing PR can hold already-published versions.
+ * 2. **Feeder-PR preview refresh (cosmetic, opt-in).** Other open PRs' "what would release" estimate
+ *    is frozen at the pre-release baseline until they're pushed again. Replaying the (idempotent)
+ *    preview brings them current. Best-effort — any failure only warns, never fails the release.
+ */
+export async function runRefreshAfterRelease(options: RefreshAfterReleaseOptions): Promise<void> {
+  const ciConfig = loadCIConfig({ cwd: options.projectDir, configPath: options.config });
+  const strategy = ciConfig?.releaseStrategy ?? 'direct';
+  const branch = ciConfig?.standingPr?.branch ?? 'release/next';
+
+  // — Half 1: reconcile the standing PR (RELEASE-CRITICAL) —
+  // Only standing-pr mode has a standing PR. No try/catch: a failure must fail the job rather than
+  // silently leave the standing PR stating versions that may already be published.
+  if (strategy === 'standing-pr') {
+    info('Reconciling the standing PR after release...');
+    await runStandingPRUpdate({
+      config: options.config,
+      projectDir: options.projectDir,
+      reconcile: true,
+      verbose: false,
+      quiet: false,
+      json: false,
+    });
+  }
+
+  // — Half 2: refresh feeder-PR previews (COSMETIC, opt-in, never fatal) —
+  const prPreview = ciConfig?.prPreview;
+  if (!prPreview?.enabled || !prPreview.refreshAfterRelease) {
+    return;
+  }
+
+  const context = getGitHubContext();
+  if (!context?.token) {
+    warn('Cannot refresh feeder-PR previews: no GitHub token in the environment.');
+    return;
+  }
+
+  try {
+    const forge = forgeFor(context);
+    const repo = `${context.owner}/${context.repo}`;
+    const open = await forge.listOpenPullRequests();
+
+    const eligible: OpenPullRequest[] = [];
+    for (const pr of open) {
+      if (pr.draft) continue; // drafts don't carry previews
+      if (pr.headRef === branch) continue; // the standing PR's manifest is authoritative, never previewed (#424)
+      // Only refresh PRs that already have a preview — never manufacture one on a PR that opted out.
+      if (!(await forge.findComment(pr.number, MARKER))) continue;
+      eligible.push(pr);
+    }
+
+    let toRefresh = eligible;
+    if (eligible.length > MAX_FEEDER_PR_REFRESH) {
+      warn(
+        `${eligible.length} open PRs have a preview; refreshing the ${MAX_FEEDER_PR_REFRESH} most recently updated and skipping the rest.`,
+      );
+      toRefresh = eligible.slice(0, MAX_FEEDER_PR_REFRESH);
+    }
+
+    if (toRefresh.length === 0) {
+      info('No open feeder PRs with a preview comment to refresh.');
+      return;
+    }
+
+    info(`Refreshing previews on ${toRefresh.length} open PR(s)...`);
+    for (const pr of toRefresh) {
+      try {
+        await runPreview({
+          config: options.config,
+          projectDir: options.projectDir,
+          pr: String(pr.number),
+          repo,
+          dryRun: false,
+          // Supply the PR's base SHA so standing-pr advisory scoping matches the event-driven path —
+          // there's no pull_request event payload on this push/dispatch-triggered run.
+          baseSha: pr.baseSha,
+        });
+      } catch (err) {
+        // One PR's failure must not abort the sweep or fail the release.
+        warn(`Could not refresh preview on PR #${pr.number}: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+  } catch (err) {
+    // The entire feeder refresh is best-effort — enumeration/forge errors only warn.
+    warn(`Feeder-PR preview refresh failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}

--- a/packages/release/test/unit/label-definitions.spec.ts
+++ b/packages/release/test/unit/label-definitions.spec.ts
@@ -20,7 +20,7 @@ function ciConfig(overrides: Partial<CIConfig> = {}): CIConfig {
   return {
     releaseStrategy: 'direct',
     releaseTrigger: 'label',
-    prPreview: true,
+    prPreview: { enabled: true, refreshAfterRelease: false },
     autoRelease: false,
     skipPatterns: ['chore: release '],
     minChanges: 1,

--- a/packages/release/test/unit/preview.spec.ts
+++ b/packages/release/test/unit/preview.spec.ts
@@ -139,7 +139,7 @@ describe('runPreview', () => {
     });
 
     it('should skip when CI config disables preview', async () => {
-      mockLoadCIConfig.mockReturnValue({ prPreview: false });
+      mockLoadCIConfig.mockReturnValue({ prPreview: { enabled: false, refreshAfterRelease: false } });
 
       await runPreview({ projectDir: '/test', dryRun: false, target: '@test/package' });
 
@@ -148,7 +148,10 @@ describe('runPreview', () => {
     });
 
     it('should run when CI config enables preview', async () => {
-      mockLoadCIConfig.mockReturnValue({ prPreview: true, releaseTrigger: 'commit' });
+      mockLoadCIConfig.mockReturnValue({
+        prPreview: { enabled: true, refreshAfterRelease: false },
+        releaseTrigger: 'commit',
+      });
 
       await runPreview({ projectDir: '/test', dryRun: false, target: '@test/package' });
 

--- a/packages/release/test/unit/refresh.spec.ts
+++ b/packages/release/test/unit/refresh.spec.ts
@@ -1,0 +1,227 @@
+import type { OpenPullRequest } from '@releasekit/forge';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// --- Mocks ---
+
+const mockLoadCIConfig = vi.fn();
+
+vi.mock('@releasekit/config', () => ({
+  loadCIConfig: (...args: unknown[]) => mockLoadCIConfig(...args),
+}));
+
+vi.mock('@releasekit/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@releasekit/core')>();
+  return { ...actual, info: vi.fn(), warn: vi.fn() };
+});
+
+const mockGetGitHubContext = vi.fn();
+
+vi.mock('../../src/git.js', () => ({
+  getGitHubContext: (...args: unknown[]) => mockGetGitHubContext(...args),
+}));
+
+const mockForgeFor = vi.fn();
+
+vi.mock('../../src/github.js', () => ({
+  MARKER: '<!-- releasekit-preview -->',
+  forgeFor: (...args: unknown[]) => mockForgeFor(...args),
+}));
+
+const mockRunStandingPRUpdate = vi.fn();
+
+vi.mock('../../src/standing-pr/standing-pr.js', () => ({
+  runStandingPRUpdate: (...args: unknown[]) => mockRunStandingPRUpdate(...args),
+}));
+
+const mockRunPreview = vi.fn();
+
+vi.mock('../../src/preview/preview.js', () => ({
+  runPreview: (...args: unknown[]) => mockRunPreview(...args),
+}));
+
+// --- Helpers ---
+
+function pr(number: number, overrides: Partial<OpenPullRequest> = {}): OpenPullRequest {
+  return { number, headRef: `feat/pr-${number}`, draft: false, baseSha: `sha-${number}`, ...overrides };
+}
+
+/** A minimal fake forge: `commentsOn` lists PR numbers that already have a preview comment. */
+function fakeForge(openPullRequests: OpenPullRequest[], commentsOn: number[] = openPullRequests.map((p) => p.number)) {
+  const present = new Set(commentsOn);
+  return {
+    listOpenPullRequests: vi.fn().mockResolvedValue(openPullRequests),
+    findComment: vi.fn(async (prNumber: number, marker: string) =>
+      present.has(prNumber) ? { id: prNumber, body: `${marker}\nbody` } : null,
+    ),
+  };
+}
+
+const context = { owner: 'owner', repo: 'repo', token: 'tok', sha: null };
+
+// --- Tests ---
+
+describe('runRefreshAfterRelease', () => {
+  let runRefreshAfterRelease: typeof import('../../src/preview/refresh.js').runRefreshAfterRelease;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockLoadCIConfig.mockReturnValue({
+      releaseStrategy: 'direct',
+      prPreview: { enabled: true, refreshAfterRelease: true },
+    });
+    mockGetGitHubContext.mockReturnValue(context);
+    mockRunStandingPRUpdate.mockResolvedValue({ action: 'noop' });
+    mockRunPreview.mockResolvedValue(undefined);
+
+    const mod = await import('../../src/preview/refresh.js');
+    runRefreshAfterRelease = mod.runRefreshAfterRelease;
+  });
+
+  describe('feeder-PR preview refresh', () => {
+    it('should refresh eligible PRs, passing each PR base SHA', async () => {
+      mockForgeFor.mockReturnValue(fakeForge([pr(10), pr(11)]));
+
+      await runRefreshAfterRelease({ projectDir: '/p' });
+
+      expect(mockRunPreview).toHaveBeenCalledTimes(2);
+      expect(mockRunPreview).toHaveBeenCalledWith(
+        expect.objectContaining({ pr: '10', repo: 'owner/repo', baseSha: 'sha-10' }),
+      );
+      expect(mockRunPreview).toHaveBeenCalledWith(
+        expect.objectContaining({ pr: '11', repo: 'owner/repo', baseSha: 'sha-11' }),
+      );
+    });
+
+    it('should skip draft PRs', async () => {
+      mockForgeFor.mockReturnValue(fakeForge([pr(10, { draft: true }), pr(11)]));
+
+      await runRefreshAfterRelease({ projectDir: '/p' });
+
+      expect(mockRunPreview).toHaveBeenCalledTimes(1);
+      expect(mockRunPreview).toHaveBeenCalledWith(expect.objectContaining({ pr: '11' }));
+    });
+
+    it('should skip the standing PR by head ref', async () => {
+      mockForgeFor.mockReturnValue(fakeForge([pr(10, { headRef: 'release/next' }), pr(11)]));
+
+      await runRefreshAfterRelease({ projectDir: '/p' });
+
+      expect(mockRunPreview).toHaveBeenCalledTimes(1);
+      expect(mockRunPreview).toHaveBeenCalledWith(expect.objectContaining({ pr: '11' }));
+    });
+
+    it('should skip PRs without an existing preview comment', async () => {
+      mockForgeFor.mockReturnValue(fakeForge([pr(10), pr(11)], [11]));
+
+      await runRefreshAfterRelease({ projectDir: '/p' });
+
+      expect(mockRunPreview).toHaveBeenCalledTimes(1);
+      expect(mockRunPreview).toHaveBeenCalledWith(expect.objectContaining({ pr: '11' }));
+    });
+
+    it('should cap the number of refreshed PRs at 50 and warn', async () => {
+      const { warn } = await import('@releasekit/core');
+      const many = Array.from({ length: 55 }, (_, i) => pr(i + 1));
+      mockForgeFor.mockReturnValue(fakeForge(many));
+
+      await runRefreshAfterRelease({ projectDir: '/p' });
+
+      expect(mockRunPreview).toHaveBeenCalledTimes(50);
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('55'));
+    });
+
+    it('should continue refreshing remaining PRs when one runPreview throws', async () => {
+      mockForgeFor.mockReturnValue(fakeForge([pr(10), pr(11), pr(12)]));
+      mockRunPreview.mockImplementation(async (opts: { pr: string }) => {
+        if (opts.pr === '11') throw new Error('boom');
+      });
+
+      await runRefreshAfterRelease({ projectDir: '/p' });
+
+      expect(mockRunPreview).toHaveBeenCalledTimes(3);
+    });
+
+    it('should not throw when the entire feeder refresh fails', async () => {
+      mockForgeFor.mockReturnValue({
+        listOpenPullRequests: vi.fn().mockRejectedValue(new Error('rate limited')),
+        findComment: vi.fn(),
+      });
+
+      await expect(runRefreshAfterRelease({ projectDir: '/p' })).resolves.toBeUndefined();
+    });
+
+    it('should skip the feeder refresh when refreshAfterRelease is off', async () => {
+      mockLoadCIConfig.mockReturnValue({
+        releaseStrategy: 'direct',
+        prPreview: { enabled: true, refreshAfterRelease: false },
+      });
+      const forge = fakeForge([pr(10)]);
+      mockForgeFor.mockReturnValue(forge);
+
+      await runRefreshAfterRelease({ projectDir: '/p' });
+
+      expect(forge.listOpenPullRequests).not.toHaveBeenCalled();
+      expect(mockRunPreview).not.toHaveBeenCalled();
+    });
+
+    it('should skip the feeder refresh when previews are disabled', async () => {
+      mockLoadCIConfig.mockReturnValue({
+        releaseStrategy: 'direct',
+        prPreview: { enabled: false, refreshAfterRelease: true },
+      });
+      const forge = fakeForge([pr(10)]);
+      mockForgeFor.mockReturnValue(forge);
+
+      await runRefreshAfterRelease({ projectDir: '/p' });
+
+      expect(forge.listOpenPullRequests).not.toHaveBeenCalled();
+    });
+
+    it('should warn and skip the feeder refresh when no token is present', async () => {
+      mockGetGitHubContext.mockReturnValue({ ...context, token: null });
+
+      await runRefreshAfterRelease({ projectDir: '/p' });
+
+      expect(mockForgeFor).not.toHaveBeenCalled();
+      expect(mockRunPreview).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('standing-PR reconcile', () => {
+    it('should not reconcile in direct mode', async () => {
+      mockForgeFor.mockReturnValue(fakeForge([pr(10)]));
+
+      await runRefreshAfterRelease({ projectDir: '/p' });
+
+      expect(mockRunStandingPRUpdate).not.toHaveBeenCalled();
+      expect(mockRunPreview).toHaveBeenCalledTimes(1); // feeders still refresh
+    });
+
+    it('should reconcile the standing PR before refreshing previews in standing-pr mode', async () => {
+      mockLoadCIConfig.mockReturnValue({
+        releaseStrategy: 'standing-pr',
+        prPreview: { enabled: true, refreshAfterRelease: true },
+      });
+      mockForgeFor.mockReturnValue(fakeForge([pr(10)]));
+
+      await runRefreshAfterRelease({ projectDir: '/p' });
+
+      expect(mockRunStandingPRUpdate).toHaveBeenCalledWith(expect.objectContaining({ reconcile: true }));
+      expect(mockRunStandingPRUpdate.mock.invocationCallOrder[0]).toBeLessThan(
+        mockRunPreview.mock.invocationCallOrder[0],
+      );
+    });
+
+    it('should propagate a reconcile failure and not refresh previews', async () => {
+      mockLoadCIConfig.mockReturnValue({
+        releaseStrategy: 'standing-pr',
+        prPreview: { enabled: true, refreshAfterRelease: true },
+      });
+      mockForgeFor.mockReturnValue(fakeForge([pr(10)]));
+      mockRunStandingPRUpdate.mockRejectedValue(new Error('reconcile failed'));
+
+      await expect(runRefreshAfterRelease({ projectDir: '/p' })).rejects.toThrow('reconcile failed');
+      expect(mockRunPreview).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/release/test/unit/refresh.spec.ts
+++ b/packages/release/test/unit/refresh.spec.ts
@@ -122,12 +122,15 @@ describe('runRefreshAfterRelease', () => {
     it('should cap the number of refreshed PRs at 50 and warn', async () => {
       const { warn } = await import('@releasekit/core');
       const many = Array.from({ length: 55 }, (_, i) => pr(i + 1));
-      mockForgeFor.mockReturnValue(fakeForge(many));
+      const forge = fakeForge(many);
+      mockForgeFor.mockReturnValue(forge);
 
       await runRefreshAfterRelease({ projectDir: '/p' });
 
       expect(mockRunPreview).toHaveBeenCalledTimes(50);
-      expect(warn).toHaveBeenCalledWith(expect.stringContaining('55'));
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('More than 50'));
+      // Probing stops one past the cap rather than checking every open PR's comments.
+      expect(forge.findComment).toHaveBeenCalledTimes(51);
     });
 
     it('should continue refreshing remaining PRs when one runPreview throws', async () => {

--- a/packages/release/test/unit/standing-pr.spec.ts
+++ b/packages/release/test/unit/standing-pr.spec.ts
@@ -274,7 +274,7 @@ describe('runStandingPRUpdate', () => {
       },
       releaseStrategy: 'standing-pr',
       releaseTrigger: 'label',
-      prPreview: true,
+      prPreview: { enabled: true, refreshAfterRelease: false },
       autoRelease: false,
       skipPatterns: ['chore: release '],
       minChanges: 1,

--- a/releasekit.schema.json
+++ b/releasekit.schema.json
@@ -1097,9 +1097,29 @@
           "description": "What triggers a release. 'label': a PR bump label (bump:patch/minor/major) is required. 'commit': conventional commits drive the bump automatically; every merge can trigger a release."
         },
         "prPreview": {
-          "type": "boolean",
           "default": true,
-          "description": "Enable PR preview comments showing what would be released if the PR is merged. Set to false to disable."
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "default": true,
+                  "description": "Whether PR preview comments are posted."
+                },
+                "refreshAfterRelease": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "After a release completes, replay the preview comment on still-open feeder PRs so their \"what would release\" estimate is not left stale against the moved baseline. Cosmetic and best-effort — a failure here never fails the release. Requires the refresh-after-release step in your release workflow."
+                }
+              }
+            }
+          ],
+          "description": "PR preview comments showing what would be released if the PR is merged. `true`/`false` toggles them; the object form additionally enables `refreshAfterRelease` to refresh feeder-PR previews after a release."
         },
         "autoRelease": {
           "type": "boolean",

--- a/scripts/generate-config-docs.ts
+++ b/scripts/generate-config-docs.ts
@@ -438,10 +438,18 @@ function renderCi(prop: SchemaProperty): void {
   emitBlank();
 
   const topProps = Object.fromEntries(
-    Object.entries(prop.properties ?? {}).filter(([k]) => k !== 'labels' && k !== 'standingPr'),
+    Object.entries(prop.properties ?? {}).filter(([k]) => k !== 'labels' && k !== 'standingPr' && k !== 'prPreview'),
   );
   emit(propsTable(topProps));
   emitBlank();
+
+  const prPreview = prop.properties?.prPreview;
+  if (prPreview?.oneOf) {
+    emit('### `ci.prPreview`', '');
+    emit(ensurePeriod(prPreview.description), '');
+    renderOneOfBooleanObject('ci.prPreview', prPreview);
+    emitBlank();
+  }
 
   const labels = prop.properties?.labels;
   if (labels) {


### PR DESCRIPTION
## What & why

When a release moves `main`, two things go stale and nothing fixes them:

1. **Feeder-PR previews** — GitHub doesn't re-fire `pull_request` events on other open PRs, so each one's "what would release" prediction stays frozen at the *pre-release* baseline until it's pushed again. (This is the original ask, #432.)
2. **The standing PR itself** — when a manual/direct release bypasses an existing standing PR, its manifest was computed against the old baseline, and the `chore: release ` commit suppresses the normal push-triggered update — so it's left stating versions that may already be published.

This adds a single, self-gating post-release primitive — **`releasekit refresh-after-release`** — run as the final step of a release job. It does both, with deliberately different failure semantics:

- **Standing-PR reconcile** (standing-pr mode) — reuses the existing `runStandingPRUpdate({ reconcile: true })` path. **Release-critical**: a failure propagates and fails the job.
- **Feeder-PR preview refresh** (opt-in via `ci.prPreview.refreshAfterRelease`) — replays the idempotent preview on still-open PRs that already have one. **Cosmetic/best-effort**: skips drafts, the standing PR, and PRs without a preview; bounded to 50 PRs; per-PR failures only warn.

## Changes

- **forge**: new `listOpenPullRequests()` seam (interface + `GitHubForge` + fake).
- **config**: widen `ci.prPreview` to `boolean | { enabled?, refreshAfterRelease? }`, normalized via a Zod transform to a canonical object. `prPreview: true`/`false` shorthand still parses.
- **preview**: `runPreview` accepts an explicit `baseSha` so standing-pr advisory scoping matches the event-driven path on a push/dispatch-triggered refresh (no `pull_request` payload there).
- **release**: new `refresh-after-release` command + runner.
- **docs**: regenerated `releasekit.schema.json` + `configuration.md`; `cli.md`; `ci-setup.md` (wired the step into the direct/manual examples + a "keeping previews fresh" note).

## Scope / follow-up

Wired into the **direct/manual (gap) workflow examples only** — purely additive. A follow-up PR consolidates the existing standing-pr reconcile steps (the `immediate-release` job and the repo's own `reconcile-after-release` job) onto this command (reconcile is idempotent, so this is safe to defer).

Widens #432.

## Verification

`pnpm turbo run lint typecheck test` — all green. `pnpm schema:check` in sync. New unit tests cover the filter/cap/ordering/hard-fail/non-fatal-per-PR behaviors (`refresh.spec.ts`) and the config normalization.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds `releasekit refresh-after-release`, a post-release command that reconciles stale state after `main` moves. It fixes two independent staleness problems — the standing PR's manifest being left at the pre-release baseline when bypassed by a direct release, and open feeder-PR preview comments staying frozen until the next push — with deliberately different failure semantics for each.

- **Standing-PR reconcile** (standing-pr mode only): reuses the existing `runStandingPRUpdate({ reconcile: true })` path with no error suppression; a failure propagates and fails the job.
- **Feeder-PR preview refresh** (opt-in via `ci.prPreview.refreshAfterRelease`): iterates open PRs sorted by `updated` desc, skipping drafts, the standing PR, and PRs without an existing preview comment; bounded to 50 refreshes per run by breaking after the 51st eligible entry; per-PR failures warn only and never abort the sweep.
- **Config**: `ci.prPreview` widened to `boolean | { enabled?, refreshAfterRelease? }` with a Zod transform that normalises both forms to a canonical object shape, preserving the existing boolean shorthand.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge. The two halves of the new command are cleanly isolated with appropriate failure semantics, the API cost is bounded, and the Zod normalisation is backward-compatible.

The change is purely additive — no existing code paths are altered except the prPreview boolean guard in preview.ts and the Zod schema (both backward-compatible). The standing-PR reconcile reuses a proven path. The feeder refresh loop correctly bounds findComment calls via the break-after-cap pattern verified by the 51-call assertion in the cap test. Config normalisation is idempotent and all callers in the diff have been updated to read prPreview.enabled.

No files require special attention. refresh.ts and schema.ts are the core of the change and both read cleanly.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/release/src/preview/refresh.ts | New post-release refresh runner; correct dual failure semantics (propagating for standing-PR reconcile, best-effort for feeder previews); findComment calls bounded to ≤51 via break-after-cap logic. |
| packages/config/src/schema.ts | prPreview widened to boolean | object union with a Zod transform normalising both to the canonical { enabled, refreshAfterRelease } object; boolean shorthand still valid. |
| packages/release/src/preview/preview.ts | prPreview guard updated to .enabled === false; baseSha option added and wired into the advisory standing-PR commit-range scoping, taking precedence over the event payload. |
| packages/forge/src/github.ts | New listOpenPullRequests() on GitHubForge; paginates up to MAX_OPEN_PR_PAGES=5 (500 PRs), sorted by updated desc; maps draft with ?? false for null safety. |
| packages/release/test/unit/refresh.spec.ts | Comprehensive new unit tests covering filter/cap/ordering/hard-fail/per-PR-non-fatal behaviours; cap test explicitly asserts findComment called exactly 51 times, validating the bounding logic. |
| packages/release/src/commands/refresh-after-release-command.ts | Thin Commander wrapper; surfaces reconcile errors to stderr and exits with GENERAL_ERROR, leaving best-effort feeder errors swallowed inside runRefreshAfterRelease. |
| packages/forge/src/types.ts | New OpenPullRequest interface (number, headRef, draft, baseSha) added; listOpenPullRequests() added to the Forge interface contract. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Job as Release Job
    participant CLI as releasekit CLI
    participant Cfg as loadCIConfig
    participant SPR as runStandingPRUpdate
    participant Forge as GitHubForge
    participant Prev as runPreview

    Job->>CLI: refresh-after-release
    CLI->>Cfg: loadCIConfig()
    Cfg-->>CLI: "{ releaseStrategy, prPreview }"

    alt "strategy === 'standing-pr'"
        CLI->>SPR: "runStandingPRUpdate({ reconcile: true })"
        SPR-->>CLI: ok (or throws → job fails)
    end

    alt "prPreview.enabled && prPreview.refreshAfterRelease"
        CLI->>Forge: listOpenPullRequests()
        Forge-->>CLI: open[] (≤500, sorted by updated desc)
        loop for each PR (until 51 eligible found)
            CLI->>Forge: findComment(pr.number, MARKER)
            Forge-->>CLI: "comment | null"
        end
        note over CLI: toRefresh = first 50 eligible
        loop for each in toRefresh
            CLI->>Prev: "runPreview({ pr, baseSha, repo, ... })"
            Prev-->>CLI: ok (or warn on error)
        end
    end
    CLI-->>Job: done
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Job as Release Job
    participant CLI as releasekit CLI
    participant Cfg as loadCIConfig
    participant SPR as runStandingPRUpdate
    participant Forge as GitHubForge
    participant Prev as runPreview

    Job->>CLI: refresh-after-release
    CLI->>Cfg: loadCIConfig()
    Cfg-->>CLI: "{ releaseStrategy, prPreview }"

    alt "strategy === 'standing-pr'"
        CLI->>SPR: "runStandingPRUpdate({ reconcile: true })"
        SPR-->>CLI: ok (or throws → job fails)
    end

    alt "prPreview.enabled && prPreview.refreshAfterRelease"
        CLI->>Forge: listOpenPullRequests()
        Forge-->>CLI: open[] (≤500, sorted by updated desc)
        loop for each PR (until 51 eligible found)
            CLI->>Forge: findComment(pr.number, MARKER)
            Forge-->>CLI: "comment | null"
        end
        note over CLI: toRefresh = first 50 eligible
        loop for each in toRefresh
            CLI->>Prev: "runPreview({ pr, baseSha, repo, ... })"
            Prev-->>CLI: ok (or warn on error)
        end
    end
    CLI-->>Job: done
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["refactor(release): address Greptile revi..."](https://github.com/goosewobbler/releasekit/commit/57d8e626dd168c6d8926a485783a18d8d8eb9a9c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39839081)</sub>

<!-- /greptile_comment -->