### PR TITLE
feat(release): manual-mode draft-then-dispatch on a tracking issue (#319)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -57,6 +57,8 @@ Run the full release pipeline: version, changelog, publish, git, and GitHub Rele
 | `--scope <name>` | string | - | Resolve scope name to target packages from `ci.scopeLabels` config |
 | `--branch <name>` | string | current | Override the git branch used for push |
 | `--npm-auth <method>` | `auto` \| `oidc` \| `token` | `auto` | NPM auth method |
+| `--draft` | boolean | `false` | Manual mode: compute the release and open a tracking issue with editable notes for review, instead of publishing |
+| `--from-draft <number>` | number | - | Manual mode: publish from a reviewed draft tracking issue (applies its edited notes), then close it |
 | `--skip-notes` | boolean | `false` | Skip changelog generation |
 | `--skip-publish` | boolean | `false` | Skip registry publishing and git operations |
 | `--skip-git` | boolean | `false` | Skip git commit/tag/push |
@@ -67,11 +69,28 @@ Run the full release pipeline: version, changelog, publish, git, and GitHub Rele
 | `-q, --quiet` | boolean | `false` | Suppress non-error output |
 | `--project-dir <path>` | string | `cwd` | Project directory |
 
-`--stable` and `--prerelease` are mutually exclusive.
+`--stable` and `--prerelease` are mutually exclusive, as are `--draft` and `--from-draft`.
 
 ```bash
 releasekit release --dry-run
 ```
+
+### Draft-then-dispatch (manual mode)
+
+Manual mode has no standing PR, so there is no PR body to review release notes in before they ship. `--draft` / `--from-draft` add a two-phase review surface:
+
+```bash
+# Phase 1 — compute the release and open a "Release draft" tracking issue (labelled
+# `release:draft`) holding the editable per-package notes. Nothing is published.
+releasekit release --draft
+
+# A human edits the notes in the issue body, keeping the <!-- releasekit-notes... --> markers.
+
+# Phase 2 — publish exactly that release with the edited notes, then close the issue.
+releasekit release --from-draft 123
+```
+
+Re-running `--draft` updates the same open draft issue in place (it never stacks). The draft is pinned to the commit it was computed at: if `main` moves before you dispatch, `--from-draft` refuses and asks you to re-run `--draft`. Both phases need a `GITHUB_TOKEN` with `issues: write`.
 
 ---
 

--- a/packages/release/src/commands/release-command.ts
+++ b/packages/release/src/commands/release-command.ts
@@ -1,5 +1,6 @@
 import { EXIT_CODES } from '@releasekit/core';
 import { Command, Option } from 'commander';
+import { publishFromDraft, runReleaseDraft } from '../draft/draft.js';
 import { runRelease } from '../release.js';
 import type { ReleaseOptions } from '../types.js';
 
@@ -26,6 +27,15 @@ export function createReleaseCommand(): Command {
     .option('--scope <name>', 'Resolve scope name to target packages from ci.scopeLabels config')
     .option('--branch <name>', 'Override the git branch used for push')
     .addOption(new Option('--npm-auth <method>', 'NPM auth method').choices(['auto', 'oidc', 'token']).default('auto'))
+    .option(
+      '--draft',
+      'Manual mode: compute the release and open a tracking issue with editable notes for review, instead of publishing (#319)',
+      false,
+    )
+    .option(
+      '--from-draft <number>',
+      'Manual mode: publish from a reviewed draft tracking issue (applies its edited notes), then close it',
+    )
     .option('--skip-notes', 'Skip changelog generation', false)
     .option('--skip-publish', 'Skip registry publishing and git operations', false)
     .option('--skip-git', 'Skip git commit/tag/push', false)
@@ -39,6 +49,20 @@ export function createReleaseCommand(): Command {
       if (opts.stable && opts.prerelease) {
         console.error('Error: Cannot use both --stable and --prerelease at the same time');
         process.exit(EXIT_CODES.INPUT_ERROR);
+      }
+
+      if (opts.draft && opts.fromDraft !== undefined) {
+        console.error('Error: Cannot use both --draft and --from-draft at the same time');
+        process.exit(EXIT_CODES.INPUT_ERROR);
+      }
+
+      let fromDraftNumber: number | undefined;
+      if (opts.fromDraft !== undefined) {
+        fromDraftNumber = Number(opts.fromDraft);
+        if (!Number.isInteger(fromDraftNumber) || fromDraftNumber <= 0) {
+          console.error(`Error: --from-draft expects a positive issue number, got "${opts.fromDraft}"`);
+          process.exit(EXIT_CODES.INPUT_ERROR);
+        }
       }
 
       const options: ReleaseOptions = {
@@ -66,7 +90,12 @@ export function createReleaseCommand(): Command {
       };
 
       try {
-        const result = await runRelease(options);
+        const result =
+          fromDraftNumber !== undefined
+            ? await publishFromDraft(fromDraftNumber, options)
+            : opts.draft
+              ? await runReleaseDraft(options)
+              : await runRelease(options);
 
         if (options.json && result) {
           console.log(JSON.stringify(result, null, 2));

--- a/packages/release/src/draft/draft.ts
+++ b/packages/release/src/draft/draft.ts
@@ -1,5 +1,5 @@
 import type { VersionOutput } from '@releasekit/core';
-import { info, success } from '@releasekit/core';
+import { info, success, warn } from '@releasekit/core';
 import { createGitCli } from '@releasekit/git';
 import { getGitHubContext } from '../git.js';
 import { forgeFor } from '../github.js';
@@ -24,6 +24,17 @@ export const DRAFT_LABEL = 'release:draft';
 /** ISO timestamp via an injectable clock so the manifest's `createdAt` stays deterministic in tests. */
 function nowIso(): string {
   return new Date().toISOString();
+}
+
+/** Whether two version outputs name the same publishable packages at the same versions. */
+function samePlan(a: VersionOutput | undefined, b: VersionOutput): boolean {
+  if (!a) return false;
+  const key = (v: VersionOutput) =>
+    publishableUpdates(v)
+      .map((u) => `${u.packageName}@${u.newVersion}`)
+      .sort()
+      .join(',');
+  return key(a) === key(b);
 }
 
 /** The human-facing tracking-issue body: a how-to preamble plus the editable per-package notes. */
@@ -74,9 +85,11 @@ export async function runReleaseDraft(options: ReleaseOptions): Promise<ReleaseO
   const manifest: StandingPRManifest = {
     schemaVersion: 2,
     versionOutput,
-    // Notes live (editable) in the issue body, not the manifest — the dispatch reads edits from the
-    // body and regenerates the rest, mirroring the standing-PR manifest's empty-releaseNotes contract.
-    releaseNotes: {},
+    // Store the drafted notes alongside the editable copy in the issue body. The draft is pinned to
+    // baseSha (no drift), so these are the reviewed baseline: at dispatch they back-stop any package
+    // whose editable region was removed/mangled, so a lost marker degrades to the reviewed notes
+    // rather than silently regenerating different ones (#463 review).
+    releaseNotes: releaseNotes ?? {},
     notesFiles: [],
     createdAt: nowIso(),
     baseSha,
@@ -88,11 +101,15 @@ export async function runReleaseDraft(options: ReleaseOptions): Promise<ReleaseO
   const body = renderDraftBody(versionOutput, releaseNotes ?? {});
   const manifestComment = serializeManifest(manifest);
 
+  // Reuse the existing draft only if it's actually ours — an open issue carrying the label AND a
+  // release manifest comment. A human-labelled, unrelated issue must not have its title/body
+  // overwritten with a release draft (#463 review); fall through to creating a fresh draft instead.
   const existing = await forge.findOpenIssueByLabel(DRAFT_LABEL);
+  const reusable = existing && (await forge.findComment(existing.number, MANIFEST_MARKER)) ? existing : null;
   let issueNumber: number;
-  if (existing) {
-    await forge.updateIssue(existing.number, { title, body });
-    issueNumber = existing.number;
+  if (reusable) {
+    await forge.updateIssue(reusable.number, { title, body });
+    issueNumber = reusable.number;
   } else {
     const ref = await forge.createIssue({ title, body, labels: [DRAFT_LABEL] });
     issueNumber = ref.number;
@@ -133,19 +150,45 @@ export async function publishFromDraft(issueNumber: number, options: ReleaseOpti
     );
   }
 
+  // baseSha pins the commit, but not the CLI flags: a dispatch run with different --target / --scope /
+  // --bump (or drifted config) would recompute a different plan than the reviewed draft. Recompute the
+  // plan (dry-run, no notes) and refuse if it no longer matches the manifest, so we never publish a
+  // plan the human didn't review (#463 review).
+  const preview = await runRelease({ ...options, dryRun: true, skipNotes: true });
+  if (!samePlan(preview?.versionOutput, manifest.versionOutput)) {
+    throw new Error(
+      `The release plan recomputed at dispatch differs from the reviewed draft #${issueNumber}. ` +
+        "Re-run 'releasekit release --draft' to refresh the draft, then dispatch with the same flags.",
+    );
+  }
+
   const issue = await forge.getIssue(issueNumber);
-  const editedNotes = extractNotesRegions(
+  const draftedNotes = manifest.releaseNotes ?? {};
+  const extracted = extractNotesRegions(
     issue.body,
     publishableUpdates(manifest.versionOutput).map((u) => u.packageName),
   );
+  // Reviewed notes win: edits read back from the body override the drafted baseline; any package
+  // whose editable region went missing (markers removed/mangled) falls back to the drafted notes
+  // rather than fresh regeneration, and is flagged (#463 review).
+  const editedNotes = { ...draftedNotes, ...extracted };
+  const droppedRegions = Object.keys(draftedNotes).filter((pkg) => !(pkg in extracted));
+  if (droppedRegions.length > 0) {
+    warn(
+      `Could not read the edited notes region for ${droppedRegions.join(', ')} on draft #${issueNumber} ` +
+        '(the markers may have been removed) — using the drafted notes for those packages.',
+    );
+  }
   if (Object.keys(editedNotes).length > 0) {
-    info(`Found human-edited notes for ${Object.keys(editedNotes).length} package(s) on draft #${issueNumber}.`);
+    info(`Applying reviewed notes for ${Object.keys(editedNotes).length} package(s) from draft #${issueNumber}.`);
   }
 
-  const result = await runRelease({ ...options, dryRun: false, editedNotes });
+  // Respect --dry-run: a dry dispatch validates without publishing or closing the issue (#463 review).
+  const result = await runRelease({ ...options, dryRun: options.dryRun, editedNotes });
 
-  // Close the draft only after a real publish — a no-op run (e.g. nothing to release) leaves it open.
-  if (result) {
+  // Close the draft only after a real publish landed — never on a dry run or a --skip-publish run,
+  // which compute without publishing anything (#463 review).
+  if (result && !options.dryRun && !options.skipPublish) {
     await forge.updateIssue(issueNumber, { state: 'closed' });
     success(`Published from draft #${issueNumber}; closed the draft issue.`);
   }

--- a/packages/release/src/draft/draft.ts
+++ b/packages/release/src/draft/draft.ts
@@ -1,0 +1,153 @@
+import type { VersionOutput } from '@releasekit/core';
+import { info, success } from '@releasekit/core';
+import { createGitCli } from '@releasekit/git';
+import { getGitHubContext } from '../git.js';
+import { forgeFor } from '../github.js';
+import { runRelease } from '../release.js';
+import { extractNotesRegions, renderNotesRegion } from '../standing-pr/notes-region.js';
+import {
+  MANIFEST_MARKER,
+  parseManifest,
+  type StandingPRManifest,
+  serializeManifest,
+} from '../standing-pr/standing-pr.js';
+import type { ReleaseOptions, ReleaseOutput } from '../types.js';
+import { publishableUpdates, syncVersionDisplay } from '../version-display.js';
+
+/**
+ * Label that marks the manual-mode release-draft tracking issue. Keyed on so re-running `--draft`
+ * reuses the one open draft issue instead of stacking new ones (the marker-idempotency invariant,
+ * applied to an issue rather than a comment).
+ */
+export const DRAFT_LABEL = 'release:draft';
+
+/** ISO timestamp via an injectable clock so the manifest's `createdAt` stays deterministic in tests. */
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+/** The human-facing tracking-issue body: a how-to preamble plus the editable per-package notes. */
+function renderDraftBody(versionOutput: VersionOutput, releaseNotes: Record<string, string>): string {
+  const updates = publishableUpdates(versionOutput);
+  const planLines = updates.map((u) => `- \`${u.packageName}\` → ${u.newVersion}`);
+  const preamble = [
+    '## Release Draft',
+    '',
+    'This issue holds a computed release awaiting review. **Edit the release notes below**, then',
+    "dispatch the publish (`releasekit release --from-draft <this issue's number>`) to publish exactly",
+    'this release with your edits.',
+    '',
+    'The release plan:',
+    '',
+    ...planLines,
+    '',
+    'Do not edit the hidden manifest comment — it carries the machine-readable release plan the',
+    'dispatch reads back. The draft is pinned to the commit it was computed at; if `main` moves before',
+    'you dispatch, re-run `--draft` to refresh it.',
+    '',
+  ].join('\n');
+  const notesRegion = renderNotesRegion(releaseNotes);
+  return notesRegion ? `${preamble}\n${notesRegion}` : preamble;
+}
+
+/**
+ * Phase 1 of manual-mode draft-then-dispatch (#319). Computes the release without mutating the tree
+ * or publishing (a dry-run pass), then opens — or updates in place — a tracking issue holding the
+ * editable per-package notes in its body and the base64 manifest in a marker comment. A human edits
+ * the notes; {@link publishFromDraft} consumes them.
+ */
+export async function runReleaseDraft(options: ReleaseOptions): Promise<ReleaseOutput | null> {
+  const context = getGitHubContext();
+  if (!context?.token) {
+    throw new Error('Cannot create a release draft: no GitHub token in the environment.');
+  }
+
+  // Dry-run pass: compute versionOutput + notes, write nothing to disk, publish nothing.
+  const result = await runRelease({ ...options, dryRun: true });
+  if (!result) {
+    info('No releasable changes — no draft created.');
+    return null;
+  }
+
+  const { versionOutput, releaseNotes } = result;
+  const baseSha = await createGitCli().headSha(options.projectDir);
+  const manifest: StandingPRManifest = {
+    schemaVersion: 2,
+    versionOutput,
+    // Notes live (editable) in the issue body, not the manifest — the dispatch reads edits from the
+    // body and regenerates the rest, mirroring the standing-PR manifest's empty-releaseNotes contract.
+    releaseNotes: {},
+    notesFiles: [],
+    createdAt: nowIso(),
+    baseSha,
+  };
+
+  const forge = forgeFor(context);
+  const display = syncVersionDisplay(versionOutput);
+  const title = display ? `Release draft: ${display}` : 'Release draft';
+  const body = renderDraftBody(versionOutput, releaseNotes ?? {});
+  const manifestComment = serializeManifest(manifest);
+
+  const existing = await forge.findOpenIssueByLabel(DRAFT_LABEL);
+  let issueNumber: number;
+  if (existing) {
+    await forge.updateIssue(existing.number, { title, body });
+    issueNumber = existing.number;
+  } else {
+    const ref = await forge.createIssue({ title, body, labels: [DRAFT_LABEL] });
+    issueNumber = ref.number;
+  }
+  // Idempotent: updates the manifest comment in place on a re-draft, creates it on a fresh issue.
+  await forge.upsertMarkerComment(issueNumber, MANIFEST_MARKER, manifestComment);
+
+  success(`Release draft ready for review: issue #${issueNumber}. Edit the notes, then dispatch --from-draft.`);
+  return result;
+}
+
+/**
+ * Phase 2 of manual-mode draft-then-dispatch (#319). Reads the manifest + human-edited notes from the
+ * draft issue, recomputes the release against HEAD (identical to the drafted plan because the baseSha
+ * guard requires HEAD to match), applies the edited notes (edited wins per package), publishes, and
+ * closes the issue on success.
+ */
+export async function publishFromDraft(issueNumber: number, options: ReleaseOptions): Promise<ReleaseOutput | null> {
+  const context = getGitHubContext();
+  if (!context?.token) {
+    throw new Error('Cannot publish from a release draft: no GitHub token in the environment.');
+  }
+
+  const forge = forgeFor(context);
+  const manifestComment = await forge.findComment(issueNumber, MANIFEST_MARKER);
+  if (!manifestComment) {
+    throw new Error(`No release-draft manifest found on issue #${issueNumber}.`);
+  }
+  const manifest = parseManifest(manifestComment.body);
+
+  // Pin to the commit the draft was computed at: recomputing on a different HEAD could publish a
+  // different version/notes than the human reviewed. Refuse and ask for a re-draft instead.
+  const currentSha = await createGitCli().headSha(options.projectDir);
+  if (currentSha !== manifest.baseSha) {
+    throw new Error(
+      `Release draft #${issueNumber} was computed at ${manifest.baseSha} but HEAD is ${currentSha}. ` +
+        "Re-run 'releasekit release --draft' to refresh the draft, then dispatch again.",
+    );
+  }
+
+  const issue = await forge.getIssue(issueNumber);
+  const editedNotes = extractNotesRegions(
+    issue.body,
+    publishableUpdates(manifest.versionOutput).map((u) => u.packageName),
+  );
+  if (Object.keys(editedNotes).length > 0) {
+    info(`Found human-edited notes for ${Object.keys(editedNotes).length} package(s) on draft #${issueNumber}.`);
+  }
+
+  const result = await runRelease({ ...options, dryRun: false, editedNotes });
+
+  // Close the draft only after a real publish — a no-op run (e.g. nothing to release) leaves it open.
+  if (result) {
+    await forge.updateIssue(issueNumber, { state: 'closed' });
+    success(`Published from draft #${issueNumber}; closed the draft issue.`);
+  }
+  return result;
+}

--- a/packages/release/src/draft/draft.ts
+++ b/packages/release/src/draft/draft.ts
@@ -26,15 +26,49 @@ function nowIso(): string {
   return new Date().toISOString();
 }
 
-/** Whether two version outputs name the same publishable packages at the same versions. */
+/**
+ * Canonical fingerprint of everything a release will publish — the full update set (including the
+ * root lockstep bump), tags, baseline tags, commit message, changelog entries, and strategy. Order-
+ * independent arrays are sorted so a reordering alone never reads as drift.
+ */
+function planFingerprint(v: VersionOutput): string {
+  const byName = <T extends { packageName: string }>(arr: readonly T[]) =>
+    [...arr].sort((a, b) => a.packageName.localeCompare(b.packageName));
+  return JSON.stringify({
+    strategy: v.strategy ?? null,
+    commitMessage: v.commitMessage ?? null,
+    tags: [...v.tags].sort(),
+    baselineTags: [...(v.baselineTags ?? [])].sort(),
+    updates: byName(v.updates),
+    changelogs: byName(v.changelogs),
+    sharedEntries: v.sharedEntries ?? [],
+  });
+}
+
+/**
+ * Whether two version outputs would publish the *same artifacts* — compared over the full plan, not
+ * just the publishable name@version projection. A recompute at the pinned baseSha can keep identical
+ * package versions yet differ in tags, commit message, the root update, or changelog shape (drifted
+ * flags or config); the narrow check would wave those through and publish a plan the human never
+ * reviewed (#463 review).
+ */
 function samePlan(a: VersionOutput | undefined, b: VersionOutput): boolean {
   if (!a) return false;
-  const key = (v: VersionOutput) =>
-    publishableUpdates(v)
-      .map((u) => `${u.packageName}@${u.newVersion}`)
-      .sort()
-      .join(',');
-  return key(a) === key(b);
+  return planFingerprint(a) === planFingerprint(b);
+}
+
+/**
+ * Whether a marker comment body actually decodes to a release manifest. Guards the `--draft` reuse
+ * path against an unrelated issue that was hand-labelled `release:draft` and happens to carry a
+ * marker-prefixed comment: without this, `--draft` would overwrite that issue's title/body (#463 review).
+ */
+function isReleaseManifestComment(body: string): boolean {
+  try {
+    parseManifest(body);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /** The human-facing tracking-issue body: a how-to preamble plus the editable per-package notes. */
@@ -102,10 +136,12 @@ export async function runReleaseDraft(options: ReleaseOptions): Promise<ReleaseO
   const manifestComment = serializeManifest(manifest);
 
   // Reuse the existing draft only if it's actually ours — an open issue carrying the label AND a
-  // release manifest comment. A human-labelled, unrelated issue must not have its title/body
-  // overwritten with a release draft (#463 review); fall through to creating a fresh draft instead.
+  // comment that decodes to a real release manifest. A human-labelled, unrelated issue (even one with
+  // an accidental marker-prefixed comment) must not have its title/body overwritten with a release
+  // draft (#463 review); fall through to creating a fresh draft instead.
   const existing = await forge.findOpenIssueByLabel(DRAFT_LABEL);
-  const reusable = existing && (await forge.findComment(existing.number, MANIFEST_MARKER)) ? existing : null;
+  const existingManifest = existing ? await forge.findComment(existing.number, MANIFEST_MARKER) : undefined;
+  const reusable = existing && existingManifest && isReleaseManifestComment(existingManifest.body) ? existing : null;
   let issueNumber: number;
   if (reusable) {
     await forge.updateIssue(reusable.number, { title, body });

--- a/packages/release/src/release.ts
+++ b/packages/release/src/release.ts
@@ -9,6 +9,7 @@ import { getGitHubContext, getHeadCommitMessage, matchesSkipPattern } from './gi
 import { fetchPRLabels, findMergedPRsForCommit, forgeFor } from './github.js';
 import { DEFAULT_LABELS, detectLabelConflicts } from './label-utils.js';
 import { refreshFeederPreviews } from './preview/refresh.js';
+import { mergeNotesRegions } from './standing-pr/notes-region.js';
 import { runNotesStep, runPublishStep, runVersionStep } from './steps.js';
 import type { ReleaseOptions, ReleaseOutput } from './types.js';
 import { publishableUpdates } from './version-display.js';
@@ -310,6 +311,13 @@ export async function runRelease(inputOptions: ReleaseOptions): Promise<ReleaseO
     notesFiles = notesResult.files;
     notesGenerated = true;
     success('Release notes generated');
+  }
+
+  // Human-edited notes win per package (manual-mode draft dispatch, #319). Merged here so the
+  // edits flow into both the publish step's release-body map and the returned releaseNotes.
+  if (options.editedNotes && Object.keys(options.editedNotes).length > 0) {
+    releaseNotes = mergeNotesRegions(releaseNotes ?? {}, options.editedNotes);
+    info(`Using human-edited release notes for ${Object.keys(options.editedNotes).length} package(s) from the draft.`);
   }
 
   // --- Step 3: Publish ---

--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -22,7 +22,7 @@ import { extractNotesRegions, mergeNotesRegions, renderNotesRegion } from './not
 import { extractSelection, renderSelectionRegion, selectionWarnings } from './selection-region.js';
 import { postStandingPRStatusSafe } from './status.js';
 
-const MANIFEST_MARKER = '<!-- releasekit-manifest -->';
+export const MANIFEST_MARKER = '<!-- releasekit-manifest -->';
 const MANIFEST_SCHEMA_VERSION = 2;
 /** Marker for the idempotent "your selection change was ignored" notice posted to an unauthorized editor (#401). */
 const SELECTION_DENIED_MARKER = '<!-- releasekit-selection-denied -->';

--- a/packages/release/src/types.ts
+++ b/packages/release/src/types.ts
@@ -43,6 +43,12 @@ export interface ReleaseOptions {
   npmAuth?: 'auto' | 'oidc' | 'token';
   /** When set, scope commit analysis (bump type + changelog) to commits after this SHA. */
   baseRef?: string;
+  /**
+   * Per-package human-edited release notes that win over freshly generated notes (edited wins per
+   * package, new packages fall back to fresh). Set by the manual-mode draft dispatch (#319) from the
+   * edited tracking-issue body; not a CLI flag.
+   */
+  editedNotes?: Record<string, string>;
 }
 
 export interface ReleaseOutput {

--- a/packages/release/test/unit/draft.spec.ts
+++ b/packages/release/test/unit/draft.spec.ts
@@ -1,0 +1,197 @@
+import type { VersionOutput } from '@releasekit/core';
+import { createFakeForge, type FakeForge } from '@releasekit/forge';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// --- Mocks ---
+
+const mockGetGitHubContext = vi.fn();
+vi.mock('../../src/git.js', () => ({
+  getGitHubContext: (...args: unknown[]) => mockGetGitHubContext(...args),
+}));
+
+const mockForgeFor = vi.fn();
+vi.mock('../../src/github.js', () => ({
+  forgeFor: (...args: unknown[]) => mockForgeFor(...args),
+}));
+
+const mockRunRelease = vi.fn();
+vi.mock('../../src/release.js', () => ({
+  runRelease: (...args: unknown[]) => mockRunRelease(...args),
+}));
+
+let headSha = 'sha-draft';
+vi.mock('@releasekit/git', () => ({
+  createGitCli: () => ({ headSha: async () => headSha }),
+}));
+
+vi.mock('@releasekit/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@releasekit/core')>();
+  return { ...actual, info: vi.fn(), success: vi.fn() };
+});
+
+// --- Helpers ---
+
+const context = { owner: 'o', repo: 'r', token: 'tok', sha: null };
+
+const versionOutput: VersionOutput = {
+  dryRun: false,
+  updates: [{ packageName: '@scope/core', newVersion: '1.2.0', filePath: 'packages/core/package.json' }],
+  changelogs: [],
+  commitMessage: 'chore: release 1.2.0',
+  tags: ['v1.2.0'],
+};
+
+const baseOptions = {
+  dryRun: false,
+  sync: false,
+  skipNotes: false,
+  skipPublish: false,
+  skipGit: false,
+  skipGithubRelease: false,
+  skipVerification: false,
+  json: false,
+  verbose: false,
+  quiet: false,
+  projectDir: '/p',
+};
+
+// --- Tests ---
+
+describe('runReleaseDraft', () => {
+  let runReleaseDraft: typeof import('../../src/draft/draft.js').runReleaseDraft;
+  let DRAFT_LABEL: string;
+  let forge: FakeForge;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    headSha = 'sha-draft';
+    mockGetGitHubContext.mockReturnValue(context);
+    forge = createFakeForge();
+    mockForgeFor.mockReturnValue(forge);
+    mockRunRelease.mockResolvedValue({
+      versionOutput,
+      notesGenerated: true,
+      releaseNotes: { '@scope/core': '- a new feature' },
+    });
+    const mod = await import('../../src/draft/draft.js');
+    runReleaseDraft = mod.runReleaseDraft;
+    DRAFT_LABEL = mod.DRAFT_LABEL;
+  });
+
+  it('should compute in dry-run so the working tree is never mutated', async () => {
+    await runReleaseDraft(baseOptions);
+    expect(mockRunRelease).toHaveBeenCalledWith(expect.objectContaining({ dryRun: true }));
+  });
+
+  it('should open a labelled draft issue carrying the editable notes and a manifest comment', async () => {
+    await runReleaseDraft(baseOptions);
+
+    expect(forge.createdIssues).toHaveLength(1);
+    const issue = forge.createdIssues[0];
+    expect(issue.labels).toEqual([DRAFT_LABEL]);
+    expect(issue.body).toContain('@scope/core');
+    expect(issue.body).toContain('- a new feature'); // editable notes region
+    // The manifest is stored as a marker comment (not in the editable body).
+    const created = await forge.findComment(42, '<!-- releasekit-manifest -->');
+    expect(created).not.toBeNull();
+  });
+
+  it('should reuse the existing open draft issue instead of stacking a new one', async () => {
+    const seeded = createFakeForge({
+      openIssues: [{ number: 7, url: 'u', labels: [DRAFT_LABEL] }],
+    });
+    mockForgeFor.mockReturnValue(seeded);
+
+    await runReleaseDraft(baseOptions);
+
+    expect(seeded.createdIssues).toHaveLength(0); // no new issue
+    expect(seeded.updatedIssues.map((u) => u.issueNumber)).toContain(7);
+  });
+
+  it('should create no issue when there are no releasable changes', async () => {
+    mockRunRelease.mockResolvedValue(null);
+    const result = await runReleaseDraft(baseOptions);
+    expect(result).toBeNull();
+    expect(forge.createdIssues).toHaveLength(0);
+  });
+
+  it('should throw when no GitHub token is present', async () => {
+    mockGetGitHubContext.mockReturnValue({ ...context, token: null });
+    await expect(runReleaseDraft(baseOptions)).rejects.toThrow(/no GitHub token/);
+  });
+});
+
+describe('publishFromDraft', () => {
+  let publishFromDraft: typeof import('../../src/draft/draft.js').publishFromDraft;
+  let serializeManifest: typeof import('../../src/standing-pr/standing-pr.js').serializeManifest;
+
+  const manifest = {
+    schemaVersion: 2 as const,
+    versionOutput,
+    releaseNotes: {},
+    notesFiles: [],
+    createdAt: '2026-01-01T00:00:00.000Z',
+    baseSha: 'sha-draft',
+  };
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    headSha = 'sha-draft';
+    mockGetGitHubContext.mockReturnValue(context);
+    mockRunRelease.mockResolvedValue({ versionOutput, notesGenerated: true });
+    const mod = await import('../../src/draft/draft.js');
+    publishFromDraft = mod.publishFromDraft;
+    ({ serializeManifest } = await import('../../src/standing-pr/standing-pr.js'));
+  });
+
+  function forgeWithDraft(body: string): FakeForge {
+    return createFakeForge({
+      issues: { 9: { body, title: 'Release draft', labels: ['release:draft'], isPullRequest: false } },
+      comments: [{ id: 1, body: serializeManifest(manifest), prNumber: 9 }],
+      openIssues: [{ number: 9, url: 'u', labels: ['release:draft'] }],
+    });
+  }
+
+  it('should extract edited notes, publish with them, and close the issue', async () => {
+    const { wrapNotesRegion } = await import('@releasekit/core');
+    const body = `## Release Notes\n${wrapNotesRegion('- EDITED BY HUMAN', '@scope/core')}`;
+    const forge = forgeWithDraft(body);
+    mockForgeFor.mockReturnValue(forge);
+
+    await publishFromDraft(9, baseOptions);
+
+    expect(mockRunRelease).toHaveBeenCalledWith(
+      expect.objectContaining({ dryRun: false, editedNotes: { '@scope/core': '- EDITED BY HUMAN' } }),
+    );
+    // Issue closed after a successful publish.
+    expect(forge.updatedIssues).toContainEqual({ issueNumber: 9, changes: { state: 'closed' } });
+  });
+
+  it('should refuse to publish when HEAD has drifted from the draft baseSha', async () => {
+    headSha = 'sha-moved';
+    const forge = forgeWithDraft('## Release Notes');
+    mockForgeFor.mockReturnValue(forge);
+
+    await expect(publishFromDraft(9, baseOptions)).rejects.toThrow(/HEAD is sha-moved/);
+    expect(mockRunRelease).not.toHaveBeenCalled();
+  });
+
+  it('should throw when the issue has no manifest comment', async () => {
+    const forge = createFakeForge({
+      issues: { 9: { body: 'x', title: 't', labels: [], isPullRequest: false } },
+    });
+    mockForgeFor.mockReturnValue(forge);
+
+    await expect(publishFromDraft(9, baseOptions)).rejects.toThrow(/No release-draft manifest/);
+  });
+
+  it('should not close the issue when the publish is a no-op', async () => {
+    mockRunRelease.mockResolvedValue(null);
+    const forge = forgeWithDraft('## Release Notes');
+    mockForgeFor.mockReturnValue(forge);
+
+    await publishFromDraft(9, baseOptions);
+
+    expect(forge.updatedIssues).not.toContainEqual({ issueNumber: 9, changes: { state: 'closed' } });
+  });
+});

--- a/packages/release/test/unit/draft.spec.ts
+++ b/packages/release/test/unit/draft.spec.ts
@@ -26,7 +26,7 @@ vi.mock('@releasekit/git', () => ({
 
 vi.mock('@releasekit/core', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@releasekit/core')>();
-  return { ...actual, info: vi.fn(), success: vi.fn() };
+  return { ...actual, info: vi.fn(), success: vi.fn(), warn: vi.fn() };
 });
 
 // --- Helpers ---
@@ -96,9 +96,11 @@ describe('runReleaseDraft', () => {
     expect(created).not.toBeNull();
   });
 
-  it('should reuse the existing open draft issue instead of stacking a new one', async () => {
+  it('should reuse the existing open draft issue (with a manifest comment) instead of stacking a new one', async () => {
     const seeded = createFakeForge({
       openIssues: [{ number: 7, url: 'u', labels: [DRAFT_LABEL] }],
+      // A real draft carries the manifest comment — that's what marks it as ours to reuse.
+      comments: [{ id: 1, body: '<!-- releasekit-manifest -->\nx', prNumber: 7 }],
     });
     mockForgeFor.mockReturnValue(seeded);
 
@@ -106,6 +108,20 @@ describe('runReleaseDraft', () => {
 
     expect(seeded.createdIssues).toHaveLength(0); // no new issue
     expect(seeded.updatedIssues.map((u) => u.issueNumber)).toContain(7);
+  });
+
+  it('should NOT overwrite a human-labelled issue that lacks a manifest comment (#463 review)', async () => {
+    // An unrelated open issue happens to carry the `release:draft` label but is not a real draft.
+    const seeded = createFakeForge({
+      openIssues: [{ number: 7, url: 'u', labels: [DRAFT_LABEL] }],
+    });
+    mockForgeFor.mockReturnValue(seeded);
+
+    await runReleaseDraft(baseOptions);
+
+    // It creates a fresh draft rather than clobbering #7's title/body.
+    expect(seeded.createdIssues).toHaveLength(1);
+    expect(seeded.updatedIssues.map((u) => u.issueNumber)).not.toContain(7);
   });
 
   it('should create no issue when there are no releasable changes', async () => {
@@ -160,6 +176,7 @@ describe('publishFromDraft', () => {
 
     await publishFromDraft(9, baseOptions);
 
+    // The real publish run carries the edited notes and the caller's dryRun (false here).
     expect(mockRunRelease).toHaveBeenCalledWith(
       expect.objectContaining({ dryRun: false, editedNotes: { '@scope/core': '- EDITED BY HUMAN' } }),
     );
@@ -176,6 +193,63 @@ describe('publishFromDraft', () => {
     expect(mockRunRelease).not.toHaveBeenCalled();
   });
 
+  it('should refuse when the recomputed plan differs from the reviewed draft (#463 review)', async () => {
+    // Preview (first runRelease call) recomputes a different plan than the manifest stored.
+    mockRunRelease.mockReset();
+    mockRunRelease.mockResolvedValueOnce({
+      versionOutput: {
+        ...versionOutput,
+        updates: [{ packageName: '@scope/core', newVersion: '2.0.0', filePath: 'p' }],
+      },
+    });
+    const forge = forgeWithDraft('## Release Notes');
+    mockForgeFor.mockReturnValue(forge);
+
+    await expect(publishFromDraft(9, baseOptions)).rejects.toThrow(/differs from the reviewed draft/);
+    // Only the preview ran — no real publish.
+    expect(mockRunRelease).toHaveBeenCalledTimes(1);
+    expect(forge.updatedIssues).not.toContainEqual({ issueNumber: 9, changes: { state: 'closed' } });
+  });
+
+  it('should respect --dry-run: validate without publishing or closing (#463 review)', async () => {
+    const forge = forgeWithDraft('## Release Notes');
+    mockForgeFor.mockReturnValue(forge);
+
+    await publishFromDraft(9, { ...baseOptions, dryRun: true });
+
+    expect(mockRunRelease).toHaveBeenCalledWith(expect.objectContaining({ dryRun: true }));
+    expect(forge.updatedIssues).not.toContainEqual({ issueNumber: 9, changes: { state: 'closed' } });
+  });
+
+  it('should not close the issue on a --skip-publish run (#463 review)', async () => {
+    const forge = forgeWithDraft('## Release Notes');
+    mockForgeFor.mockReturnValue(forge);
+
+    await publishFromDraft(9, { ...baseOptions, skipPublish: true });
+
+    expect(forge.updatedIssues).not.toContainEqual({ issueNumber: 9, changes: { state: 'closed' } });
+  });
+
+  it('should fall back to drafted notes and warn when an editable region was removed (#463 review)', async () => {
+    const { warn } = await import('@releasekit/core');
+    // The draft stored notes for @scope/core, but the editable region is gone from the body.
+    const draftWithNotes = { ...manifest, releaseNotes: { '@scope/core': '- reviewed in the draft' } };
+    const forge = createFakeForge({
+      issues: { 9: { body: 'no markers here', title: 't', labels: ['release:draft'], isPullRequest: false } },
+      comments: [{ id: 1, body: serializeManifest(draftWithNotes), prNumber: 9 }],
+      openIssues: [{ number: 9, url: 'u', labels: ['release:draft'] }],
+    });
+    mockForgeFor.mockReturnValue(forge);
+
+    await publishFromDraft(9, baseOptions);
+
+    expect(vi.mocked(warn)).toHaveBeenCalledWith(expect.stringContaining('markers may have been removed'));
+    // The reviewed drafted notes are used rather than fresh regeneration.
+    expect(mockRunRelease).toHaveBeenCalledWith(
+      expect.objectContaining({ editedNotes: { '@scope/core': '- reviewed in the draft' } }),
+    );
+  });
+
   it('should throw when the issue has no manifest comment', async () => {
     const forge = createFakeForge({
       issues: { 9: { body: 'x', title: 't', labels: [], isPullRequest: false } },
@@ -183,15 +257,5 @@ describe('publishFromDraft', () => {
     mockForgeFor.mockReturnValue(forge);
 
     await expect(publishFromDraft(9, baseOptions)).rejects.toThrow(/No release-draft manifest/);
-  });
-
-  it('should not close the issue when the publish is a no-op', async () => {
-    mockRunRelease.mockResolvedValue(null);
-    const forge = forgeWithDraft('## Release Notes');
-    mockForgeFor.mockReturnValue(forge);
-
-    await publishFromDraft(9, baseOptions);
-
-    expect(forge.updatedIssues).not.toContainEqual({ issueNumber: 9, changes: { state: 'closed' } });
   });
 });

--- a/packages/release/test/unit/draft.spec.ts
+++ b/packages/release/test/unit/draft.spec.ts
@@ -1,6 +1,7 @@
 import type { VersionOutput } from '@releasekit/core';
 import { createFakeForge, type FakeForge } from '@releasekit/forge';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { serializeManifest } from '../../src/standing-pr/standing-pr.js';
 
 // --- Mocks ---
 
@@ -40,6 +41,16 @@ const versionOutput: VersionOutput = {
   commitMessage: 'chore: release 1.2.0',
   tags: ['v1.2.0'],
 };
+
+const manifest = {
+  schemaVersion: 2 as const,
+  versionOutput,
+  releaseNotes: {},
+  notesFiles: [],
+  createdAt: '2026-01-01T00:00:00.000Z',
+  baseSha: 'sha-draft',
+};
+const validManifestComment = serializeManifest(manifest);
 
 const baseOptions = {
   dryRun: false,
@@ -99,8 +110,8 @@ describe('runReleaseDraft', () => {
   it('should reuse the existing open draft issue (with a manifest comment) instead of stacking a new one', async () => {
     const seeded = createFakeForge({
       openIssues: [{ number: 7, url: 'u', labels: [DRAFT_LABEL] }],
-      // A real draft carries the manifest comment — that's what marks it as ours to reuse.
-      comments: [{ id: 1, body: '<!-- releasekit-manifest -->\nx', prNumber: 7 }],
+      // A real draft carries a decodable manifest comment — that's what marks it as ours to reuse.
+      comments: [{ id: 1, body: validManifestComment, prNumber: 7 }],
     });
     mockForgeFor.mockReturnValue(seeded);
 
@@ -124,6 +135,21 @@ describe('runReleaseDraft', () => {
     expect(seeded.updatedIssues.map((u) => u.issueNumber)).not.toContain(7);
   });
 
+  it('should NOT reuse an issue whose marker comment is not a valid manifest (#463 review)', async () => {
+    // Hand-labelled issue with an accidental marker-prefixed comment that does not decode to a manifest.
+    const seeded = createFakeForge({
+      openIssues: [{ number: 7, url: 'u', labels: [DRAFT_LABEL] }],
+      comments: [{ id: 1, body: '<!-- releasekit-manifest -->\nnot-a-real-manifest', prNumber: 7 }],
+    });
+    mockForgeFor.mockReturnValue(seeded);
+
+    await runReleaseDraft(baseOptions);
+
+    // The invalid marker comment must not make #7 look reusable — a fresh draft is created.
+    expect(seeded.createdIssues).toHaveLength(1);
+    expect(seeded.updatedIssues.map((u) => u.issueNumber)).not.toContain(7);
+  });
+
   it('should create no issue when there are no releasable changes', async () => {
     mockRunRelease.mockResolvedValue(null);
     const result = await runReleaseDraft(baseOptions);
@@ -139,16 +165,6 @@ describe('runReleaseDraft', () => {
 
 describe('publishFromDraft', () => {
   let publishFromDraft: typeof import('../../src/draft/draft.js').publishFromDraft;
-  let serializeManifest: typeof import('../../src/standing-pr/standing-pr.js').serializeManifest;
-
-  const manifest = {
-    schemaVersion: 2 as const,
-    versionOutput,
-    releaseNotes: {},
-    notesFiles: [],
-    createdAt: '2026-01-01T00:00:00.000Z',
-    baseSha: 'sha-draft',
-  };
 
   beforeEach(async () => {
     vi.clearAllMocks();
@@ -157,7 +173,6 @@ describe('publishFromDraft', () => {
     mockRunRelease.mockResolvedValue({ versionOutput, notesGenerated: true });
     const mod = await import('../../src/draft/draft.js');
     publishFromDraft = mod.publishFromDraft;
-    ({ serializeManifest } = await import('../../src/standing-pr/standing-pr.js'));
   });
 
   function forgeWithDraft(body: string): FakeForge {
@@ -207,6 +222,21 @@ describe('publishFromDraft', () => {
 
     await expect(publishFromDraft(9, baseOptions)).rejects.toThrow(/differs from the reviewed draft/);
     // Only the preview ran — no real publish.
+    expect(mockRunRelease).toHaveBeenCalledTimes(1);
+    expect(forge.updatedIssues).not.toContainEqual({ issueNumber: 9, changes: { state: 'closed' } });
+  });
+
+  it('should refuse when only tags/commit-message drift even though name@version matches (#463 review)', async () => {
+    // Same publishable name@version as the manifest, but different tags + commit message — the narrow
+    // name@version check would have waved this through; the full-plan fingerprint catches it.
+    mockRunRelease.mockReset();
+    mockRunRelease.mockResolvedValueOnce({
+      versionOutput: { ...versionOutput, tags: ['v9.9.9'], commitMessage: 'chore: a different release' },
+    });
+    const forge = forgeWithDraft('## Release Notes');
+    mockForgeFor.mockReturnValue(forge);
+
+    await expect(publishFromDraft(9, baseOptions)).rejects.toThrow(/differs from the reviewed draft/);
     expect(mockRunRelease).toHaveBeenCalledTimes(1);
     expect(forge.updatedIssues).not.toContainEqual({ issueNumber: 9, changes: { state: 'closed' } });
   });

--- a/packages/release/test/unit/release.spec.ts
+++ b/packages/release/test/unit/release.spec.ts
@@ -998,4 +998,16 @@ describe('runRelease', () => {
       expect(mockRefreshFeederPreviews).not.toHaveBeenCalled();
     });
   });
+
+  describe('editedNotes (manual-mode draft dispatch, #319)', () => {
+    it('should merge editedNotes over generated notes before publish (edited wins per package)', async () => {
+      await runRelease({ ...defaultOptions, editedNotes: { 'test-pkg': '- edited by human' } });
+
+      // runPublishStep forwards releaseNotes as the 3rd positional to the publish pipeline.
+      const publishOptions = vi.mocked(mockPublishRunPipeline).mock.calls[0]?.[2] as {
+        releaseNotes?: Record<string, string>;
+      };
+      expect(publishOptions.releaseNotes).toMatchObject({ 'test-pkg': '- edited by human' });
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Closes #319. Manual mode (`workflow_dispatch`) has no standing PR, so there's no body to review release notes in before they ship. This adds a two-phase **draft-then-dispatch** flow built on a tracking issue.

> **Stacked on #462** (the Forge issue API). Review/merge that first; this PR targets its branch and the diff here is just the feature.

## Flow

```bash
# Phase 1 — compute (dry-run, no publish) and open a `release:draft` tracking issue
# holding the editable per-package notes in its body + the manifest in a marker comment.
releasekit release --draft

# Human edits the notes in the issue body (keeping the <!-- releasekit-notes... --> markers).

# Phase 2 — publish exactly that release with the edits applied, then close the issue.
releasekit release --from-draft 123
```

## Design

- **Reuses standing-PR machinery wholesale**: `serializeManifest`/`parseManifest`, the notes-region `render`/`extract`/`merge` helpers, and `runRelease` itself.
- **`--draft`** runs `runRelease({ dryRun: true })` — computes versionOutput + notes, writes nothing to disk, publishes nothing — then writes the issue. Re-running updates the **one** open draft issue in place (via `findOpenIssueByLabel`), never stacks.
- **`--from-draft <n>`** reads the manifest + edited notes, then calls `runRelease` with a new `editedNotes` option (merged over generated notes, edited wins per package), and closes the issue on a successful publish.
- **Pinned to the drafted commit**: the dispatch refuses if HEAD ≠ the draft's `baseSha`, asking for a re-draft — so it never publishes a different version/notes than the human reviewed. (Recompute on the matching HEAD is identical to the drafted plan.)

## Scope notes

- The `release:draft` label is auto-created by GitHub on first `--draft` (issue creation with a new label name). Adding it to `releasekit labels` and a consumer **workflow template** in `ci-setup.md` are sensible follow-ups; `docs/cli.md` documents the flags here.

## Test plan

- `pnpm turbo run lint typecheck test` — green (32 tasks).
- New `draft.spec.ts` (9 tests): dry-run compute, issue create/reuse, manifest comment, no-changes no-op, token guard; dispatch extracts edits → publishes with `editedNotes` → closes, refuses on baseSha drift, errors with no manifest, leaves issue open on a no-op publish.
- `release.spec.ts`: `editedNotes` merges over generated notes before publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a manual draft-and-dispatch flow for releases. The main changes are:

- New `--draft` and `--from-draft` release command flags.
- Draft tracking issues with editable release notes and a stored manifest.
- Dispatch from a reviewed draft with commit and plan checks.
- Human-edited notes merged into the publish flow.
- Unit tests for draft creation, reuse, dispatch, drift checks, and note fallback.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/release/src/draft/draft.ts | Adds the draft issue workflow, reviewed-note dispatch, drift checks, note fallback, and guarded issue reuse. |
| packages/release/src/release.ts | Merges edited draft notes over generated notes before publishing. |
| packages/release/src/commands/release-command.ts | Adds and routes the manual draft release command flags. |
| packages/release/src/standing-pr/standing-pr.ts | Exports the manifest marker for the draft issue flow. |
| packages/release/test/unit/draft.spec.ts | Covers draft creation, reuse, dispatch, drift refusal, note fallback, and non-publishing validation paths. |

</details>

<sub>Reviews (4): Last reviewed commit: ["fix(release): harden draft-dispatch plan..."](https://github.com/goosewobbler/releasekit/commit/229deba5c00dbb214ae61ed7b667b435adcc414b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40282971)</sub>

<!-- /greptile_comment -->