### PR TITLE
docs: add pre-1.0.0 instability notice to READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ Releases to npm, crates.io, and pub.dev today, with more ecosystems on the way.
    Independent CLIs, piped via a VersionOutput JSON contract — run one stage or all three.
 ```
 
+> [!WARNING]
+> ### 🚧 Pre-1.0.0 — here be dragons 🐉
+>
+> ReleaseKit is **under active development** and evolving fast while the core feature set settles. **💥 Breaking changes are common between releases** and aren't always gated behind a major bump while we're pre-`1.0.0`. It's **🚫 not recommended for production** yet — if you're trying it out, **📌 pin an exact version** and skim the release notes before upgrading. 🧪 Once the API stabilises, `v1.0.0` will mark the switch to semver-stable guarantees. 🎯
+
 ## Why ReleaseKit
 
 - **One config, every ecosystem** — npm (JavaScript/TypeScript), crates.io (Rust), and pub.dev (Dart/Flutter) packages release from the same `releasekit.config.json`, including mixed monorepos. The pipeline is registry-agnostic — new ecosystems plug in without changing your workflow.

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -1,5 +1,8 @@
 # @releasekit/config
 
+> [!WARNING]
+> 🚧 **Pre-1.0.0** — ReleaseKit is evolving fast and **💥 breaking changes are common**; it's **🚫 not production-ready** until `v1.0.0`. 📌 Pin exact versions. See the [main README](../../README.md) for details.
+
 Shared configuration loading and validation for ReleaseKit packages.
 
 ## Overview

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,5 +1,8 @@
 # @releasekit/core
 
+> [!WARNING]
+> 🚧 **Pre-1.0.0** — ReleaseKit is evolving fast and **💥 breaking changes are common**; it's **🚫 not production-ready** until `v1.0.0`. 📌 Pin exact versions. See the [main README](../../README.md) for details.
+
 Shared types and utilities for ReleaseKit packages.
 
 ## Overview

--- a/packages/notes/README.md
+++ b/packages/notes/README.md
@@ -1,5 +1,8 @@
 # @releasekit/notes
 
+> [!WARNING]
+> 🚧 **Pre-1.0.0** — ReleaseKit is evolving fast and **💥 breaking changes are common**; it's **🚫 not production-ready** until `v1.0.0`. 📌 Pin exact versions. See the [main README](../../README.md) for details.
+
 [![@releasekit/notes](https://img.shields.io/badge/@releasekit-notes-9feaf9?labelColor=1a1a1a&style=plastic)](https://www.npmjs.com/package/@releasekit/notes)
 [![Version](https://img.shields.io/npm/v/@releasekit/notes?color=28a745&labelColor=1a1a1a)](https://www.npmjs.com/package/@releasekit/notes)
 [![Downloads](https://img.shields.io/npm/dw/@releasekit/notes?color=6f42c1&labelColor=1a1a1a)](https://www.npmjs.com/package/@releasekit/notes)

--- a/packages/publish/README.md
+++ b/packages/publish/README.md
@@ -1,5 +1,8 @@
 # @releasekit/publish
 
+> [!WARNING]
+> 🚧 **Pre-1.0.0** — ReleaseKit is evolving fast and **💥 breaking changes are common**; it's **🚫 not production-ready** until `v1.0.0`. 📌 Pin exact versions. See the [main README](../../README.md) for details.
+
 [![@releasekit/publish](https://img.shields.io/badge/@releasekit-publish-9feaf9?labelColor=1a1a1a&style=plastic)](https://www.npmjs.com/package/@releasekit/publish)
 [![Version](https://img.shields.io/npm/v/@releasekit/publish?color=28a745&labelColor=1a1a1a)](https://www.npmjs.com/package/@releasekit/publish)
 [![Downloads](https://img.shields.io/npm/dw/@releasekit/publish?color=6f42c1&labelColor=1a1a1a)](https://www.npmjs.com/package/@releasekit/publish)

--- a/packages/release/README.md
+++ b/packages/release/README.md
@@ -1,5 +1,8 @@
 # @releasekit/release
 
+> [!WARNING]
+> 🚧 **Pre-1.0.0** — ReleaseKit is evolving fast and **💥 breaking changes are common**; it's **🚫 not production-ready** until `v1.0.0`. 📌 Pin exact versions. See the [main README](../../README.md) for details.
+
 [![@releasekit/release](https://img.shields.io/badge/@releasekit-release-9feaf9?labelColor=1a1a1a&style=plastic)](https://www.npmjs.com/package/@releasekit/release)
 [![Version](https://img.shields.io/npm/v/@releasekit/release?color=28a745&labelColor=1a1a1a)](https://www.npmjs.com/package/@releasekit/release)
 [![Downloads](https://img.shields.io/npm/dw/@releasekit/release?color=6f42c1&labelColor=1a1a1a)](https://www.npmjs.com/package/@releasekit/release)

--- a/packages/version/README.md
+++ b/packages/version/README.md
@@ -1,5 +1,8 @@
 # @releasekit/version
 
+> [!WARNING]
+> 🚧 **Pre-1.0.0** — ReleaseKit is evolving fast and **💥 breaking changes are common**; it's **🚫 not production-ready** until `v1.0.0`. 📌 Pin exact versions. See the [main README](../../README.md) for details.
+
 Semantic versioning based on Git history and conventional commits.
 
 ## Features


### PR DESCRIPTION
## What

Adds a prominent **pre-1.0.0 warning** to the root README (below the pipeline diagram) and to each published package README (`core`, `config`, `version`, `notes`, `publish`, `release`).

## Why

ReleaseKit is pre-1.0.0 and evolving fast while the core feature set settles — breaking changes are common and aren't always gated behind a major bump. Anyone discovering the project should know up front that it's 🚫 not production-ready until `v1.0.0` and should 📌 pin exact versions.

Rendered (root):

> [!WARNING]
> ### 🚧 Pre-1.0.0 — here be dragons 🐉
>
> ReleaseKit is **under active development** and evolving fast while the core feature set settles. **💥 Breaking changes are common between releases** and aren't always gated behind a major bump while we're pre-`1.0.0`. It's **🚫 not recommended for production** yet — if you're trying it out, **📌 pin an exact version** and skim the release notes before upgrading. 🧪 Once the API stabilises, `v1.0.0` will mark the switch to semver-stable guarantees. 🎯

Docs-only; no code changes.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a `[!WARNING]` GitHub-flavored Markdown callout to the root README and to each of the six published package READMEs (`core`, `config`, `version`, `notes`, `publish`, `release`) advising users that ReleaseKit is pre-1.0.0, that breaking changes are common, and that they should pin exact versions.

- The root README gets the full-length warning block placed between the pipeline diagram and the \"Why ReleaseKit\" section; the six package READMEs each get a compact one-liner variant that links back to `../../README.md` for full details.
- All relative back-links (`../../README.md`) resolve correctly given the `packages/<name>/README.md` directory depth.
</details>

<h3>Confidence Score: 5/5</h3>

Documentation-only change with no code modifications; safe to merge.

All seven files receive identical, well-formed [!WARNING] callouts. The relative back-links (../../README.md) resolve correctly from packages/<name>/README.md. The warning text is accurate and consistent across the root and all package READMEs. No code, configuration, or build artifacts are touched.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| README.md | Adds full-length pre-1.0.0 WARNING callout between the pipeline diagram and "Why ReleaseKit" section; text and placement are accurate. |
| packages/core/README.md | Adds compact pre-1.0.0 WARNING immediately after the package heading; relative link to root README is correct. |
| packages/config/README.md | Adds compact pre-1.0.0 WARNING immediately after the package heading; relative link to root README is correct. |
| packages/notes/README.md | Adds compact pre-1.0.0 WARNING immediately after the package heading; relative link to root README is correct. |
| packages/publish/README.md | Adds compact pre-1.0.0 WARNING immediately after the package heading; relative link to root README is correct. |
| packages/release/README.md | Adds compact pre-1.0.0 WARNING immediately after the package heading; relative link to root README is correct. |
| packages/version/README.md | Adds compact pre-1.0.0 WARNING immediately after the package heading; relative link to root README is correct. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User discovers ReleaseKit] --> B[Reads README.md]
    B --> C{Sees pre-1.0.0 WARNING callout}
    C -->|Root README| D[Full warning with context\nand semver-stable roadmap]
    C -->|Package README\ncore / config / version\nnotes / publish / release| E[Compact one-liner warning\nlinks to ../../README.md]
    D --> F[User pins exact version\nbefore adopting]
    E --> F
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User discovers ReleaseKit] --> B[Reads README.md]
    B --> C{Sees pre-1.0.0 WARNING callout}
    C -->|Root README| D[Full warning with context\nand semver-stable roadmap]
    C -->|Package README\ncore / config / version\nnotes / publish / release| E[Compact one-liner warning\nlinks to ../../README.md]
    D --> F[User pins exact version\nbefore adopting]
    E --> F
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add pre-1.0.0 instability notice t..."](https://github.com/goosewobbler/releasekit/commit/b52326c7ae60de824b052e20063319f9b8dac4e1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39859791)</sub>

<!-- /greptile_comment -->