### PR TITLE
fix(publish): don't push the branch in standing-PR publish

### DIFF
--- a/.github/workflows/_release.reusable.yml
+++ b/.github/workflows/_release.reusable.yml
@@ -40,6 +40,7 @@ on:
 permissions:
   id-token: write
   contents: write
+  pull-requests: write # post the partial-publish failure report on the merged standing PR
 
 env:
   TURBO_TELEMETRY_DISABLED: 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,6 +155,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
+      pull-requests: write # post the partial-publish failure report on the merged standing PR
     with:
       packages: all
       bump: ${{ needs.check-labels.outputs.bump || 'auto' }}
@@ -172,6 +173,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
+      pull-requests: write # post the partial-publish failure report on the merged standing PR
     with:
       packages: ${{ inputs.packages }}
       bump: ${{ inputs.bump }}
@@ -193,6 +195,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
+      pull-requests: write # post the partial-publish failure report on the merged standing PR
     with:
       packages: all
       bump: auto

--- a/packages/publish/src/pipeline/index.ts
+++ b/packages/publish/src/pipeline/index.ts
@@ -75,7 +75,12 @@ export async function runPipeline(
     // tags and baseline tags need to be pushed; the github-release stage filters back down
     // to consumer tags via `ctx.input.tags`.
     if (options.skipGitCommit && !options.skipGit) {
-      ctx.output.git.committed = !!input.commitMessage;
+      // The caller already created the release commit AND it is already on the remote: the
+      // standing-PR squash merge landed it on the target branch before this publish ran. This
+      // runner has no local commit to contribute, so `committed` stays false and the push stage
+      // skips the branch push — only the tags need pushing. Pushing the branch here is at best a
+      // no-op and at worst races a concurrent push to the branch (e.g. a direct edit on GitHub),
+      // whose rejected `git push` would strand the tags and GitHub release behind it.
       ctx.output.git.tags = [...input.tags, ...(input.baselineTags ?? [])];
     } else if (!options.skipGit) {
       await runGitCommitStage(ctx);

--- a/packages/publish/src/stages/git-push.ts
+++ b/packages/publish/src/stages/git-push.ts
@@ -164,15 +164,13 @@ export async function runGitPushStage(ctx: PipelineContext): Promise<void> {
       }
     }
 
-    // Push the load-bearing tags first. They carry the release commit, gate the GitHub release,
-    // and are what consumers and `release/*` baselines point at — so push them before the branch
-    // ref, whose push can lose a race to a concurrent push and would otherwise strand the tags.
-    if (output.git.tags.length > 0) {
-      await runGit(dryRun, `git push ${remote} --tags`, () => git.push({ remote: pushRemote, tags: true, cwd }));
-    }
-
-    // Push the branch only when this runner created the release commit locally. Branch resolution
-    // is deferred to here so a tags-only push never triggers the detached-HEAD guard unnecessarily.
+    // Push the branch first, then tags. When this runner created the release commit (direct mode),
+    // the branch must land before the tags so a tag never points at a commit absent from the branch
+    // — and a branch rejected by a concurrent push / ruleset aborts before any tag is pushed, rather
+    // than leaving orphan tags on the remote with `git.pushed` false (no GitHub release). Standing-PR
+    // mode sets committed=false (the commit is already on the remote via the merge) and pushes tags
+    // only. Branch resolution is deferred to here so a tags-only push never triggers the detached-HEAD
+    // guard unnecessarily.
     let branch: string | undefined;
     if (output.git.committed) {
       branch = config.git.branch;
@@ -186,6 +184,11 @@ export async function runGitPushStage(ctx: PipelineContext): Promise<void> {
         }
       }
       await runGit(dryRun, `git push ${remote} ${branch}`, () => git.push({ remote: pushRemote, ref: branch, cwd }));
+    }
+
+    // Push tags
+    if (output.git.tags.length > 0) {
+      await runGit(dryRun, `git push ${remote} --tags`, () => git.push({ remote: pushRemote, tags: true, cwd }));
     }
 
     ctx.output.git.pushed = true;

--- a/packages/publish/src/stages/git-push.ts
+++ b/packages/publish/src/stages/git-push.ts
@@ -164,8 +164,15 @@ export async function runGitPushStage(ctx: PipelineContext): Promise<void> {
       }
     }
 
