### PR TITLE
feat(release): drive feeder-PR preview refresh in-process after a release

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -385,7 +385,7 @@ Set to `false` to disable.
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `enabled` | boolean | `true` | Whether PR preview comments are posted. |
-| `refreshAfterRelease` | boolean | `false` | After a release completes, replay the preview comment on still-open feeder PRs so their "what would release" estimate is not left stale against the moved baseline. Cosmetic and best-effort — a failure here never fails the release. Requires the refresh-after-release step in your release workflow. |
+| `refreshAfterRelease` | boolean | `false` | After a release completes, replay the preview comment on still-open feeder PRs so their "what would release" estimate is not left stale against the moved baseline. Cosmetic and best-effort — a failure here never fails the release. Driven automatically in-process after a successful release (both the direct and standing-PR publish paths); the standalone `refresh-after-release` command also performs it for setups that run it as a separate step. |
 
 
 ### `ci.labels`

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -610,7 +610,7 @@ export const CIConfigSchema = z.object({
           .boolean()
           .default(false)
           .describe(
-            'After a release completes, replay the preview comment on still-open feeder PRs so their "what would release" estimate is not left stale against the moved baseline. Cosmetic and best-effort — a failure here never fails the release. Requires the refresh-after-release step in your release workflow.',
+            'After a release completes, replay the preview comment on still-open feeder PRs so their "what would release" estimate is not left stale against the moved baseline. Cosmetic and best-effort — a failure here never fails the release. Driven automatically in-process after a successful release (both the direct and standing-PR publish paths); the standalone `refresh-after-release` command also performs it for setups that run it as a separate step.',
           ),
       }),
     ])

--- a/packages/release/src/preview/refresh.ts
+++ b/packages/release/src/preview/refresh.ts
@@ -15,21 +15,22 @@ export interface RefreshAfterReleaseOptions {
 const MAX_FEEDER_PR_REFRESH = 50;
 
 /**
- * Post-release cleanup of state that goes stale when a release moves `main`. Run as the final step of
- * a release/publish job. Two halves with deliberately different failure semantics:
+ * Post-release cleanup of state that goes stale when a release moves `main`. Two halves with
+ * deliberately different failure semantics:
  *
  * 1. **Standing-PR reconcile (release-critical).** A direct/manual/immediate release that bypasses
  *    the standing PR leaves its manifest computed against the old baseline — and the `chore: release `
  *    commit suppresses the normal push-triggered update. Reusing the existing `--reconcile` path
  *    re-syncs it. A failure here propagates: a stale standing PR can hold already-published versions.
- * 2. **Feeder-PR preview refresh (cosmetic, opt-in).** Other open PRs' "what would release" estimate
- *    is frozen at the pre-release baseline until they're pushed again. Replaying the (idempotent)
- *    preview brings them current. Best-effort — any failure only warns, never fails the release.
+ *    This half pushes the release branch, so it needs a workflow-triggering credential — hence it
+ *    lives in this CLI step rather than being driven from the orchestrator.
+ * 2. **Feeder-PR preview refresh (cosmetic, opt-in).** Delegated to {@link refreshFeederPreviews},
+ *    which the release orchestrator also calls in-process after a successful publish (so a consumer
+ *    no longer needs this CLI step purely for the cosmetic half).
  */
 export async function runRefreshAfterRelease(options: RefreshAfterReleaseOptions): Promise<void> {
   const ciConfig = loadCIConfig({ cwd: options.projectDir, configPath: options.config });
   const strategy = ciConfig?.releaseStrategy ?? 'direct';
-  const branch = ciConfig?.standingPr?.branch ?? 'release/next';
 
   // — Half 1: reconcile the standing PR (RELEASE-CRITICAL) —
   // Only standing-pr mode has a standing PR. No try/catch: a failure must fail the job rather than
@@ -47,18 +48,32 @@ export async function runRefreshAfterRelease(options: RefreshAfterReleaseOptions
   }
 
   // — Half 2: refresh feeder-PR previews (COSMETIC, opt-in, never fatal) —
-  const prPreview = ciConfig?.prPreview;
-  if (!prPreview?.enabled || !prPreview.refreshAfterRelease) {
-    return;
-  }
+  await refreshFeederPreviews(options);
+}
 
-  const context = getGitHubContext();
-  if (!context?.token) {
-    warn('Cannot refresh feeder-PR previews: no GitHub token in the environment.');
-    return;
-  }
-
+/**
+ * Replay the (idempotent) "what would release" preview comment on still-open feeder PRs after a
+ * release moves `main`, so their estimate isn't frozen at the pre-release baseline. Cosmetic and
+ * opt-in (`ci.prPreview.refreshAfterRelease`); a pure forge-API operation (no git push) needing only
+ * a `pull-requests: write` token. Best-effort — it **never throws**, so the release orchestrator can
+ * drive it in-process after any successful publish (the standing-PR publish path as well as the
+ * direct/scoped path) without risking the release.
+ */
+export async function refreshFeederPreviews(options: RefreshAfterReleaseOptions): Promise<void> {
   try {
+    const ciConfig = loadCIConfig({ cwd: options.projectDir, configPath: options.config });
+    const prPreview = ciConfig?.prPreview;
+    if (!prPreview?.enabled || !prPreview.refreshAfterRelease) {
+      return;
+    }
+    const branch = ciConfig?.standingPr?.branch ?? 'release/next';
+
+    const context = getGitHubContext();
+    if (!context?.token) {
+      warn('Cannot refresh feeder-PR previews: no GitHub token in the environment.');
+      return;
+    }
+
     const forge = forgeFor(context);
     const repo = `${context.owner}/${context.repo}`;
     const open = await forge.listOpenPullRequests();
@@ -108,7 +123,7 @@ export async function runRefreshAfterRelease(options: RefreshAfterReleaseOptions
       }
     }
   } catch (err) {
-    // The entire feeder refresh is best-effort — enumeration/forge errors only warn.
+    // Best-effort — config/enumeration/forge errors only warn, never fail the release.
     warn(`Feeder-PR preview refresh failed: ${err instanceof Error ? err.message : String(err)}`);
   }
 }

