### PR TITLE
fix(version): preserve the prerelease in linked/fixed group baselines

### DIFF
--- a/packages/version/src/core/groupStrategy.ts
+++ b/packages/version/src/core/groupStrategy.ts
@@ -84,7 +84,12 @@ interface MemberPlan {
 
 function cleanBaseline(version: string | undefined): string {
   if (!version) return '0.0.0';
-  return semver.valid(semver.coerce(version) ?? '') ?? semver.clean(version) ?? '0.0.0';
+  // semver.coerce() strips the prerelease (1.0.0-next.0 -> 1.0.0), which would graduate a linked or
+  // fixed group off its prerelease line on every increment. Parse prerelease-preserving first:
+  // clean() for a bare semver, then coerce({ includePrerelease }) only to pull it from a tag prefix.
+  return (
+    semver.valid(semver.clean(version) ?? '') ?? semver.coerce(version, { includePrerelease: true })?.version ?? '0.0.0'
+  );
 }
 
 /**

--- a/packages/version/test/unit/core/groupStrategy.spec.ts
+++ b/packages/version/test/unit/core/groupStrategy.spec.ts
@@ -355,6 +355,41 @@ describe('createGroupStrategy', () => {
         undefined,
       );
     });
+
+    it('should increment within the prerelease for a fixed group when the latest tag is a prerelease', async () => {
+      // Same interrupted-release baseline as the linked case, but `fixed` releases ALL members at the
+      // shared group version — so a stable-baseline regression here would silently write the wrong
+      // version to every member. Both must land on 1.0.0-next.1, not graduate to 2.0.0-next.0.
+      const service = mkPackage('@wdio/flutter-service', '0.0.1');
+      const contract = mkPackage('wdio_flutter', '0.0.1');
+
+      vi.mocked(gitTags.getLatestTagForPackage).mockImplementation(async (name) =>
+        name === '@wdio/flutter-service' ? 'wdio-flutter-service@v1.0.0-next.0' : '',
+      );
+      vi.mocked(calculator.calculateVersion).mockImplementation(async (_cfg, opts) =>
+        opts.name === '@wdio/flutter-service' ? '1.0.0-next.1' : '',
+      );
+
+      const strategy = createGroupStrategy(
+        baseConfig({
+          prereleaseIdentifier: 'next',
+          groups: { flutter: { packages: ['@wdio/flutter-service', 'wdio_flutter'], sync: 'fixed' } },
+        }),
+      );
+      await strategy(workspace([service, contract]));
+
+      expect(packageManagement.updatePackageVersion).toHaveBeenCalledTimes(2);
+      expect(packageManagement.updatePackageVersion).toHaveBeenCalledWith(
+        '/ws/packages/wdio-flutter-service/package.json',
+        '1.0.0-next.1',
+        undefined,
+      );
+      expect(packageManagement.updatePackageVersion).toHaveBeenCalledWith(
+        '/ws/packages/wdio_flutter/package.json',
+        '1.0.0-next.1',
+        undefined,
+      );
+    });
   });
 
   describe('group baseline = max(member baselines)', () => {

--- a/packages/version/test/unit/core/groupStrategy.spec.ts
+++ b/packages/version/test/unit/core/groupStrategy.spec.ts
@@ -324,6 +324,37 @@ describe('createGroupStrategy', () => {
         undefined,
       );
     });
+
+    it('should increment within the prerelease when the latest tag is a prerelease', async () => {
+      // The published prerelease lives in the tag while the manifest still reads 0.0.1 (an
+      // interrupted release that tagged+published but never committed the bump). The baseline must
+      // keep the tag's prerelease, else it coerces to a stable 1.0.0 and the group graduates to
+      // 2.0.0-next.0 instead of incrementing to 1.0.0-next.1.
+      const service = mkPackage('@wdio/flutter-service', '0.0.1');
+      const contract = mkPackage('wdio_flutter', '0.0.1');
+
+      vi.mocked(gitTags.getLatestTagForPackage).mockImplementation(async (name) =>
+        name === '@wdio/flutter-service' ? 'wdio-flutter-service@v1.0.0-next.0' : '',
+      );
+      vi.mocked(calculator.calculateVersion).mockImplementation(async (_cfg, opts) =>
+        opts.name === '@wdio/flutter-service' ? '1.0.0-next.1' : '',
+      );
+
+      const strategy = createGroupStrategy(
+        baseConfig({
+          prereleaseIdentifier: 'next',
+          groups: { flutter: { packages: ['@wdio/flutter-service', 'wdio_flutter'], sync: 'linked' } },
+        }),
+      );
+      await strategy(workspace([service, contract]));
+
+      expect(packageManagement.updatePackageVersion).toHaveBeenCalledTimes(1);
+      expect(packageManagement.updatePackageVersion).toHaveBeenCalledWith(
+        '/ws/packages/wdio-flutter-service/package.json',
+        '1.0.0-next.1',
+        undefined,
+      );
+    });
   });
 
   describe('group baseline = max(member baselines)', () => {


### PR DESCRIPTION
## Bug

In a `linked` or `fixed` group whose latest release is a **prerelease**, the next prerelease *increment* graduates off the prerelease line — `1.0.0-next.0` → **`2.0.0-next.0`** instead of `1.0.0-next.1`.

`computeGroup` derives the group baseline from `max(member baselines)`, and each member baseline goes through `cleanBaseline()`:

```ts
return semver.valid(semver.coerce(version) ?? '') ?? semver.clean(version) ?? '0.0.0';
```

`semver.coerce()` **strips the prerelease** — `coerce('…@v1.0.0-next.0')` and even `coerce('1.0.0-next.0')` both return `1.0.0`. So the group baseline becomes a *stable* `1.0.0`, and the next prerelease bump from a stable baseline (correctly, post-#421) produces the next-major prerelease `2.0.0-next.0`. The bump input (`major` vs `prerelease`) doesn't matter — the coerced-stable baseline drives it either way.

Surfaced doing a follow-up flutter prerelease where the published `1.0.0-next.0` lived in the tag (`wdio-flutter-service@v1.0.0-next.0`) while the manifest lagged at `0.0.1`; every dry run computed `2.0.0-next.0`.

## Fix

Parse prerelease-preserving first — `clean()` for a bare semver, then `coerce({ includePrerelease: true })` only to pull the version out of a prefixed tag string:

```ts
return semver.valid(semver.clean(version) ?? '') ?? semver.coerce(version, { includePrerelease: true })?.version ?? '0.0.0';
```

Bare versions (`1.0.0-next.0`) and tag strings (`pkg@v1.0.0-next.0`) both keep their prerelease now.

## Tests

- New regression test: a linked group whose published prerelease lives in the tag (manifest lagging at `0.0.1`) increments to `1.0.0-next.1`. Verified it **fails on `main`** (`expected '1.0.0-next.1', got '2.0.0-next.0'`) and **passes with the fix**.
- Full `@wdio/version` unit suite: **648/648 pass**. `tsc --noEmit` and `biome check` clean.

Companion to #421 (which fixed prerelease *creation* from a stable baseline); this fixes prerelease *increments* within a linked/fixed group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a prerelease-graduation bug in `linked`/`fixed` group versioning: `semver.coerce()` was stripping prerelease identifiers from tag strings (e.g., `1.0.0-next.0` → `1.0.0`), causing the next prerelease increment to compute from a stable baseline and jump to `2.0.0-next.0` instead of `1.0.0-next.1`. The fix restructures `cleanBaseline()` to try `semver.clean()` first (preserving prerelease on bare semver strings) and fall back to `semver.coerce({ includePrerelease: true })` only for tag-prefixed strings.

- **`groupStrategy.ts`** — `cleanBaseline()` now parses prerelease-preserving: `clean()` for bare versions, `coerce({ includePrerelease: true })` for package-prefixed tag strings like `pkg@v1.0.0-next.0`.
- **`groupStrategy.spec.ts`** — Adds two regression tests covering the interrupted-release scenario (manifest at `0.0.1`, tag at `1.0.0-next.0`) for both `linked` and `fixed` group sync modes, verifying `1.0.0-next.1` rather than `2.0.0-next.0`; this also closes the coverage gap flagged in the previous review cycle.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a minimal, well-reasoned reordering of two semver parsing calls with no side effects outside cleanBaseline().

The fix is surgically narrow: one function, one line changed. The new parsing order (clean → coerce with includePrerelease) is idempotent on already-valid versions, correctly strips tag prefixes, and preserves prerelease identifiers for every realistic input shape. Both new regression tests fail on main and pass with the fix, and the previous review gap (missing fixed group coverage) has been closed.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/version/src/core/groupStrategy.ts | cleanBaseline() reordered to try semver.clean() before coerce(); fix is correct and handles all tag-string shapes (bare semver, v-prefixed, pkg@v-prefixed) while preserving prerelease identifiers. |
| packages/version/test/unit/core/groupStrategy.spec.ts | Two new regression tests added for linked and fixed groups; both cover the interrupted-release scenario and correctly assert the incremented prerelease version for all releasing members. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["cleanBaseline(version)"] --> B{version falsy?}
    B -- Yes --> Z["return '0.0.0'"]
    B -- No --> C["semver.clean(version)"]
    C --> D{valid semver?}
    D -- "Yes (bare version, e.g. '1.0.0-next.0' or 'v1.0.0-next.0')" --> E["semver.valid(cleaned)\nprerelease preserved ✓"]
    E --> F["return cleaned version\ne.g. '1.0.0-next.0'"]
    D -- "No (tag string, e.g. 'pkg@v1.0.0-next.0')" --> G["semver.coerce(version,\n{ includePrerelease: true })"]
    G --> H{coerced?}
    H -- Yes --> I["return coerced.version\ne.g. '1.0.0-next.0'"]
    H -- No --> Z

    style F fill:#22c55e,color:#fff
    style I fill:#22c55e,color:#fff
    style Z fill:#6b7280,color:#fff
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["cleanBaseline(version)"] --> B{version falsy?}
    B -- Yes --> Z["return '0.0.0'"]
    B -- No --> C["semver.clean(version)"]
    C --> D{valid semver?}
    D -- "Yes (bare version, e.g. '1.0.0-next.0' or 'v1.0.0-next.0')" --> E["semver.valid(cleaned)\nprerelease preserved ✓"]
    E --> F["return cleaned version\ne.g. '1.0.0-next.0'"]
    D -- "No (tag string, e.g. 'pkg@v1.0.0-next.0')" --> G["semver.coerce(version,\n{ includePrerelease: true })"]
    G --> H{coerced?}
    H -- Yes --> I["return coerced.version\ne.g. '1.0.0-next.0'"]
    H -- No --> Z

    style F fill:#22c55e,color:#fff
    style I fill:#22c55e,color:#fff
    style Z fill:#6b7280,color:#fff
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["test(version): cover the fixed-group pre..."](https://github.com/goosewobbler/releasekit/commit/0001f57882951f7024fd95cdafffc3cce80eebdc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39850356)</sub>

<!-- /greptile_comment -->