### PR TITLE
docs(ci-setup): correct standing-PR ruleset docs after live verification

### DIFF
--- a/packages/release/docs/ci-setup.md
+++ b/packages/release/docs/ci-setup.md
@@ -415,13 +415,15 @@ With `authorization` configured (threshold `admin` shown):
 
 The in-code gates keep the *manifest* clean, but the merge itself is a GitHub action — gate it with two **repository rulesets** (Settings → Rules → Rulesets). Create them once, by hand or via your IaC/Terraform; they're repo policy and want an admin to apply deliberately.
 
+> **Rulesets require the right plan.** They're available on **public** repositories on any plan, and on **private** repositories only with **GitHub Pro / Team / Enterprise** — a private repo on Free has no rulesets at all. The **evaluate** (dry-run) enforcement mode mentioned below is **Enterprise-only**.
+
 **1. Lock the release branch** — target `release/next` (your `ci.standingPr.branch`). Enable **Restrict creations**, **Restrict updates**, and **Restrict deletions** so only bypass actors can write the branch — no one can inject a commit that would then be published.
 
-> ⚠️ The release bot pushes this branch, so it **must** be a bypass actor or releases break. ReleaseKit can't infer the bot's identity for you. Create this ruleset in **evaluate** (dry-run) mode first, confirm in the repo's rule insights that the bot isn't tripped, then switch to **active**.
+> ⚠️ The release bot pushes (and force-pushes) this branch, so it **must** be on the ruleset's *Bypass list* or releases break — ReleaseKit can't infer the bot's identity for you. **Add the bot as a bypass actor before the ruleset goes `active`.** On **GitHub Enterprise** you can instead create it in **evaluate** (dry-run) mode first and confirm in the repo's *rule insights* that the bot isn't tripped, then switch to active — but **evaluate mode is Enterprise-only**, so on every other plan add the bypass actor first and create the ruleset directly as `active`. (A bypass actor's force-push is not blocked by the lock, so the standing-PR refresh keeps working.)
 
 **2. Require review on the default branch** — target `main` (or `~DEFAULT_BRANCH`). Enable **Require a pull request before merging** (≥ 1 approval), **Block force pushes**, and **Restrict deletions**. Since merging the standing PR is the publish, this gates the publish behind review.
 