--- a/packages/release/src/release.ts
+++ b/packages/release/src/release.ts
@@ -8,6 +8,7 @@ import { postFailureReport, resolveFailureReportIfPresent } from './failure-repo
 import { getGitHubContext, getHeadCommitMessage, matchesSkipPattern } from './git.js';
 import { fetchPRLabels, findMergedPRsForCommit, forgeFor } from './github.js';
 import { DEFAULT_LABELS, detectLabelConflicts } from './label-utils.js';
+import { refreshFeederPreviews } from './preview/refresh.js';
 import { runNotesStep, runPublishStep, runVersionStep } from './steps.js';
 import type { ReleaseOptions, ReleaseOutput } from './types.js';
 import { publishableUpdates } from './version-display.js';
@@ -342,6 +343,11 @@ export async function runRelease(inputOptions: ReleaseOptions): Promise<ReleaseO
           `Failed to resolve prior publish-failure report: ${resolveErr instanceof Error ? resolveErr.message : String(resolveErr)}`,
         );
       }
+
+      // The release moved `main`: refresh still-open feeder PRs' "what would release" preview in
+      // process (opt-in via ci.prPreview.refreshAfterRelease) so they aren't left stale against the
+      // new baseline. Best-effort and never throws — must not fail an already-successful release.
+      await refreshFeederPreviews({ config: options.config, projectDir: options.projectDir });
     }
   }
 

--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -13,6 +13,7 @@ import { getGitHubContext, getHeadCommitMessage, matchesSkipPattern } from '../g
 import { forgeFor } from '../github.js';
 import { deriveLabelDefinitions, syncLabels } from '../label-definitions.js';
 import { DEFAULT_LABELS } from '../label-utils.js';
+import { refreshFeederPreviews } from '../preview/refresh.js';
 import { runNotesStep, runPublishStep, runVersionStep } from '../steps.js';
 import type { ReleaseOptions, ReleaseOutput } from '../types.js';
 import { publishableUpdates, syncVersionDisplay } from '../version-display.js';
@@ -1457,6 +1458,10 @@ export async function publishFromManifest(prNumber: number, options: StandingPRO
   // Publish succeeded — clear any prior failure report on this PR (resolves it and the supersede
   // warning that would otherwise show on the next standing PR).
   await resolveFailureReportIfPresent(forge, prNumber, manifest.versionOutput);
+
+  // The standing-PR publish moved `main` just like a direct release, so still-open feeder PRs'
+  // previews go stale here too. Refresh them in-process (opt-in, best-effort, never throws).
+  await refreshFeederPreviews({ config: options.config, projectDir: cwd });
 
   // Cleanup: delete release branch if configured
   if (deleteBranchOnMerge) {

--- a/packages/release/test/unit/refresh.spec.ts
+++ b/packages/release/test/unit/refresh.spec.ts
@@ -227,4 +227,24 @@ describe('runRefreshAfterRelease', () => {
       expect(mockRunPreview).not.toHaveBeenCalled();
     });
   });
