### PR TITLE
fix(release): display bare previous version in changelog headers

### DIFF
--- a/packages/release/src/preview/format.ts
+++ b/packages/release/src/preview/format.ts
@@ -4,7 +4,7 @@ import { formatDuration } from '../duration.js';
 import { MARKER } from '../github.js';
 import type { StandingPRSnapshot } from '../standing-pr/standing-pr.js';
 import type { ReleaseOutput } from '../types.js';
-import { publishableUpdates, syncVersionDisplay, syncVersionRange } from '../version-display.js';
+import { publishableUpdates, syncVersionDisplay, syncVersionRange, toDisplayVersion } from '../version-display.js';
 import type { MergedRow } from './merge.js';
 
 export type ReleaseStrategy = 'manual' | 'direct' | 'standing-pr';
@@ -414,7 +414,9 @@ function renderQueuedTable(snapshot: StandingPRSnapshot): string[] {
     '|---------|---------|------|',
   ];
   for (const cl of changelogs) {
-    lines.push(`| \`${cl.packageName}\` | ${cl.previousVersion ?? '—'} | ${cl.version} |`);
+    lines.push(
+      `| \`${cl.packageName}\` | ${cl.previousVersion ? toDisplayVersion(cl.previousVersion) : '—'} | ${cl.version} |`,
+    );
   }
   lines.push('');
   return lines;
