### PR TITLE
fix(version): show prerelease predecessor as previousVersion on graduation

### DIFF
--- a/packages/version/src/core/baselineResolver.ts
+++ b/packages/version/src/core/baselineResolver.ts
@@ -182,11 +182,18 @@ export class BaselineResolver {
     }
 
     // previousVersion is shown to users in the changelog header — strip the baseline-tag scheme back
-    // to its consumer-facing form so `release/v0.22.0` appears as `v0.22.0`. Omit it when we fell
-    // back to all-history so the changelog doesn't claim a baseline it never diffed against (#339).
+    // to its consumer-facing form so `release/v0.22.0` appears as `v0.22.0`. On graduation with no
+    // prior stable tag, `changelogBaseTag` widens to '' (so the range spans the whole prerelease
+    // line) but the package's real predecessor is still its prerelease `latestTag` — fall back to it
+    // for the label so a graduating package reads `<prerelease> → <stable>` instead of being
+    // mislabeled a first release (#474). Kept in tag form: `generateCompareUrl` rebuilds the `to` tag
+    // from it, so a bare value would break compare links. Omit it when we fell back to all-history so
+    // the changelog doesn't claim a baseline it never diffed against (#339); a genuine first release
+    // (no tag at all) leaves both empty and stays null.
+    const previousTag = changelogBaseTag || latestTag;
     const previousVersion =
-      changelogBaseTag && !baselineUnreachable
-        ? displayTag(changelogBaseTag, input.baselineTagPrefix, input.formattedPrefix)
+      previousTag && !baselineUnreachable
+        ? displayTag(previousTag, input.baselineTagPrefix, input.formattedPrefix)
         : null;
 
     return { revisionRange, previousVersion, baselineUnreachable };

--- a/packages/version/test/unit/core/baselineResolver.spec.ts
+++ b/packages/version/test/unit/core/baselineResolver.spec.ts
@@ -167,8 +167,33 @@ describe('BaselineResolver.resolve', () => {
       makeInput({ latestTag: 'v1.0.0-next.1', nextVersion: '1.0.0' }),
     );
     expect(result.revisionRange).toBe('v0.9.0..HEAD');
-    expect(result.previousVersion).toBeNull();
+    // Range floors by the nearest reachable tag (#370); the LABEL still falls back to the prerelease
+    // predecessor rather than rendering N/A (#474) — the two are decoupled.
+    expect(result.previousVersion).toBe('v1.0.0-next.1');
     expect(verifyTag).not.toHaveBeenCalled();
+  });
+
+  it('should label previousVersion with the prerelease predecessor when graduating with no prior stable tag (#474)', async () => {
+    // Graduation widens the range to the whole prerelease line by re-basing onto the last stable tag,
+    // but with no prior stable that lookup returns '' — so the package's only predecessor is its
+    // prerelease latestTag. Fall back to it for the label (kept in tag form so generateCompareUrl can
+    // rebuild the `to` tag) instead of rendering N/A and mislabeling a graduating package a first
+    // release. Realistic floor: git describe finds the prerelease tag itself as the nearest reachable.
+    vi.mocked(getLatestStableTag).mockResolvedValue('');
+    vi.mocked(getNearestReachableTag).mockResolvedValue('v1.1.0-next.0');
+    const result = await new BaselineResolver(makeOpts()).resolve(
+      makeInput({ latestTag: 'v1.1.0-next.0', nextVersion: '1.1.0' }),
+    );
+    expect(result.previousVersion).toBe('v1.1.0-next.0');
+    expect(result.baselineUnreachable).toBe(false);
+  });
+
+  it('should still leave previousVersion null for a genuine first release with no prior tag (#474)', async () => {
+    // The fallback only kicks in when there IS a tag to fall back to: with no tag at all, both
+    // changelogBaseTag and latestTag are empty, so a true first release stays null → N/A.
+    vi.mocked(getNearestReachableTag).mockResolvedValue('');
+    const result = await new BaselineResolver(makeOpts()).resolve(makeInput({ latestTag: '', hasRealTag: false }));
+    expect(result.previousVersion).toBeNull();
   });
 
   it('should strip a baseline marker tag back to consumer form for previousVersion (#330)', async () => {


### PR DESCRIPTION
## Summary

Prerelease-graduating packages with no prior stable tag rendered their previous version as `N/A` (e.g. `@wdio/dioxus-bridge — N/A → 1.1.0`) and were mislabeled first releases, even though their real predecessor is the prerelease tag.

The resolver deliberately re-bases the changelog *range* onto the last stable tag on graduation so the notes span the whole prerelease line. With no prior stable that lookup returns `''`, which also nulled the displayed `previousVersion` label and discarded the prerelease predecessor.

## Changes

- `baselineResolver.ts`: fall back to `latestTag` for the `previousVersion` label when `changelogBaseTag` is empty (`changelogBaseTag || latestTag`), kept in `displayTag` (tag) form so `generateCompareUrl` can rebuild the `to` tag. A genuine first release (no tag at all) still resolves to `null`. Rewrote the explanatory comment.
- `baselineResolver.spec.ts`: added a graduation-with-no-prior-stable case asserting the prerelease label (not null) and a genuine-first-release case asserting null; updated the pre-existing #370 test that encoded the old buggy null label.

## Test plan

- `pnpm turbo run lint typecheck test --filter=@releasekit/version...` — all pass (652 tests; baselineResolver spec 23 tests).

Closes #474

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes the displayed previous version for prerelease graduations without a prior stable tag. The main changes are:

- Falls back from an empty changelog base tag to the prerelease latest tag for the displayed label.
- Keeps true first releases showing no previous version.
- Adds and updates unit tests for graduation and first-release cases.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/version/src/core/baselineResolver.ts | Adds a `latestTag` fallback for the user-facing previous version label while preserving the existing unreachable-baseline guard. |
| packages/version/test/unit/core/baselineResolver.spec.ts | Adds coverage for prerelease graduation without a prior stable tag and preserves true first-release behavior. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(version): show prerelease predecesso..."](https://github.com/goosewobbler/releasekit/commit/52df9520cad2e8202605dfd4c80d7ef37b23f97e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40593534)</sub>

<!-- /greptile_comment -->