+
+  describe('refreshFeederPreviews (direct)', () => {
+    it('should refresh eligible feeder PRs when called directly', async () => {
+      mockForgeFor.mockReturnValue(fakeForge([pr(10)]));
+      const { refreshFeederPreviews } = await import('../../src/preview/refresh.js');
+
+      await refreshFeederPreviews({ projectDir: '/p' });
+
+      expect(mockRunPreview).toHaveBeenCalledWith(expect.objectContaining({ pr: '10' }));
+    });
+
+    it('should never throw, so the orchestrator can call it without a guard', async () => {
+      mockLoadCIConfig.mockImplementation(() => {
+        throw new Error('config parse error');
+      });
+      const { refreshFeederPreviews } = await import('../../src/preview/refresh.js');
+
+      await expect(refreshFeederPreviews({ projectDir: '/p' })).resolves.toBeUndefined();
+    });
+  });
 });

--- a/packages/release/test/unit/release.spec.ts
+++ b/packages/release/test/unit/release.spec.ts
@@ -10,6 +10,12 @@ const mockLoadCIConfig = vi.fn();
 const mockForgeFor = vi.fn();
 const mockFindMergedPRsForCommit = vi.fn();
 const mockFetchPRLabels = vi.fn();
+const mockRefreshFeederPreviews = vi.fn();
+
+vi.mock('../../src/preview/refresh.js', () => ({
+  refreshFeederPreviews: (...args: unknown[]) => mockRefreshFeederPreviews(...args),
+  runRefreshAfterRelease: vi.fn(),
+}));
 
 vi.mock('@releasekit/config', () => ({
   loadConfig: (...args: unknown[]) => ({ ...mockLoadReleaseKitConfig(...args), ci: mockLoadCIConfig() }),
@@ -973,6 +979,23 @@ describe('runRelease', () => {
           'scope:electron': '@wdio/electron-*',
         }),
       ).toThrow('Scope "unknown" not found in ci.scopeLabels. Available: scope:electron');
+    });
+  });
+
+  describe('feeder-preview refresh (#459)', () => {
+    it('should refresh feeder previews in-process after a successful release', async () => {
+      await runRelease(defaultOptions);
+      expect(mockRefreshFeederPreviews).toHaveBeenCalledWith(expect.objectContaining({ projectDir: '/test/project' }));
+    });
+
+    it('should not refresh feeder previews on a dry run', async () => {
+      await runRelease({ ...defaultOptions, dryRun: true });
+      expect(mockRefreshFeederPreviews).not.toHaveBeenCalled();
+    });
+
+    it('should not refresh feeder previews when publish is skipped', async () => {
+      await runRelease({ ...defaultOptions, skipPublish: true });
+      expect(mockRefreshFeederPreviews).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/release/test/unit/standing-pr.spec.ts
+++ b/packages/release/test/unit/standing-pr.spec.ts
@@ -98,6 +98,11 @@ vi.mock('../../src/github.js', () => ({
   forgeFor: vi.fn(),
 }));
 
+vi.mock('../../src/preview/refresh.js', () => ({
+  refreshFeederPreviews: vi.fn(),
+  runRefreshAfterRelease: vi.fn(),
+}));
+
 function createMockVersionOutput(updates: { packageName: string; newVersion: string }[] = []) {
   return {
     dryRun: false,
@@ -1788,6 +1793,9 @@ describe('runStandingPRPublish', () => {
       { '@scope/core': '- regenerated at publish time' },
       expect.arrayContaining(['RELEASE_NOTES.md', ...baseManifest.notesFiles]),
     );
+    // The publish moved `main`, so feeder-PR previews are refreshed in-process (#459).
+    const { refreshFeederPreviews } = await import('../../src/preview/refresh.js');
+    expect(vi.mocked(refreshFeederPreviews)).toHaveBeenCalledWith(expect.objectContaining({ projectDir: '/test' }));
   });
 
   it('should refuse to publish when override labels diverge from the manifest (#337)', async () => {

--- a/releasekit.schema.json
+++ b/releasekit.schema.json
@@ -1042,7 +1042,7 @@
                 "refreshAfterRelease": {
                   "type": "boolean",
                   "default": false,
-                  "description": "After a release completes, replay the preview comment on still-open feeder PRs so their \"what would release\" estimate is not left stale against the moved baseline. Cosmetic and best-effort — a failure here never fails the release. Requires the refresh-after-release step in your release workflow."
+                  "description": "After a release completes, replay the preview comment on still-open feeder PRs so their \"what would release\" estimate is not left stale against the moved baseline. Cosmetic and best-effort — a failure here never fails the release. Driven automatically in-process after a successful release (both the direct and standing-PR publish paths); the standalone `refresh-after-release` command also performs it for setups that run it as a separate step."
                 }
               }
             }


### PR DESCRIPTION
## Summary

Closes #459 — drives the **feeder-PR preview refresh** in-process after a successful release on **both** paths, closing the publish-path gap #438/webdriverio/desktop-mobile#486 left open.

A standing-PR publish moves `main` exactly like a direct release, so still-open feeder PRs' "what would release" preview goes stale against the new baseline — but nothing refreshed them on the publish path (wdio gates its `refresh-after-release` step to the scoped path; releasekit's own publish job had no refresh).

## Changes

- **`refresh.ts`** — extract the feeder half of `runRefreshAfterRelease` into a standalone, **never-throwing** `refreshFeederPreviews()`. `runRefreshAfterRelease` (the CLI step) now delegates to it.
- **`release.ts`** — call `refreshFeederPreviews` after a successful non-dry direct/scoped release.
- **`standing-pr.ts`** — call it after `publishFromManifest` completes (the standing-PR publish path).
- **`schema.ts`** — update the `ci.prPreview.refreshAfterRelease` description (driven in-process now; the CLI command remains for split-job setups). Regenerated `releasekit.schema.json` + `docs/configuration.md`.

## Why only the feeder half

Per the issue's per-half analysis: the feeder refresh is a pure forge-API operation (no git push), so it needs only a `pull-requests: write` token and runs cleanly on the OIDC publish path. The **reconcile** half pushes the release branch and needs a workflow-triggering credential (deploy key) — a per-job concern — so it stays in the `refresh-after-release` CLI step. That resolves the issue's main open decision: don't internalize the reconcile half.

## Safety

- Gated by `ci.prPreview.refreshAfterRelease` (default off) — no behaviour change for anyone who hasn't enabled it.
- `refreshFeederPreviews` **never throws** (whole body wrapped best-effort), so the orchestrator calls it without a guard and a refresh failure can't fail an already-successful release. A regression test locks this contract.

## Test plan

- `pnpm turbo run lint typecheck test` — green (32 tasks); release build bundles clean (no import-cycle issue from `standing-pr.ts → refresh.ts`).
- New tests: `release.spec.ts` (refreshes after success; skips on dry-run / skip-publish), `standing-pr.spec.ts` (publish path refreshes), `refresh.spec.ts` (direct call refreshes; never throws on a config-load failure). Existing `runRefreshAfterRelease` tests pass unchanged (it delegates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR refreshes feeder PR previews in-process after releases. The main changes are:

- Extracted feeder preview refresh into `refreshFeederPreviews()`.
- Called the refresh after successful direct/scoped releases.
- Called the refresh after successful standing-PR publishes.
- Updated config schema, generated docs, and unit tests.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/release/src/preview/refresh.ts | Extracts the feeder preview refresh into a best-effort helper and keeps the CLI path delegating to it. |
| packages/release/src/release.ts | Runs the feeder preview refresh after a successful non-dry publish. |
| packages/release/src/standing-pr/standing-pr.ts | Runs the feeder preview refresh after a successful standing-PR publish. |
| packages/config/src/schema.ts | Updates the `refreshAfterRelease` configuration description. |
| docs/configuration.md | Documents the new in-process refresh behavior. |
| releasekit.schema.json | Regenerates the JSON schema description for the updated option. |
| packages/release/test/unit/refresh.spec.ts | Adds direct coverage for feeder preview refresh behavior and its never-throw contract. |
| packages/release/test/unit/release.spec.ts | Adds coverage for release-path refresh calls and skip conditions. |
| packages/release/test/unit/standing-pr.spec.ts | Adds coverage for standing-PR publish refresh calls. |

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(release): drive feeder-PR preview r..."](https://github.com/goosewobbler/releasekit/commit/2a862b611a8bbbcb9dfbb9d59302e1eb1ac7a56d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40270190)</sub>

<!-- /greptile_comment -->