@@ -495,7 +497,7 @@ function renderEntries(entries: VersionChangelogEntry[]): string[] {
 
 function formatPackageChangelog(changelog: VersionPackageChangelog): string[] {
   const lines: string[] = [];
-  const prevVersion = changelog.previousVersion ?? 'N/A';
+  const prevVersion = changelog.previousVersion ? toDisplayVersion(changelog.previousVersion) : 'N/A';
   const summary = `<b>${changelog.packageName}</b> ${prevVersion} → ${changelog.version}`;
 
   lines.push('<details>', `<summary>${summary}</summary>`, '');

--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -16,7 +16,7 @@ import { DEFAULT_LABELS } from '../label-utils.js';
 import { refreshFeederPreviews } from '../preview/refresh.js';
 import { runNotesStep, runPublishStep, runVersionStep } from '../steps.js';
 import type { ReleaseOptions, ReleaseOutput } from '../types.js';
-import { publishableUpdates, syncVersionDisplay } from '../version-display.js';
+import { publishableUpdates, syncVersionDisplay, toDisplayVersion } from '../version-display.js';
 import { type EventActor, getEventActor, isAuthorizedActor, type StandingPrAuthorization } from './authorization.js';
 import { extractNotesRegions, mergeNotesRegions, renderNotesRegion } from './notes-region.js';
 import {
@@ -345,7 +345,10 @@ function renderChangelogSection(versionOutput: VersionOutput): string {
 
   for (const cl of versionOutput.changelogs) {
     if (cl.entries.length === 0) continue;
-    inner.push(`#### ${cl.packageName} — ${cl.previousVersion ?? 'N/A'} → ${cl.version}`, '');
+    inner.push(
+      `#### ${cl.packageName} — ${cl.previousVersion ? toDisplayVersion(cl.previousVersion) : 'N/A'} → ${cl.version}`,
+      '',
+    );
     inner.push(...renderChangelogEntries(cl.entries));
   }
 

--- a/packages/release/src/version-display.ts
+++ b/packages/release/src/version-display.ts
@@ -21,6 +21,18 @@ export function syncVersionDisplay(versionOutput: VersionOutput): string {
   return sharedTag ?? publishableUpdates(versionOutput)[0]?.newVersion ?? '';
 }
 
+/**
+ * Bare semver for display. `previousVersion` is persisted as the consumer tag (e.g. `pkg@v10.1.0`,
+ * `release/v1.2.0`, `v1.2.0`) so compare-URL generation can build links from it; renderers want the
+ * bare version. Extract the semver from the TAIL of the string with an end-anchored match so a
+ * numeric package name stays safe (`package2@v1.0.0` → `1.0.0`, not `2.0.0`). Returns the input
+ * unchanged when it carries no recognisable semver.
+ */
+export function toDisplayVersion(tagOrVersion: string): string {
+  const match = tagOrVersion.match(/(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?)$/);
+  return match?.[1] ?? tagOrVersion;
+}
+
 /** Previous-to-next version range when the previous version is known, otherwise just the next version. */
 export function syncVersionRange(versionOutput: VersionOutput): string {
   const next = syncVersionDisplay(versionOutput);

--- a/packages/release/test/unit/preview-format.spec.ts
+++ b/packages/release/test/unit/preview-format.spec.ts
@@ -219,6 +219,37 @@ describe('formatPreviewComment', () => {
     expect(result).toContain('</details>');
   });
 
+  it('should render the changelog header with a bare previous version when previousVersion is a package tag', () => {
+    const taggedOutput: ReleaseOutput = {
+      versionOutput: {
+        dryRun: true,
+        updates: [
+          {
+            packageName: '@wdio/electron-service',
+            newVersion: '10.2.0',
+            filePath: 'packages/electron-service/package.json',
+          },
+        ],
+        changelogs: [
+          {
+            packageName: '@wdio/electron-service',
+            version: '10.2.0',
+            // Stored as the consumer tag; the header must strip it to the bare semver.
+            previousVersion: 'wdio-electron-service@v10.1.0',
+            revisionRange: 'wdio-electron-service@v10.1.0..HEAD',
+            repoUrl: null,
+            entries: [{ type: 'added', description: 'New widget' }],
+          },
+        ],
+        tags: ['wdio-electron-service@v10.2.0'],
+      },
+      notesGenerated: false,
+    };
+    const result = formatPreviewComment(taggedOutput);
+    expect(result).toContain('<b>@wdio/electron-service</b> 10.1.0 → 10.2.0');
+    expect(result).not.toContain('wdio-electron-service@v10.1.0 → 10.2.0');
+  });
+
   it('should not include tags section', () => {
     const result = formatPreviewComment(releaseOutput);
     expect(result).not.toContain('### Tags');
@@ -572,8 +603,9 @@ describe('formatPreviewComment', () => {
         {
           packageName: '@a/version',
           version: '0.3.2',
-          previousVersion: '0.3.1',
-          revisionRange: 'v0.3.1..HEAD',
+          // Stored as the consumer tag; the table must strip it to the bare semver.
+          previousVersion: '@a/version@v0.3.1',
+          revisionRange: '@a/version@v0.3.1..HEAD',
           repoUrl: null,
           entries: [{ type: 'fix', description: 'queued fix' }],
         },

--- a/packages/release/test/unit/standing-pr.spec.ts
+++ b/packages/release/test/unit/standing-pr.spec.ts
@@ -1074,6 +1074,36 @@ describe('runStandingPRUpdate', () => {
     expect(body).toContain('@scope/core — 1.2.2 → 1.2.3');
   });
 
+  it('should render the changelog header with a bare previous version when previousVersion is a package tag', async () => {
+    const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
+    const versionOutput = {
+      ...createMockVersionOutput([{ packageName: '@wdio/electron-service', newVersion: '10.2.0' }]),
+      changelogs: [
+        {
+          packageName: '@wdio/electron-service',
+          version: '10.2.0',
+          // Stored as the consumer tag (compare-URL generation depends on it); the header must strip it.
+          previousVersion: 'wdio-electron-service@v10.1.0',
+          revisionRange: 'wdio-electron-service@v10.1.0..HEAD',
+          repoUrl: null,
+          entries: [{ type: 'feat', description: 'Add new widget' }],
+        },
+      ],
+    };
+    vi.mocked(runVersionStep)
+      .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>)
+      .mockResolvedValueOnce(versionOutput as unknown as Awaited<ReturnType<typeof runVersionStep>>);
+    vi.mocked(runNotesStep).mockResolvedValue({ packageNotes: {}, releaseNotes: {}, files: [] });
+
+    const forge = await mockForge({ standingPR: null });
+
+    await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
+
+    const body = forge.createdPullRequests[0]?.body;
+    expect(body).toContain('@wdio/electron-service — 10.1.0 → 10.2.0');
+    expect(body).not.toContain('wdio-electron-service@v10.1.0 → 10.2.0');
+  });
+
   it("should truncate the PR body when the changelog would exceed GitHub's limit (#333)", async () => {
     const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
     // A no-baseline-tag package's full-history changelog: thousands of entries blow past 65,536 chars.

--- a/packages/release/test/unit/version-display.spec.ts
+++ b/packages/release/test/unit/version-display.spec.ts
@@ -1,6 +1,11 @@
 import type { VersionOutput } from '@releasekit/core';
 import { describe, expect, it } from 'vitest';
-import { publishableUpdates, syncVersionDisplay, syncVersionRange } from '../../src/version-display.js';
+import {
+  publishableUpdates,
+  syncVersionDisplay,
+  syncVersionRange,
+  toDisplayVersion,
+} from '../../src/version-display.js';
 
 function output(overrides: Partial<VersionOutput> = {}): VersionOutput {
   return {
@@ -67,6 +72,37 @@ describe('syncVersionDisplay', () => {
 
   it('should return an empty string for empty output', () => {
     expect(syncVersionDisplay(output())).toBe('');
+  });
+});
+
+describe('toDisplayVersion', () => {
+  it('should strip a package-specific tag prefix down to the bare semver', () => {
+    expect(toDisplayVersion('wdio-electron-service@v10.1.0')).toBe('10.1.0');
+  });
+
+  it('should strip a plain vX.Y.Z tag', () => {
+    expect(toDisplayVersion('v1.2.0')).toBe('1.2.0');
+  });
+
+  it('should strip a baseline release/v… tag', () => {
+    expect(toDisplayVersion('release/v1.2.0')).toBe('1.2.0');
+  });
+
+  it('should preserve a prerelease (and build) suffix', () => {
+    expect(toDisplayVersion('@scope/pkg@v1.1.0-next.0')).toBe('1.1.0-next.0');
+    expect(toDisplayVersion('v2.0.0-rc.1+build.5')).toBe('2.0.0-rc.1+build.5');
+  });
+
+  it('should anchor at the tail so a numeric package name is not mistaken for the version', () => {
+    expect(toDisplayVersion('package2@v1.0.0')).toBe('1.0.0');
+  });
+
+  it('should return an already-bare version unchanged', () => {
+    expect(toDisplayVersion('10.2.0')).toBe('10.2.0');
+  });
+
+  it('should return the input unchanged when it carries no semver', () => {
+    expect(toDisplayVersion('not-a-version')).toBe('not-a-version');
   });
 });
 


### PR DESCRIPTION
## Summary

The standing-PR (and preview) changelog rendered the previous version as the full git tag while the new version was a bare semver — asymmetric and noisy (`#### @wdio/electron-service — wdio-electron-service@v10.1.0 → 10.2.0`). The tag form is stored intentionally (compare-URL generation depends on it), so the fix display-strips at the render sites only.

## Changes

- Add `toDisplayVersion(tagOrVersion: string): string` to `packages/release/src/version-display.ts` — extracts the bare semver from the tail of the string with an end-anchored regex, preserving prerelease/build suffixes and returning the input unchanged when no semver matches. End-anchoring keeps numeric package names safe (`package2@v1.0.0` → `1.0.0`).
- Apply it at the render sites: the standing-PR changelog header (`standing-pr.ts`) and the preview changelog header + queued-for-release table (`preview/format.ts`). Stored `previousVersion` is unchanged.
- Unit-test `toDisplayVersion` (package-specific tag, plain `vX.Y.Z`, baseline `release/v…`, prerelease/build suffix, numeric-package-name safety, already-bare passthrough, no-semver passthrough) and add render assertions showing the bare `10.1.0 → 10.2.0` form in both standing-pr.spec and preview-format.spec.

## Test plan

- `pnpm turbo run lint typecheck test --filter=@releasekit/release...` → 31/31 tasks pass (release: 700 tests).

Closes #475

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR cleans up previous-version display in release changelog output. The main changes are:

- Added `toDisplayVersion` for stripping tag prefixes from display-only versions.
- Applied the helper to standing PR changelog headers.
- Applied the helper to preview changelog headers and queued-release tables.
- Added unit tests for tag parsing and rendered changelog output.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/release/src/version-display.ts | Adds a pure helper that extracts a display semver from the end of a tag or returns the input unchanged. |
| packages/release/src/preview/format.ts | Uses the new display helper for preview changelog previous-version text. |
| packages/release/src/standing-pr/standing-pr.ts | Uses the new display helper for standing PR changelog previous-version text. |
| packages/release/test/unit/version-display.spec.ts | Adds focused coverage for package tags, v-prefixed tags, release-prefixed tags, suffixes, bare versions, and passthrough cases. |
| packages/release/test/unit/preview-format.spec.ts | Adds preview output assertions for bare previous-version display. |
| packages/release/test/unit/standing-pr.spec.ts | Adds standing PR output assertions for bare previous-version display. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(release): display bare previous vers..."](https://github.com/goosewobbler/releasekit/commit/39f637480101281b90c68e0cf2d06c9f4e6d12c7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40593782)</sub>

<!-- /greptile_comment -->