### PR TITLE
refactor(config)!: remove dead monorepo.mode

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -46,7 +46,6 @@ Monorepo configuration.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `mode` | `"root"` \| `"packages"` \| `"both"` | — | Changelog aggregation mode |
 | `rootPath` | string | — | Path to root changelog |
 | `packagesPath` | string | — | Path to packages directory |
 

--- a/packages/config/src/load.ts
+++ b/packages/config/src/load.ts
@@ -79,6 +79,16 @@ function assertNoRemovedVersionFields(config: unknown): void {
   );
 }
 
+/**
+ * `monorepo.mode` was removed — it never drove behaviour (changelog aggregation is controlled by
+ * notes.changelog.mode). Fail loudly with migration guidance rather than silently stripping it.
+ */
+function assertNoRemovedMonorepoMode(config: unknown): void {
+  if (isRecord(config) && isRecord(config.monorepo) && 'mode' in config.monorepo) {
+    throw new ConfigError('monorepo.mode was removed — changelog aggregation is controlled by notes.changelog.mode.');
+  }
+}
+
 function loadConfigFile(configPath: string): ReleaseKitConfig {
   if (!fs.existsSync(configPath)) {
     return {};
@@ -90,6 +100,7 @@ function loadConfigFile(configPath: string): ReleaseKitConfig {
     const substituted = substituteInObject(parsed);
     assertNoRemovedReleaseNotesFields(substituted);
     assertNoRemovedVersionFields(substituted);
+    assertNoRemovedMonorepoMode(substituted);
     return ReleaseKitConfigSchema.parse(substituted);
   } catch (error: unknown) {
     if (error instanceof z.ZodError) {

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -22,7 +22,6 @@ export const GitConfigSchema = z.object({
 });
 
 export const MonorepoConfigSchema = z.object({
-  mode: z.enum(['root', 'packages', 'both']).optional().describe('Changelog aggregation mode'),
   rootPath: z.string().optional().describe('Path to root changelog'),
   packagesPath: z.string().optional().describe('Path to packages directory'),
 });

--- a/packages/config/test/unit/load.spec.ts
+++ b/packages/config/test/unit/load.spec.ts
@@ -106,6 +106,13 @@ describe('loadConfig', () => {
     expect(() => loadConfig()).toThrow(/version no longer supports/);
   });
 
+  it('should throw a migration error for the removed monorepo.mode', () => {
+    mockedFs.existsSync.mockReturnValue(true);
+    mockedFs.readFileSync.mockReturnValue(JSON.stringify({ monorepo: { mode: 'packages' } }));
+
+    expect(() => loadConfig()).toThrow(/monorepo\.mode was removed/);
+  });
+
   it('should parse JSONC with comments', () => {
     mockedFs.existsSync.mockReturnValue(true);
     mockedFs.readFileSync.mockReturnValue(`{

--- a/packages/config/test/unit/schema.spec.ts
+++ b/packages/config/test/unit/schema.spec.ts
@@ -54,15 +54,10 @@ describe('MonorepoConfigSchema', () => {
     expect(result).toEqual({});
   });
 
-  it('should accept valid mode values', () => {
-    for (const mode of ['root', 'packages', 'both'] as const) {
-      const result = MonorepoConfigSchema.parse({ mode });
-      expect(result.mode).toBe(mode);
-    }
-  });
-
-  it('should reject invalid mode', () => {
-    expect(() => MonorepoConfigSchema.parse({ mode: 'invalid' })).toThrow();
+  it('should accept rootPath and packagesPath', () => {
+    const result = MonorepoConfigSchema.parse({ rootPath: 'CHANGELOG.md', packagesPath: 'packages' });
+    expect(result.rootPath).toBe('CHANGELOG.md');
+    expect(result.packagesPath).toBe('packages');
   });
 });
 
@@ -664,14 +659,14 @@ describe('ReleaseKitConfigSchema', () => {
   it('should accept all sections', () => {
     const result = ReleaseKitConfigSchema.parse({
       git: { remote: 'origin' },
-      monorepo: { mode: 'packages' },
+      monorepo: { rootPath: 'CHANGELOG.md' },
       version: { preset: 'conventional' },
       publish: { npm: { enabled: true } },
       notes: { changelog: { mode: 'packages' } },
       ci: { prPreview: true },
     });
     expect(result.git?.remote).toBe('origin');
-    expect(result.monorepo?.mode).toBe('packages');
+    expect(result.monorepo?.rootPath).toBe('CHANGELOG.md');
     expect(result.version?.preset).toBe('conventional');
     expect(result.publish?.npm.enabled).toBe(true);
     expect(result.notes?.changelog).toMatchObject({ mode: 'packages' });

--- a/packages/notes/src/command.ts
+++ b/packages/notes/src/command.ts
@@ -167,7 +167,6 @@ export function createNotesCommand(): Command {
 
         if (options.monorepo) {
           const monoMode = options.monorepo as 'root' | 'packages' | 'both';
-          config.monorepo = { ...config.monorepo, mode: monoMode };
           // Wire --monorepo through to the changelog's location mode. Release notes use a per-version
           // directory rather than location modes, so they're unaffected.
           if (config.changelog !== false && !options.changelogMode) {

--- a/releasekit.schema.json
+++ b/releasekit.schema.json
@@ -52,15 +52,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "mode": {
-          "type": "string",
-          "enum": [
-            "root",
-            "packages",
-            "both"
-          ],
-          "description": "Changelog aggregation mode"
-        },
         "rootPath": {
           "type": "string",
           "description": "Path to root changelog"


### PR DESCRIPTION
The audit's last dead-config straggler.

`monorepo.mode` (the config-file field) never drove behaviour — changelog aggregation is `notes.changelog.mode`, and the notes pipeline reads only `monorepo.rootPath`/`packagesPath`. The `--monorepo` CLI flag *also* wrote `config.monorepo.mode`, but its real effect is setting `changelog.mode`; that wiring stays, only the dead `config.monorepo` write is removed.

- Removed `MonorepoConfigSchema.mode` + the dead command.ts write.
- Added a migration error (loud-fail with guidance to `notes.changelog.mode`), consistent with the other removed-key migrations.
- Regenerated schema + configuration.md; updated tests.

**BREAKING:** `monorepo.mode` is removed (it had no effect). Config/notes suites green.

_Note: lightly overlaps #452 in load.ts (both add a migration check) — trivial merge resolution._

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR removes the unused `monorepo.mode` config field. The main changes are:

- Removed `monorepo.mode` from the config schema, generated schema, and docs.
- Added a migration error that points users to `notes.changelog.mode`.
- Kept the notes CLI `--monorepo` behavior wired through changelog mode.
- Updated config and schema tests for the removed field.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/config/src/load.ts | Adds a migration error for legacy `monorepo.mode` config. |
| packages/config/src/schema.ts | Removes `mode` from the monorepo config schema. |
| packages/notes/src/command.ts | Stops writing the removed monorepo field while preserving `--monorepo` changelog behavior. |
| releasekit.schema.json | Removes `monorepo.mode` from the generated schema. |
| docs/configuration.md | Removes the obsolete `monorepo.mode` documentation entry. |

</details>

<sub>Reviews (2): Last reviewed commit: ["refactor(config)!: remove dead monorepo...."](https://github.com/goosewobbler/releasekit/commit/def6ff117a40bb94cf800689f657821e1a5e6265) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40143367)</sub>

<!-- /greptile_comment -->