### PR TITLE
refactor(version): remove dead baseBranch plumbing

### DIFF
--- a/packages/version/src/config.ts
+++ b/packages/version/src/config.ts
@@ -4,7 +4,7 @@ import { toVersionConfig } from './types.js';
 
 export function loadConfig(options?: LoadOptions): Config {
   const fullConfig = loadReleaseKitConfig(options);
-  return toVersionConfig(fullConfig.version, fullConfig.git);
+  return toVersionConfig(fullConfig.version);
 }
 
 export type { LoadOptions } from '@releasekit/config';

--- a/packages/version/src/core/groupStrategy.ts
+++ b/packages/version/src/core/groupStrategy.ts
@@ -119,7 +119,6 @@ async function planMember(
   const ownNext = await calculateVersion(config, {
     latestTag,
     versionPrefix: formattedPrefix,
-    baseBranch: config.baseBranch,
     prereleaseIdentifier: config.prereleaseIdentifier,
     path: pkg.dir,
     name,

--- a/packages/version/src/core/versionStrategies.ts
+++ b/packages/version/src/core/versionStrategies.ts
@@ -107,7 +107,6 @@ export function createSyncStrategy(config: Config): StrategyFunction {
       const {
         versionPrefix,
         tagTemplate,
-        baseBranch,
         commitMessage = `chore: release \${packageName} v\${version}`,
         prereleaseIdentifier,
         dryRun,
@@ -193,7 +192,6 @@ export function createSyncStrategy(config: Config): StrategyFunction {
       const nextVersion = await calculateVersion(config, {
         latestTag,
         versionPrefix: formattedPrefix,
-        baseBranch,
         prereleaseIdentifier,
         path: versionSourcePath,
         commitCheckPath: repoRoot,
@@ -534,7 +532,6 @@ export function createSingleStrategy(config: Config): StrategyFunction {
       nextVersion = await calculateVersion(config, {
         latestTag,
         versionPrefix: formattedPrefix,
-        baseBranch: config.baseBranch,
         prereleaseIdentifier: config.prereleaseIdentifier,
         path: pkgPath,
         name: packageName,
@@ -698,7 +695,6 @@ export function createAsyncStrategy(config: Config): StrategyFunction {
     fullConfig: config,
     // Extract common version configuration properties
     config: {
-      baseBranch: config.baseBranch || 'main',
       prereleaseIdentifier: config.prereleaseIdentifier,
       type: config.type,
       // Without this the per-package resolver always saw strictReachable=false, so the async path

--- a/packages/version/src/package/packageProcessor.ts
+++ b/packages/version/src/package/packageProcessor.ts
@@ -189,7 +189,6 @@ export class PackageProcessor {
         versionPrefix: formattedPrefix,
         path: pkgPath,
         name,
-        baseBranch: this.config.baseBranch,
         prereleaseIdentifier: this.config.prereleaseIdentifier,
         type: this.config.type,
       });

--- a/packages/version/src/types.ts
+++ b/packages/version/src/types.ts
@@ -1,4 +1,4 @@
-import type { GitConfig, VersionConfig, VersionGroup } from '@releasekit/config';
+import type { VersionConfig, VersionGroup } from '@releasekit/config';
 import type { ReleaseType } from 'semver';
 
 /**
@@ -67,7 +67,6 @@ export interface VersionConfigBase {
   versionPrefix: string;
   type?: ReleaseType;
   prereleaseIdentifier?: string;
-  baseBranch?: string;
   path?: string;
   /** Override the directory used for commit-count checks. When set, commit counting
    *  uses this path instead of `path`. Useful in sync mode where the version is read
@@ -178,7 +177,7 @@ export interface PackageVersion {
   dryRun?: boolean;
 }
 
-export function toVersionConfig(config: VersionConfig | undefined, gitConfig?: GitConfig): Config {
+export function toVersionConfig(config: VersionConfig | undefined): Config {
   if (!config) {
     return {
       tagTemplate: 'v{version}',
@@ -187,7 +186,6 @@ export function toVersionConfig(config: VersionConfig | undefined, gitConfig?: G
       sync: true,
       packages: [],
       versionPrefix: '',
-      baseBranch: gitConfig?.branch,
     };
   }
 
@@ -209,7 +207,6 @@ export function toVersionConfig(config: VersionConfig | undefined, gitConfig?: G
     zeroMajor: config.zeroMajor,
     versionPrefix: config.versionPrefix ?? '',
     prereleaseIdentifier: config.prereleaseIdentifier,
-    baseBranch: gitConfig?.branch,
     cargo: config.cargo,
     pub: config.pub,
   };

--- a/packages/version/test/unit/config.spec.ts
+++ b/packages/version/test/unit/config.spec.ts
@@ -89,19 +89,5 @@ describe('Config', () => {
 
       expect(() => loadConfig({ cwd: dir })).toThrow();
     });
-
-    it('should read baseBranch from top-level git.branch', () => {
-      const dir = createTmpDir();
-      fs.writeFileSync(
-        path.join(dir, 'releasekit.config.json'),
-        JSON.stringify({
-          git: { branch: 'develop' },
-          version: { preset: 'angular' },
-        }),
-      );
-
-      const config = loadConfig({ cwd: dir });
-      expect(config.baseBranch).toBe('develop');
-    });
   });
 });

--- a/packages/version/test/unit/core/groupStrategy.spec.ts
+++ b/packages/version/test/unit/core/groupStrategy.spec.ts
@@ -49,7 +49,6 @@ const baseConfig = (overrides: Partial<Config>): Config =>
     packages: [],
     tagTemplate: '${prefix}${version}',
     versionPrefix: '',
-    baseBranch: 'main',
     ...overrides,
   }) as Config;
 

--- a/packages/version/test/unit/core/versionCalculator.spec.ts
+++ b/packages/version/test/unit/core/versionCalculator.spec.ts
@@ -50,7 +50,6 @@ describe('Version Calculator', () => {
     preset: 'angular',
     versionPrefix: 'v',
     tagTemplate: '${' + 'prefix}${' + 'version}',
-    baseBranch: 'main',
   };
 
   beforeEach(() => {

--- a/packages/version/test/unit/core/versionEngine.spec.ts
+++ b/packages/version/test/unit/core/versionEngine.spec.ts
@@ -51,7 +51,6 @@ describe('Version Engine', () => {
     sync: true,
     versionPrefix: 'v',
     tagTemplate: '${' + 'packageName}@${' + 'prefix}${' + 'version}',
-    baseBranch: 'main',
     packages: [],
   };
 
@@ -91,7 +90,6 @@ describe('Version Engine', () => {
         sync: true,
         versionPrefix: 'v',
         tagTemplate: '${' + 'packageName}@${' + 'prefix}${' + 'version}',
-        baseBranch: 'main',
         packages: [],
       };
 

--- a/packages/version/test/unit/core/versionStrategies.spec.ts
+++ b/packages/version/test/unit/core/versionStrategies.spec.ts
@@ -87,7 +87,6 @@ describe('Version Strategies', () => {
     preset: 'conventional-commits',
     versionPrefix: 'v',
     tagTemplate: '${' + 'prefix}${' + 'version}',
-    baseBranch: 'main',
   };
 
   beforeEach(() => {

--- a/packages/version/test/unit/package/packageProcessor.spec.ts
+++ b/packages/version/test/unit/package/packageProcessor.spec.ts
@@ -119,7 +119,6 @@ describe('Package Processor', () => {
     preset: 'conventional',
     versionPrefix: 'v',
     tagTemplate: '${prefix}${version}',
-    baseBranch: 'main',
     packages: [],
     commitMessage: 'chore(release): version ${version}',
   };
@@ -135,7 +134,6 @@ describe('Package Processor', () => {
     dryRun: false,
     getLatestTag: mockGetLatestTag,
     config: {
-      baseBranch: 'main',
       prereleaseIdentifier: undefined,
       type: undefined,
     },


### PR DESCRIPTION
Closes #448. Follow-up to the branch-pattern removal.

`baseBranch` (sourced from `git.branch`) was threaded through `toVersionConfig` and every strategy into `calculateVersion`, but **nothing ever read it** — branch logic used a live `getCurrentBranch()` call (the only consumer was the now-removed branch-pattern matcher). Removed: the `VersionConfigBase.baseBranch` field, the `toVersionConfig` `gitConfig` param (its sole use) + the `GitConfig` import, the strategy pass-throughs, and the dead test/fixtures.

`git.branch` itself is untouched (still live in publish git-push + standing-pr). Version/config suites green.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR removes unused branch plumbing from version calculation. The main changes are:

- Drops `baseBranch` from version config types and conversion.
- Stops passing `git.branch` into version config loading.
- Removes `baseBranch` forwarding from version strategies and package processing.
- Updates unit test fixtures for the slimmer config shape.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/version/src/types.ts | Removes `baseBranch` from the version config shape and simplifies `toVersionConfig`. |
| packages/version/src/config.ts | Updates config loading to pass only version settings into `toVersionConfig`. |
| packages/version/src/core/versionStrategies.ts | Removes `baseBranch` forwarding from sync, single, and async strategy setup. |
| packages/version/src/core/groupStrategy.ts | Removes `baseBranch` from grouped package version planning. |
| packages/version/src/package/packageProcessor.ts | Removes `baseBranch` from package-level version calculation inputs. |
| packages/version/test/unit/config.spec.ts | Removes the test that expected `git.branch` to populate version config. |
| packages/version/test/unit/core/groupStrategy.spec.ts | Updates grouped strategy fixtures to omit `baseBranch`. |
| packages/version/test/unit/core/versionCalculator.spec.ts | Updates version calculator fixtures to omit `baseBranch`. |
| packages/version/test/unit/core/versionEngine.spec.ts | Updates version engine fixtures to omit `baseBranch`. |
| packages/version/test/unit/core/versionStrategies.spec.ts | Updates strategy fixtures to omit `baseBranch`. |
| packages/version/test/unit/package/packageProcessor.spec.ts | Updates package processor fixtures and mocked config inputs to omit `baseBranch`. |

</details>

<sub>Reviews (2): Last reviewed commit: ["refactor(version): remove dead baseBranc..."](https://github.com/goosewobbler/releasekit/commit/f7c8165670e123ff25e9438cbdaaaf722bf0c1a4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40142321)</sub>

<!-- /greptile_comment -->