### PR TITLE
fix(version): keep explicit prereleases on their line in linked/fixed groups

### DIFF
--- a/packages/version/src/core/groupStrategy.ts
+++ b/packages/version/src/core/groupStrategy.ts
@@ -177,28 +177,34 @@ function computeGroup(group: ResolvedGroup, plans: MemberPlan[], config: Config)
   const maxRank = Math.max(...changedPlans.map(memberBumpRank));
   const bumpType = RANK_TO_TYPE[maxRank] ?? 'patch';
 
+  // Whether this release belongs on a prerelease line. Two signals, by design: `config.isPrerelease`
+  // is the explicit, authoritative request (the user passed --prerelease / the prerelease channel);
+  // the member-scan is the inference fallback for when the flag isn't set globally but a member's own
+  // calculation already produced a prerelease.
+  const wantsPrerelease =
+    config.isPrerelease || changedPlans.some((p) => semver.valid(p.ownNext) && semver.prerelease(p.ownNext) !== null);
+
   // A member can be *creating* a prerelease from a stable baseline (premajor/preminor/prepatch —
   // e.g. 0.0.1 -> 1.0.0-next.0). RANK_TO_TYPE collapses those to a stable major/minor/patch
   // magnitude, so applying the aggregate directly would graduate the group to a stable release,
   // and the never-regress guard below can't recover it (1.0.0-next.0 < 1.0.0 in semver). Detect
   // that and apply the pre-variant + identifier so the group stays on the prerelease line.
-  //
-  // Two signals, by design: `config.isPrerelease` is the explicit, authoritative request (the user
-  // passed --prerelease / the prerelease channel) — when set, the group belongs on the prerelease
-  // line regardless of per-member magnitudes. The member-scan is the inference fallback for when the
-  // flag isn't set globally but a member's own calculation already produced a prerelease.
-  const creatingPrerelease =
-    bumpType !== 'prerelease' &&
-    !semver.prerelease(maxBaseline) &&
-    (config.isPrerelease || changedPlans.some((p) => semver.valid(p.ownNext) && semver.prerelease(p.ownNext) !== null));
+  const creatingPrerelease = bumpType !== 'prerelease' && !semver.prerelease(maxBaseline) && wantsPrerelease;
 
-  // Apply the aggregate bump once to the highest baseline in the group. For prerelease rank
-  // (all changed members are on a prerelease family), pass the identifier so semver.inc
-  // increments within the prerelease instead of graduating to a stable release. Members whose
-  // own bump already produced a higher version still pull the group version up via the
-  // never-regress guard below.
+  // The baseline is *already* a prerelease and the request is a prerelease: a stable aggregate
+  // magnitude here is often spurious — e.g. a member whose manifest lags its published prerelease
+  // tag computes an ownNext *below* maxBaseline, so the backwards `semver.diff` reads as a `major`.
+  // Applying it would graduate the explicit prerelease to a stable release, which never-regress can't
+  // recover (#458). Increment within the prerelease line instead; graduation requires stable=true.
+  const stayOnPrereleaseLine = bumpType !== 'prerelease' && !!semver.prerelease(maxBaseline) && wantsPrerelease;
+
+  // Apply the aggregate bump once to the highest baseline in the group. For a prerelease increment —
+  // or a request that must stay on an existing prerelease line — pass the identifier so semver.inc
+  // increments within the prerelease instead of graduating to a stable release. Members whose own
+  // bump already produced a higher version still pull the group version up via the never-regress
+  // guard below.
   let groupVersion: string;
