### PR TITLE
feat(config): migration errors for removed ci/monorepo keys

### DIFF
--- a/packages/config/src/load.ts
+++ b/packages/config/src/load.ts
@@ -79,6 +79,28 @@ function assertNoRemovedVersionFields(config: unknown): void {
   );
 }
 
+/**
+ * `ci.autoRelease` was removed (it had no effect), and the top-level `ci.skipPatterns` / `ci.minChanges`
+ * were shadowed dead duplicates — the live settings are `release.ci.skipPatterns` / `release.ci.minChanges`.
+ * `monorepo.mainPackage` duplicated `version.mainPackage`. Fail loudly with migration guidance rather than
+ * silently stripping these (which also diverges from the JSON schema's unknown-key rejection).
+ */
+function assertNoRemovedTopLevelFields(config: unknown): void {
+  if (!isRecord(config)) return;
+  if (isRecord(config.ci)) {
+    const removed = ['autoRelease', 'skipPatterns', 'minChanges'].filter((k) => k in (config.ci as object));
+    if (removed.length > 0) {
+      throw new ConfigError(
+        `ci no longer supports ${removed.join(', ')}. autoRelease was removed (it had no effect); ` +
+          'skipPatterns and minChanges live under release.ci (release.ci.skipPatterns / release.ci.minChanges).',
+      );
+    }
+  }
+  if (isRecord(config.monorepo) && 'mainPackage' in config.monorepo) {
+    throw new ConfigError('monorepo.mainPackage was removed — use version.mainPackage instead.');
+  }
+}
+
 function loadConfigFile(configPath: string): ReleaseKitConfig {
   if (!fs.existsSync(configPath)) {
     return {};
@@ -90,6 +112,7 @@ function loadConfigFile(configPath: string): ReleaseKitConfig {
     const substituted = substituteInObject(parsed);
     assertNoRemovedReleaseNotesFields(substituted);
     assertNoRemovedVersionFields(substituted);
+    assertNoRemovedTopLevelFields(substituted);
     return ReleaseKitConfigSchema.parse(substituted);
   } catch (error: unknown) {
     if (error instanceof z.ZodError) {

--- a/packages/config/test/unit/load.spec.ts
+++ b/packages/config/test/unit/load.spec.ts
@@ -106,6 +106,20 @@ describe('loadConfig', () => {
     expect(() => loadConfig()).toThrow(/version no longer supports/);
   });
 
+  it('should throw a migration error for removed ci fields', () => {
+    mockedFs.existsSync.mockReturnValue(true);
+    mockedFs.readFileSync.mockReturnValue(JSON.stringify({ ci: { skipPatterns: ['chore: release '] } }));
+
+    expect(() => loadConfig()).toThrow(/ci no longer supports/);
+  });
+
+  it('should throw a migration error for the removed monorepo.mainPackage', () => {
+    mockedFs.existsSync.mockReturnValue(true);
+    mockedFs.readFileSync.mockReturnValue(JSON.stringify({ monorepo: { mainPackage: 'core' } }));
+
+    expect(() => loadConfig()).toThrow(/monorepo\.mainPackage was removed/);
+  });
+
   it('should parse JSONC with comments', () => {
     mockedFs.existsSync.mockReturnValue(true);
     mockedFs.readFileSync.mockReturnValue(`{


### PR DESCRIPTION
Consistency follow-up to #449 (which made removed *version* keys fail loudly). The dead-config removal (#444) stripped `ci.autoRelease`, the top-level `ci.skipPatterns`/`ci.minChanges`, and `monorepo.mainPackage` — but a config still carrying them silently stripped at runtime while the generated JSON schema rejects the same keys.

Adds `assertNoRemovedTopLevelFields` (matching the existing `notes.releaseNotes` / version migration pattern): such a config now throws a `ConfigError` pointing at the live homes — `release.ci.skipPatterns` / `release.ci.minChanges` and `version.mainPackage`. Tests added; config suite green (212).

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds loud migration errors for removed config keys. The main changes are:

- A new config-load guard for removed top-level `ci` fields.
- A new config-load guard for removed `monorepo.mainPackage`.
- Unit tests for the new migration errors.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/config/src/load.ts | Adds migration checks for removed `ci` and `monorepo.mainPackage` config fields. |
| packages/config/test/unit/load.spec.ts | Adds unit coverage for the new migration errors. |

</details>

<sub>Reviews (3): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mai..."](https://github.com/goosewobbler/releasekit/commit/5a2d36e757c59ba57a8b0d31be251044a235d217) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40142763)</sub>

<!-- /greptile_comment -->