### PR TITLE
docs: break the pre-1.0.0 warning into readable paragraphs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,11 @@ Releases to npm, crates.io, and pub.dev today, with more ecosystems on the way.
 > [!WARNING]
 > ### 🚧 Pre-1.0.0 — here be dragons 🐉
 >
-> ReleaseKit is **under active development** and evolving fast while the core feature set settles. **💥 Breaking changes are common between releases** and won't be gated behind a major bump while we're pre-`1.0.0`. It's **not recommended for production** yet — if you're trying it out, **pin an exact version** and skim the release notes before upgrading. Once the API stabilises, `v1.0.0` will mark the switch to semver-stable guarantees.
+> ReleaseKit is **under active development** and evolving fast while the core feature set settles.
+>
+> **💥 Breaking changes are common between releases** and won't be gated behind a major bump while we're pre-`1.0.0`. It's **not recommended for production** yet — if you're trying it out, **pin an exact version** and skim the release notes before upgrading.
+>
+> Once the API stabilises, `v1.0.0` will mark the switch to semver-stable guarantees.
 
 ## Why ReleaseKit
 


### PR DESCRIPTION
## Summary

The pre-1.0.0 warning in the root README was a single dense blockquote line that renders as a hard-to-scan wall of text. Split it into three blockquote paragraphs — **wording unchanged** — so the *breaking-changes / not-recommended-for-production / pin-an-exact-version* caveat stands on its own, with the lead and the `v1.0.0` note set apart.

No content or rendering-semantics change beyond the paragraph breaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR reformats the pre-1.0.0 warning block in `README.md` by splitting one long blockquote line into three separate blockquote paragraphs. The wording is identical to the original; only the visual paragraph breaks are new.

- The lead sentence ("ReleaseKit is under active development…") is now its own paragraph, followed by the breaking-changes/not-recommended/pin-version caveat, and then the `v1.0.0` guarantee note — each on its own line for easier scanning.
- No content, rendering semantics, or links are changed.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is purely cosmetic formatting in a Markdown file with no logic, config, or code affected.

The only modified file is README.md, and the change amounts to inserting two blank blockquote lines to break one paragraph into three. Text content is identical to the original, so there is no risk of introducing incorrect information or breaking any downstream process.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| README.md | Splits a single dense pre-1.0.0 warning blockquote into three blockquote paragraphs for readability; wording is unchanged |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["README.md — Pre-1.0.0 Warning Block"] --> B["Before: Single dense blockquote line"]
    A --> C["After: Three blockquote paragraphs"]
    C --> D["Paragraph 1: Under active development / evolving fast"]
    C --> E["Paragraph 2: Breaking changes common / not for production / pin exact version"]
    C --> F["Paragraph 3: v1.0.0 will mark semver-stable guarantees"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["README.md — Pre-1.0.0 Warning Block"] --> B["Before: Single dense blockquote line"]
    A --> C["After: Three blockquote paragraphs"]
    C --> D["Paragraph 1: Under active development / evolving fast"]
    C --> E["Paragraph 2: Breaking changes common / not for production / pin exact version"]
    C --> F["Paragraph 3: v1.0.0 will mark semver-stable guarantees"]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: break the pre-1.0.0 warning into r..."](https://github.com/goosewobbler/releasekit/commit/70271530b4b2fb034ae7a102486336c79332253d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40612865)</sub>

<!-- /greptile_comment -->