-    // Push commits — branch resolution is deferred to here so a tags-only push
-    // never triggers the detached-HEAD guard unnecessarily.
+    // Push the load-bearing tags first. They carry the release commit, gate the GitHub release,
+    // and are what consumers and `release/*` baselines point at — so push them before the branch
+    // ref, whose push can lose a race to a concurrent push and would otherwise strand the tags.
+    if (output.git.tags.length > 0) {
+      await runGit(dryRun, `git push ${remote} --tags`, () => git.push({ remote: pushRemote, tags: true, cwd }));
+    }
+
+    // Push the branch only when this runner created the release commit locally. Branch resolution
+    // is deferred to here so a tags-only push never triggers the detached-HEAD guard unnecessarily.
     let branch: string | undefined;
     if (output.git.committed) {
       branch = config.git.branch;
@@ -179,11 +186,6 @@ export async function runGitPushStage(ctx: PipelineContext): Promise<void> {
         }
       }
       await runGit(dryRun, `git push ${remote} ${branch}`, () => git.push({ remote: pushRemote, ref: branch, cwd }));
-    }
-
-    // Push tags
-    if (output.git.tags.length > 0) {
-      await runGit(dryRun, `git push ${remote} --tags`, () => git.push({ remote: pushRemote, tags: true, cwd }));
     }
 
     ctx.output.git.pushed = true;

--- a/packages/publish/test/unit/pipeline.spec.ts
+++ b/packages/publish/test/unit/pipeline.spec.ts
@@ -162,7 +162,10 @@ describe('pipeline', () => {
 
     expect(runGitCommitStage).not.toHaveBeenCalled();
     expect(runGitPushStage).toHaveBeenCalled();
-    expect(result.git.committed).toBe(true);
+    // `committed` stays false: the caller already landed the commit on the remote (the standing-PR
+    // merge), so this runner has no local commit to push. The push stage pushes only the tags;
+    // marking `committed` would make it push the branch and race a concurrent push to it.
+    expect(result.git.committed).toBe(false);
     expect(result.git.tags).toEqual(['v1.0.0', 'pkg-a@v1.0.0']);
   });
 

--- a/packages/publish/test/unit/stages/git-push.spec.ts
+++ b/packages/publish/test/unit/stages/git-push.spec.ts
@@ -78,10 +78,10 @@ describe('git-push stage', () => {
 
     await runGitPushStage(ctx);
 
-    // branch push then tags push, both to the plain remote name.
+    // tags push then branch push, both to the plain remote name.
     expect(fakeGit.pushed).toEqual([
-      expect.objectContaining({ remote: 'origin', ref: 'main' }),
       expect.objectContaining({ remote: 'origin', tags: true }),
+      expect.objectContaining({ remote: 'origin', ref: 'main' }),
     ]);
     expect(ctx.output.git.pushed).toBe(true);
   });
