### PR TITLE
fix(notes): make scopes.mode 'packages' use workspace package names

### DIFF
--- a/packages/notes/src/core/pipeline.ts
+++ b/packages/notes/src/core/pipeline.ts
@@ -197,6 +197,7 @@ async function processWithLLM(
   context: TemplateContext,
   llmConfig: LLMConfig,
   examples: Example[],
+  packageNames: string[],
 ): Promise<TemplateContext> {
   const tasks = llmConfig.tasks ?? {};
   const llmContext = {
@@ -209,6 +210,7 @@ async function processWithLLM(
     scopes: llmConfig.scopes,
     prompts: llmConfig.prompts,
     examples,
+    packageNames,
   };
 
   const enhanced: EnhancedData = {
@@ -453,8 +455,11 @@ export async function runPipeline(
       }));
     }
 
+    const allPackageNames = contexts.map((c) => c.packageName);
     contexts = await Promise.all(
-      contexts.map((ctx) => processWithLLM(ctx, llmConfig, examplesByPackage.get(ctx.packageName) ?? [])),
+      contexts.map((ctx) =>
+        processWithLLM(ctx, llmConfig, examplesByPackage.get(ctx.packageName) ?? [], allPackageNames),
+      ),
     );
   }
 

--- a/packages/notes/src/llm/index.ts
+++ b/packages/notes/src/llm/index.ts
@@ -25,6 +25,8 @@ export interface LLMContext {
   packageName?: string;
   version?: string;
   previousVersion?: string;
+  /** Workspace package names — the allow-list for `scopes.mode: 'packages'` scope validation. */
+  packageNames?: string[];
 }
 
 export type { Example } from './examples/types.js';

--- a/packages/notes/src/llm/scopes.ts
+++ b/packages/notes/src/llm/scopes.ts
@@ -87,8 +87,9 @@ export function validateEntryScopes(
   entries: ChangelogEntry[],
   scopeConfig: ScopeConfig | undefined,
   categories?: LLMCategory[],
+  packageNames?: string[],
 ): ScopeValidationResult {
-  const allowedScopes = resolveAllowedScopes(scopeConfig, categories);
+  const allowedScopes = resolveAllowedScopes(scopeConfig, categories, packageNames);
   if (allowedScopes === null) return { valid: true, entries, errors: [] };
 
   const caseSensitive = scopeConfig?.rules?.caseSensitive ?? false;

--- a/packages/notes/src/llm/scopes.ts
+++ b/packages/notes/src/llm/scopes.ts
@@ -29,6 +29,23 @@ export function getAllowedScopesFromCategories(categories: LLMCategory[]): Map<s
 }
 
 /**
+ * Expand workspace package names into the scope forms a conventional-commit might use: the full
+ * name, the unscoped form (`@acme/core` → `acme/core`), and the bare short name
+ * (`@acme/core` → `core`). Commit scopes are typically short (`core`), not the full npm name, so
+ * `scopes.mode: 'packages'` must accept all three to avoid stripping a valid package scope.
+ */
+function expandPackageScopes(packageNames: string[]): string[] {
+  const forms = new Set<string>();
+  for (const name of packageNames) {
+    forms.add(name);
+    forms.add(name.replace(/^@/, ''));
+    const slash = name.lastIndexOf('/');
+    forms.add(slash >= 0 ? name.slice(slash + 1) : name);
+  }
+  return [...forms];
+}
+
+/**
  * Build the complete allowed scope list from config + categories.
  * Returns `null` for unrestricted, `[]` for none, populated array for restricted/packages.
  */
