### PR TITLE
refactor(config)!: remove dead config fields with no consumer

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -49,7 +49,6 @@ Monorepo configuration.
 | `mode` | `"root"` \| `"packages"` \| `"both"` | — | Changelog aggregation mode |
 | `rootPath` | string | — | Path to root changelog |
 | `packagesPath` | string | — | Path to packages directory |
-| `mainPackage` | string | — | Main package name for versioning |
 
 ---
 
@@ -388,9 +387,6 @@ CI automation configuration for release triggers, PR previews, and label managem
 |-----|------|---------|-------------|
 | `releaseStrategy` | `"manual"` \| `"direct"` \| `"standing-pr"` | `"direct"` | How releases are delivered. 'direct': release on merge to main. 'manual': releases triggered manually (e.g. workflow_dispatch). 'standing-pr': changes accumulate in a release PR; gate mode acts as the immediate-release evaluator, firing only for merges labelled with the immediate label. |
 | `releaseTrigger` | `"commit"` \| `"label"` | `"label"` | What triggers a release. 'label': a PR bump label (bump:patch/minor/major) is required. 'commit': conventional commits drive the bump automatically; every merge can trigger a release. |
-| `autoRelease` | boolean | `false` | Automatically trigger a release when CI conditions are met, without manual intervention. |
-| `skipPatterns` | `string[]` | `["chore: release "]` | Commit message prefixes that suppress a release. The default matches the release commit template to prevent release loops. |
-| `minChanges` | integer | `1` | Minimum number of packages with releasable changes required to trigger a release. |
 | `scopeLabels` | object | — | Map of scope labels to package patterns. When a PR has a label matching a key, only packages matching the corresponding pattern are released. |
 
 ### `ci.prPreview`

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -358,7 +358,7 @@ See [ci-setup.md — CI concurrency caveat](../packages/release/docs/ci-setup.md
 **Cause:** Two common cases:
 
 - **Label trigger mode:** the merged PR has no `bump:*` label. Without a bump label, the label trigger exits cleanly.
-- **Commit mode:** all commits since the last tag match `release.ci.skipPatterns` (default `["chore: release "]`) or are non-releasable types under the preset.
+- **Commit mode:** all commits since the last tag match `release.ci.skipPatterns` (configure this explicitly, e.g. `["chore: release "]`, to suppress release commits) or are non-releasable types under the preset.
 
 **Fix:** In label mode, ensure the merged PR carries a `bump:patch`, `bump:minor`, or `bump:major` label. In commit mode, confirm releasable commits (`feat:`, `fix:`) exist since the last tag with `git log <last-tag>..HEAD --oneline`. Run with `--dry-run --verbose` to see the commit analysis without making changes.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -358,7 +358,7 @@ See [ci-setup.md — CI concurrency caveat](../packages/release/docs/ci-setup.md
 **Cause:** Two common cases:
 
 - **Label trigger mode:** the merged PR has no `bump:*` label. Without a bump label, the label trigger exits cleanly.
-- **Commit mode:** all commits since the last tag match `ci.skipPatterns` (default `["chore: release "]`) or are non-releasable types under the preset.
+- **Commit mode:** all commits since the last tag match `release.ci.skipPatterns` (default `["chore: release "]`) or are non-releasable types under the preset.
 
 **Fix:** In label mode, ensure the merged PR carries a `bump:patch`, `bump:minor`, or `bump:major` label. In commit mode, confirm releasable commits (`feat:`, `fix:`) exist since the last tag with `git log <last-tag>..HEAD --oneline`. Run with `--dry-run --verbose` to see the commit analysis without making changes.
 

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -25,7 +25,6 @@ export const MonorepoConfigSchema = z.object({
   mode: z.enum(['root', 'packages', 'both']).optional().describe('Changelog aggregation mode'),
   rootPath: z.string().optional().describe('Path to root changelog'),
   packagesPath: z.string().optional().describe('Path to packages directory'),
-  mainPackage: z.string().optional().describe('Main package name for versioning'),
 });
 
 export const BranchPatternSchema = z.object({
@@ -639,22 +638,6 @@ export const CIConfigSchema = z.object({
     .describe(
       'PR preview comments showing what would be released if the PR is merged. `true`/`false` toggles them; the object form additionally enables `refreshAfterRelease` to refresh feeder-PR previews after a release.',
     ),
-  autoRelease: z
-    .boolean()
-    .default(false)
-    .describe('Automatically trigger a release when CI conditions are met, without manual intervention.'),
-  skipPatterns: z
-    .array(z.string())
-    .default(['chore: release '])
-    .describe(
-      'Commit message prefixes that suppress a release. The default matches the release commit template to prevent release loops.',
-    ),
-  minChanges: z
-    .number()
-    .int()
-    .positive()
-    .default(1)
-    .describe('Minimum number of packages with releasable changes required to trigger a release.'),
   labels: CILabelsConfigSchema.default({
     stable: 'channel:stable',
     prerelease: 'channel:prerelease',

--- a/packages/config/test/unit/load.spec.ts
+++ b/packages/config/test/unit/load.spec.ts
@@ -327,13 +327,12 @@ describe('loadCIConfig', () => {
     mockedFs.existsSync.mockReturnValue(true);
     mockedFs.readFileSync.mockReturnValue(
       JSON.stringify({
-        ci: { prPreview: false, autoRelease: true },
+        ci: { prPreview: false },
       }),
     );
 
     const result = loadCIConfig();
     expect(result?.prPreview).toEqual({ enabled: false, refreshAfterRelease: false });
-    expect(result?.autoRelease).toBe(true);
   });
 
   it('should return undefined when no CI config', () => {

--- a/packages/config/test/unit/schema.spec.ts
+++ b/packages/config/test/unit/schema.spec.ts
@@ -504,9 +504,6 @@ describe('CIConfigSchema', () => {
     expect(result.releaseStrategy).toBe('direct');
     expect(result.releaseTrigger).toBe('label');
     expect(result.prPreview).toEqual({ enabled: true, refreshAfterRelease: false });
-    expect(result.autoRelease).toBe(false);
-    expect(result.skipPatterns).toEqual(['chore: release ']);
-    expect(result.minChanges).toBe(1);
     expect(result.labels).toEqual({
       stable: 'channel:stable',
       prerelease: 'channel:prerelease',
@@ -525,15 +522,9 @@ describe('CIConfigSchema', () => {
     const result = CIConfigSchema.parse({
       releaseStrategy: 'direct',
       prPreview: false,
-      autoRelease: true,
-      skipPatterns: ['chore(deps):', 'ci:'],
-      minChanges: 3,
     });
     expect(result.releaseStrategy).toBe('direct');
     expect(result.prPreview).toEqual({ enabled: false, refreshAfterRelease: false });
-    expect(result.autoRelease).toBe(true);
-    expect(result.skipPatterns).toEqual(['chore(deps):', 'ci:']);
-    expect(result.minChanges).toBe(3);
   });
 
   it('should accept all releaseStrategy values', () => {
@@ -590,11 +581,6 @@ describe('CIConfigSchema', () => {
 
   it('should reject an allowedActors entry like "@octocat" (an @-prefix without the team slash)', () => {
     expect(() => CIConfigSchema.parse({ standingPr: { authorization: { allowedActors: ['@octocat'] } } })).toThrow();
-  });
-
-  it('should reject non-positive minChanges', () => {
-    expect(() => CIConfigSchema.parse({ minChanges: 0 })).toThrow();
-    expect(() => CIConfigSchema.parse({ minChanges: -1 })).toThrow();
   });
 
   it('should accept all releaseTrigger values', () => {
@@ -717,7 +703,7 @@ describe('ReleaseKitConfigSchema', () => {
       version: { preset: 'conventional' },
       publish: { npm: { enabled: true } },
       notes: { changelog: { mode: 'packages' } },
-      ci: { prPreview: true, autoRelease: false },
+      ci: { prPreview: true },
     });
     expect(result.git?.remote).toBe('origin');
     expect(result.monorepo?.mode).toBe('packages');
@@ -725,7 +711,6 @@ describe('ReleaseKitConfigSchema', () => {
     expect(result.publish?.npm.enabled).toBe(true);
     expect(result.notes?.changelog).toMatchObject({ mode: 'packages' });
     expect(result.ci?.prPreview).toEqual({ enabled: true, refreshAfterRelease: false });
-    expect(result.ci?.autoRelease).toBe(false);
   });
 
   it('should reject invalid nested values', () => {

--- a/packages/release/test/unit/label-definitions.spec.ts
+++ b/packages/release/test/unit/label-definitions.spec.ts
@@ -21,9 +21,6 @@ function ciConfig(overrides: Partial<CIConfig> = {}): CIConfig {
     releaseStrategy: 'direct',
     releaseTrigger: 'label',
     prPreview: { enabled: true, refreshAfterRelease: false },
-    autoRelease: false,
-    skipPatterns: ['chore: release '],
-    minChanges: 1,
     labels: DEFAULT_LABELS_CONFIG,
     ...overrides,
   } as CIConfig;

--- a/packages/release/test/unit/standing-pr.spec.ts
+++ b/packages/release/test/unit/standing-pr.spec.ts
@@ -275,9 +275,6 @@ describe('runStandingPRUpdate', () => {
       releaseStrategy: 'standing-pr',
       releaseTrigger: 'label',
       prPreview: { enabled: true, refreshAfterRelease: false },
-      autoRelease: false,
-      skipPatterns: ['chore: release '],
-      minChanges: 1,
       labels: {
         stable: 'channel:stable',
         prerelease: 'channel:prerelease',

--- a/releasekit.schema.json
+++ b/releasekit.schema.json
@@ -68,10 +68,6 @@
         "packagesPath": {
           "type": "string",
           "description": "Path to packages directory"
-        },
-        "mainPackage": {
-          "type": "string",
-          "description": "Main package name for versioning"
         }
       },
       "description": "Monorepo configuration"
@@ -1120,27 +1116,6 @@
             }
           ],
           "description": "PR preview comments showing what would be released if the PR is merged. `true`/`false` toggles them; the object form additionally enables `refreshAfterRelease` to refresh feeder-PR previews after a release."
-        },
-        "autoRelease": {
-          "type": "boolean",
-          "default": false,
-          "description": "Automatically trigger a release when CI conditions are met, without manual intervention."
-        },
-        "skipPatterns": {
-          "type": "array",
-          "default": [
-            "chore: release "
-          ],
-          "items": {
-            "type": "string"
-          },
-          "description": "Commit message prefixes that suppress a release. The default matches the release commit template to prevent release loops."
-        },
-        "minChanges": {
-          "type": "integer",
-          "minimum": 1,
-          "default": 1,
-          "description": "Minimum number of packages with releasable changes required to trigger a release."
         },
         "labels": {
           "type": "object",


### PR DESCRIPTION
Follow-up to the `defaultReleaseType` discussion: an audit of the config schema turned up several fields that are defined (and shown in the generated docs) but **never read by any code**. This PR removes the unambiguous ones — vestigial or shadowed duplicates, no capability lost.

## Removed

| field | why dead |
|---|---|
| `ci.autoRelease` | zero references anywhere outside the schema |
| `ci.skipPatterns` (top-level `CIConfigSchema`) | shadowed duplicate — every live read is `release.ci.skipPatterns` |
| `ci.minChanges` (top-level `CIConfigSchema`) | shadowed duplicate — every live read is `release.ci.minChanges` |
| `monorepo.mainPackage` | dead duplicate of `version.mainPackage` (the one the engine reads) |

Each promised behaviour that didn't exist — worse than absent. The release-commit skip-pattern invariant is **unaffected** (it reads `release.ci.skipPatterns`, untouched). Regenerated `releasekit.schema.json` + `configuration.md`; fixed a stale `troubleshooting.md` reference to use the live `release.ci.skipPatterns` path.

## Deliberately NOT in this PR (tracked separately)

The audit also found, but these are **decisions, not cleanup**:
- **Branch-pattern versioning** (`version.versionStrategy` + `branchPatterns` + `defaultReleaseType`) — a whole documented feature that's fully unwired (the engine reads a singular `branchPattern` the loader never populates). Remove the feature *or* implement it.
- **`notes…llm.options.timeout`** and **`version.updateInternalDependencies`** — half-built; likely worth *implementing* rather than removing.
- Four live-but-half-wired paths (latent bugs) for follow-up issues.

## Breaking change

`ci.autoRelease`, top-level `ci.skipPatterns`/`ci.minChanges`, and `monorepo.mainPackage` are removed. The first three did nothing; use `release.ci.skipPatterns` / `release.ci.minChanges` and `version.mainPackage`.

## Verification

`pnpm turbo run lint typecheck test` — green (32/32). `pnpm schema:check` in sync.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR removes unused config fields from the schema and docs. The main changes are:

- Removed dead top-level CI fields from the runtime schema and generated JSON schema.
- Removed `monorepo.mainPackage` in favor of the live `version.mainPackage` path.
- Updated tests and documentation to match the narrowed config surface.
- Reworded troubleshooting guidance to use explicit `release.ci.skipPatterns` configuration.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/config/src/schema.ts | Removed unused schema fields while leaving the live `release.ci.*` and `version.mainPackage` paths intact. |
| releasekit.schema.json | Updated the generated schema to match the runtime config schema. |
| docs/configuration.md | Removed documentation for the deleted config fields. |
| docs/troubleshooting.md | Updated commit-mode guidance to point users at `release.ci.skipPatterns`. |
| packages/config/test/unit/load.spec.ts | Updated loader tests for the narrowed CI config shape. |
| packages/config/test/unit/schema.spec.ts | Updated schema tests after removing the unused fields. |
| packages/release/test/unit/label-definitions.spec.ts | Updated release test fixtures to match the current CI config type. |
| packages/release/test/unit/standing-pr.spec.ts | Updated standing PR test fixtures to match the current CI config type. |

</details>

<sub>Reviews (2): Last reviewed commit: ["docs: clarify release.ci.skipPatterns ha..."](https://github.com/goosewobbler/releasekit/commit/768e0f97f8ab48a10dc74dcefe41afafb1d855ef) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39945018)</sub>

<!-- /greptile_comment -->