### PR TITLE
fix(config): inherit top-level git.push when publish.git omits it

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -149,7 +149,7 @@ Git publishing options.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `push` | boolean | `true` | Push tags and commits to remote |
+| `push` | boolean | — | Push tags and commits to remote. When unset, inherits the top-level git.push (which defaults to push). |
 | `pushMethod` | `"auto"` \| `"ssh"` \| `"https"` | — | Push method override |
 | `remote` | string | — | Remote name override |
 | `branch` | string | — | Branch name override |

--- a/packages/config/src/merge.ts
+++ b/packages/config/src/merge.ts
@@ -16,7 +16,9 @@ export function mergeGitConfig(topLevel?: GitConfig, packageLevel?: PublishGitCo
     branch: packageLevel.branch ?? base.branch,
     pushMethod: packageLevel.pushMethod ?? base.pushMethod,
     httpsTokenEnv: packageLevel.httpsTokenEnv ?? base.httpsTokenEnv,
-    push: packageLevel.push,
+    // Fall back to the top-level git.push when publish.git doesn't set it — otherwise a `publish.git`
+    // block (even one not mentioning push) would silently override a top-level `git.push: false`.
+    push: packageLevel.push ?? base.push,
     skipHooks: packageLevel.skipHooks ?? base.skipHooks,
   };
 }

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -150,7 +150,10 @@ export const PubPublishConfigSchema = z.object({
 });
 
 export const PublishGitConfigSchema = z.object({
-  push: z.boolean().default(true).describe('Push tags and commits to remote'),
+  push: z
+    .boolean()
+    .optional()
+    .describe('Push tags and commits to remote. When unset, inherits the top-level git.push (which defaults to push).'),
   pushMethod: z.enum(['auto', 'ssh', 'https']).optional().describe('Push method override'),
   remote: z.string().optional().describe('Remote name override'),
   branch: z.string().optional().describe('Branch name override'),

--- a/packages/config/test/unit/load.spec.ts
+++ b/packages/config/test/unit/load.spec.ts
@@ -242,6 +242,34 @@ describe('loadPublishConfig', () => {
     expect(result?.git?.remote).toBe('origin');
   });
 
+  it('should not let a publish.git block override an explicit top-level git.push: false', () => {
+    mockedFs.existsSync.mockReturnValue(true);
+    mockedFs.readFileSync.mockReturnValue(
+      JSON.stringify({
+        git: { push: false },
+        publish: { git: { remote: 'upstream' } },
+      }),
+    );
+
+    // The publish.git block doesn't set push, so it must inherit the top-level git.push: false —
+    // not be silently flipped back to true by a default.
+    const result = loadPublishConfig();
+    expect(result?.git?.push).toBe(false);
+  });
+
+  it('should let publish.git.push explicitly override top-level git.push', () => {
+    mockedFs.existsSync.mockReturnValue(true);
+    mockedFs.readFileSync.mockReturnValue(
+      JSON.stringify({
+        git: { push: false },
+        publish: { git: { push: true } },
+      }),
+    );
+
+    const result = loadPublishConfig();
+    expect(result?.git?.push).toBe(true);
+  });
+
   it('should inherit skipHooks from top-level git config', () => {
     mockedFs.existsSync.mockReturnValue(true);
     mockedFs.readFileSync.mockReturnValue(

--- a/releasekit.schema.json
+++ b/releasekit.schema.json
@@ -265,8 +265,7 @@
           "properties": {
             "push": {
               "type": "boolean",
-              "default": true,
-              "description": "Push tags and commits to remote"
+              "description": "Push tags and commits to remote. When unset, inherits the top-level git.push (which defaults to push)."
             },
             "pushMethod": {
               "type": "string",


### PR DESCRIPTION
Closes #447.

## Bug
A `publish.git` block — even one not mentioning `push` — silently overrode an explicit top-level `git.push: false`. `mergeGitConfig` took `packageLevel.push` unconditionally while `PublishGitConfigSchema.push` defaulted to `true`, so once any `publish.git` block existed the user's `git.push: false` was flipped back to `true` and tags/commits got pushed anyway. Silent reversal of a safety opt-out.

## Fix
- `merge.ts`: `push: packageLevel.push ?? base.push` (was unconditional).
- Schema: drop the `.default(true)` on `publish.git.push` (now optional) so an unset value genuinely falls through. The effective default-push still applies via `loadPublishConfig`'s `?? true`.
- Tests: explicit `git.push: false` + a `publish.git` block → stays `false`; an explicit `publish.git.push: true` still overrides.

Regenerated schema + configuration.md. Config/publish suites green.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes how package-level publish git settings inherit the top-level push setting.

- `mergeGitConfig` now falls back to top-level `git.push` when `publish.git.push` is unset.
- `publish.git.push` is now optional in the runtime schema and generated JSON schema.
- Configuration docs now describe the inherited behavior.
- Unit tests cover inherited `false` and explicit package-level override cases.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/config/src/merge.ts | Updates git config merging so an unset package-level push value inherits the top-level setting. |
| packages/config/src/schema.ts | Makes `publish.git.push` optional so merge inheritance can distinguish unset from explicit values. |
| packages/config/test/unit/load.spec.ts | Adds tests for inherited top-level `git.push: false` and explicit package-level override behavior. |
| releasekit.schema.json | Removes the generated default from `publish.git.push` to match the runtime schema. |
| docs/configuration.md | Documents that `publish.git.push` inherits the top-level push setting when unset. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(config): inherit top-level git.push ..."](https://github.com/goosewobbler/releasekit/commit/44a56f43581bfd58c49070ba0745ad45bf57967e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40141701)</sub>

<!-- /greptile_comment -->