@@ -39,7 +56,7 @@ export function resolveAllowedScopes(
 ): string[] | null {
   if (!scopeConfig || scopeConfig.mode === 'unrestricted') return null;
   if (scopeConfig.mode === 'none') return [];
-  if (scopeConfig.mode === 'packages') return packageNames ?? [];
+  if (scopeConfig.mode === 'packages') return expandPackageScopes(packageNames ?? []);
 
   if (scopeConfig.mode === 'restricted') {
     const explicit = scopeConfig.rules?.allowed ?? [];

--- a/packages/notes/src/llm/tasks/categorize.ts
+++ b/packages/notes/src/llm/tasks/categorize.ts
@@ -83,7 +83,7 @@ export function createCategorizeValidator(
     // Validate scopes. The validator applies `invalidScopeAction` (default `remove`) and
     // returns `valid: true` — scope mismatches don't trigger an LLM retry, since the configured
     // action defines the resolution. Surface a warning so disallowed scopes stay visible.
-    const scopeResult = validateEntryScopes(withScopes, context.scopes, context.categories);
+    const scopeResult = validateEntryScopes(withScopes, context.scopes, context.categories, context.packageNames);
     if (scopeResult.errors.length > 0) {
       const offenders = [...new Set(scopeResult.errors.map((e) => e.providedScope))];
       warn(

--- a/packages/notes/src/llm/tasks/enhance-and-categorize.ts
+++ b/packages/notes/src/llm/tasks/enhance-and-categorize.ts
@@ -121,7 +121,7 @@ export function createEnhanceAndCategorizeValidator(
     // returns `valid: true` once the action has been applied — we don't retry the LLM for
     // scope mismatches, since the configured action defines the resolution. We do surface a
     // warning so users can see which scopes the LLM produced that didn't match the allow list.
-    const scopeResult = validateEntryScopes(enhancedEntries, context.scopes, context.categories);
+    const scopeResult = validateEntryScopes(enhancedEntries, context.scopes, context.categories, context.packageNames);
     if (scopeResult.errors.length > 0) {
       const offenders = [...new Set(scopeResult.errors.map((e) => e.providedScope))];
       warn(

--- a/packages/notes/test/unit/scopes.spec.ts
+++ b/packages/notes/test/unit/scopes.spec.ts
@@ -66,9 +66,10 @@ describe('resolveAllowedScopes()', () => {
     expect(resolveAllowedScopes({ mode: 'none' })).toEqual([]);
   });
 
-  it('should return package names for packages mode', () => {
-    const result = resolveAllowedScopes({ mode: 'packages' }, undefined, ['@acme/core', '@acme/ui']);
-    expect(result).toEqual(['@acme/core', '@acme/ui']);
+  it('should return package names and their short forms for packages mode', () => {
+    const result = resolveAllowedScopes({ mode: 'packages' }, undefined, ['@acme/core', 'standalone']);
+    // Full name, unscoped form, and bare short name — so a commit scoped `core` matches `@acme/core`.
+    expect(result).toEqual(expect.arrayContaining(['@acme/core', 'acme/core', 'core', 'standalone']));
   });
 
   it('should return empty array for packages mode without package names', () => {

--- a/packages/notes/test/unit/scopes.spec.ts
+++ b/packages/notes/test/unit/scopes.spec.ts
@@ -173,6 +173,21 @@ describe('validateEntryScopes()', () => {
     expect(result.errors).toHaveLength(0);
   });
 
+  it('should use packageNames as the allow-list for packages mode', () => {
+    const result = validateEntryScopes(entries, { mode: 'packages' }, undefined, ['CI', 'core']);
+    expect(result.valid).toBe(true);
+    // 'CI' is a workspace package name → kept; 'InvalidScope' is not → removed (default action).
+    expect(result.entries[0]?.scope).toBe('CI');
+    expect(result.entries[1]?.scope).toBeUndefined();
+    expect(result.errors).toHaveLength(1);
+  });
+
+  it('should strip all scopes in packages mode when no packageNames are provided', () => {
+    const result = validateEntryScopes(entries, { mode: 'packages' });
+    expect(result.entries[0]?.scope).toBeUndefined();
+    expect(result.entries[1]?.scope).toBeUndefined();
+  });
+
   it('should strip all scopes for none mode (and remain valid — invalidScopeAction defines resolution)', () => {
     const result = validateEntryScopes(entries, { mode: 'none' });
     expect(result.valid).toBe(true);


### PR DESCRIPTION
Closes #446.

## Bug
`notes.releaseNotes.llm.scopes.mode: 'packages'` is documented to derive the scope allow-list from workspace package names, but `validateEntryScopes` invoked `resolveAllowedScopes` **without** the `packageNames` argument. So the 'packages' branch returned `[]`, and `validateScope` treats an empty allow-list as 'strip every scope' — making `packages` mode behave identically to `none` (silently dropping all scopes).

## Fix
Thread the workspace package names through: the pipeline collects them from the per-package contexts, sets `packageNames` on the LLM context, and the two scope-validating tasks (`categorize`, `enhance-and-categorize`) pass them to `validateEntryScopes` → `resolveAllowedScopes`. Added tests for packages-mode validation with and without package names. Notes suite green.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes package-based scope validation for notes generated with LLM tasks. The main changes are:

- Package names are passed from the notes pipeline into the LLM context.
- Scope validation now receives package names in both categorize tasks.
- Scoped package names are expanded into full, unscoped, and short scope forms.
- Unit tests cover package-mode validation with and without package names.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/notes/src/core/pipeline.ts | Collects package names from the notes contexts and passes them into LLM processing. |
| packages/notes/src/llm/index.ts | Adds package names to the LLM context shape. |
| packages/notes/src/llm/scopes.ts | Expands package names into accepted scope forms and threads them through validation. |
| packages/notes/src/llm/tasks/categorize.ts | Uses package names when validating categorized entry scopes. |
| packages/notes/src/llm/tasks/enhance-and-categorize.ts | Uses package names when validating enhanced categorized entry scopes. |
| packages/notes/test/unit/scopes.spec.ts | Adds tests for package-mode scope resolution and validation. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(notes): match short package-name for..."](https://github.com/goosewobbler/releasekit/commit/4ad4c72ea3c1aa2fb415d6694f6a3c8e42f9930e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40144298)</sub>

<!-- /greptile_comment -->