### PR TITLE
fix(version): dedupe hybrid package updates by directory (npm wins)

### DIFF
--- a/packages/version/src/utils/jsonOutput.ts
+++ b/packages/version/src/utils/jsonOutput.ts
@@ -106,8 +106,10 @@ export function addPackageUpdate(packageName: string, newVersion: string, filePa
   if (!_jsonOutputMode) return;
 
   const update = { packageName, newVersion, filePath, ...(isRoot ? { isRoot } : {}) };
-  const dir = path.dirname(filePath);
-  const existingIndex = _jsonData.updates.findIndex((u) => path.dirname(u.filePath) === dir);
+  // Resolve to an absolute path before keying so a mix of absolute and relative filePaths for the
+  // same directory still dedupes (callers don't all pass the same path form for every manifest write).
+  const dir = path.dirname(path.resolve(filePath));
+  const existingIndex = _jsonData.updates.findIndex((u) => path.dirname(path.resolve(u.filePath)) === dir);
   if (existingIndex !== -1) {
     // Only let an incoming package.json replace an already-recorded native sibling; otherwise keep
     // the existing record (the package.json, or the first native manifest) and drop this duplicate.

--- a/packages/version/src/utils/jsonOutput.ts
+++ b/packages/version/src/utils/jsonOutput.ts
@@ -4,6 +4,7 @@
  */
 
 import fs from 'node:fs';
+import path from 'node:path';
 import type { VersionAction, VersionChangelogEntry, VersionOutput, VersionPackageChangelog } from '@releasekit/core';
 
 /** @deprecated Use {@link VersionOutput} from `@releasekit/core` instead. */
@@ -91,16 +92,34 @@ export function setVersioningStrategy(strategy: 'sync' | 'single' | 'async' | 'g
 /**
  * Add a package update to the JSON output
  * @param isRoot True when this is the workspace-root package.json bumped in lockstep (sync mode)
+ *
+ * A hybrid package (one directory carrying both a `package.json` and a native manifest like
+ * `Cargo.toml`/`pubspec.yaml`) is a SINGLE package — npm owns its identity. Every strategy writes the
+ * `package.json` first, then syncs the sibling native manifest to the same version; that second write
+ * must not register a second update under the crate/pub name, or the package surfaces twice
+ * downstream — a phantom selection row / extra changelog entry under its crate name (#476). Dedupe by
+ * directory, mirroring discovery's dir-keyed merge (`mergePackageLists`): npm wins, so a `package.json`
+ * supersedes a previously-recorded native sibling and a native sibling is dropped once a `package.json`
+ * for the same directory exists.
  */
 export function addPackageUpdate(packageName: string, newVersion: string, filePath: string, isRoot?: boolean): void {
   if (!_jsonOutputMode) return;
 
-  _jsonData.updates.push({
-    packageName,
-    newVersion,
-    filePath,
-    ...(isRoot ? { isRoot } : {}),
-  });
+  const update = { packageName, newVersion, filePath, ...(isRoot ? { isRoot } : {}) };
+  const dir = path.dirname(filePath);
+  const existingIndex = _jsonData.updates.findIndex((u) => path.dirname(u.filePath) === dir);
+  if (existingIndex !== -1) {
+    // Only let an incoming package.json replace an already-recorded native sibling; otherwise keep
+    // the existing record (the package.json, or the first native manifest) and drop this duplicate.
+    const incomingIsPackageJson = path.basename(filePath) === 'package.json';
+    const existingIsPackageJson = path.basename(_jsonData.updates[existingIndex].filePath) === 'package.json';
+    if (incomingIsPackageJson && !existingIsPackageJson) {
+      _jsonData.updates[existingIndex] = update;
+    }
+    return;
+  }
+
+  _jsonData.updates.push(update);
 }
 
 /**

--- a/packages/version/test/unit/utils/jsonOutput.spec.ts
+++ b/packages/version/test/unit/utils/jsonOutput.spec.ts
@@ -117,6 +117,51 @@ describe('JSON Output Utilities', () => {
         filePath: '/path/to/packages/a/package.json',
       });
     });
+
+    // A hybrid package (one dir, both package.json + a native manifest) is a single package — npm
+    // owns its identity. Without dir-keyed dedup the native sibling's write registers a second
+    // update under its crate/pub name and the package surfaces twice downstream (#476).
+    it('should keep one update per directory for a hybrid, with npm winning regardless of write order', () => {
+      enableJsonOutput();
+      // package.json written first (the order every strategy uses), then the Cargo.toml sibling.
+      addPackageUpdate('@scope/x-y', '1.1.0', '/ws/packages/x/package.json');
+      addPackageUpdate('x-y', '1.1.0', '/ws/packages/x/Cargo.toml');
+
+      const data = getJsonData();
+      expect(data.updates).toHaveLength(1);
+      expect(data.updates[0]).toEqual({
+        packageName: '@scope/x-y',
+        newVersion: '1.1.0',
+        filePath: '/ws/packages/x/package.json',
+      });
+    });
+
+    it('should let a package.json supersede a native sibling recorded first (order-independent npm-wins)', () => {
+      enableJsonOutput();
+      addPackageUpdate('x-y', '1.1.0', '/ws/packages/x/Cargo.toml');
+      addPackageUpdate('@scope/x-y', '1.1.0', '/ws/packages/x/package.json');
+
+      const data = getJsonData();
+      expect(data.updates).toHaveLength(1);
+      expect(data.updates[0]).toEqual({
+        packageName: '@scope/x-y',
+        newVersion: '1.1.0',
+        filePath: '/ws/packages/x/package.json',
+      });
+    });
+
+    it('should still record the update for a native-only package (no package.json sibling)', () => {
+      enableJsonOutput();
+      addPackageUpdate('pure-crate', '2.0.0', '/ws/crates/pure/Cargo.toml');
+
+      const data = getJsonData();
+      expect(data.updates).toHaveLength(1);
+      expect(data.updates[0]).toEqual({
+        packageName: 'pure-crate',
+        newVersion: '2.0.0',
+        filePath: '/ws/crates/pure/Cargo.toml',
+      });
+    });
   });
 
   describe('addChangelogData', () => {
@@ -305,10 +350,12 @@ describe('JSON Output Utilities', () => {
       expect(data.updates[0]?.tag).toBeUndefined();
     });
 
-    it('should only set tag on the first matching update when duplicates exist', () => {
+    it('should only set tag on the first matching update when same-named updates exist', () => {
       enableJsonOutput();
-      addPackageUpdate('my-package', '1.1.0', '/path/to/package.json');
-      addPackageUpdate('my-package', '1.1.0', '/path/to/Cargo.toml');
+      // Different directories, so dir-keyed dedup keeps both; setPackageUpdateTag still tags only the
+      // first match by name.
+      addPackageUpdate('my-package', '1.1.0', '/path/to/a/package.json');
+      addPackageUpdate('my-package', '1.1.0', '/path/to/b/package.json');
 
       setPackageUpdateTag('my-package', 'my-package@v1.1.0');
 

--- a/packages/version/test/unit/utils/jsonOutput.spec.ts
+++ b/packages/version/test/unit/utils/jsonOutput.spec.ts
@@ -162,6 +162,18 @@ describe('JSON Output Utilities', () => {
         filePath: '/ws/crates/pure/Cargo.toml',
       });
     });
+
+    it('should dedupe a hybrid when manifest paths are not string-identical for the same directory', () => {
+      enableJsonOutput();
+      addPackageUpdate('@scope/x-y', '1.1.0', '/ws/packages/x/package.json');
+      // Same directory, written via a non-normalized path form — keying on path.dirname alone would
+      // miss this and re-admit the crate-name duplicate; resolving first dedupes it (#476).
+      addPackageUpdate('x-y', '1.1.0', '/ws/packages/./x/Cargo.toml');
+
+      const data = getJsonData();
+      expect(data.updates).toHaveLength(1);
+      expect(data.updates[0].packageName).toBe('@scope/x-y');
+    });
   });
 
   describe('addChangelogData', () => {


### PR DESCRIPTION
## Summary

A hybrid npm+cargo package (one directory with both `package.json` and `Cargo.toml`) surfaced as **two** standing-PR selection rows — once under its npm name, once under its crate name.

Package discovery was already correct: `mergePackageLists` dedupes hybrids by directory and npm wins. The duplicate entered **downstream of discovery**. Every version strategy writes the npm `package.json` first, then syncs the sibling native manifest (`Cargo.toml`/`pubspec.yaml`) to the same version. The native-manifest writers (`updateCargoVersion`, `updatePubVersion`) each call `addPackageUpdate` with the manifest's *own* name — which for a hybrid is the crate/pub name, distinct from the npm name. So `versionOutput.updates` gained a second, orphaned entry under the crate name (no tag/group/action), and the standing-PR selection list — keyed off `updates` `packageName` — rendered it as a phantom row.

Confirmed with a real-git-repo repro of the issue's recipe: the group dry-run yielded `[ '@scope/x-y', 'x-y' ]` before the fix, `[ '@scope/x-y' ]` after. The crate-name/sanitized-npm-name collision noted in the issue is incidental — the duplicate occurs for any hybrid, across the group/single/async/PackageProcessor paths (all share `addPackageUpdate`).

### What changed
- `packages/version/src/utils/jsonOutput.ts`: `addPackageUpdate` now dedupes by the directory of `filePath`, mirroring discovery's `mergePackageLists` (npm wins). A `package.json` supersedes an already-recorded native sibling; a native sibling is dropped once a same-directory `package.json` exists; native-only packages keep their single update.
- `packages/version/test/unit/utils/jsonOutput.spec.ts`: regression tests for the hybrid case (same-dir dedup, order-independent npm-wins, native-only preserved); repurposed the now-inaccurate same-dir "duplicates" test to use distinct directories.

## Test plan
- `pnpm turbo run lint typecheck test --filter=@releasekit/version...` — all tasks pass (653 unit tests).
- New `jsonOutput` tests assert a hybrid dir yields exactly one update under the npm name regardless of manifest write order.

## Follow-up (out of scope)
The dedup keys on directory, so it covers *same-directory* hybrids (the #476 case). The `cargo.paths` config (a JS package pointing at `Cargo.toml` in sibling subdirectories) still emits a separate update per crate dir — existing, arguably intended behavior, left untouched.

Closes #476

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR dedupes hybrid package version updates by manifest directory. The main changes are:

- Added directory-based update dedupe in `addPackageUpdate`.
- Made `package.json` entries win over same-directory native manifests.
- Added tests for hybrid packages, write order, native-only packages, and normalized path forms.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/version/src/utils/jsonOutput.ts | Adds resolved-directory dedupe for package update records while preserving npm identity for same-directory hybrids. |
| packages/version/test/unit/utils/jsonOutput.spec.ts | Adds tests for hybrid dedupe behavior, write order, native-only packages, and normalized same-directory paths. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(version): resolve manifest paths bef..."](https://github.com/goosewobbler/releasekit/commit/dc99c3c0632b49ea42d927637522652bac3acfc5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40595887)</sub>

<!-- /greptile_comment -->