### PR TITLE
fix(release): drop bump-kind suffix from standing-PR selection rows

### DIFF
--- a/packages/release/src/standing-pr/selection-region.ts
+++ b/packages/release/src/standing-pr/selection-region.ts
@@ -6,7 +6,6 @@ import {
   shouldMatchPackageTargets,
   wrapSelectionRegion,
 } from '@releasekit/core';
-import semver from 'semver';
 
 type Update = VersionOutput['updates'][number];
 
@@ -26,29 +25,11 @@ const REGION_HINT =
   '> Untick a package to hold it back from the next release, then save — the bot re-runs and updates this PR. ' +
   'Keep the `<!-- rk-sel... -->` marker comments; they identify each row.';
 
-/** A ` (minor)`-style bump suffix derived from the package's previous→new version, when known. */
-export function bumpSuffix(versionOutput: VersionOutput, packageName: string, newVersion: string): string {
-  const previous = versionOutput.changelogs.find((c) => c.packageName === packageName)?.previousVersion;
-  if (!previous) return '';
-  // `previousVersion` can carry a package-specific tag prefix (e.g. `name@v1.2.3`) in repos using
-  // `packageSpecificTags` — not valid semver, so a bare `semver.diff` throws and would crash the
-  // whole standing-PR render. Strip to the part after the last `@`, then diff inside a guard: a
-  // cosmetic bump suffix must never abort the update (regressed packageSpecificTags repos on 0.31.0).
-  const prev = previous.includes('@') ? previous.slice(previous.lastIndexOf('@') + 1) : previous;
-  try {
-    const kind = semver.diff(prev, newVersion);
-    return kind ? ` (${kind})` : '';
-  } catch {
-    return '';
-  }
-}
-
 function checkbox(selected: boolean): string {
   return selected ? '[x]' : '[ ]';
 }
 
 function row(
-  versionOutput: VersionOutput,
   update: VersionOutput['updates'][number],
   selected: boolean,
   opts: { indent?: boolean; bold?: boolean; prefix?: string } = {},
@@ -56,8 +37,7 @@ function row(
   const indent = opts.indent ? '  ' : '';
   const name = opts.bold ? `**\`${update.packageName}\`**` : `\`${update.packageName}\``;
   const prefix = opts.prefix ?? '';
-  const suffix = bumpSuffix(versionOutput, update.packageName, update.newVersion);
-  return `${indent}- ${checkbox(selected)} ${prefix}${name} → ${update.newVersion}${suffix} ${rkSelMarker(update.packageName)}`;
+  return `${indent}- ${checkbox(selected)} ${prefix}${name} → ${update.newVersion} ${rkSelMarker(update.packageName)}`;
 }
 
 /** Config controlling the hierarchical (release-unit) render. Absent / empty `primaryPackages` keeps
@@ -203,35 +183,26 @@ export function validatePrimaryPackages(
 
 /** A primary's task-list row: bold name, interactive checkbox, identity marker. Renders `— no change`
  *  when the primary anchors its unit without bumping. */
-function primaryRow(versionOutput: VersionOutput, unit: ReleaseUnit, selected: boolean): string {
-  const label = unit.primaryUpdate
-    ? `→ ${unit.primaryUpdate.newVersion}${bumpSuffix(versionOutput, unit.primaryName, unit.primaryUpdate.newVersion)}`
-    : '— no change';
+function primaryRow(unit: ReleaseUnit, selected: boolean): string {
+  const label = unit.primaryUpdate ? `→ ${unit.primaryUpdate.newVersion}` : '— no change';
   return `- ${checkbox(selected)} **\`${unit.primaryName}\`** ${label} ${rkSelMarker(unit.primaryName)}`;
 }
 
 /** A streamlined child: a plain bullet (never a task item, so GitHub can't make it interactive and
  *  fight the cascade) and intentionally markerless — its state is derived from its primary each run. */
-function childBullet(versionOutput: VersionOutput, child: Update): string {
-  return `  - \`${child.packageName}\` → ${child.newVersion}${bumpSuffix(versionOutput, child.packageName, child.newVersion)} · coupled`;
+function childBullet(child: Update): string {
+  return `  - \`${child.packageName}\` → ${child.newVersion} · coupled`;
 }
 
-function renderFlat(
-  lines: string[],
-  versionOutput: VersionOutput,
-  updates: Update[],
-  selected: (name: string) => boolean,
-): void {
+function renderFlat(lines: string[], updates: Update[], selected: (name: string) => boolean): void {
   const prerequisites = updates.filter((u) => u.role === 'prerequisite');
   const rendered = new Set<string>();
   if (prerequisites.length > 0) {
     for (const target of updates.filter((u) => u.role === 'target')) {
-      lines.push(row(versionOutput, target, selected(target.packageName), { bold: true }));
+      lines.push(row(target, selected(target.packageName), { bold: true }));
       rendered.add(target.packageName);
       for (const prereq of prerequisites.filter((p) => p.prerequisiteOf?.includes(target.packageName))) {
-        lines.push(
-          row(versionOutput, prereq, selected(prereq.packageName), { indent: true, prefix: '↳ prerequisite ' }),
-        );
+        lines.push(row(prereq, selected(prereq.packageName), { indent: true, prefix: '↳ prerequisite ' }));
         rendered.add(prereq.packageName);
       }
     }
@@ -239,13 +210,12 @@ function renderFlat(
   // Flat rows for the plain-async case, and for any prerequisite whose target had no update entry of
   // its own (it would otherwise be silently dropped).
   for (const update of updates.filter((u) => !rendered.has(u.packageName))) {
-    lines.push(row(versionOutput, update, selected(update.packageName)));
+    lines.push(row(update, selected(update.packageName)));
   }
 }
 
 function renderHierarchical(
   lines: string[],
-  versionOutput: VersionOutput,
   updates: Update[],
   selected: (name: string) => boolean,
   primary: PrimaryConfig,
@@ -253,24 +223,24 @@ function renderHierarchical(
   const hierarchy = computeHierarchy(updates, primary);
   const streamlined = primary.selection !== 'granular';
   for (const unit of hierarchy.units) {
-    lines.push(primaryRow(versionOutput, unit, selected(unit.primaryName)));
+    lines.push(primaryRow(unit, selected(unit.primaryName)));
     if (unit.children.length === 0) continue;
     if (streamlined) {
       // Children inside a collapsed pane as plain bullets — a blank line after <summary> lets GitHub
       // render the nested markdown list.
       lines.push(`  <details><summary>ships ${unit.children.length} coupled</summary>`, '');
-      for (const child of unit.children) lines.push(childBullet(versionOutput, child));
+      for (const child of unit.children) lines.push(childBullet(child));
       lines.push('  </details>');
     } else {
       // granular: every child keeps its own interactive, marker'd checkbox indented under the primary.
       for (const child of unit.children) {
-        lines.push(row(versionOutput, child, selected(child.packageName), { indent: true }));
+        lines.push(row(child, selected(child.packageName), { indent: true }));
       }
     }
   }
   // Orphans — changed packages outside every known unit — stay flat top-level checkboxes (fail-safe).
   for (const orphan of hierarchy.orphans) {
-    lines.push(row(versionOutput, orphan, selected(orphan.packageName)));
+    lines.push(row(orphan, selected(orphan.packageName)));
   }
 }
 
@@ -282,7 +252,6 @@ function renderHierarchical(
  * Every row is ticked unless its package is in `deselected`. Returns the marker-wrapped block.
  */
 export function renderSelectionRegion(
-  versionOutput: VersionOutput,
   updates: VersionOutput['updates'],
   deselected: ReadonlySet<string>,
   primary?: PrimaryConfig,
@@ -291,9 +260,9 @@ export function renderSelectionRegion(
   const lines: string[] = [REGION_HEADING, '', REGION_HINT, ''];
 
   if (primary && primary.primaryPackages.length > 0) {
-    renderHierarchical(lines, versionOutput, updates, selected, primary);
+    renderHierarchical(lines, updates, selected, primary);
   } else {
-    renderFlat(lines, versionOutput, updates, selected);
+    renderFlat(lines, updates, selected);
   }
 
   return wrapSelectionRegion(lines.join('\n'));

--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -1141,7 +1141,7 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
   // of a still-selected target) ride below the region and surface in the run log.
   let selectionBlock: string | undefined;
   if (versionOutputDry.strategy !== 'sync') {
-    const region = renderSelectionRegion(versionOutputDry, dryUpdates, effectiveDeselected, primaryConfig);
+    const region = renderSelectionRegion(dryUpdates, effectiveDeselected, primaryConfig);
     const warnings = selectionWarnings(dryUpdates, effectiveDeselected, groups);
     for (const w of warnings) warn(`Selection: ${w.reason}`);
     selectionBlock = warnings.length > 0 ? `${region}\n\n${warnings.map((w) => `> ⚠️ ${w.reason}`).join('\n')}` : region;

--- a/packages/release/test/unit/selection-region.spec.ts
+++ b/packages/release/test/unit/selection-region.spec.ts
@@ -12,22 +12,6 @@ import {
 
 type Update = VersionOutput['updates'][number];
 
-function mockOutput(updates: Update[], changelogs: VersionOutput['changelogs'] = []): VersionOutput {
-  return {
-    dryRun: true,
-    strategy: 'async',
-    updates,
-    changelogs,
-    tags: [],
-    commitMessage: '',
-    sharedEntries: [],
-  } as unknown as VersionOutput;
-}
-
-function changelog(packageName: string, previousVersion: string, version: string) {
-  return { packageName, version, previousVersion, revisionRange: '', repoUrl: null, entries: [] };
-}
-
 describe('selection-region', () => {
   describe('renderSelectionRegion', () => {
     it('should render every package ticked by default with a per-row identity marker', () => {
@@ -35,7 +19,7 @@ describe('selection-region', () => {
         { packageName: '@scope/a', newVersion: '1.1.0', filePath: '' },
         { packageName: '@scope/b', newVersion: '2.0.0', filePath: '' },
       ];
-      const region = renderSelectionRegion(mockOutput(updates), updates, new Set());
+      const region = renderSelectionRegion(updates, new Set());
 
       expect(region).toContain('- [x] `@scope/a` → 1.1.0 <!-- rk-sel:@scope/a -->');
       expect(region).toContain('- [x] `@scope/b` → 2.0.0 <!-- rk-sel:@scope/b -->');
@@ -48,42 +32,17 @@ describe('selection-region', () => {
         { packageName: '@scope/a', newVersion: '1.1.0', filePath: '' },
         { packageName: '@scope/b', newVersion: '2.0.0', filePath: '' },
       ];
-      const region = renderSelectionRegion(mockOutput(updates), updates, new Set(['@scope/b']));
+      const region = renderSelectionRegion(updates, new Set(['@scope/b']));
 
       expect(region).toContain('- [x] `@scope/a` → 1.1.0 <!-- rk-sel:@scope/a -->');
       expect(region).toContain('- [ ] `@scope/b` → 2.0.0 <!-- rk-sel:@scope/b -->');
     });
 
-    it('should show the commit-driven bump kind when the previous version is known', () => {
+    it('should render a plain `→ version` row with no bump-kind parenthetical', () => {
       const updates: Update[] = [{ packageName: '@scope/a', newVersion: '1.1.0', filePath: '' }];
-      const region = renderSelectionRegion(
-        mockOutput(updates, [changelog('@scope/a', '1.0.0', '1.1.0')]),
-        updates,
-        new Set(),
-      );
-      expect(region).toContain('→ 1.1.0 (minor)');
-    });
-
-    it('should not crash and still derive the bump kind from a package-specific tag previousVersion', () => {
-      // packageSpecificTags repos carry previousVersion as a full tag (`name@vX.Y.Z`) — a bare
-      // semver.diff throws "Invalid Version" and would abort the whole render (regression #NNN).
-      const updates: Update[] = [{ packageName: 'wdio-electron-cdp-bridge', newVersion: '10.1.0', filePath: '' }];
-      const region = renderSelectionRegion(
-        mockOutput(updates, [changelog('wdio-electron-cdp-bridge', 'wdio-electron-cdp-bridge@v10.0.0', '10.1.0')]),
-        updates,
-        new Set(),
-      );
-      expect(region).toContain('→ 10.1.0 (minor)');
-    });
-
-    it('should drop the suffix rather than throw on an unparseable previousVersion', () => {
-      const updates: Update[] = [{ packageName: 'pkg', newVersion: '1.1.0', filePath: '' }];
-      const region = renderSelectionRegion(
-        mockOutput(updates, [changelog('pkg', 'not-a-version', '1.1.0')]),
-        updates,
-        new Set(),
-      );
+      const region = renderSelectionRegion(updates, new Set());
       expect(region).toContain('→ 1.1.0');
+      expect(region).not.toContain('(minor)');
       expect(region).not.toContain('(');
     });
 
@@ -98,7 +57,7 @@ describe('selection-region', () => {
           prerequisiteOf: ['@scope/app'],
         },
       ];
-      const region = renderSelectionRegion(mockOutput(updates), updates, new Set());
+      const region = renderSelectionRegion(updates, new Set());
 
       expect(region).toContain('- [x] **`@scope/app`** → 2.0.0 <!-- rk-sel:@scope/app -->');
       expect(region).toContain('  - [x] ↳ prerequisite `@scope/core` → 1.1.0 <!-- rk-sel:@scope/core -->');
@@ -115,7 +74,7 @@ describe('selection-region', () => {
           prerequisiteOf: ['@scope/app'],
         },
       ];
-      const region = renderSelectionRegion(mockOutput(updates), updates, new Set());
+      const region = renderSelectionRegion(updates, new Set());
 
       expect(region).toContain('rk-sel:@scope/core');
     });
@@ -131,7 +90,7 @@ describe('selection-region', () => {
         { packageName: '@scope/a', newVersion: '1.1.0', filePath: '' },
         { packageName: '@scope/b', newVersion: '2.0.0', filePath: '' },
       ];
-      const body = `## Release\n\n${renderSelectionRegion(mockOutput(updates), updates, new Set(['@scope/b']))}\n\nchangelog`;
+      const body = `## Release\n\n${renderSelectionRegion(updates, new Set(['@scope/b']))}\n\nchangelog`;
 
       expect(extractSelection(body)).toEqual({ deselected: ['@scope/b'] });
     });
@@ -148,10 +107,10 @@ describe('selection-region', () => {
         { packageName: '@scope/b', newVersion: '2.0.0', filePath: '' },
       ];
       // First render all-ticked, simulate the human unticking b, then re-render from the extracted set.
-      const seeded = renderSelectionRegion(mockOutput(updates), updates, new Set());
+      const seeded = renderSelectionRegion(updates, new Set());
       const edited = seeded.replace('[x] `@scope/b`', '[ ] `@scope/b`');
       const extracted = extractSelection(edited);
-      const rerendered = renderSelectionRegion(mockOutput(updates), updates, new Set(extracted?.deselected));
+      const rerendered = renderSelectionRegion(updates, new Set(extracted?.deselected));
 
       expect(rerendered).toContain('- [ ] `@scope/b`');
       expect(rerendered).toContain('- [x] `@scope/a`');
@@ -226,7 +185,6 @@ describe('selection-region', () => {
       { packageName: '@wdio/tauri-plugin', newVersion: '1.4.0', filePath: '', group: 'tauri' },
       { packageName: 'tauri-plugin-wdio-webdriver', newVersion: '1.4.0', filePath: '', group: 'tauri' },
     ];
-    const tauriChangelogs = tauriUpdates.map((u) => changelog(u.packageName, '1.3.0', '1.4.0'));
     const cfg = (over: Partial<PrimaryConfig> = {}): PrimaryConfig => ({
       primaryPackages: ['@wdio/tauri-service'],
       selection: 'streamlined',
@@ -358,11 +316,11 @@ describe('selection-region', () => {
 
     describe('renderSelectionRegion (hierarchical)', () => {
       it('should render a streamlined primary with read-only coupled bullets in a collapsed pane', () => {
-        const region = renderSelectionRegion(mockOutput(tauriUpdates, tauriChangelogs), tauriUpdates, new Set(), cfg());
-        expect(region).toContain('- [x] **`@wdio/tauri-service`** → 1.4.0 (minor) <!-- rk-sel:@wdio/tauri-service -->');
+        const region = renderSelectionRegion(tauriUpdates, new Set(), cfg());
+        expect(region).toContain('- [x] **`@wdio/tauri-service`** → 1.4.0 <!-- rk-sel:@wdio/tauri-service -->');
         expect(region).toContain('  <details><summary>ships 2 coupled</summary>');
-        expect(region).toContain('  - `@wdio/tauri-plugin` → 1.4.0 (minor) · coupled');
-        expect(region).toContain('  - `tauri-plugin-wdio-webdriver` → 1.4.0 (minor) · coupled');
+        expect(region).toContain('  - `@wdio/tauri-plugin` → 1.4.0 · coupled');
+        expect(region).toContain('  - `tauri-plugin-wdio-webdriver` → 1.4.0 · coupled');
         expect(region).toContain('  </details>');
         // Children are never task items and carry no marker — their state is derived, not toggled.
         expect(region).not.toContain('[x] `@wdio/tauri-plugin`');
@@ -373,19 +331,14 @@ describe('selection-region', () => {
         const pluginOnly: Update[] = [
           { packageName: '@wdio/tauri-plugin', newVersion: '1.4.0', filePath: '', group: 'tauri' },
         ];
-        const region = renderSelectionRegion(mockOutput(pluginOnly), pluginOnly, new Set(), cfg());
+        const region = renderSelectionRegion(pluginOnly, new Set(), cfg());
         expect(region).toContain('- [x] **`@wdio/tauri-service`** — no change <!-- rk-sel:@wdio/tauri-service -->');
       });
 
       it('should give every package its own marker’d checkbox in granular mode, no <details>', () => {
-        const region = renderSelectionRegion(
-          mockOutput(tauriUpdates, tauriChangelogs),
-          tauriUpdates,
-          new Set(),
-          cfg({ selection: 'granular' }),
-        );
-        expect(region).toContain('- [x] **`@wdio/tauri-service`** → 1.4.0 (minor) <!-- rk-sel:@wdio/tauri-service -->');
-        expect(region).toContain('  - [x] `@wdio/tauri-plugin` → 1.4.0 (minor) <!-- rk-sel:@wdio/tauri-plugin -->');
+        const region = renderSelectionRegion(tauriUpdates, new Set(), cfg({ selection: 'granular' }));
+        expect(region).toContain('- [x] **`@wdio/tauri-service`** → 1.4.0 <!-- rk-sel:@wdio/tauri-service -->');
+        expect(region).toContain('  - [x] `@wdio/tauri-plugin` → 1.4.0 <!-- rk-sel:@wdio/tauri-plugin -->');
         expect(region).not.toContain('<details>');
       });
 
@@ -394,8 +347,8 @@ describe('selection-region', () => {
           { packageName: '@scope/a', newVersion: '1.1.0', filePath: '' },
           { packageName: '@scope/b', newVersion: '2.0.0', filePath: '' },
         ];
-        const flat = renderSelectionRegion(mockOutput(updates), updates, new Set());
-        const withEmpty = renderSelectionRegion(mockOutput(updates), updates, new Set(), {
+        const flat = renderSelectionRegion(updates, new Set());
+        const withEmpty = renderSelectionRegion(updates, new Set(), {
           primaryPackages: [],
           selection: 'streamlined',
           groups: {},
@@ -424,7 +377,7 @@ describe('selection-region', () => {
     });
 
     it('should round-trip a primary untick through render → extract → cascade (children excluded)', () => {
-      const seeded = renderSelectionRegion(mockOutput(tauriUpdates, tauriChangelogs), tauriUpdates, new Set(), cfg());
+      const seeded = renderSelectionRegion(tauriUpdates, new Set(), cfg());
       const edited = seeded.replace('[x] **`@wdio/tauri-service`**', '[ ] **`@wdio/tauri-service`**');
       const extracted = extractSelection(`## Release\n\n${edited}`);
       expect(extracted?.deselected).toEqual(['@wdio/tauri-service']);

--- a/packages/release/test/unit/standing-pr.spec.ts
+++ b/packages/release/test/unit/standing-pr.spec.ts
@@ -439,10 +439,10 @@ describe('runStandingPRUpdate', () => {
 
     const body = forge.createdPullRequests[0]?.body ?? '';
     expect(body).toContain('@scope/app');
-    expect(body).toContain('(major)'); // target's overridden bump
+    expect(body).toContain('→ 2.0.0'); // target row
     expect(body).toContain('prerequisite');
     expect(body).toContain('@scope/core');
-    expect(body).toContain('(minor)'); // prerequisite's own commit-driven bump
+    expect(body).toContain('→ 1.1.0'); // prerequisite row
   });
 
   it('should list a prerequisite whose target has no update entry rather than render an empty body', async () => {
@@ -477,7 +477,7 @@ describe('runStandingPRUpdate', () => {
 
     const body = forge.createdPullRequests[0]?.body ?? '';
     expect(body).toContain('@scope/core');
-    expect(body).toContain('(minor)');
+    expect(body).toContain('→ 1.1.0');
   });
 
   it('should exclude a package the maintainer unticked in the selection region (#367)', async () => {


### PR DESCRIPTION
## Summary

In the standing-PR **Packages to release** list, the `(minor)`-style bump-kind suffix rendered on some rows but not others — present only when a package had a known prior stable `previousVersion`, absent on first-release / prerelease-graduating packages. The `previous → new` transition already conveys the bump, so this removes the suffix for a uniform render.

What changed:
- Removed the `bumpSuffix()` call from `row()`, `primaryRow()`, and `childBullet()` in `selection-region.ts`; selection rows now read `→ <version>` with no parenthetical, in both flat and hierarchical (streamlined/granular) renders.
- Deleted the now-unused `bumpSuffix` export and the dead `semver` import.
- Removed the now-dead `versionOutput` parameter from the render helpers and the public `renderSelectionRegion(updates, deselected, primary?)` signature; updated the single caller in `standing-pr.ts`.
- Updated `selection-region.spec.ts` (dropped the suffix-specific cases, removed `(minor)` from the hierarchical assertions) and two `standing-pr.spec.ts` cases whose `(major)`/`(minor)` assertions were reading the selection-region suffix (now assert the rendered `→ <version>` rows).
- The changelog header in `standing-pr.ts` is left untouched.

## Test plan

- `pnpm turbo run lint typecheck test --filter=@releasekit/release...` — all pass (689 tests).
- Verified no `(minor)`/`(patch)`/`(major)` text remains in the selection region or its tests.

Closes #473

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR removes bump-kind text from standing PR selection rows. The main changes are:

- Plain `→ <version>` rendering for flat and hierarchical package rows.
- Removal of the unused `bumpSuffix` helper and `semver` import.
- A simpler `renderSelectionRegion` signature and updated standing PR caller.
- Updated tests for the new row text.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/release/src/standing-pr/selection-region.ts | Removes suffix generation and renders selection rows with only the new version. |
| packages/release/src/standing-pr/standing-pr.ts | Updates the standing PR render call to the simplified selection-region API. |
| packages/release/test/unit/selection-region.spec.ts | Updates selection-region expectations and removes helpers used only for suffix tests. |
| packages/release/test/unit/standing-pr.spec.ts | Updates standing PR body assertions to match plain version rows. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(release): drop bump-kind suffix from..."](https://github.com/goosewobbler/releasekit/commit/1bfcff69d34646b8170fe86c58b9e83b5b35452d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40596212)</sub>

<!-- /greptile_comment -->