-  if (bumpType === 'prerelease') {
+  if (bumpType === 'prerelease' || stayOnPrereleaseLine) {
     groupVersion = config.prereleaseIdentifier
       ? (semver.inc(maxBaseline, 'prerelease', config.prereleaseIdentifier) ?? maxBaseline)
       : maxBaseline;

--- a/packages/version/src/core/groupStrategy.ts
+++ b/packages/version/src/core/groupStrategy.ts
@@ -204,7 +204,15 @@ function computeGroup(group: ResolvedGroup, plans: MemberPlan[], config: Config)
   // bump already produced a higher version still pull the group version up via the never-regress
   // guard below.
   let groupVersion: string;
-  if (bumpType === 'prerelease' || stayOnPrereleaseLine) {
+  if (stayOnPrereleaseLine) {
+    // maxBaseline is guaranteed a prerelease here, so incrementing it never regresses a stable
+    // release. A missing identifier still advances the existing prerelease counter
+    // (1.0.0-next.0 -> 1.0.0-next.1), so an explicit prerelease never re-emits the published
+    // baseline when prereleaseIdentifier is unset (#460).
+    groupVersion = config.prereleaseIdentifier
+      ? (semver.inc(maxBaseline, 'prerelease', config.prereleaseIdentifier) ?? maxBaseline)
+      : (semver.inc(maxBaseline, 'prerelease') ?? maxBaseline);
+  } else if (bumpType === 'prerelease') {
     groupVersion = config.prereleaseIdentifier
       ? (semver.inc(maxBaseline, 'prerelease', config.prereleaseIdentifier) ?? maxBaseline)
       : maxBaseline;

--- a/packages/version/src/core/groupStrategy.ts
+++ b/packages/version/src/core/groupStrategy.ts
@@ -191,12 +191,16 @@ function computeGroup(group: ResolvedGroup, plans: MemberPlan[], config: Config)
   // that and apply the pre-variant + identifier so the group stays on the prerelease line.
   const creatingPrerelease = bumpType !== 'prerelease' && !semver.prerelease(maxBaseline) && wantsPrerelease;
 
-  // The baseline is *already* a prerelease and the request is a prerelease: a stable aggregate
-  // magnitude here is often spurious — e.g. a member whose manifest lags its published prerelease
-  // tag computes an ownNext *below* maxBaseline, so the backwards `semver.diff` reads as a `major`.
-  // Applying it would graduate the explicit prerelease to a stable release, which never-regress can't
-  // recover (#458). Increment within the prerelease line instead; graduation requires stable=true.
-  const stayOnPrereleaseLine = bumpType !== 'prerelease' && !!semver.prerelease(maxBaseline) && wantsPrerelease;
+  // The baseline is *already* a prerelease and the request is a prerelease: stay on that line and
+  // advance within it (1.0.0-next.0 -> 1.0.0-next.1) rather than graduate to a stable release —
+  // graduation requires stable=true. This covers two ways the published baseline would otherwise be
+  // re-emitted, neither of which never-regress can recover when a member's ownNext sits below it:
+  //  - a *stable* aggregate magnitude that's spurious because a member's manifest lags its prerelease
+  //    tag, so the backwards `semver.diff` reads as a `major` (#458); and
+  //  - a *prerelease* aggregate rank with no identifier, where the legacy branch returned the
+  //    baseline unchanged (#460).
+  // It is gated on a prerelease baseline, so incrementing never regresses a stable release.
+  const stayOnPrereleaseLine = !!semver.prerelease(maxBaseline) && wantsPrerelease;
 
   // Apply the aggregate bump once to the highest baseline in the group. For a prerelease increment —
   // or a request that must stay on an existing prerelease line — pass the identifier so semver.inc
@@ -205,17 +209,15 @@ function computeGroup(group: ResolvedGroup, plans: MemberPlan[], config: Config)
   // guard below.
   let groupVersion: string;
   if (stayOnPrereleaseLine) {
-    // maxBaseline is guaranteed a prerelease here, so incrementing it never regresses a stable
-    // release. A missing identifier still advances the existing prerelease counter
-    // (1.0.0-next.0 -> 1.0.0-next.1), so an explicit prerelease never re-emits the published
-    // baseline when prereleaseIdentifier is unset (#460).
+    // A missing identifier still advances the existing prerelease counter (1.0.0-next.0 ->
+    // 1.0.0-next.1), so an explicit prerelease never re-emits the published baseline.
     groupVersion = config.prereleaseIdentifier
       ? (semver.inc(maxBaseline, 'prerelease', config.prereleaseIdentifier) ?? maxBaseline)
       : (semver.inc(maxBaseline, 'prerelease') ?? maxBaseline);
   } else if (bumpType === 'prerelease') {
-    groupVersion = config.prereleaseIdentifier
-      ? (semver.inc(maxBaseline, 'prerelease', config.prereleaseIdentifier) ?? maxBaseline)
-      : maxBaseline;
+    // Rank 0 with a *stable* max baseline (a lower member is on a prerelease line). Don't regress
+    // the stable baseline; never-regress pulls the group up to the member's own prerelease next.
+    groupVersion = maxBaseline;
   } else if (creatingPrerelease) {
     const preBump = `pre${bumpType}` as ReleaseType;
     groupVersion = config.prereleaseIdentifier

--- a/packages/version/test/unit/core/groupStrategy.spec.ts
+++ b/packages/version/test/unit/core/groupStrategy.spec.ts
@@ -486,6 +486,38 @@ describe('createGroupStrategy', () => {
         undefined,
       );
     });
+
+    it('should advance the prerelease when the aggregate rank is itself prerelease and no identifier is set (#460)', async () => {
+      // The changed member earns a *prerelease-rank* bump (its own line increments), while a higher
+      // member's prerelease tag sets the group baseline (1.0.0-next.0). Pre-fix, the prerelease-rank
+      // branch returned the baseline unchanged when no identifier was set, and never-regress couldn't
+      // raise it (the changed member's own next sits below the group baseline) — republishing
+      // 1.0.0-next.0. It must advance to 1.0.0-next.1.
+      const service = mkPackage('@wdio/flutter-service', '1.0.0-next.0');
+      const contract = mkPackage('wdio_flutter', '0.9.0-next.0');
+
+      vi.mocked(gitTags.getLatestTagForPackage).mockImplementation(async (name) =>
+        name === '@wdio/flutter-service' ? 'wdio-flutter-service@v1.0.0-next.0' : '',
+      );
+      // Only the contract changed — a within-prerelease increment on its own (lower) line.
+      vi.mocked(calculator.calculateVersion).mockImplementation(async (_cfg, opts) =>
+        opts.name === 'wdio_flutter' ? '0.9.0-next.1' : '',
+      );
+
+      const strategy = createGroupStrategy(
+        baseConfig({
+          isPrerelease: true, // no prereleaseIdentifier configured
+          groups: { flutter: { packages: ['@wdio/flutter-service', 'wdio_flutter'], sync: 'linked' } },
+        }),
+      );
+      await strategy(workspace([service, contract]));
+
+      expect(packageManagement.updatePackageVersion).toHaveBeenCalledWith(
+        '/ws/packages/wdio_flutter/package.json',
+        '1.0.0-next.1',
+        undefined,
+      );
+    });
   });
 
   describe('group baseline = max(member baselines)', () => {

--- a/packages/version/test/unit/core/groupStrategy.spec.ts
+++ b/packages/version/test/unit/core/groupStrategy.spec.ts
@@ -388,6 +388,75 @@ describe('createGroupStrategy', () => {
         undefined,
       );
     });
+
+    it('should not graduate an explicit prerelease when a member manifest lags its prerelease tag (#458)', async () => {
+      // Interrupted release: the published prerelease (1.0.0-next.0) lives in the tag, but the member's
+      // manifest still reads 0.0.1 AND the tag isn't reachable from HEAD, so the per-package calculator
+      // computes ownNext from the manifest (0.0.2-next.0) — *below* the tag-derived group baseline
+      // (1.0.0-next.0). The backwards diff reads as a `major`; pre-fix that graduated the explicit
+      // prerelease (stable=false) to a stable 1.0.0, and never-regress couldn't recover it. The group
+      // must stay on the prerelease line (1.0.0-next.1) — graduation requires stable=true.
+      const service = mkPackage('@wdio/flutter-service', '0.0.1');
+      const contract = mkPackage('wdio_flutter', '0.0.1');
+
+      vi.mocked(gitTags.getLatestTagForPackage).mockImplementation(async (name) =>
+        name === '@wdio/flutter-service' ? 'wdio-flutter-service@v1.0.0-next.0' : '',
+      );
+      vi.mocked(calculator.calculateVersion).mockImplementation(async (_cfg, opts) =>
+        opts.name === '@wdio/flutter-service' ? '0.0.2-next.0' : '',
+      );
+
+      const strategy = createGroupStrategy(
+        baseConfig({
+          isPrerelease: true,
+          prereleaseIdentifier: 'next',
+          groups: { flutter: { packages: ['@wdio/flutter-service', 'wdio_flutter'], sync: 'linked' } },
+        }),
+      );
+      await strategy(workspace([service, contract]));
+
+      expect(packageManagement.updatePackageVersion).toHaveBeenCalledTimes(1);
+      expect(packageManagement.updatePackageVersion).toHaveBeenCalledWith(
+        '/ws/packages/wdio-flutter-service/package.json',
+        '1.0.0-next.1',
+        undefined,
+      );
+    });
+
+    it('should not graduate an explicit prerelease in a fixed group when a member manifest lags its tag (#458)', async () => {
+      // As above, but `fixed` writes the shared version to ALL members — a silent graduation would
+      // stamp a stable 1.0.0 across the whole group. Both must stay on 1.0.0-next.1.
+      const service = mkPackage('@wdio/flutter-service', '0.0.1');
+      const contract = mkPackage('wdio_flutter', '0.0.1');
+
+      vi.mocked(gitTags.getLatestTagForPackage).mockImplementation(async (name) =>
+        name === '@wdio/flutter-service' ? 'wdio-flutter-service@v1.0.0-next.0' : '',
+      );
+      vi.mocked(calculator.calculateVersion).mockImplementation(async (_cfg, opts) =>
+        opts.name === '@wdio/flutter-service' ? '0.0.2-next.0' : '',
+      );
+
+      const strategy = createGroupStrategy(
+        baseConfig({
+          isPrerelease: true,
+          prereleaseIdentifier: 'next',
+          groups: { flutter: { packages: ['@wdio/flutter-service', 'wdio_flutter'], sync: 'fixed' } },
+        }),
+      );
+      await strategy(workspace([service, contract]));
+
+      expect(packageManagement.updatePackageVersion).toHaveBeenCalledTimes(2);
+      expect(packageManagement.updatePackageVersion).toHaveBeenCalledWith(
+        '/ws/packages/wdio-flutter-service/package.json',
+        '1.0.0-next.1',
+        undefined,
+      );
+      expect(packageManagement.updatePackageVersion).toHaveBeenCalledWith(
+        '/ws/packages/wdio_flutter/package.json',
+        '1.0.0-next.1',
+        undefined,
+      );
+    });
   });
 
   describe('group baseline = max(member baselines)', () => {

--- a/packages/version/test/unit/core/groupStrategy.spec.ts
+++ b/packages/version/test/unit/core/groupStrategy.spec.ts
@@ -457,6 +457,35 @@ describe('createGroupStrategy', () => {
         undefined,
       );
     });
+
+    it('should still advance the prerelease when no prereleaseIdentifier is configured (#460)', async () => {
+      // Same manifest-lags-tag scenario, but with no configured prereleaseIdentifier. The group must
+      // still increment the existing prerelease (1.0.0-next.0 -> 1.0.0-next.1) rather than re-emit the
+      // published baseline — never-regress can't help (ownNext sits below maxBaseline).
+      const service = mkPackage('@wdio/flutter-service', '0.0.1');
+      const contract = mkPackage('wdio_flutter', '0.0.1');
+
+      vi.mocked(gitTags.getLatestTagForPackage).mockImplementation(async (name) =>
+        name === '@wdio/flutter-service' ? 'wdio-flutter-service@v1.0.0-next.0' : '',
+      );
+      vi.mocked(calculator.calculateVersion).mockImplementation(async (_cfg, opts) =>
+        opts.name === '@wdio/flutter-service' ? '0.0.2-next.0' : '',
+      );
+
+      const strategy = createGroupStrategy(
+        baseConfig({
+          isPrerelease: true, // no prereleaseIdentifier configured
+          groups: { flutter: { packages: ['@wdio/flutter-service', 'wdio_flutter'], sync: 'linked' } },
+        }),
+      );
+      await strategy(workspace([service, contract]));
+
+      expect(packageManagement.updatePackageVersion).toHaveBeenCalledWith(
+        '/ws/packages/wdio-flutter-service/package.json',
+        '1.0.0-next.1',
+        undefined,
+      );
+    });
   });
 
   describe('group baseline = max(member baselines)', () => {


### PR DESCRIPTION
## Summary

Fixes #458 — an explicit **prerelease** request (`stable=false`) silently graduated to a **stable** release when a `linked`/`fixed` group member's manifest version lagged its published prerelease tag. Observed on v0.34.0.

## Root cause

In `computeGroup` (`packages/version/src/core/groupStrategy.ts`), for a member whose manifest (`0.0.1`) lags an unreachable prerelease tag (`pkg@v1.0.0-next.0`):

- `baseline`/`maxBaseline` is taken from the tag → `1.0.0-next.0`
- `ownNext` is computed by the per-package calculator from the stale manifest → `0.0.2-next.0` (**below** the baseline)
- `memberBumpRank` = `semver.diff('1.0.0-next.0', '0.0.2-next.0')` → `major` (a spurious magnitude from a *backwards* diff)
- the `creatingPrerelease` guard only covers a **stable** baseline (`!semver.prerelease(maxBaseline)`), so it doesn't fire
- → `semver.inc('1.0.0-next.0', 'major')` = **`1.0.0`** (graduates the explicit prerelease)
- the never-regress guard can't recover it (`0.0.2-next.0 < 1.0.0`)

## Fix

Gate the stable graduation on the channel. Factor the prerelease intent into a shared `wantsPrerelease` signal (`config.isPrerelease` ∨ a member's own next is a prerelease), then add a `stayOnPrereleaseLine` case symmetric to `creatingPrerelease`: when the baseline is **already** a prerelease and the request is a prerelease, increment within the prerelease line (`1.0.0-next.1`) instead of applying the (often spurious) stable magnitude. Graduation now requires `stable=true`.

## Test plan

- `pnpm turbo run lint typecheck test` — all green (32 tasks).
- Two new `groupStrategy.spec.ts` tests (linked + fixed) reproduce #458 — manifest-lags-tag with `stable=false` — and assert the group stays on `1.0.0-next.1`. Both fail before the fix (graduate to `1.0.0`), pass after. No regressions across the 23-test spec.

Companion to #421 (create-from-stable) and #440 (baseline coercion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR keeps explicit prerelease group releases on the prerelease line.

- Adds a shared prerelease-intent check in group versioning.
- Advances existing prerelease baselines instead of graduating them to stable releases.
- Adds linked and fixed group tests for lagging manifests and missing prerelease identifiers.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/version/src/core/groupStrategy.ts | Updates group prerelease handling so explicit prerelease requests advance existing prerelease baselines. |
| packages/version/test/unit/core/groupStrategy.spec.ts | Adds tests for linked and fixed prerelease group behavior. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(version): stay on the prerelease lin..."](https://github.com/goosewobbler/releasekit/commit/9dbcdd876a459642c250de488282956190639a46) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40268655)</sub>

<!-- /greptile_comment -->