@@ -96,9 +96,9 @@ describe('git-push stage', () => {
     await runGitPushStage(ctx);
 
     const authedUrl = 'https://x-access-token:gh_test_token@github.com/org/repo.git';
-    // Both pushes target the authed URL as the remote.
-    expect(fakeGit.pushed[0]).toEqual(expect.objectContaining({ remote: authedUrl, ref: 'main' }));
-    expect(fakeGit.pushed[1]).toEqual(expect.objectContaining({ remote: authedUrl, tags: true }));
+    // Both pushes target the authed URL as the remote (tags first, then branch).
+    expect(fakeGit.pushed[0]).toEqual(expect.objectContaining({ remote: authedUrl, tags: true }));
+    expect(fakeGit.pushed[1]).toEqual(expect.objectContaining({ remote: authedUrl, ref: 'main' }));
   });
 
   it('should not attempt token auth when httpsTokenEnv is not configured', async () => {
@@ -109,8 +109,8 @@ describe('git-push stage', () => {
 
     // No remoteUrl read happened (no authed rewrite); pushes target the plain remote name.
     expect(fakeGit.pushed).toEqual([
-      expect.objectContaining({ remote: 'origin', ref: 'main' }),
       expect.objectContaining({ remote: 'origin', tags: true }),
+      expect.objectContaining({ remote: 'origin', ref: 'main' }),
     ]);
   });
 
@@ -124,8 +124,8 @@ describe('git-push stage', () => {
     await runGitPushStage(ctx);
 
     expect(fakeGit.pushed).toEqual([
-      expect.objectContaining({ remote: 'origin', ref: 'main' }),
       expect.objectContaining({ remote: 'origin', tags: true }),
+      expect.objectContaining({ remote: 'origin', ref: 'main' }),
     ]);
 
     delete process.env.MY_TOKEN;
@@ -136,7 +136,8 @@ describe('git-push stage', () => {
     const ctx = createContext();
     await runGitPushStage(ctx);
 
-    expect(fakeGit.pushed[0]).toEqual(expect.objectContaining({ remote: 'origin', ref: 'feature/my-branch' }));
+    // Tags push is pushed[0]; the branch push (resolved via currentBranch) is pushed[1].
+    expect(fakeGit.pushed[1]).toEqual(expect.objectContaining({ remote: 'origin', ref: 'feature/my-branch' }));
   });
 
   it('should throw a clear error when in detached HEAD state', async () => {
@@ -173,7 +174,8 @@ describe('git-push stage', () => {
 
     await runGitPushStage(ctx);
 
-    expect(fakeGit.pushed[0]).toEqual(expect.objectContaining({ remote: 'origin', ref: 'release/v2' }));
+    // Tags push is pushed[0]; the branch push (from explicit config) is pushed[1].
+    expect(fakeGit.pushed[1]).toEqual(expect.objectContaining({ remote: 'origin', ref: 'release/v2' }));
     expect(currentBranchSpy).not.toHaveBeenCalled();
   });
 

--- a/packages/publish/test/unit/stages/git-push.spec.ts
+++ b/packages/publish/test/unit/stages/git-push.spec.ts
@@ -78,10 +78,10 @@ describe('git-push stage', () => {
 
     await runGitPushStage(ctx);
 
-    // tags push then branch push, both to the plain remote name.
+    // branch push then tags push, both to the plain remote name.
     expect(fakeGit.pushed).toEqual([
-      expect.objectContaining({ remote: 'origin', tags: true }),
       expect.objectContaining({ remote: 'origin', ref: 'main' }),
+      expect.objectContaining({ remote: 'origin', tags: true }),
     ]);
     expect(ctx.output.git.pushed).toBe(true);
   });
@@ -96,9 +96,9 @@ describe('git-push stage', () => {
     await runGitPushStage(ctx);
 
     const authedUrl = 'https://x-access-token:gh_test_token@github.com/org/repo.git';
-    // Both pushes target the authed URL as the remote (tags first, then branch).
-    expect(fakeGit.pushed[0]).toEqual(expect.objectContaining({ remote: authedUrl, tags: true }));
-    expect(fakeGit.pushed[1]).toEqual(expect.objectContaining({ remote: authedUrl, ref: 'main' }));
+    // Both pushes target the authed URL as the remote.
+    expect(fakeGit.pushed[0]).toEqual(expect.objectContaining({ remote: authedUrl, ref: 'main' }));
+    expect(fakeGit.pushed[1]).toEqual(expect.objectContaining({ remote: authedUrl, tags: true }));
   });
 
   it('should not attempt token auth when httpsTokenEnv is not configured', async () => {
@@ -109,8 +109,8 @@ describe('git-push stage', () => {
 
     // No remoteUrl read happened (no authed rewrite); pushes target the plain remote name.
     expect(fakeGit.pushed).toEqual([
-      expect.objectContaining({ remote: 'origin', tags: true }),
       expect.objectContaining({ remote: 'origin', ref: 'main' }),
+      expect.objectContaining({ remote: 'origin', tags: true }),
     ]);
   });
 
@@ -124,8 +124,8 @@ describe('git-push stage', () => {
     await runGitPushStage(ctx);
 
     expect(fakeGit.pushed).toEqual([
-      expect.objectContaining({ remote: 'origin', tags: true }),
       expect.objectContaining({ remote: 'origin', ref: 'main' }),
+      expect.objectContaining({ remote: 'origin', tags: true }),
     ]);
 
     delete process.env.MY_TOKEN;
@@ -136,8 +136,7 @@ describe('git-push stage', () => {
     const ctx = createContext();
     await runGitPushStage(ctx);
 
-    // Tags push is pushed[0]; the branch push (resolved via currentBranch) is pushed[1].
-    expect(fakeGit.pushed[1]).toEqual(expect.objectContaining({ remote: 'origin', ref: 'feature/my-branch' }));
+    expect(fakeGit.pushed[0]).toEqual(expect.objectContaining({ remote: 'origin', ref: 'feature/my-branch' }));
   });
 
   it('should throw a clear error when in detached HEAD state', async () => {
@@ -174,8 +173,7 @@ describe('git-push stage', () => {
 
     await runGitPushStage(ctx);
 
-    // Tags push is pushed[0]; the branch push (from explicit config) is pushed[1].
-    expect(fakeGit.pushed[1]).toEqual(expect.objectContaining({ remote: 'origin', ref: 'release/v2' }));
+    expect(fakeGit.pushed[0]).toEqual(expect.objectContaining({ remote: 'origin', ref: 'release/v2' }));
     expect(currentBranchSpy).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## What happened

The `v0.34.0` standing-PR publish ([run](https://github.com/goosewobbler/releasekit/actions/runs/28261569545/job/83738046835)) published all 4 packages to npm successfully, then **failed on the final `git push origin main`**:

```
! [rejected]        main -> main (fetch first)
Error: standing-pr publish failed with exit code 1
```

A README edit made directly on GitHub landed on `main` while the publish was running. In standing-PR mode the release commit is already on the remote (the squash merge lands it before publish runs), yet the pipeline marked `git.committed` true and pushed the branch anyway — a no-op that lost the race. Net result: npm had `0.34.0`, but the `v0.34.0` / `release/v0.34.0` tags and the GitHub Release (which run after the branch push) were stranded. (Recovered separately via the `release:retry` label on #443.)

A secondary failure in the same run — the partial-publish failure report `403`'d (`Resource not accessible by integration`) — is also fixed here.

## Root cause

In standing-PR mode the release commit is already on the remote. But `pipeline/index.ts` still set `git.committed = true`, which made `runGitPushStage` attempt `git push origin main` — a push with no local commit to contribute. That push is a no-op at best and races a concurrent push at worst.

## Fixes

**`fix(publish)` — the branch-push race**
- `skipGitCommit` no longer marks `git.committed`, so in standing-PR mode the push stage pushes **only the tags**; the commit needs no push (it's already on `origin`). With no branch push, there's nothing to race.
- Push order stays **branch-first, then tags** in the direct-release (`committed`) path: the release commit must land on the branch before any tag is pushed, so a tag never points at a commit absent from the branch and a rejected branch push aborts cleanly (no orphan tags / skipped GitHub release).

**`fix(ci)` — failure-report permissions**
- Granted `pull-requests: write` to the three release jobs in `release.yml` and the top-level of `_release.reusable.yml` (reusable-workflow effective perms are the intersection of caller + callee), so the failure report can post on the merged standing PR instead of `403`-ing.

## Test plan

- `pnpm turbo run lint typecheck test` — all green (272 publish tests, 32 tasks total).
- `pipeline.spec.ts`: `skipGitCommit` now leaves `committed` false (runner pushes tags only).
- `git-push.spec.ts`: branch-first-then-tags order retained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adjusts release publishing so standing-PR runs avoid an unnecessary branch push.

- Leaves `git.committed` false when `skipGitCommit` is used.
- Pushes the branch before tags in the batch git-push stage.
- Adds PR write permissions for release failure reporting.
- Updates pipeline tests for the standing-PR publish path.
</details>


<h3>Confidence Score: 4/5</h3>

This is close, but the per-package push path should be fixed before merging.

- The standing-PR path now avoids the racing branch push.
- The batch push path now sends the branch before tags.
- The per-package helper can still leave a remote tag behind when the later branch push fails.

packages/publish/src/stages/git-push.ts

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/_release.reusable.yml | Adds PR write permission to the reusable release workflow. |
| .github/workflows/release.yml | Adds PR write permission to release jobs that call the reusable workflow. |
| packages/publish/src/pipeline/index.ts | Keeps standing-PR publish runs from marking a branch commit as pending push. |
| packages/publish/src/stages/git-push.ts | Changes batch push ordering, while the per-package helper still pushes tags before the branch. |
| packages/publish/test/unit/pipeline.spec.ts | Updates the standing-PR pipeline expectation for `git.committed`. |

</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/publish/src/stages/git-push.ts`, line 106-113 ([link](https://github.com/goosewobbler/releasekit/blob/741f321c1fcd9df9488114590c06b288802f4995/packages/publish/src/stages/git-push.ts#L106-L113)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Per-Package Tags Still Lead**

   In per-package mode this helper still pushes `refs/tags/${tag}` before the branch push. When a normal per-package release has `output.git.committed` set and the later branch push is rejected by branch protection or a concurrent update, the tag has already landed remotely but `output.git.pushed` is not set. The GitHub Release step can then be skipped with the tag stranded on the remote. This path needs the same branch-before-tag ordering or equivalent cleanup as the batch push path.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fpublish%2Fsrc%2Fstages%2Fgit-push.ts%0ALine%3A%20106-113%0A%0AComment%3A%0A**Per-Package%20Tags%20Still%20Lead**%0A%0AIn%20per-package%20mode%20this%20helper%20still%20pushes%20%60refs%2Ftags%2F%24%7Btag%7D%60%20before%20the%20branch%20push.%20When%20a%20normal%20per-package%20release%20has%20%60output.git.committed%60%20set%20and%20the%20later%20branch%20push%20is%20rejected%20by%20branch%20protection%20or%20a%20concurrent%20update%2C%20the%20tag%20has%20already%20landed%20remotely%20but%20%60output.git.pushed%60%20is%20not%20set.%20The%20GitHub%20Release%20step%20can%20then%20be%20skipped%20with%20the%20tag%20stranded%20on%20the%20remote.%20This%20path%20needs%20the%20same%20branch-before-tag%20ordering%20or%20equivalent%20cleanup%20as%20the%20batch%20push%20path.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=goosewobbler%2Freleasekit&pr=457&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fpublish%2Fsrc%2Fstages%2Fgit-push.ts%0ALine%3A%20106-113%0A%0AComment%3A%0A**Per-Package%20Tags%20Still%20Lead**%0A%0AIn%20per-package%20mode%20this%20helper%20still%20pushes%20%60refs%2Ftags%2F%24%7Btag%7D%60%20before%20the%20branch%20push.%20When%20a%20normal%20per-package%20release%20has%20%60output.git.committed%60%20set%20and%20the%20later%20branch%20push%20is%20rejected%20by%20branch%20protection%20or%20a%20concurrent%20update%2C%20the%20tag%20has%20already%20landed%20remotely%20but%20%60output.git.pushed%60%20is%20not%20set.%20The%20GitHub%20Release%20step%20can%20then%20be%20skipped%20with%20the%20tag%20stranded%20on%20the%20remote.%20This%20path%20needs%20the%20same%20branch-before-tag%20ordering%20or%20equivalent%20cleanup%20as%20the%20batch%20push%20path.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=457&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fpublish%2Fsrc%2Fstages%2Fgit-push.ts%3A106-113%0A**Per-Package%20Tags%20Still%20Lead**%0A%0AIn%20per-package%20mode%20this%20helper%20still%20pushes%20%60refs%2Ftags%2F%24%7Btag%7D%60%20before%20the%20branch%20push.%20When%20a%20normal%20per-package%20release%20has%20%60output.git.committed%60%20set%20and%20the%20later%20branch%20push%20is%20rejected%20by%20branch%20protection%20or%20a%20concurrent%20update%2C%20the%20tag%20has%20already%20landed%20remotely%20but%20%60output.git.pushed%60%20is%20not%20set.%20The%20GitHub%20Release%20step%20can%20then%20be%20skipped%20with%20the%20tag%20stranded%20on%20the%20remote.%20This%20path%20needs%20the%20same%20branch-before-tag%20ordering%20or%20equivalent%20cleanup%20as%20the%20batch%20push%20path.%0A%0A&repo=goosewobbler%2Freleasekit&pr=457&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fpublish%2Fsrc%2Fstages%2Fgit-push.ts%3A106-113%0A**Per-Package%20Tags%20Still%20Lead**%0A%0AIn%20per-package%20mode%20this%20helper%20still%20pushes%20%60refs%2Ftags%2F%24%7Btag%7D%60%20before%20the%20branch%20push.%20When%20a%20normal%20per-package%20release%20has%20%60output.git.committed%60%20set%20and%20the%20later%20branch%20push%20is%20rejected%20by%20branch%20protection%20or%20a%20concurrent%20update%2C%20the%20tag%20has%20already%20landed%20remotely%20but%20%60output.git.pushed%60%20is%20not%20set.%20The%20GitHub%20Release%20step%20can%20then%20be%20skipped%20with%20the%20tag%20stranded%20on%20the%20remote.%20This%20path%20needs%20the%20same%20branch-before-tag%20ordering%20or%20equivalent%20cleanup%20as%20the%20batch%20push%20path.%0A%0A&pr=457&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["fix(publish): keep branch-first push ord..."](https://github.com/goosewobbler/releasekit/commit/741f321c1fcd9df9488114590c06b288802f4995) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40216425)</sub>

<!-- /greptile_comment -->