### PR TITLE
feat(release)!: rename graduation label channel:stable → release:graduate

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -185,7 +185,7 @@ outputs:
     description: Resolved target packages (gate mode)
     value: ${{ steps.run.outputs.gate-target }}
   gate-stable:
-    description: Whether the release should be a stable graduation (gate mode, channel:stable label)
+    description: Whether the release should be a stable graduation (gate mode, release:graduate label)
     value: ${{ steps.run.outputs.gate-stable }}
   has-changes:
     description: "Whether a release has changes (release mode, requires json: true)"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -110,7 +110,7 @@ How the bump type is determined. Configure under `ci.releaseTrigger`.
 
 **`label`** (default) — A PR label (`bump:patch`, `bump:minor`, or `bump:major`) must be present for a release to fire. The label controls the bump type. PRs without a release label are silently skipped, giving reviewers direct control over when and at what level a release ships.
 
-Both modes support `bump:major` as an override and `channel:stable`/`channel:prerelease` as channel modifiers.
+Both modes support `bump:major` as an override, `channel:prerelease` as a channel modifier, and `release:graduate` to graduate a prerelease to its stable base version.
 
 | | Commit trigger | Label trigger |
 |---|---|---|

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -400,7 +400,7 @@ PR label names used for release control. Override to match your repository's lab
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `stable` | string | `"channel:stable"` | Label to graduate a prerelease to stable |
+| `graduate` | string | `"release:graduate"` | Label that graduates a prerelease to its stable base version (e.g. 1.0.0-next.6 → 1.0.0). A standalone release trigger in label/direct mode; in standing-pr mode it sets the next merge to graduate. |
 | `prerelease` | string | `"channel:prerelease"` | Label to create a prerelease |
 | `skip` | string | `"release:skip"` | Label to suppress a release on this PR |
 | `immediate` | string | `"release:immediate"` | Label to bypass the standing PR for one merge — triggers a direct release. Standing-pr mode only. |

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -510,7 +510,12 @@ export const NotesConfigSchema = z.object({
 });
 
 export const CILabelsConfigSchema = z.object({
-  stable: z.string().default('channel:stable').describe('Label to graduate a prerelease to stable'),
+  graduate: z
+    .string()
+    .default('release:graduate')
+    .describe(
+      'Label that graduates a prerelease to its stable base version (e.g. 1.0.0-next.6 → 1.0.0). A standalone release trigger in label/direct mode; in standing-pr mode it sets the next merge to graduate.',
+    ),
   prerelease: z.string().default('channel:prerelease').describe('Label to create a prerelease'),
   skip: z.string().default('release:skip').describe('Label to suppress a release on this PR'),
   immediate: z
@@ -638,7 +643,7 @@ export const CIConfigSchema = z.object({
     .default(1)
     .describe('Minimum number of packages with releasable changes required to trigger a release.'),
   labels: CILabelsConfigSchema.default({
-    stable: 'channel:stable',
+    graduate: 'release:graduate',
     prerelease: 'channel:prerelease',
     skip: 'release:skip',
     immediate: 'release:immediate',

--- a/packages/config/test/unit/schema.spec.ts
+++ b/packages/config/test/unit/schema.spec.ts
@@ -508,7 +508,7 @@ describe('CIConfigSchema', () => {
     expect(result.skipPatterns).toEqual(['chore: release ']);
     expect(result.minChanges).toBe(1);
     expect(result.labels).toEqual({
-      stable: 'channel:stable',
+      graduate: 'release:graduate',
       prerelease: 'channel:prerelease',
       skip: 'release:skip',
       immediate: 'release:immediate',
@@ -575,7 +575,7 @@ describe('CIConfigSchema', () => {
   it('should accept custom label names', () => {
     const result = CIConfigSchema.parse({
       labels: {
-        stable: 'stable',
+        graduate: 'graduate',
         prerelease: 'pre',
         skip: 'no-release',
         major: 'breaking',
@@ -583,7 +583,7 @@ describe('CIConfigSchema', () => {
         patch: 'fix',
       },
     });
-    expect(result.labels.stable).toBe('stable');
+    expect(result.labels.graduate).toBe('graduate');
     expect(result.labels.prerelease).toBe('pre');
     expect(result.labels.skip).toBe('no-release');
     expect(result.labels.major).toBe('breaking');
@@ -592,8 +592,8 @@ describe('CIConfigSchema', () => {
   });
 
   it('should apply label defaults for partial labels config', () => {
-    const result = CIConfigSchema.parse({ labels: { stable: 'custom-stable' } });
-    expect(result.labels.stable).toBe('custom-stable');
+    const result = CIConfigSchema.parse({ labels: { graduate: 'custom-graduate' } });
+    expect(result.labels.graduate).toBe('custom-graduate');
     expect(result.labels.prerelease).toBe('channel:prerelease');
     expect(result.labels.skip).toBe('release:skip');
     expect(result.labels.major).toBe('bump:major');

--- a/packages/release/README.md
+++ b/packages/release/README.md
@@ -287,7 +287,7 @@ The `ci` section controls automation behavior:
 
     // Customise PR label names
     "labels": {
-      "stable": "channel:stable",
+      "graduate": "release:graduate",
       "prerelease": "channel:prerelease",
       "skip": "release:skip",
       "immediate": "release:immediate",
@@ -312,7 +312,7 @@ The `ci` section controls automation behavior:
 
 **`commit`** — Conventional commits drive the bump type automatically. Every merge can trigger a release. Use the `release:skip` label to prevent a release, or `bump:major` to override the commit-derived bump to major.
 
-Both modes support `channel:stable` and `channel:prerelease` as channel modifiers. `channel:stable` alone graduates any prerelease packages to their stable base version and skips packages that are already stable — no bump label required. `channel:prerelease` must be combined with a `bump:*` label — alone, it does not trigger a release.
+Both modes support `release:graduate` and `channel:prerelease`. `release:graduate` alone graduates any prerelease packages to their stable base version and skips packages that are already stable — no bump label required (it's a standalone release-flow trigger). `channel:prerelease` is a channel modifier and must be combined with a `bump:*` label — alone, it does not trigger a release.
 
 > **Standing-pr strategy is different.** When `releaseStrategy: "standing-pr"`, labels on **feeder PRs** are advisory only — the standing PR itself is the canonical override surface (add `bump:major` etc. to the standing PR to drive the next release). To bypass the queue and ship one PR directly, label it `release:immediate`. See [CI setup → Label semantics in standing-pr mode](./docs/ci-setup.md#label-semantics-in-standing-pr-mode).
 
@@ -361,7 +361,7 @@ Multiple scope labels are combined with OR logic. Without a `release:*` label, c
 
 In label trigger mode, conflicting labels will block the release and post a comment explaining the issue:
 - Multiple bump labels (`bump:major` + `bump:minor` + `bump:patch`) → blocked
-- Conflicting release type (`channel:stable` + `channel:prerelease`) → blocked (both modes)
+- Conflicting release type (`release:graduate` + `channel:prerelease`) → blocked (both modes)
 
 **How it works:**
 

--- a/packages/release/docs/ci-setup.md
+++ b/packages/release/docs/ci-setup.md
@@ -68,7 +68,7 @@ Only release when a PR is merged with a release label. Conventional commits dete
 | `bump:patch` | Bump patch version |
 | `bump:minor` | Bump minor version |
 | `bump:major` | Bump major version |
-| `channel:stable` | Graduate a prerelease to stable |
+| `release:graduate` | Graduate a prerelease to stable |
 | `channel:prerelease` | Create a prerelease (requires bump:* label) |
 | `release:skip` | Suppress release on this PR |
 
@@ -99,10 +99,10 @@ In CI, add `--check`: it exits non-zero on a missing label, catching the silent 
 | `channel:prerelease` + `bump:minor` | `1.0.0-next.6` | `1.1.0-next.0` — starts a fresh minor prerelease line |
 | `channel:prerelease` + `bump:major` | `1.0.0-next.6` | `2.0.0-next.0` — starts a fresh major prerelease line |
 | `channel:prerelease` alone | any | No release — add a `bump:*` label |
-| `channel:stable` alone | `1.0.0-next.6` | `1.0.0` |
-| `channel:stable` alone | `1.0.0` | No release — already at stable version |
-| `channel:stable` + any `bump:*` | `1.0.0-next.6` | `1.0.0` — bump label is ignored during stable promotion |
-| `channel:stable` + `bump:minor` | `1.0.0` | `1.1.0` — bump applies to already-stable packages |
+| `release:graduate` alone | `1.0.0-next.6` | `1.0.0` |
+| `release:graduate` alone | `1.0.0` | No release — already at stable version |
+| `release:graduate` + any `bump:*` | `1.0.0-next.6` | `1.0.0` — bump label is ignored during stable promotion |
+| `release:graduate` + `bump:minor` | `1.0.0` | `1.1.0` — bump applies to already-stable packages |
 
 > **`channel:prerelease` + `bump:*` escalates — it starts a *fresh* prerelease line at the chosen
 > magnitude, even when the package is already on a prerelease.** So `bump:major` + `channel:prerelease`
@@ -113,11 +113,13 @@ In CI, add `--check`: it exits non-zero on a missing label, catching the silent 
 
 > **`channel:prerelease` is a channel modifier, never a standalone release trigger.** It does
 > nothing without a `bump:*` label in label/direct mode (it can't pick a magnitude on its own), and
-> in standing-pr mode it simply sets the channel for the next merge. `channel:stable` is the one
-> channel label that can stand alone in label/direct mode — but only because graduating a prerelease
-> resolves to exactly one version (`1.0.0-next.6` → `1.0.0`); on an already-stable package it's a
-> no-op. In standing-pr mode the *merge* is the trigger, so both channel labels are pure modifiers
-> there.
+> in standing-pr mode it simply sets the channel for the next merge. Graduating a prerelease to its
+> stable base version is a distinct, standalone action carried by the `release:graduate` *flow*
+> label (`1.0.0-next.6` → `1.0.0`); it can stand alone in label/direct mode because graduation
+> resolves to exactly one version, and on an already-stable package it's a no-op. In standing-pr
+> mode the *merge* is the trigger, so `channel:prerelease` and `release:graduate` both act as
+> modifiers on the next merge. (The `release:` namespace is deliberate — graduation is a release
+> *decision*, not a channel selection.)
 
 ```yaml
 # .github/workflows/release.yml
@@ -573,7 +575,7 @@ jobs:
 2. **Merge → publish:** Maintainers merge the standing PR when ready. The `pull_request.closed` trigger fires `standing-pr publish`, which reads the release manifest from the bot's PR comment and publishes the packages — no second version analysis is run, so the publish reflects exactly what was reviewed.
 3. **Recurring re-evaluation:** The hourly `schedule` trigger re-runs `update`, which is essentially free when nothing has changed but advances the `minAge` countdown so the status check transitions from `pending` to `success` as time passes.
 
-Use `channel:stable` and `channel:prerelease` labels on **the standing PR itself** to control release type during merge.
+Use `release:graduate` and `channel:prerelease` labels on **the standing PR itself** to control release type during merge.
 
 ### Lifecycle and edge cases
 
@@ -597,7 +599,7 @@ Labels behave differently in standing-pr mode than in direct mode. There are two
 
 **1. Feeder PRs (PRs being merged into `main`)** — labels are **advisory**.
 
-`bump:*`, `scope:*`, `channel:stable`, and `channel:prerelease` on a feeder PR are shown in the preview comment so reviewers know they were noticed, but they do **not** drive behavior on merge. Bumps for the standing PR come from conventional commits across the union of queued changes; scope is global (the standing PR aggregates everything).
+`bump:*`, `scope:*`, `release:graduate`, and `channel:prerelease` on a feeder PR are shown in the preview comment so reviewers know they were noticed, but they do **not** drive behavior on merge. Bumps for the standing PR come from conventional commits across the union of queued changes; scope is global (the standing PR aggregates everything).
 
 **2. The standing PR itself** — labels are the **canonical override surface**.
 
@@ -607,7 +609,7 @@ A maintainer can edit labels directly on the standing PR (via the GitHub UI or `
 |---|---|
 | `bump:patch` / `bump:minor` / `bump:major` | Forces that bump magnitude, overriding what conventional commits would otherwise produce. |
 | `scope:foo` (per `ci.scopeLabels`) | Limits the release to scoped packages on the next update. |
-| `channel:stable` | Graduates a prerelease to stable. |
+| `release:graduate` | Graduates a prerelease to stable. |
 | `channel:prerelease` | Switches the standing PR to prerelease versioning. |
 
 Conflicts (e.g. both `bump:patch` and `bump:major`) surface as a `pending` `releasekit/standing-pr` status check on the release branch and a workflow warning. The override is dropped (falls back to commit-driven) until the conflict is resolved by removing one of the labels.
@@ -699,7 +701,7 @@ Standing-pr mode handles both batched and one-off releases through a single work
 | Routine feature — batch with others | Merge PR without a label. Bumps come from conventional commits. |
 | Critical fix that needs to ship now | Add `release:immediate` (optionally `+ bump:patch`) to the PR. |
 | Adjust the standing PR's bump magnitude | Add `bump:major` (etc.) to the standing PR itself; the next update applies it. |
-| Promote accumulated prereleases to stable | Add `channel:stable` to the standing PR and merge it. |
+| Promote accumulated prereleases to stable | Add `release:graduate` to the standing PR and merge it. |
 | Retry a publish that failed partway | Add `release:retry` to the **merged** standing PR. |
 
 ---

--- a/packages/release/src/gate/evaluate-pr.ts
+++ b/packages/release/src/gate/evaluate-pr.ts
@@ -30,7 +30,7 @@ export interface PREvaluation {
  * Evaluate a single PR's labels against the gate's release rules.
  *
  * In `label` trigger mode:
- *  - `bump:*` or `channel:stable` ⇒ release
+ *  - `bump:*` or `release:graduate` ⇒ release
  *  - `channel:prerelease` alone ⇒ NO release (requires `bump:*`)
  *  - No release labels ⇒ no release
  *  - Conflicting labels on the same PR ⇒ blocked
@@ -60,7 +60,7 @@ export function evaluatePR(
     labelConfig.major,
     labelConfig.minor,
     labelConfig.patch,
-    labelConfig.stable,
+    labelConfig.graduate,
     labelConfig.prerelease,
     labelConfig.immediate,
   ]);
@@ -120,7 +120,7 @@ export function evaluatePR(
       labels,
       shouldRelease: false,
       blocked: true,
-      reason: `PR #${prNumber} has conflicting release labels: ${labelConfig.stable} + ${labelConfig.prerelease}`,
+      reason: `PR #${prNumber} has conflicting release labels: ${labelConfig.graduate} + ${labelConfig.prerelease}`,
       hasReleaseIntent,
       scope,
       target,
@@ -133,11 +133,11 @@ export function evaluatePR(
     const hasBumpLabel = labels.some(
       (l) => l === labelConfig.major || l === labelConfig.minor || l === labelConfig.patch,
     );
-    const hasStableLabel = labels.includes(labelConfig.stable);
+    const hasGraduateLabel = labels.includes(labelConfig.graduate);
     const hasPrereleaseLabel = labels.includes(labelConfig.prerelease);
 
-    if (hasBumpLabel || hasStableLabel) {
-      const isStable = hasStableLabel && !hasPrereleaseLabel;
+    if (hasBumpLabel || hasGraduateLabel) {
+      const isGraduation = hasGraduateLabel && !hasPrereleaseLabel;
       return {
         prNumber,
         labels,
@@ -145,8 +145,8 @@ export function evaluatePR(
         bump,
         scope,
         target,
-        stable: isStable,
-        reason: hasStableLabel ? `${labelConfig.stable} label found` : `bump label found: ${bump}`,
+        stable: isGraduation,
+        reason: hasGraduateLabel ? `${labelConfig.graduate} label found` : `bump label found: ${bump}`,
         hasReleaseIntent,
       };
     }
@@ -171,7 +171,7 @@ export function evaluatePR(
       scope,
       target,
       stable: false,
-      reason: `No release labels found (need bump:* or ${labelConfig.stable})`,
+      reason: `No release labels found (need bump:* or ${labelConfig.graduate})`,
       hasReleaseIntent,
     };
   }

--- a/packages/release/src/gate/gate.ts
+++ b/packages/release/src/gate/gate.ts
@@ -256,7 +256,7 @@ function buildNotifyBody(e: PREvaluation, labelConfig: LabelConfig): string {
   const actionLines = e.blocked
     ? [
         'Remove the conflicting labels so only one bump label remains (or only one of',
-        `\`${labelConfig.stable}\` / \`${labelConfig.prerelease}\`), then re-run the release workflow.`,
+        `\`${labelConfig.graduate}\` / \`${labelConfig.prerelease}\`), then re-run the release workflow.`,
       ]
     : [
         `Add a bump label (\`${labelConfig.major}\`, \`${labelConfig.minor}\`, or \`${labelConfig.patch}\`) and re-run the release workflow.`,

--- a/packages/release/src/label-definitions.ts
+++ b/packages/release/src/label-definitions.ts
@@ -35,11 +35,15 @@ export function deriveLabelDefinitions(ciConfig: CIConfig | undefined): LabelDef
     { name: labels.patch, color: COLOR_BUMP, description: 'ReleaseKit: request a patch version bump' },
     { name: labels.minor, color: COLOR_BUMP, description: 'ReleaseKit: request a minor version bump' },
     { name: labels.major, color: COLOR_BUMP, description: 'ReleaseKit: request a major version bump' },
-    { name: labels.stable, color: COLOR_CHANNEL, description: 'ReleaseKit: release to the stable channel' },
     {
       name: labels.prerelease,
       color: COLOR_CHANNEL,
       description: 'ReleaseKit: release to the prerelease channel',
+    },
+    {
+      name: labels.graduate,
+      color: COLOR_RELEASE,
+      description: 'ReleaseKit: graduate a prerelease to its stable base version',
     },
     { name: labels.skip, color: COLOR_RELEASE, description: 'ReleaseKit: skip the release for this change' },
     {

--- a/packages/release/src/label-utils.ts
+++ b/packages/release/src/label-utils.ts
@@ -1,5 +1,5 @@
 export interface LabelConfig {
-  stable: string;
+  graduate: string;
   prerelease: string;
   skip: string;
   immediate: string;
@@ -12,7 +12,7 @@ export interface LabelConfig {
 }
 
 export const DEFAULT_LABELS: LabelConfig = {
-  stable: 'channel:stable',
+  graduate: 'release:graduate',
   prerelease: 'channel:prerelease',
   skip: 'release:skip',
   immediate: 'release:immediate',
@@ -28,7 +28,7 @@ export interface LabelConflictResult {
   bumpConflict: boolean;
   bumpLabelsPresent: string[];
   prereleaseConflict: boolean;
-  hasStable: boolean;
+  hasGraduate: boolean;
   hasPrerelease: boolean;
 }
 
@@ -41,15 +41,15 @@ export function detectLabelConflicts(prLabels: string[], labels: LabelConfig = D
 
   const bumpConflict = bumpLabelsPresent.length > 1;
 
-  const hasStable = prLabels.includes(labels.stable);
+  const hasGraduate = prLabels.includes(labels.graduate);
   const hasPrerelease = prLabels.includes(labels.prerelease);
-  const prereleaseConflict = hasStable && hasPrerelease;
+  const prereleaseConflict = hasGraduate && hasPrerelease;
 
   return {
     bumpConflict,
     bumpLabelsPresent,
     prereleaseConflict,
-    hasStable,
+    hasGraduate,
     hasPrerelease,
   };
 }
@@ -67,10 +67,10 @@ export function detectLabelConflicts(prLabels: string[], labels: LabelConfig = D
  * prerelease (`2.0.0-next.0` → `2.0.0-next.1`), use the prerelease label alone (no `bump:*`),
  * which returns `'prerelease'`.
  *
- * `channel:stable` wins over everything and returns undefined (graduation is bump-less).
+ * `release:graduate` wins over everything and returns undefined (graduation is bump-less).
  */
 export function composeBumpFromLabels(prLabels: string[], labels: LabelConfig = DEFAULT_LABELS): string | undefined {
-  if (prLabels.includes(labels.stable)) return undefined;
+  if (prLabels.includes(labels.graduate)) return undefined;
 
   if (prLabels.includes(labels.prerelease)) {
     if (prLabels.includes(labels.major)) return 'premajor';

--- a/packages/release/src/preview/format.ts
+++ b/packages/release/src/preview/format.ts
@@ -37,7 +37,7 @@ export interface LabelContext {
   prerelease?: boolean;
   stable?: boolean;
   labels?: {
-    stable: string;
+    graduate: string;
     prerelease: string;
     skip: string;
     immediate: string;
@@ -128,7 +128,7 @@ function getLabelBanner(labelContext?: LabelContext): string[] {
     }
     if (labelContext.stable) {
       descriptor.push('stable');
-      sources.push(`\`${labelContext.labels?.stable ?? 'channel:stable'}\``);
+      sources.push(`\`${labelContext.labels?.graduate ?? 'release:graduate'}\``);
     }
 
     const releasePart = descriptor.length > 0 ? `**${descriptor.join(' ')}** release` : 'release';
@@ -152,7 +152,7 @@ function getLabelBanner(labelContext?: LabelContext): string[] {
     const seen: string[] = [];
     if (labelContext.bumpLabel) seen.push(`\`bump:${labelContext.bumpLabel}\``);
     if (labelContext.scopeLabels?.length) seen.push(...labelContext.scopeLabels.map((s) => `\`${s}\``));
-    if (labelContext.stable) seen.push(`\`${labelContext.labels?.stable ?? 'channel:stable'}\``);
+    if (labelContext.stable) seen.push(`\`${labelContext.labels?.graduate ?? 'release:graduate'}\``);
     if (labelContext.prerelease) seen.push(`\`${labelContext.labels?.prerelease ?? 'channel:prerelease'}\``);
     const seenStr = seen.length ? ` (saw: ${seen.join(', ')})` : '';
     const immediateLabel = labelContext.labels?.immediate ?? 'release:immediate';
@@ -182,11 +182,11 @@ function getLabelBanner(labelContext?: LabelContext): string[] {
   // Show prereleaseConflict error regardless of trigger mode
   if (labelContext.prereleaseConflict) {
     const labels = labelContext.labels;
-    const stableLabel = labels?.stable ?? 'channel:stable';
+    const graduateLabel = labels?.graduate ?? 'release:graduate';
     const prereleaseLabel = labels?.prerelease ?? 'channel:prerelease';
     lines.push(
       '> **Error:** Conflicting release type labels detected.',
-      `> **Note:** Please use only one of \`${stableLabel}\` or \`${prereleaseLabel}\` at a time.`,
+      `> **Note:** Please use only one of \`${graduateLabel}\` or \`${prereleaseLabel}\` at a time.`,
       '',
     );
     return lines;

--- a/packages/release/src/preview/preview.ts
+++ b/packages/release/src/preview/preview.ts
@@ -346,7 +346,7 @@ async function applyLabelOverrides(
       prLabels.includes(labels.patch) ||
       prLabels.includes(labels.minor) ||
       prLabels.includes(labels.major) ||
-      prLabels.includes(labels.stable);
+      prLabels.includes(labels.graduate);
 
     if (willRelease) {
       const scopeLabelsConfigured = Object.keys(scopeLabels).length > 0;
@@ -365,7 +365,7 @@ async function applyLabelOverrides(
     if (prLabels.includes(labels.major)) labelContext.bumpLabel = 'major';
     else if (prLabels.includes(labels.minor)) labelContext.bumpLabel = 'minor';
     else if (prLabels.includes(labels.patch)) labelContext.bumpLabel = 'patch';
-    if (prLabels.includes(labels.stable)) labelContext.stable = true;
+    if (prLabels.includes(labels.graduate)) labelContext.stable = true;
     if (prLabels.includes(labels.prerelease)) labelContext.prerelease = true;
     return { options: result, labelContext };
   }
@@ -384,7 +384,7 @@ async function applyLabelOverrides(
     if (conflict.prereleaseConflict) {
       labelContext.prereleaseConflict = true;
       labelContext.noBumpLabel = true;
-      warn(`Conflicting labels "${labels.stable}" and "${labels.prerelease}" detected — release blocked`);
+      warn(`Conflicting labels "${labels.graduate}" and "${labels.prerelease}" detected — release blocked`);
     }
     if (!labelContext.noBumpLabel) {
       // Carry the COMPOSED bump (e.g. premajor) so a major+prerelease on an existing
@@ -396,7 +396,7 @@ async function applyLabelOverrides(
         labelContext.bumpLabel = magnitude;
         result.bump = composedBump;
       }
-      if (prLabels.includes(labels.stable)) {
+      if (prLabels.includes(labels.graduate)) {
         labelContext.stable = true;
         result.stable = true;
       } else if (prLabels.includes(labels.prerelease)) {
@@ -422,7 +422,7 @@ async function applyLabelOverrides(
         warn(`Conflicting bump labels detected (${conflict.bumpLabelsPresent.join(', ')}) — release blocked`);
       }
       if (conflict.prereleaseConflict) {
-        warn(`Conflicting labels "${labels.stable}" and "${labels.prerelease}" detected — release blocked`);
+        warn(`Conflicting labels "${labels.graduate}" and "${labels.prerelease}" detected — release blocked`);
       }
     } else {
       // Releasing — carry the gate's COMPOSED bump (e.g. premajor) verbatim so the preview
@@ -456,7 +456,7 @@ async function applyLabelOverrides(
   const conflict = detectLabelConflicts(prLabels, labels);
 
   if (conflict.prereleaseConflict) {
-    warn(`Conflicting labels "${labels.stable}" and "${labels.prerelease}" detected — release blocked`);
+    warn(`Conflicting labels "${labels.graduate}" and "${labels.prerelease}" detected — release blocked`);
     labelContext.noBumpLabel = true;
     labelContext.prereleaseConflict = true;
   }
@@ -474,9 +474,9 @@ async function applyLabelOverrides(
 
   // Stable/prerelease modifiers (commit mode only — label mode handles them in evaluation).
   if (!options.stable && options.prerelease === undefined) {
-    if (!(conflict.hasStable && conflict.hasPrerelease)) {
-      if (conflict.hasStable) {
-        info(`PR label "${labels.stable}" detected — using stable release preview`);
+    if (!(conflict.hasGraduate && conflict.hasPrerelease)) {
+      if (conflict.hasGraduate) {
+        info(`PR label "${labels.graduate}" detected — using stable release preview`);
         result.stable = true;
         labelContext.stable = true;
       } else if (conflict.hasPrerelease) {

--- a/packages/release/src/release.ts
+++ b/packages/release/src/release.ts
@@ -134,7 +134,7 @@ async function applyScopeLabelsFromPR(
     }
 
     if (conflict.prereleaseConflict) {
-      warn(`PR #${prNumber} has conflicting labels "${labels.stable}" and "${labels.prerelease}" — release blocked`);
+      warn(`PR #${prNumber} has conflicting labels "${labels.graduate}" and "${labels.prerelease}" — release blocked`);
       return { target: options.target, scopeLabels: [], labels: [], blocked: true };
     }
     if (conflict.bumpConflict && (ciConfig?.releaseTrigger ?? 'label') === 'label') {
@@ -226,7 +226,7 @@ export async function runRelease(inputOptions: ReleaseOptions): Promise<ReleaseO
 
   // Only apply scope labels in non-dry-run (release) mode
   // In dry-run/preview mode, preview.ts already handles scope labels via applyLabelOverrides
-  // However, we still call applyScopeLabelsFromPR to detect label conflicts (e.g., channel:stable + channel:prerelease)
+  // However, we still call applyScopeLabelsFromPR to detect label conflicts (e.g., release:graduate + channel:prerelease)
   const scopeResult = await applyScopeLabelsFromPR(ciConfig, options);
   if (scopeResult.blocked) {
     info('Release blocked due to conflicting PR labels');

--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -894,10 +894,11 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
   const previewNotesEnabled = effectiveLabels.includes(previewNotesLabel);
 
   const overrides = resolveStandingPrLabelOverrides(effectiveLabels, ciConfig);
+  const overrideLabelNames = ciConfig?.labels ?? DEFAULT_LABELS;
   if (overrides.bump) info(`Standing PR label override: bump=${overrides.bump}`);
   if (overrides.target) info(`Standing PR label override: target=${overrides.target}`);
-  if (overrides.stable) info(`Standing PR label override: release:graduate`);
-  if (overrides.prerelease) info(`Standing PR label override: channel:prerelease`);
+  if (overrides.stable) info(`Standing PR label override: ${overrideLabelNames.graduate}`);
+  if (overrides.prerelease) info(`Standing PR label override: ${overrideLabelNames.prerelease}`);
   for (const conflict of overrides.conflicts) warn(conflict);
 
   // Use the version.sync setting from config; fall back to false (per-package versioning)

--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -586,7 +586,7 @@ function relevantOverrideLabelNames(ciConfig: CIConfig | undefined): Set<string>
     labels.major,
     labels.minor,
     labels.patch,
-    labels.stable,
+    labels.graduate,
     labels.prerelease,
     labels.withPrerequisites,
     ...Object.keys(scopeLabels),
@@ -624,15 +624,15 @@ function resolveStandingPrLabelOverrides(prLabels: string[], ciConfig: CIConfig 
   else if (prLabels.includes(labels.minor)) bump = 'minor';
   else if (prLabels.includes(labels.patch)) bump = 'patch';
 
-  // Channel modifiers
-  const hasStable = prLabels.includes(labels.stable);
+  // Graduate / prerelease release-type
+  const hasGraduate = prLabels.includes(labels.graduate);
   const hasPrerelease = prLabels.includes(labels.prerelease);
   let stable: boolean | undefined;
   let prerelease: boolean | undefined;
-  if (hasStable && hasPrerelease) {
-    conflicts.push(`Conflicting channel labels on standing PR (${labels.stable} and ${labels.prerelease})`);
+  if (hasGraduate && hasPrerelease) {
+    conflicts.push(`Conflicting release-type labels on standing PR (${labels.graduate} and ${labels.prerelease})`);
   } else {
-    if (hasStable) stable = true;
+    if (hasGraduate) stable = true;
     if (hasPrerelease) prerelease = true;
   }
 
@@ -647,7 +647,7 @@ function resolveStandingPrLabelOverrides(prLabels: string[], ciConfig: CIConfig 
 
   // Compose the bump to match composeBumpFromLabels (the label→bump SSOT), kept inline here
   // because this path layers its own conflict detection on top:
-  //   - channel:stable wins and drops the bump — graduation is bump-less, so don't leak a stale
+  //   - release:graduate wins and drops the bump — graduation is bump-less, so don't leak a stale
   //     magnitude into { bump, stable } (engine ignores it today, but the contract must hold).
   //   - prerelease + magnitude escalates to a fresh line (premajor → 2.0.0-next.0) rather than
   //     incrementing an existing prerelease (#335).
@@ -896,7 +896,7 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
   const overrides = resolveStandingPrLabelOverrides(effectiveLabels, ciConfig);
   if (overrides.bump) info(`Standing PR label override: bump=${overrides.bump}`);
   if (overrides.target) info(`Standing PR label override: target=${overrides.target}`);
-  if (overrides.stable) info(`Standing PR label override: channel:stable`);
+  if (overrides.stable) info(`Standing PR label override: release:graduate`);
   if (overrides.prerelease) info(`Standing PR label override: channel:prerelease`);
   for (const conflict of overrides.conflicts) warn(conflict);
 

--- a/packages/release/test/unit/gate.spec.ts
+++ b/packages/release/test/unit/gate.spec.ts
@@ -67,7 +67,7 @@ describe('Gate', () => {
           major: 'bump:major',
           minor: 'bump:minor',
           patch: 'bump:patch',
-          stable: 'channel:stable',
+          graduate: 'release:graduate',
           prerelease: 'channel:prerelease',
           skip: 'release:skip',
           immediate: 'release:immediate',
@@ -177,9 +177,9 @@ describe('Gate', () => {
     expect(result.shouldRelease).toBe(false);
   });
 
-  it('should return blocked: true when channel:prerelease + channel:stable conflict', async () => {
+  it('should return blocked: true when channel:prerelease + release:graduate conflict', async () => {
     mockFindMergedPRsSinceLastRelease.mockResolvedValue([123]);
-    mockFetchPRLabels.mockResolvedValue(['channel:prerelease', 'channel:stable']);
+    mockFetchPRLabels.mockResolvedValue(['channel:prerelease', 'release:graduate']);
 
     const result = await runGate();
 
@@ -205,9 +205,9 @@ describe('Gate', () => {
     expect(result.bump).toBe('patch');
   });
 
-  it('should return bump undefined when only channel:stable label', async () => {
+  it('should return bump undefined when only release:graduate label', async () => {
     mockFindMergedPRsSinceLastRelease.mockResolvedValue([123]);
-    mockFetchPRLabels.mockResolvedValue(['channel:stable']);
+    mockFetchPRLabels.mockResolvedValue(['release:graduate']);
 
     const result = await runGate();
 
@@ -227,21 +227,21 @@ describe('Gate', () => {
     expect(result.stable).toBe(false);
   });
 
-  it('should return stable: true when bump:patch and channel:stable labels present (stable takes precedence over bump)', async () => {
+  it('should return stable: true when bump:patch and release:graduate labels present (stable takes precedence over bump)', async () => {
     mockFindMergedPRsSinceLastRelease.mockResolvedValue([123]);
-    mockFetchPRLabels.mockResolvedValue(['bump:patch', 'channel:stable']);
+    mockFetchPRLabels.mockResolvedValue(['bump:patch', 'release:graduate']);
 
     const result = await runGate();
 
     expect(result.shouldRelease).toBe(true);
-    // channel:stable causes detectBumpFromLabels to return undefined (auto-detect from commits)
+    // release:graduate causes detectBumpFromLabels to return undefined (auto-detect from commits)
     expect(result.bump).toBeUndefined();
     expect(result.stable).toBe(true);
   });
 
-  it('should return stable: false when channel:stable and channel:prerelease conflict', async () => {
+  it('should return stable: false when release:graduate and channel:prerelease conflict', async () => {
     mockFindMergedPRsSinceLastRelease.mockResolvedValue([123]);
-    mockFetchPRLabels.mockResolvedValue(['channel:stable', 'channel:prerelease']);
+    mockFetchPRLabels.mockResolvedValue(['release:graduate', 'channel:prerelease']);
 
     const result = await runGate();
 
@@ -333,7 +333,7 @@ describe('Gate', () => {
             major: 'bump:major',
             minor: 'bump:minor',
             patch: 'bump:patch',
-            stable: 'channel:stable',
+            graduate: 'release:graduate',
             prerelease: 'channel:prerelease',
             skip: 'release:skip',
             immediate: 'release:immediate',
@@ -465,7 +465,7 @@ describe('Gate', () => {
           major: 'bump:major',
           minor: 'bump:minor',
           patch: 'bump:patch',
-          stable: 'channel:stable',
+          graduate: 'release:graduate',
           prerelease: 'channel:prerelease',
           skip: 'release:skip',
           immediate: 'release:immediate',
@@ -501,7 +501,7 @@ describe('Gate', () => {
           major: 'bump:major',
           minor: 'bump:minor',
           patch: 'bump:patch',
-          stable: 'channel:stable',
+          graduate: 'release:graduate',
           prerelease: 'channel:prerelease',
           skip: 'release:skip',
           immediate: 'release:immediate',
@@ -619,7 +619,7 @@ describe('Gate', () => {
             major: 'bump:major',
             minor: 'bump:minor',
             patch: 'bump:patch',
-            stable: 'channel:stable',
+            graduate: 'release:graduate',
             prerelease: 'channel:prerelease',
             skip: 'release:skip',
             immediate: 'release:immediate',

--- a/packages/release/test/unit/label-definitions.spec.ts
+++ b/packages/release/test/unit/label-definitions.spec.ts
@@ -6,7 +6,7 @@ import { checkLabels, deriveLabelDefinitions, type LabelDefinition, syncLabels }
 // A fully-defaulted CIConfig.labels block (mirrors CILabelsConfigSchema defaults). Tests build
 // on this so a rename only has to override the field under test.
 const DEFAULT_LABELS_CONFIG = {
-  stable: 'channel:stable',
+  graduate: 'release:graduate',
   prerelease: 'channel:prerelease',
   skip: 'release:skip',
   immediate: 'release:immediate',
@@ -41,7 +41,7 @@ describe('deriveLabelDefinitions', () => {
         'bump:patch',
         'bump:minor',
         'bump:major',
-        'channel:stable',
+        'release:graduate',
         'channel:prerelease',
         'release:skip',
         'release:immediate',

--- a/packages/release/test/unit/label-utils.spec.ts
+++ b/packages/release/test/unit/label-utils.spec.ts
@@ -22,9 +22,9 @@ describe('composeBumpFromLabels', () => {
     expect(composeBumpFromLabels(['channel:prerelease'])).toBe('prerelease');
   });
 
-  it('should return undefined when channel:stable is present (graduation is bump-less), even with a bump label', () => {
-    expect(composeBumpFromLabels(['channel:stable'])).toBeUndefined();
-    expect(composeBumpFromLabels(['channel:stable', 'bump:major'])).toBeUndefined();
+  it('should return undefined when release:graduate is present (graduation is bump-less), even with a bump label', () => {
+    expect(composeBumpFromLabels(['release:graduate'])).toBeUndefined();
+    expect(composeBumpFromLabels(['release:graduate', 'bump:major'])).toBeUndefined();
   });
 
   it('should return undefined when no bump or channel labels are present', () => {

--- a/packages/release/test/unit/labels-command.spec.ts
+++ b/packages/release/test/unit/labels-command.spec.ts
@@ -53,7 +53,7 @@ describe('runLabelsSync', () => {
     // Default config implies the 8 reserved labels + the default 'release' standing-PR label.
     expect(forge.createdLabels.length).toBeGreaterThan(0);
     const created = forge.createdLabels.map((l) => l.name);
-    expect(created).toEqual(expect.arrayContaining(['bump:minor', 'channel:stable', 'release:skip', 'release']));
+    expect(created).toEqual(expect.arrayContaining(['bump:minor', 'release:graduate', 'release:skip', 'release']));
     expect(exitSpy).not.toHaveBeenCalled();
   });
 
@@ -80,7 +80,7 @@ describe('runLabelsSync', () => {
       'bump:patch',
       'bump:minor',
       'bump:major',
-      'channel:stable',
+      'release:graduate',
       'channel:prerelease',
       'release:skip',
       'release:immediate',

--- a/packages/release/test/unit/preview-format.spec.ts
+++ b/packages/release/test/unit/preview-format.spec.ts
@@ -601,7 +601,7 @@ describe('formatPreviewComment', () => {
           noBumpLabel: false,
           immediate: true,
           labels: {
-            stable: 'channel:stable',
+            graduate: 'release:graduate',
             prerelease: 'channel:prerelease',
             skip: 'release:skip',
             immediate: 'release:immediate',
@@ -626,7 +626,7 @@ describe('formatPreviewComment', () => {
           immediate: true,
           bumpLabel: 'minor',
           labels: {
-            stable: 'channel:stable',
+            graduate: 'release:graduate',
             prerelease: 'channel:prerelease',
             skip: 'release:skip',
             immediate: 'release:immediate',
@@ -652,7 +652,7 @@ describe('formatPreviewComment', () => {
           prerelease: true,
           scopeLabels: ['scope:docs'],
           labels: {
-            stable: 'channel:stable',
+            graduate: 'release:graduate',
             prerelease: 'channel:prerelease',
             skip: 'release:skip',
             immediate: 'release:immediate',
@@ -677,7 +677,7 @@ describe('formatPreviewComment', () => {
           immediate: true,
           scopeLabels: ['scope:all'],
           labels: {
-            stable: 'channel:stable',
+            graduate: 'release:graduate',
             prerelease: 'channel:prerelease',
             skip: 'release:skip',
             immediate: 'release:immediate',
@@ -732,7 +732,7 @@ describe('formatPreviewComment', () => {
           bumpLabel: 'patch',
           scopeLabels: ['scope:all'],
           labels: {
-            stable: 'channel:stable',
+            graduate: 'release:graduate',
             prerelease: 'channel:prerelease',
             skip: 'release:skip',
             immediate: 'release:immediate',
@@ -758,7 +758,7 @@ describe('formatPreviewComment', () => {
           noBumpLabel: false,
           advisoryInStandingPr: true,
           labels: {
-            stable: 'channel:stable',
+            graduate: 'release:graduate',
             prerelease: 'channel:prerelease',
             skip: 'release:skip',
             immediate: 'release:immediate',

--- a/packages/release/test/unit/preview-github.spec.ts
+++ b/packages/release/test/unit/preview-github.spec.ts
@@ -149,17 +149,17 @@ describe('fetchPRLabels', () => {
   }
 
   it('should return label names from PR', async () => {
-    const forge = forgeWithLabels(['channel:stable', 'bug']);
+    const forge = forgeWithLabels(['release:graduate', 'bug']);
 
     const labels = await fetchPRLabels(forge, 1);
-    expect(labels).toEqual(['channel:stable', 'bug']);
+    expect(labels).toEqual(['release:graduate', 'bug']);
   });
 
   it('should handle string labels', async () => {
-    const forge = forgeWithLabels(['channel:stable', 'enhancement']);
+    const forge = forgeWithLabels(['release:graduate', 'enhancement']);
 
     const labels = await fetchPRLabels(forge, 1);
-    expect(labels).toEqual(['channel:stable', 'enhancement']);
+    expect(labels).toEqual(['release:graduate', 'enhancement']);
   });
 
   it('should return empty array when no labels', async () => {

--- a/packages/release/test/unit/preview.spec.ts
+++ b/packages/release/test/unit/preview.spec.ts
@@ -310,7 +310,7 @@ describe('runPreview', () => {
       });
 
       it('should take priority over stable PR label', async () => {
-        mockFetchPRLabels.mockResolvedValue(['channel:stable']);
+        mockFetchPRLabels.mockResolvedValue(['release:graduate']);
 
         await runPreview({ projectDir: '/test', dryRun: false, prerelease: 'beta', target: '@test/package' });
 
@@ -554,8 +554,8 @@ describe('runPreview', () => {
     });
 
     describe('stable/prerelease conflicts', () => {
-      it('should block release when channel:stable and channel:prerelease both present', async () => {
-        mockFetchPRLabels.mockResolvedValue(['channel:stable', 'channel:prerelease', 'bump:minor']);
+      it('should block release when release:graduate and channel:prerelease both present', async () => {
+        mockFetchPRLabels.mockResolvedValue(['release:graduate', 'channel:prerelease', 'bump:minor']);
         mockLoadCIConfig.mockReturnValue({ releaseTrigger: 'label' });
 
         await runPreview({ projectDir: '/test', dryRun: false, target: '@test/package' });
@@ -621,21 +621,21 @@ describe('runPreview', () => {
 
     describe('stable label', () => {
       it('should graduate prerelease to stable when stable label is present', async () => {
-        mockFetchPRLabels.mockResolvedValue(['channel:stable', 'bump:minor']);
+        mockFetchPRLabels.mockResolvedValue(['release:graduate', 'bump:minor']);
         mockLoadCIConfig.mockReturnValue({ releaseTrigger: 'label' });
         mockDetectPrerelease.mockReturnValue({ isPrerelease: true, identifier: 'beta' });
 
         await runPreview({ projectDir: '/test', dryRun: false, target: '@test/package' });
 
         const callArgs = mockRunRelease.mock.calls[0][0];
-        // Per gate semantics: channel:stable causes bump to be auto-detected from commits.
+        // Per gate semantics: release:graduate causes bump to be auto-detected from commits.
         // bump label magnitude is not propagated when graduation is the primary intent.
         expect(callArgs.bump).toBeUndefined();
         expect(callArgs.stable).toBe(true);
       });
 
       it('should run release analysis but not set bump when stable label present without bump label', async () => {
-        mockFetchPRLabels.mockResolvedValue(['channel:stable']);
+        mockFetchPRLabels.mockResolvedValue(['release:graduate']);
         mockLoadCIConfig.mockReturnValue({ releaseTrigger: 'label' });
         mockDetectPrerelease.mockReturnValue({ isPrerelease: true, identifier: 'beta' });
 
@@ -718,7 +718,7 @@ describe('runPreview', () => {
 
     it('should NOT release in label mode for scope-only PR — gate requires bump or stable label', async () => {
       // Aligned with gate semantics: in label trigger mode, scope alone does not trigger
-      // a release. The user must add bump:* or channel:stable. Conventional-commits-driven
+      // a release. The user must add bump:* or release:graduate. Conventional-commits-driven
       // bumps are only supported in commit trigger mode.
       mockLoadCIConfig.mockReturnValue({
         releaseTrigger: 'label',
@@ -832,7 +832,7 @@ describe('runPreview', () => {
         releaseTrigger: 'label',
         scopeLabels: { 'scope:all': '@releasekit/*' },
         labels: {
-          stable: 'channel:stable',
+          graduate: 'release:graduate',
           prerelease: 'channel:prerelease',
           skip: 'release:skip',
           immediate: 'release:immediate',
@@ -1010,7 +1010,7 @@ describe('runPreview', () => {
         releaseStrategy: 'standing-pr',
         releaseTrigger: 'label',
         labels: {
-          stable: 'channel:stable',
+          graduate: 'release:graduate',
           prerelease: 'channel:prerelease',
           skip: 'release:skip',
           immediate: 'release:immediate',
@@ -1081,7 +1081,7 @@ describe('runPreview', () => {
         releaseStrategy: 'direct',
         releaseTrigger: 'label',
         labels: {
-          stable: 'channel:stable',
+          graduate: 'release:graduate',
           prerelease: 'channel:prerelease',
           skip: 'release:skip',
           immediate: 'release:immediate',

--- a/packages/release/test/unit/release-gate.spec.ts
+++ b/packages/release/test/unit/release-gate.spec.ts
@@ -54,8 +54,8 @@ describe('evaluatePR — label mode', () => {
     expect(result.bump).toBe('prepatch');
   });
 
-  it('should return shouldRelease=true with stable=true and bump=undefined for channel:stable alone', () => {
-    const result = evaluatePR(1, ['channel:stable'], DEFAULT_LABELS, labelMode);
+  it('should return shouldRelease=true with stable=true and bump=undefined for release:graduate alone', () => {
+    const result = evaluatePR(1, ['release:graduate'], DEFAULT_LABELS, labelMode);
     expect(result.shouldRelease).toBe(true);
     expect(result.stable).toBe(true);
     // Stable graduation auto-detects magnitude from commits — bump intentionally undefined.
@@ -70,11 +70,11 @@ describe('evaluatePR — label mode', () => {
     expect(result.reason).toContain('minor');
   });
 
-  it('should return blocked=true for channel:stable + channel:prerelease on the same PR', () => {
-    const result = evaluatePR(1, ['channel:stable', 'channel:prerelease'], DEFAULT_LABELS, labelMode);
+  it('should return blocked=true for release:graduate + channel:prerelease on the same PR', () => {
+    const result = evaluatePR(1, ['release:graduate', 'channel:prerelease'], DEFAULT_LABELS, labelMode);
     expect(result.blocked).toBe(true);
     expect(result.shouldRelease).toBe(false);
-    expect(result.reason).toContain('channel:stable');
+    expect(result.reason).toContain('release:graduate');
     expect(result.reason).toContain('channel:prerelease');
   });
 
@@ -86,7 +86,7 @@ describe('evaluatePR — label mode', () => {
     expect(result.shouldRelease).toBe(false);
     // Scope label still counts as release intent — user gets a notify comment.
     expect(result.hasReleaseIntent).toBe(true);
-    expect(result.reason).toMatch(/no release labels|need bump|channel:stable/i);
+    expect(result.reason).toMatch(/no release labels|need bump|release:graduate/i);
   });
 
   it('should return hasReleaseIntent=false when no release-related labels present', () => {
@@ -141,8 +141,8 @@ describe('evaluatePR — commit mode', () => {
     expect(result.shouldRelease).toBe(true);
   });
 
-  it('should block on channel:stable + channel:prerelease conflict in commit mode', () => {
-    const result = evaluatePR(1, ['channel:stable', 'channel:prerelease'], DEFAULT_LABELS, commitMode);
+  it('should block on release:graduate + channel:prerelease conflict in commit mode', () => {
+    const result = evaluatePR(1, ['release:graduate', 'channel:prerelease'], DEFAULT_LABELS, commitMode);
     expect(result.blocked).toBe(true);
   });
 });

--- a/packages/release/test/unit/release.spec.ts
+++ b/packages/release/test/unit/release.spec.ts
@@ -761,7 +761,7 @@ describe('runRelease', () => {
     it('should block release when prerelease + stable conflict detected without scopeLabels', async () => {
       mockLoadCIConfig.mockReturnValue({});
       mockFindMergedPRsForCommit.mockResolvedValue([123]);
-      mockFetchPRLabels.mockResolvedValue(['channel:stable', 'channel:prerelease']);
+      mockFetchPRLabels.mockResolvedValue(['release:graduate', 'channel:prerelease']);
 
       const { runRelease } = await import('../../src/release.js');
       const result = await runRelease(defaultOptions);
@@ -776,7 +776,7 @@ describe('runRelease', () => {
         },
       });
       mockFindMergedPRsForCommit.mockResolvedValue([123]);
-      mockFetchPRLabels.mockResolvedValue(['scope:shared', 'channel:stable', 'channel:prerelease']);
+      mockFetchPRLabels.mockResolvedValue(['scope:shared', 'release:graduate', 'channel:prerelease']);
 
       const { runRelease } = await import('../../src/release.js');
       const result = await runRelease(defaultOptions);
@@ -847,7 +847,7 @@ describe('runRelease', () => {
         },
       });
       mockFindMergedPRsForCommit.mockResolvedValue([123]);
-      mockFetchPRLabels.mockResolvedValue(['channel:stable', 'channel:prerelease']);
+      mockFetchPRLabels.mockResolvedValue(['release:graduate', 'channel:prerelease']);
 
       const { runRelease } = await import('../../src/release.js');
       const result = await runRelease({ ...defaultOptions, dryRun: true });

--- a/packages/release/test/unit/standing-pr.spec.ts
+++ b/packages/release/test/unit/standing-pr.spec.ts
@@ -279,7 +279,7 @@ describe('runStandingPRUpdate', () => {
       skipPatterns: ['chore: release '],
       minChanges: 1,
       labels: {
-        stable: 'channel:stable',
+        graduate: 'release:graduate',
         prerelease: 'channel:prerelease',
         skip: 'release:skip',
         immediate: 'release:immediate',
@@ -1443,12 +1443,12 @@ describe('runStandingPRUpdate', () => {
       expect(manifest.overrideLabels).toEqual(['bump:major', 'channel:prerelease']);
     });
 
-    it('should drop the bump under channel:stable (graduation is bump-less, matching the SSOT)', async () => {
-      const { runVersionStepMock } = await setupWithStandingPRLabels(['release', 'bump:major', 'channel:stable']);
+    it('should drop the bump under release:graduate (graduation is bump-less, matching the SSOT)', async () => {
+      const { runVersionStepMock } = await setupWithStandingPRLabels(['release', 'bump:major', 'release:graduate']);
 
       await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
 
-      // channel:stable wins — bump is dropped (not leaked as 'major'), consistent with
+      // release:graduate wins — bump is dropped (not leaked as 'major'), consistent with
       // composeBumpFromLabels returning undefined for stable.
       expect(runVersionStepMock.mock.calls[0]?.[0]).toMatchObject({ stable: true });
       expect(runVersionStepMock.mock.calls[0]?.[0]?.bump).toBeUndefined();

--- a/packages/version/src/core/versionCalculator.ts
+++ b/packages/version/src/core/versionCalculator.ts
@@ -214,7 +214,7 @@ async function calculateVersionInner(config: Config, options: VersionOptions): P
     }
 
     // Handle stableOnly mode: graduate prerelease → stable base; skip already-stable packages.
-    // This is triggered by `channel:stable` without a bump label.
+    // This is triggered by `release:graduate` without a bump label.
     log(`Checking stableOnly mode: ${config.stableOnly}`, 'debug');
     if (config.stableOnly) {
       log(`StableOnly mode activated`, 'debug');

--- a/packages/version/test/unit/core/versionCalculator.spec.ts
+++ b/packages/version/test/unit/core/versionCalculator.spec.ts
@@ -1804,7 +1804,7 @@ describe('Version Calculator', () => {
     });
   });
 
-  describe('stableOnly mode (channel:stable without bump label)', () => {
+  describe('stableOnly mode (release:graduate without bump label)', () => {
     it('should graduate a prerelease package to its stable base version', async () => {
       const config: Partial<Config> = {
         ...defaultConfig,
@@ -1836,7 +1836,7 @@ describe('Version Calculator', () => {
       const config: Partial<Config> = {
         ...defaultConfig,
         stableOnly: true,
-        // No type — channel:stable alone, no bump:* label
+        // No type — release:graduate alone, no bump:* label
       };
 
       const options: VersionOptions = {
@@ -1853,7 +1853,7 @@ describe('Version Calculator', () => {
       expect(versionUtils.bumpVersion).not.toHaveBeenCalled();
     });
 
-    it('should apply bump label to an already-stable package (channel:stable + bump:minor)', async () => {
+    it('should apply bump label to an already-stable package (release:graduate + bump:minor)', async () => {
       const config: Partial<Config> = {
         ...defaultConfig,
         stableOnly: true,

--- a/releasekit.schema.json
+++ b/releasekit.schema.json
@@ -1126,10 +1126,10 @@
           "type": "object",
           "additionalProperties": false,
           "properties": {
-            "stable": {
+            "graduate": {
               "type": "string",
-              "default": "channel:stable",
-              "description": "Label to graduate a prerelease to stable"
+              "default": "release:graduate",
+              "description": "Label that graduates a prerelease to its stable base version (e.g. 1.0.0-next.6 → 1.0.0). A standalone release trigger in label/direct mode; in standing-pr mode it sets the next merge to graduate."
             },
             "prerelease": {
               "type": "string",


### PR DESCRIPTION
Closes #341.

## What

Renames the prerelease-graduation label from `channel:stable` to **`release:graduate`** — a clean break (no alias), since releasekit is pre-1.0.0.

- `ci.labels.stable` → `ci.labels.graduate`; default value `channel:stable` → `release:graduate`
- the label moves into the `release:*` namespace (and gets the orange release-flow colour)
- **behaviour is unchanged** — `release:graduate` drives the exact same graduation code path; only the label name and config key change

## Why (Option 2 from the #341 discussion)

`channel:stable` was the odd one out: in label/direct mode it triggered a release **on its own** (graduating a prerelease to its base version, `1.0.0-next.6` → `1.0.0`), yet its `channel:` name made it look like a peer modifier of `channel:prerelease`. Graduation is a release *decision*, so it belongs on the release-flow axis.

After the rename the namespaces match their roles:
- `bump:*` — magnitude triggers
- `channel:prerelease` — the sole channel modifier (needs a `bump:*` in label mode; sets the channel on merge in standing-pr mode)
- `release:graduate`, `release:skip`, `release:immediate`, … — release-flow labels

The modifier-vs-trigger asymmetry the old docs had to *explain* is now simply gone.

## Scope

- Config schema (`ci.labels.graduate`), `LabelConfig`, gate/`evaluate-pr`, `label-utils`, `label-definitions`, standing-PR overrides, preview banner — all renamed; internal version-engine `stable` flag is untouched (it's the correct term at that layer).
- Docs: ci-setup label tables + the modifier-vs-trigger note, architecture, README, regenerated `releasekit.schema.json` + `configuration.md`.
- Tests updated across the gate/preview/standing-pr/label suites.

## Breaking change

The graduation label is now `release:graduate` and its config key is `ci.labels.graduate` (was `ci.labels.stable` / `channel:stable`). Update any `ci.labels` overrides and re-run `releasekit labels sync` to create the new label.

## Verification

`pnpm turbo run lint typecheck test` — all green (32/32). `pnpm schema:check` in sync.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR renames the prerelease graduation label from `channel:stable` → `release:graduate` and its config key from `ci.labels.stable` → `ci.labels.graduate` across the entire codebase. It is a clean, intentional breaking change on a pre-1.0.0 project.

- **Schema & types**: `CILabelsConfigSchema`, `LabelConfig`, `LabelConflictResult` all updated; the internal `stable` boolean flag in `PREvaluation`/`LabelContext` is deliberately preserved as the correct semantic term at the version-engine layer.
- **Label definitions**: `release:graduate` moves from `COLOR_CHANNEL` (blue) to `COLOR_RELEASE` (orange), correctly reflecting its classification as a release-flow trigger rather than a channel modifier.
- **Docs, tests, and the generated `releasekit.schema.json`** are fully updated; the previously flagged log-message issue (hardcoded label strings in `standing-pr.ts`) is resolved by reading from `overrideLabelNames`.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the rename is applied uniformly across all 28 files with no missing callsites and no logic changes.

Every reference to the old `stable` label key and `channel:stable` string has been updated in source, tests, docs, and the generated schema. The internal `stable` boolean flag used by the version engine is correctly left untouched. The previously flagged log-message hardcoding in `standing-pr.ts` is resolved. Test coverage (32/32) and schema check are reported green.

No files require special attention — the rename is complete and consistent across the codebase.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/config/src/schema.ts | Renames `stable` → `graduate` in `CILabelsConfigSchema` and its explicit default object in `CIConfigSchema`; description updated to reflect standalone trigger semantics. |
| packages/release/src/label-utils.ts | Renames `LabelConfig.stable` → `graduate`, `DEFAULT_LABELS.stable` → `graduate`, and `LabelConflictResult.hasStable` → `hasGraduate` consistently; all callers updated. |
| packages/release/src/label-definitions.ts | Moves `graduate` label after `prerelease` in definition order and switches color from `COLOR_CHANNEL` to `COLOR_RELEASE`; ordering change is cosmetic and tests use `arrayContaining` so no mismatch. |
| packages/release/src/gate/evaluate-pr.ts | Renames internal variable `hasStableLabel` → `hasGraduateLabel` and `isStable` → `isGraduation`; correctly preserves `stable: isGraduation` in the returned `PREvaluation` (the internal flag is intentionally unchanged). |
| packages/release/src/standing-pr/standing-pr.ts | Resolves the previously flagged hardcoded-label-string issue: introduces `overrideLabelNames` from config and uses `.graduate`/`.prerelease` in log messages; `hasStable` → `hasGraduate` throughout. |
| packages/release/src/preview/format.ts | Renames `LabelContext.labels.stable` → `graduate` and updates all fallback strings from `'channel:stable'` to `'release:graduate'`; the `stable?: boolean` state field is correctly preserved. |
| releasekit.schema.json | Regenerated JSON schema reflects the `stable` → `graduate` field rename and updated description; default value updated to `release:graduate`. |
| packages/release/src/preview/preview.ts | All `labels.stable` references replaced with `labels.graduate` and `conflict.hasStable` → `conflict.hasGraduate`; warn messages updated to use new label name. |
| packages/release/src/gate/gate.ts | Single-line update to the conflict notification body replaces `labelConfig.stable` with `labelConfig.graduate`. |
| packages/version/src/core/versionCalculator.ts | Comment-only update clarifying that `stableOnly` mode is triggered by `release:graduate`; no logic change. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    PR[PR Merged / Evaluated] --> labels{Labels present?}

    labels -->|bump:patch/minor/major| BUMP[Bump release]
    labels -->|channel:prerelease + bump:*| PRE[Prerelease release]
    labels -->|release:graduate| GRAD[Graduate prerelease → stable]
    labels -->|release:graduate + channel:prerelease| CONFLICT[Blocked — conflicting labels]
    labels -->|release:skip| SKIP[No release]
    labels -->|none| NOOP[No release]

    GRAD --> ENGINE[Version engine\nstableOnly=true]
    ENGINE -->|isPrerelease| STABLE_OUT[e.g. 1.0.0-next.6 → 1.0.0]
    ENGINE -->|already stable| NOOP2[No release for this package]

    style GRAD fill:#d93f0b,color:#fff
    style CONFLICT fill:#b60205,color:#fff
    style STABLE_OUT fill:#0e8a16,color:#fff
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    PR[PR Merged / Evaluated] --> labels{Labels present?}

    labels -->|bump:patch/minor/major| BUMP[Bump release]
    labels -->|channel:prerelease + bump:*| PRE[Prerelease release]
    labels -->|release:graduate| GRAD[Graduate prerelease → stable]
    labels -->|release:graduate + channel:prerelease| CONFLICT[Blocked — conflicting labels]
    labels -->|release:skip| SKIP[No release]
    labels -->|none| NOOP[No release]

    GRAD --> ENGINE[Version engine\nstableOnly=true]
    ENGINE -->|isPrerelease| STABLE_OUT[e.g. 1.0.0-next.6 → 1.0.0]
    ENGINE -->|already stable| NOOP2[No release for this package]

    style GRAD fill:#d93f0b,color:#fff
    style CONFLICT fill:#b60205,color:#fff
    style STABLE_OUT fill:#0e8a16,color:#fff
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["docs(version): update lingering channel:..."](https://github.com/goosewobbler/releasekit/commit/45d0e2f5c670f24d412e816ed6a66923ad606374) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39863177)</sub>

<!-- /greptile_comment -->