-**Mapping `allowedActors` to ruleset bypass actors:** a `@org/team-slug` entry maps to a **Team** bypass actor (add the team in the ruleset's *Bypass list*). A plain **username can't** be a ruleset bypass actor — GitHub only exempts roles, teams, and apps — so usernames stay enforced by the in-code gates only. Always keep org/repo admins on the bypass list so you can't lock yourself out.
+**Mapping `allowedActors` to ruleset bypass actors:** a `@org/team-slug` entry maps to a **Team** bypass actor and a plain **username** maps to a **User** bypass actor — add either to the ruleset's *Bypass list*. (GitHub also exposes repository **roles** and **Apps**, which is how a bot running as a GitHub App or the Actions bot is exempted.) Always keep org/repo admins on the bypass list so you can't lock yourself out.
 
 #### Token caveats
 


### PR DESCRIPTION
## Summary

Verified the two documented standing-PR branch rulesets (#405) against a **live GitHub repo** via the rulesets API, and fixed the drift found. Closes #416.

### Verified correct (no change)
- Rule toggle wording — `Restrict creations`/`updates`/`deletions`, `Require a pull request before merging`, `Block force pushes` (confirmed against GitHub's docs + accepted by the API).
- `~DEFAULT_BRANCH` accepted as a target ref.
- An **active** lock on `release/next` with a bypass actor does **not** block a force-push — a true non-fast-forward rewind succeeded (the standing-PR refresh keeps working).
- Rule-insights (`rule-suites`) endpoint exists.

### Fixed (drift found)
1. **`evaluate` (dry-run) mode is Enterprise-only** (`422: "Enforcement evaluate option is not supported on this plan. Please upgrade to Enterprise"`). The docs recommended creating the lock in evaluate mode first — a path most users can't take. Now documented, with a non-Enterprise fallback: add the bot to the *Bypass list* first, then create the ruleset directly as `active`.
2. **Usernames *can* now be ruleset bypass actors** (`actor_type: User` was accepted). The docs claimed a plain username can't be a bypass actor. Corrected the `allowedActors` → bypass-actor mapping (username → User, team → Team, plus roles/Apps).
3. **Plan requirement.** Rulesets are available on public repos on any plan, but on **private** repos only with GitHub Pro/Team/Enterprise (private + Free = `403`, no rulesets). Added a note.

### Not click-tested (no org / no Enterprise)
- Adding a real `@org/team` as a Team bypass actor — confirmed via the API model (`actor_type: Team`) but not exercised (test account is a personal user).
- The evaluate → rule-insights *UI* flow — moot for the docs now that evaluate is documented as Enterprise-only.

Verified on a throwaway repo via the rulesets REST API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR corrects the branch rulesets documentation in `ci-setup.md` after live API verification against a real GitHub repository, fixing three points of drift from prior documentation.

- Adds a plan-requirement note clarifying that rulesets are free for public repos on any plan but require GitHub Pro/Team/Enterprise for private repos, and that evaluate (dry-run) mode is Enterprise-only — each corrected against a 422/403 from the live API.
- Updates the bypass-actor guidance to reflect that plain usernames *can* be ruleset bypass actors (`actor_type: User`), reversing the previous claim that only roles, teams, and apps are valid.
- Revises the recommended setup flow for non-Enterprise users: add the bot as a bypass actor first, then create the ruleset directly as `active`, instead of the previously-recommended evaluate → rule-insights → active path that is now known to be Enterprise-only.
</details>

<h3>Confidence Score: 5/5</h3>

Documentation-only change with no runtime impact; corrections are backed by live API verification described in the PR.

The change touches a single documentation file and corrects three factual claims — evaluate-mode availability, bypass-actor types, and plan requirements — each verified against a live GitHub repository. The updated guidance for non-Enterprise users is a safer default than the old flow.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/release/docs/ci-setup.md | Documentation-only corrections to GitHub ruleset setup guidance: plan requirements, bypass-actor types, and evaluate-mode availability all updated based on live API verification. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Create branch ruleset for release/next] --> B{GitHub Plan?}
    B -->|Enterprise| C[Option A: Create in evaluate mode]
    B -->|Pro / Team / Free+public| D[Add bot to Bypass list first]
    C --> E[Check rule insights - confirm bot not tripped]
    E --> F[Switch ruleset to active]
    D --> G[Create ruleset directly as active]
    F --> H[Ruleset live: bot force-pushes unblocked]
    G --> H
    H --> I[Create default-branch ruleset on main / ~DEFAULT_BRANCH]
    I --> J[Require PR + 1 approval, Block force pushes, Restrict deletions]
    J --> K[Merge gate in place]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Create branch ruleset for release/next] --> B{GitHub Plan?}
    B -->|Enterprise| C[Option A: Create in evaluate mode]
    B -->|Pro / Team / Free+public| D[Add bot to Bypass list first]
    C --> E[Check rule insights - confirm bot not tripped]
    E --> F[Switch ruleset to active]
    D --> G[Create ruleset directly as active]
    F --> H[Ruleset live: bot force-pushes unblocked]
    G --> H
    H --> I[Create default-branch ruleset on main / ~DEFAULT_BRANCH]
    I --> J[Require PR + 1 approval, Block force pushes, Restrict deletions]
    J --> K[Merge gate in place]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(ci-setup): correct standing-PR rule..."](https://github.com/goosewobbler/releasekit/commit/f06ccf27fc668db3c5d7735af6ec48426dd7f2d3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40643104)</sub>

<!-- /greptile_comment -->