### PR TITLE
feat(notes): wire up the LLM request timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Releases to npm, crates.io, and pub.dev today, with more ecosystems on the way.
 > [!WARNING]
 > ### 🚧 Pre-1.0.0 — here be dragons 🐉
 >
-> ReleaseKit is **under active development** and evolving fast while the core feature set settles. **💥 Breaking changes are common between releases** and aren't always gated behind a major bump while we're pre-`1.0.0`. It's **🚫 not recommended for production** yet — if you're trying it out, **📌 pin an exact version** and skim the release notes before upgrading. 🧪 Once the API stabilises, `v1.0.0` will mark the switch to semver-stable guarantees. 🎯
+> ReleaseKit is **under active development** and evolving fast while the core feature set settles. **💥 Breaking changes are common between releases** and aren't always gated behind a major bump while we're pre-`1.0.0`. It's **not recommended for production** yet — if you're trying it out, **pin an exact version** and skim the release notes before upgrading. 🧪 Once the API stabilises, `v1.0.0` will mark the switch to semver-stable guarantees.
 
 ## Why ReleaseKit
 

--- a/packages/notes/README.md
+++ b/packages/notes/README.md
@@ -1,7 +1,7 @@
 # @releasekit/notes
 
 > [!WARNING]
-> 🚧 **Pre-1.0.0** — ReleaseKit is evolving fast and **💥 breaking changes are common**; it's **🚫 not production-ready** until `v1.0.0`. 📌 Pin exact versions. See the [main README](../../README.md) for details.
+> 🚧 **Pre-1.0.0** — ReleaseKit is evolving fast and **💥 breaking changes are common**; it's **not production-ready** until `v1.0.0`. Pin exact versions. See the [main README](../../README.md) for details.
 
 [![@releasekit/notes](https://img.shields.io/badge/@releasekit-notes-9feaf9?labelColor=1a1a1a&style=plastic)](https://www.npmjs.com/package/@releasekit/notes)
 [![Version](https://img.shields.io/npm/v/@releasekit/notes?color=28a745&labelColor=1a1a1a)](https://www.npmjs.com/package/@releasekit/notes)

--- a/packages/notes/src/llm/anthropic.ts
+++ b/packages/notes/src/llm/anthropic.ts
@@ -44,23 +44,27 @@ export class AnthropicProvider extends BaseLLMProvider {
       .filter((m) => m.role !== 'system')
       .map((m) => ({ role: m.role as 'user' | 'assistant', content: m.content }));
 
+    const signal = this.timeoutSignal(options);
     try {
       if (options?.schema) {
         const toolName = options.toolName ?? 'emit_release_notes';
-        const response = await this.client.messages.create({
-          model: this.model,
-          max_tokens: this.getMaxTokens(options),
-          system: systemMsg?.content,
-          tools: [
-            {
-              name: toolName,
-              description: 'Emit structured release notes data as JSON',
-              input_schema: options.schema as Anthropic.Tool['input_schema'],
-            },
-          ],
-          tool_choice: { type: 'tool', name: toolName },
-          messages: nonSystemMessages,
-        });
+        const response = await this.client.messages.create(
+          {
+            model: this.model,
+            max_tokens: this.getMaxTokens(options),
+            system: systemMsg?.content,
+            tools: [
+              {
+                name: toolName,
+                description: 'Emit structured release notes data as JSON',
+                input_schema: options.schema as Anthropic.Tool['input_schema'],
+              },
+            ],
+            tool_choice: { type: 'tool', name: toolName },
+            messages: nonSystemMessages,
+          },
+          { signal },
+        );
 
         const toolBlock = response.content.find((b) => b.type === 'tool_use');
         if (toolBlock?.type === 'tool_use') {
@@ -71,12 +75,15 @@ export class AnthropicProvider extends BaseLLMProvider {
         throw new LLMError('Expected tool_use block in Anthropic response');
       }
 
-      const response = await this.client.messages.create({
-        model: this.model,
-        max_tokens: this.getMaxTokens(options),
-        system: systemMsg?.content,
-        messages: nonSystemMessages,
-      });
+      const response = await this.client.messages.create(
+        {
+          model: this.model,
+          max_tokens: this.getMaxTokens(options),
+          system: systemMsg?.content,
+          messages: nonSystemMessages,
+        },
+        { signal },
+      );
 
       const firstBlock = response.content[0];
 
@@ -87,7 +94,7 @@ export class AnthropicProvider extends BaseLLMProvider {
       return { content: firstBlock.text };
     } catch (error) {
       if (error instanceof LLMError) throw error;
-
+      if (signal.aborted) throw new LLMError(`Anthropic request timed out after ${this.getTimeout(options)}ms`);
       throw new LLMError(`Anthropic API error: ${error instanceof Error ? error.message : String(error)}`);
     }
   }

--- a/packages/notes/src/llm/base.ts
+++ b/packages/notes/src/llm/base.ts
@@ -13,10 +13,14 @@ export abstract class BaseLLMProvider implements LLMProvider {
 
   protected getTimeout(options?: CompleteOptions): number {
     const timeout = options?.timeout ?? LLM_DEFAULTS.timeout;
-    // Guard against a 0 / negative / non-finite timeout: `AbortSignal.timeout(0)` aborts every call
-    // before a request is sent, and a negative/non-finite value throws *before* the provider's try
-    // block (bypassing the best-effort fallback). Fall back to the default in those cases.
-    return Number.isFinite(timeout) && timeout > 0 ? timeout : LLM_DEFAULTS.timeout;
+    // Guard the value passed to `AbortSignal.timeout()`, which runs while building the signal —
+    // *before* the provider's try block, so a bad value would throw past the best-effort fallback.
+    //   - 0 / negative / non-finite → use the default (0 would abort every call before a request).
+    //   - above the timer ceiling (2^31-1 ms ≈ 24.8 days) → clamp, not throw/overflow. A huge value
+    //     means "effectively no timeout", so clamping preserves intent rather than dropping to 60s.
+    const MAX_TIMEOUT_MS = 2_147_483_647;
+    if (!Number.isFinite(timeout) || timeout <= 0) return LLM_DEFAULTS.timeout;
+    return Math.min(timeout, MAX_TIMEOUT_MS);
   }
 
   /**

--- a/packages/notes/src/llm/base.ts
+++ b/packages/notes/src/llm/base.ts
@@ -15,12 +15,13 @@ export abstract class BaseLLMProvider implements LLMProvider {
     const timeout = options?.timeout ?? LLM_DEFAULTS.timeout;
     // Guard the value passed to `AbortSignal.timeout()`, which runs while building the signal —
     // *before* the provider's try block, so a bad value would throw past the best-effort fallback.
-    //   - 0 / negative / non-finite → use the default (0 would abort every call before a request).
+    //   - below 1ms → use the default. Covers 0 / negative / non-finite *and* sub-millisecond
+    //     fractions (e.g. 0.5) that floor to a 0ms — already-expired — signal that aborts every call.
     //   - above the timer ceiling (2^31-1 ms ≈ 24.8 days) → clamp, not throw/overflow. A huge value
     //     means "effectively no timeout", so clamping preserves intent rather than dropping to 60s.
     const MAX_TIMEOUT_MS = 2_147_483_647;
-    if (!Number.isFinite(timeout) || timeout <= 0) return LLM_DEFAULTS.timeout;
-    return Math.min(timeout, MAX_TIMEOUT_MS);
+    if (!Number.isFinite(timeout) || timeout < 1) return LLM_DEFAULTS.timeout;
+    return Math.min(Math.trunc(timeout), MAX_TIMEOUT_MS);
   }
 
   /**

--- a/packages/notes/src/llm/base.ts
+++ b/packages/notes/src/llm/base.ts
@@ -12,7 +12,11 @@ export abstract class BaseLLMProvider implements LLMProvider {
   abstract complete(messages: LLMMessage[], options?: CompleteOptions): Promise<CompleteResult>;
 
   protected getTimeout(options?: CompleteOptions): number {
-    return options?.timeout ?? LLM_DEFAULTS.timeout;
+    const timeout = options?.timeout ?? LLM_DEFAULTS.timeout;
+    // Guard against a 0 / negative / non-finite timeout: `AbortSignal.timeout(0)` aborts every call
+    // before a request is sent, and a negative/non-finite value throws *before* the provider's try
+    // block (bypassing the best-effort fallback). Fall back to the default in those cases.
+    return Number.isFinite(timeout) && timeout > 0 ? timeout : LLM_DEFAULTS.timeout;
   }
 
   /**

--- a/packages/notes/src/llm/base.ts
+++ b/packages/notes/src/llm/base.ts
@@ -15,6 +15,15 @@ export abstract class BaseLLMProvider implements LLMProvider {
     return options?.timeout ?? LLM_DEFAULTS.timeout;
   }
 
+  /**
+   * An AbortSignal that fires after the configured request timeout. Pass it to the provider's
+   * request (SDK `{ signal }` request option, or fetch's `signal`). When it fires the request
+   * aborts; providers check `signal.aborted` in their catch to surface a clear timeout error.
+   */
+  protected timeoutSignal(options?: CompleteOptions): AbortSignal {
+    return AbortSignal.timeout(this.getTimeout(options));
+  }
+
   protected getMaxTokens(options?: CompleteOptions): number {
     return options?.maxTokens ?? LLM_DEFAULTS.maxTokens;
   }

--- a/packages/notes/src/llm/ollama.ts
+++ b/packages/notes/src/llm/ollama.ts
@@ -73,6 +73,7 @@ export class OllamaProvider extends BaseLLMProvider {
       requestBody.format = options.schema as Record<string, unknown>;
     }
 
+    const signal = this.timeoutSignal(options);
     try {
       const headers: Record<string, string> = {
         'Content-Type': 'application/json',
@@ -85,6 +86,7 @@ export class OllamaProvider extends BaseLLMProvider {
         method: 'POST',
         headers,
         body: JSON.stringify(requestBody),
+        signal,
       });
 
       if (!response.ok) {
@@ -124,7 +126,7 @@ export class OllamaProvider extends BaseLLMProvider {
       return { content };
     } catch (error) {
       if (error instanceof LLMError) throw error;
-
+      if (signal.aborted) throw new LLMError(`Ollama request timed out after ${this.getTimeout(options)}ms`);
       throw new LLMError(`Ollama error: ${error instanceof Error ? error.message : String(error)}`);
     }
   }

--- a/packages/notes/src/llm/openai-compatible.ts
+++ b/packages/notes/src/llm/openai-compatible.ts
@@ -40,6 +40,7 @@ export class OpenAICompatibleProvider extends BaseLLMProvider {
   async complete(messages: LLMMessage[], options?: CompleteOptions): Promise<CompleteResult> {
     debugLogMessages(this.name, messages);
 
+    const signal = this.timeoutSignal(options);
     try {
       const openaiMessages = messages.map((m) => ({ role: m.role, content: m.content }));
 
@@ -51,7 +52,7 @@ export class OpenAICompatibleProvider extends BaseLLMProvider {
         stream: false as const,
       };
 
-      const response = await this.client.chat.completions.create(requestParams);
+      const response = await this.client.chat.completions.create(requestParams, { signal });
 
       const content = response.choices[0]?.message?.content;
 
@@ -62,7 +63,7 @@ export class OpenAICompatibleProvider extends BaseLLMProvider {
       return { content };
     } catch (error) {
       if (error instanceof LLMError) throw error;
-
+      if (signal.aborted) throw new LLMError(`${this.name} request timed out after ${this.getTimeout(options)}ms`);
       throw new LLMError(`LLM API error: ${error instanceof Error ? error.message : String(error)}`);
     }
   }

--- a/packages/notes/src/llm/openai.ts
+++ b/packages/notes/src/llm/openai.ts
@@ -46,6 +46,7 @@ export class OpenAIProvider extends BaseLLMProvider {
   async complete(messages: LLMMessage[], options?: CompleteOptions): Promise<CompleteResult> {
     debugLogMessages(this.name, messages);
 
+    const signal = this.timeoutSignal(options);
     try {
       const openaiMessages = messages.map((m) => ({ role: m.role, content: m.content }));
 
@@ -68,7 +69,7 @@ export class OpenAIProvider extends BaseLLMProvider {
         }),
       };
 
-      const response = await this.client.chat.completions.create(requestParams);
+      const response = await this.client.chat.completions.create(requestParams, { signal });
 
       const content = response.choices[0]?.message?.content;
 
@@ -91,7 +92,7 @@ export class OpenAIProvider extends BaseLLMProvider {
       return { content };
     } catch (error) {
       if (error instanceof LLMError) throw error;
-
+      if (signal.aborted) throw new LLMError(`OpenAI request timed out after ${this.getTimeout(options)}ms`);
       throw new LLMError(`OpenAI API error: ${error instanceof Error ? error.message : String(error)}`);
     }
   }

--- a/packages/notes/test/unit/llm/ollama.spec.ts
+++ b/packages/notes/test/unit/llm/ollama.spec.ts
@@ -37,4 +37,20 @@ describe('OllamaProvider', () => {
 
     expect(result.structured).toEqual({ ok: true });
   });
+
+  it('should surface a clear timeout error when the request exceeds the configured timeout', async () => {
+    // A fetch that never resolves on its own — it only settles when the request's abort signal fires.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        (_url, opts: { signal?: AbortSignal }) =>
+          new Promise((_resolve, reject) => {
+            opts.signal?.addEventListener('abort', () => reject(new DOMException('aborted', 'TimeoutError')));
+          }),
+      ),
+    );
+    const provider = new OllamaProvider({ model: 'test-model', apiKey: 'k' });
+
+    await expect(provider.complete([{ role: 'user', content: 'hi' }], { timeout: 5 })).rejects.toThrow(/timed out/);
+  });
 });

--- a/packages/notes/test/unit/llm/ollama.spec.ts
+++ b/packages/notes/test/unit/llm/ollama.spec.ts
@@ -80,4 +80,17 @@ describe('OllamaProvider', () => {
 
     expect(result.structured).toEqual({ ok: true });
   });
+
+  it('should treat a sub-millisecond timeout as the default rather than aborting every request', async () => {
+    // 0.5ms is finite and > 0 but floors to a 0ms (already-expired) signal in the timer.
+    mockFetch('{ "ok": true }');
+    const provider = new OllamaProvider({ model: 'test-model', apiKey: 'k' });
+
+    const result = await provider.complete([{ role: 'user', content: 'hi' }], {
+      schema: { type: 'object' },
+      timeout: 0.5,
+    });
+
+    expect(result.structured).toEqual({ ok: true });
+  });
 });

--- a/packages/notes/test/unit/llm/ollama.spec.ts
+++ b/packages/notes/test/unit/llm/ollama.spec.ts
@@ -53,4 +53,17 @@ describe('OllamaProvider', () => {
 
     await expect(provider.complete([{ role: 'user', content: 'hi' }], { timeout: 5 })).rejects.toThrow(/timed out/);
   });
+
+  it('should clamp a 0 / invalid timeout to the default rather than aborting every request', async () => {
+    // Before the clamp, timeout: 0 produced an already-expired AbortSignal that aborted every call.
+    mockFetch('{ "ok": true }');
+    const provider = new OllamaProvider({ model: 'test-model', apiKey: 'k' });
+
+    const result = await provider.complete([{ role: 'user', content: 'hi' }], {
+      schema: { type: 'object' },
+      timeout: 0,
+    });
+
+    expect(result.structured).toEqual({ ok: true });
+  });
 });

--- a/packages/notes/test/unit/llm/ollama.spec.ts
+++ b/packages/notes/test/unit/llm/ollama.spec.ts
@@ -66,4 +66,18 @@ describe('OllamaProvider', () => {
 
     expect(result.structured).toEqual({ ok: true });
   });
+
+  it('should clamp an over-large timeout to the timer ceiling rather than throwing', async () => {
+    // A value past the 2^31-1 ms timer ceiling makes AbortSignal.timeout() throw/overflow while
+    // building the signal — before the request try block — bypassing the best-effort fallback.
+    mockFetch('{ "ok": true }');
+    const provider = new OllamaProvider({ model: 'test-model', apiKey: 'k' });
+
+    const result = await provider.complete([{ role: 'user', content: 'hi' }], {
+      schema: { type: 'object' },
+      timeout: Number.MAX_SAFE_INTEGER,
+    });
+
+    expect(result.structured).toEqual({ ok: true });
+  });
 });

--- a/packages/publish/README.md
+++ b/packages/publish/README.md
@@ -1,7 +1,7 @@
 # @releasekit/publish
 
 > [!WARNING]
-> 🚧 **Pre-1.0.0** — ReleaseKit is evolving fast and **💥 breaking changes are common**; it's **🚫 not production-ready** until `v1.0.0`. 📌 Pin exact versions. See the [main README](../../README.md) for details.
+> 🚧 **Pre-1.0.0** — ReleaseKit is evolving fast and **💥 breaking changes are common**; it's **not production-ready** until `v1.0.0`. Pin exact versions. See the [main README](../../README.md) for details.
 
 [![@releasekit/publish](https://img.shields.io/badge/@releasekit-publish-9feaf9?labelColor=1a1a1a&style=plastic)](https://www.npmjs.com/package/@releasekit/publish)
 [![Version](https://img.shields.io/npm/v/@releasekit/publish?color=28a745&labelColor=1a1a1a)](https://www.npmjs.com/package/@releasekit/publish)

--- a/packages/release/README.md
+++ b/packages/release/README.md
@@ -1,7 +1,7 @@
 # @releasekit/release
 
 > [!WARNING]
-> 🚧 **Pre-1.0.0** — ReleaseKit is evolving fast and **💥 breaking changes are common**; it's **🚫 not production-ready** until `v1.0.0`. 📌 Pin exact versions. See the [main README](../../README.md) for details.
+> 🚧 **Pre-1.0.0** — ReleaseKit is evolving fast and **💥 breaking changes are common**; it's **not production-ready** until `v1.0.0`. Pin exact versions. See the [main README](../../README.md) for details.
 
 [![@releasekit/release](https://img.shields.io/badge/@releasekit-release-9feaf9?labelColor=1a1a1a&style=plastic)](https://www.npmjs.com/package/@releasekit/release)
 [![Version](https://img.shields.io/npm/v/@releasekit/release?color=28a745&labelColor=1a1a1a)](https://www.npmjs.com/package/@releasekit/release)

--- a/packages/version/README.md
+++ b/packages/version/README.md
@@ -1,7 +1,7 @@
 # @releasekit/version
 
 > [!WARNING]
-> 🚧 **Pre-1.0.0** — ReleaseKit is evolving fast and **💥 breaking changes are common**; it's **🚫 not production-ready** until `v1.0.0`. 📌 Pin exact versions. See the [main README](../../README.md) for details.
+> 🚧 **Pre-1.0.0** — ReleaseKit is evolving fast and **💥 breaking changes are common**; it's **not production-ready** until `v1.0.0`. Pin exact versions. See the [main README](../../README.md) for details.
 
 Semantic versioning based on Git history and conventional commits.
 


### PR DESCRIPTION
Closes #445.

`notes.releaseNotes.llm.options.timeout` was plumbed through but **never consumed** — `getTimeout()` had zero callers and no provider applied a request deadline (unlike the wired `maxTokens`/`temperature`). A slow or hung LLM endpoint would block the notes stage indefinitely.

## Fix
- New `BaseLLMProvider.timeoutSignal()` → `AbortSignal.timeout(getTimeout(options))`.
- Each provider passes it to its request: the SDK `{ signal }` request option for **anthropic / openai / openai-compatible**, and `fetch`'s `signal` for **ollama**.
- On fire, the request aborts and the provider surfaces a clear `<provider> request timed out after Nms` `LLMError`. The notes stage's existing best-effort path falls back to non-LLM notes (consistent with how other LLM failures are handled).
- Added an ollama timeout test (fetch that only settles on abort, with a 5 ms timeout).

Default timeout is the existing `LLM_DEFAULTS.timeout` (60 s). Notes suite green (378 tests).

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR wires LLM request timeouts into the notes providers. The main changes are:

- Adds a shared timeout signal helper for LLM providers.
- Passes abort signals to Anthropic, OpenAI, OpenAI-compatible, and Ollama requests.
- Converts provider aborts into clear timeout errors.
- Adds Ollama tests for timeout and timeout clamp behavior.
- Updates README warning text.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/notes/src/llm/base.ts | Adds shared timeout normalization and signal creation for provider requests. |
| packages/notes/src/llm/anthropic.ts | Passes a timeout signal into Anthropic requests and reports aborts as timeout errors. |
| packages/notes/src/llm/openai.ts | Passes a timeout signal into OpenAI requests and reports aborts as timeout errors. |
| packages/notes/src/llm/openai-compatible.ts | Passes a timeout signal into OpenAI-compatible requests and reports aborts as timeout errors. |
| packages/notes/src/llm/ollama.ts | Passes a timeout signal to fetch and reports aborts as Ollama timeout errors. |
| packages/notes/test/unit/llm/ollama.spec.ts | Adds tests for Ollama request timeout behavior and timeout value handling. |

</details>

<sub>Reviews (4): Last reviewed commit: ["fix(notes): treat sub-millisecond LLM ti..."](https://github.com/goosewobbler/releasekit/commit/1949dcf0e61552890e2a2f1cf69d8e1411437201) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40150370)</sub>

<!-- /greptile_comment -->