### PR TITLE
fix(core): strict, validated package.json private check

### DIFF
--- a/packages/config/src/packageFiltering.ts
+++ b/packages/config/src/packageFiltering.ts
@@ -4,7 +4,7 @@
 
 import path from 'node:path';
 import type { Package } from '@manypkg/get-packages';
-import { log, matchesPackageTarget as matchTarget } from '@releasekit/core';
+import { isPrivatePackageJson, log, matchesPackageTarget as matchTarget } from '@releasekit/core';
 import { minimatch } from 'minimatch';
 
 /**
@@ -14,7 +14,7 @@ export function filterPackagesByConfig(packages: Package[], configTargets: strin
   if (configTargets.length === 0) {
     log('No config targets specified, returning all non-private packages', 'debug');
     return packages.filter((pkg) => {
-      if (pkg.packageJson.private) {
+      if (isPrivatePackageJson(pkg.packageJson, path.join(pkg.dir, 'package.json'))) {
         log(`Package "${pkg.packageJson.name || pkg.dir}" is private and will be excluded from release`, 'warn');
         return false;
       }

--- a/packages/config/test/unit/packageFiltering.spec.ts
+++ b/packages/config/test/unit/packageFiltering.spec.ts
@@ -1,11 +1,15 @@
 import type { Package } from '@manypkg/get-packages';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-// Mock the logger
-vi.mock('@releasekit/core', () => ({
-  log: vi.fn(),
-  matchesPackageTarget: vi.fn(),
-}));
+// Mock the logger + package matcher, but keep the real isPrivatePackageJson (it's under test here).
+vi.mock('@releasekit/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@releasekit/core')>();
+  return {
+    log: vi.fn(),
+    matchesPackageTarget: vi.fn(),
+    isPrivatePackageJson: actual.isPrivatePackageJson,
+  };
+});
 
 // Import after mocking
 import { log, matchesPackageTarget } from '@releasekit/core';
@@ -68,6 +72,18 @@ describe('filterPackagesByConfig', () => {
       expect(log).toHaveBeenCalledWith('No config targets specified, returning all non-private packages', 'debug');
       expect(log).toHaveBeenCalledWith('Package "private-pkg-1" is private and will be excluded from release', 'warn');
       expect(log).toHaveBeenCalledWith('Package "private-pkg-2" is private and will be excluded from release', 'warn');
+    });
+
+    it('should throw on a quoted "private": "true" rather than silently publishing it', () => {
+      const pkg = {
+        dir: '/workspace/packages/leaky',
+        relativeDir: 'packages/leaky',
+        packageJson: { name: '@scope/leaky', version: '1.0.0', private: 'true' },
+      } as unknown as Package;
+
+      expect(() => filterPackagesByConfig([pkg], [], workspaceRoot)).toThrow(
+        '/workspace/packages/leaky/package.json: "private" must be a boolean, got string "true". Use `"private": true` (no quotes).',
+      );
     });
   });
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -29,6 +29,7 @@ export {
   wrapNotesRegion,
 } from './notesRegion.js';
 export {
+  isPrivatePackageJson,
   matchesPackageTarget,
   shouldMatchPackageTargets,
   shouldProcessPackage,

--- a/packages/core/src/packageUtils.ts
+++ b/packages/core/src/packageUtils.ts
@@ -56,3 +56,30 @@ export function shouldProcessPackage(packageName: string, skip: string[] = []): 
 
   return !shouldMatchPackageTargets(packageName, skip);
 }
+
+/**
+ * Whether a parsed package.json marks the package private (npm refuses to publish these).
+ *
+ * Returns `true` ONLY for the boolean `true`. A non-boolean `private` — most insidiously the quoted
+ * `"private": "true"` — is treated as a hard configuration error rather than guessed at: a truthy
+ * read would silently skip a `"private": "false"` string, and a strict `=== true` read would let a
+ * `"private": "true"` string slip through and get **published** (irreversible). So we throw instead.
+ * This trap is npm-specific: Cargo `publish = false` (TOML boolean/array) and pub `publish_to: none`
+ * (YAML string) are typed by their formats, whereas JSON gives `private` no schema guard.
+ *
+ * @param pkgJsonPath path to the offending package.json, used verbatim in the error so the fix is obvious.
+ */
+export function isPrivatePackageJson(pkgJson: { private?: unknown } | null | undefined, pkgJsonPath: string): boolean {
+  const value = pkgJson?.private;
+  // Absent (or JSON `null`) means not private — matches npm and both legacy read paths.
+  if (value === undefined || value === null) {
+    return false;
+  }
+  if (typeof value === 'boolean') {
+    return value;
+  }
+  throw new Error(
+    `${pkgJsonPath}: "private" must be a boolean, got ${typeof value} ${JSON.stringify(value)}. ` +
+      'Use `"private": true` (no quotes).',
+  );
+}

--- a/packages/core/test/unit/packageUtils.spec.ts
+++ b/packages/core/test/unit/packageUtils.spec.ts
@@ -8,7 +8,12 @@ vi.mock('minimatch', async (importOriginal) => {
 });
 
 import { minimatch } from 'minimatch';
-import { matchesPackageTarget, shouldMatchPackageTargets, shouldProcessPackage } from '../../src/packageUtils.js';
+import {
+  isPrivatePackageJson,
+  matchesPackageTarget,
+  shouldMatchPackageTargets,
+  shouldProcessPackage,
+} from '../../src/packageUtils.js';
 
 describe('packageUtils', () => {
   beforeEach(() => {
@@ -101,6 +106,49 @@ describe('packageUtils', () => {
     it('should handle multiple skip patterns', () => {
       expect(shouldProcessPackage('@releasekit/core', ['@other/*', '@releasekit/notes'])).toBe(true);
       expect(shouldProcessPackage('@releasekit/notes', ['@other/*', '@releasekit/notes'])).toBe(false);
+    });
+  });
+
+  describe('isPrivatePackageJson', () => {
+    const PKG_PATH = '/repo/packages/secret/package.json';
+
+    it('should treat boolean true as private', () => {
+      expect(isPrivatePackageJson({ private: true }, PKG_PATH)).toBe(true);
+    });
+
+    it('should treat boolean false as releasable', () => {
+      expect(isPrivatePackageJson({ private: false }, PKG_PATH)).toBe(false);
+    });
+
+    it('should treat an absent private field as releasable', () => {
+      expect(isPrivatePackageJson({}, PKG_PATH)).toBe(false);
+    });
+
+    it('should treat undefined/null package.json as releasable', () => {
+      expect(isPrivatePackageJson(undefined, PKG_PATH)).toBe(false);
+      expect(isPrivatePackageJson(null, PKG_PATH)).toBe(false);
+    });
+
+    it('should treat null private as releasable', () => {
+      expect(isPrivatePackageJson({ private: null }, PKG_PATH)).toBe(false);
+    });
+
+    it('should throw on a quoted "private": "true" string', () => {
+      expect(() => isPrivatePackageJson({ private: 'true' }, PKG_PATH)).toThrow(
+        '/repo/packages/secret/package.json: "private" must be a boolean, got string "true". Use `"private": true` (no quotes).',
+      );
+    });
+
+    it('should throw on a quoted "private": "false" string', () => {
+      expect(() => isPrivatePackageJson({ private: 'false' }, PKG_PATH)).toThrow('got string "false"');
+    });
+
+    it('should throw on a numeric private value', () => {
+      expect(() => isPrivatePackageJson({ private: 1 }, PKG_PATH)).toThrow('got number 1');
+    });
+
+    it('should include the package.json path in the error so the fix is locatable', () => {
+      expect(() => isPrivatePackageJson({ private: 'true' }, PKG_PATH)).toThrow(PKG_PATH);
     });
   });
 });

--- a/packages/publish/src/registry/npm.ts
+++ b/packages/publish/src/registry/npm.ts
@@ -1,6 +1,6 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { buildDependencyGraph, debug, type GraphPackage } from '@releasekit/core';
+import { buildDependencyGraph, debug, type GraphPackage, isPrivatePackageJson } from '@releasekit/core';
 import { createPublishError, PublishErrorCode } from '../errors/index.js';
 import type { PipelineContext } from '../types.js';
 import { detectNpmAuth } from '../utils/auth.js';
@@ -117,19 +117,23 @@ export const npmRegistry: Registry<NpmTarget, NpmSession> = {
     }
 
     const pkgJsonPath = path.resolve(ctx.cwd, target.filePath);
+    let pkgJson: { private?: unknown } | undefined;
     try {
-      const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf-8'));
-      debug(`Package.json files field: ${JSON.stringify(pkgJson.files)}`);
-      debug(`Package.json version: ${pkgJson.version}`);
-      debug(`Package.json name: ${pkgJson.name}`);
-
-      if (pkgJson.private) {
-        debug(`Skipping private package: ${target.packageName}`);
-        return { reason: 'Package is private' };
-      }
+      const parsed = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf-8'));
+      pkgJson = parsed;
+      debug(`Package.json files field: ${JSON.stringify(parsed.files)}`);
+      debug(`Package.json version: ${parsed.version}`);
+      debug(`Package.json name: ${parsed.name}`);
     } catch (error) {
       // A genuinely unreadable/malformed package.json — log and continue with empty metadata.
       debug(`Failed to read package.json: ${error}`);
+    }
+
+    // Validate `private` OUTSIDE the parse try/catch: a quoted `"private": "true"` must abort the
+    // publish, not get swallowed as a "malformed package.json" and then published (irreversible).
+    if (isPrivatePackageJson(pkgJson, pkgJsonPath)) {
+      debug(`Skipping private package: ${target.packageName}`);
+      return { reason: 'Package is private' };
     }
     return undefined;
   },

--- a/packages/publish/test/unit/registry/npm.spec.ts
+++ b/packages/publish/test/unit/registry/npm.spec.ts
@@ -1,0 +1,66 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { npmRegistry } from '../../../src/registry/npm.js';
+import type { PipelineContext } from '../../../src/types.js';
+
+// precheckSkip reads the on-disk package.json under ctx.cwd, so these drive it against a real temp
+// file rather than a mock — the point is the `private` validation, which depends on what JSON.parse
+// actually yields.
+describe('npmRegistry.precheckSkip', () => {
+  let cwd: string;
+
+  beforeEach(() => {
+    cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'rk-npm-precheck-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(cwd, { recursive: true, force: true });
+  });
+
+  const ctx = (): PipelineContext => ({ cwd }) as unknown as PipelineContext;
+  const target = (overrides: { filePath?: string } = {}) => ({
+    packageName: '@scope/pkg',
+    version: '1.0.0',
+    filePath: 'package.json',
+    ...overrides,
+  });
+
+  function writePkg(pkg: Record<string, unknown>): void {
+    fs.writeFileSync(path.join(cwd, 'package.json'), JSON.stringify(pkg));
+  }
+
+  it('should skip non-package.json manifests as not-npm', () => {
+    expect(npmRegistry.precheckSkip(target({ filePath: 'Cargo.toml' }), ctx())).toEqual({
+      reason: 'Not an npm package',
+    });
+  });
+
+  it('should skip a package with "private": true', () => {
+    writePkg({ name: '@scope/pkg', version: '1.0.0', private: true });
+    expect(npmRegistry.precheckSkip(target(), ctx())).toEqual({ reason: 'Package is private' });
+  });
+
+  it('should treat an absent private field as publishable', () => {
+    writePkg({ name: '@scope/pkg', version: '1.0.0' });
+    expect(npmRegistry.precheckSkip(target(), ctx())).toBeUndefined();
+  });
+
+  it('should treat "private": false as publishable', () => {
+    writePkg({ name: '@scope/pkg', version: '1.0.0', private: false });
+    expect(npmRegistry.precheckSkip(target(), ctx())).toBeUndefined();
+  });
+
+  it('should throw on a quoted "private": "true" instead of swallowing it and publishing', () => {
+    writePkg({ name: '@scope/pkg', version: '1.0.0', private: 'true' });
+    expect(() => npmRegistry.precheckSkip(target(), ctx())).toThrow(
+      '"private" must be a boolean, got string "true". Use `"private": true` (no quotes).',
+    );
+  });
+
+  it('should throw on a numeric private value', () => {
+    writePkg({ name: '@scope/pkg', version: '1.0.0', private: 1 });
+    expect(() => npmRegistry.precheckSkip(target(), ctx())).toThrow('got number 1');
+  });
+});

--- a/packages/version/src/core/versionEngine.ts
+++ b/packages/version/src/core/versionEngine.ts
@@ -3,7 +3,7 @@ import * as path from 'node:path';
 import { cwd } from 'node:process';
 import { getPackagesSync, type Package, type Packages } from '@manypkg/get-packages';
 import { filterPackagesByConfig, parseCargoToml, parsePubspec } from '@releasekit/config';
-import { shouldMatchPackageTargets } from '@releasekit/core';
+import { isPrivatePackageJson, shouldMatchPackageTargets } from '@releasekit/core';
 import { minimatch } from 'minimatch';
 import * as yaml from 'yaml';
 import { GitError } from '../errors/gitError.js';
@@ -467,7 +467,7 @@ export class VersionEngine {
         const namedExactly = new Set(this.config.packages ?? []);
         const beforeCount = mergedPackages.packages.length;
         mergedPackages.packages = mergedPackages.packages.filter((pkg) => {
-          if (pkg.packageJson.private !== true) return true;
+          if (!isPrivatePackageJson(pkg.packageJson, path.join(pkg.dir, 'package.json'))) return true;
           if (namedExactly.has(pkg.packageJson.name)) return true;
           if (this.isNativelyPublishable(pkg.dir)) return true;
           log(`Skipping private npm package ${pkg.packageJson.name}: package.json "private": true`, 'debug');


### PR DESCRIPTION
## What
Introduces a single `isPrivatePackageJson(pkgJson, pkgJsonPath)` helper in `@releasekit/core` and routes all three `private` reads through it.

## Why
The package.json `private` field was read inconsistently:
- `packages/config/src/packageFiltering.ts` — truthy `if (pkg.packageJson.private)`
- `packages/publish/src/registry/npm.ts` — truthy `if (pkgJson.private)`
- `packages/version/src/core/versionEngine.ts` — strict `!== true`

A quoted `"private": "true"` (string) passed the strict path as **not** private and could be **published** — irreversible. A `"private": "false"` string read truthy and was wrongly skipped.

## Change
- **One helper, used everywhere.** `isPrivatePackageJson` returns `true` only for the boolean `true`; absent / `false` / `null` are releasable.
- **Validate, don't guess.** A non-boolean `private` throws `<path>/package.json: "private" must be a boolean, got string "true". Use "private": true (no quotes).`, aborting the release for that package. Each call site passes its package.json path.
- **No swallowing.** In `npm.precheckSkip` the check now runs outside the parse try/catch, so the error aborts the publish instead of being caught as a "malformed package.json" and published anyway.
- **Scope note:** Cargo `publish = false` and pub `publish_to: none` are format-typed (TOML boolean/array, YAML string) and read consistently — the quoted-boolean trap is npm-specific, so they're unchanged.

## Tests
- Core helper: `true`→private; `false`/absent/`null`/undefined→releasable; `"true"`/`"false"`/`1`→error (exact message + path asserted).
- Config call site: `"private": "true"` throws instead of publishing.
- Publish call site: `npmRegistry.precheckSkip` against a real temp package.json — `private:true`→skip, absent/`false`→publishable, `"true"`/`1`→throw.

Closes #484

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes an inconsistency in how the `private` field of `package.json` was read across three consumers (`packageFiltering`, `npm.ts`, `versionEngine`), where mixed truthy/strict checks let a quoted `"private": "true"` string slip past the strict path and get published, or a `"private": "false"` string get wrongly skipped. A single `isPrivatePackageJson(pkgJson, pkgJsonPath)` helper in `@releasekit/core` normalises all three sites to the same logic.

- **New helper** (`packages/core/src/packageUtils.ts`): returns `true` only for boolean `true`; returns `false` for `undefined`/`null`/`false`; throws a descriptive error with the file path for any non-boolean value.
- **`npm.ts` fix**: the `private` check is moved outside the parse `try/catch` so a malformed-but-parseable `"private": "true"` can no longer be swallowed as a JSON parse error and inadvertently published.
- **Tests**: unit tests for the helper cover every branch; the `precheckSkip` tests drive real temp files to verify the JSON parse → validation path end-to-end.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge. The change is narrowly scoped, the three call sites each receive consistent behaviour, and the new throw path is intentional and well-documented. Moving the `private` check outside the parse `try/catch` in `npm.ts` is the critical fix, and the test suite exercises it with real on-disk files.

The helper is simple and deterministic, every branch is directly tested, and the only behavioural change for non-boolean `private` values (throw instead of silently skip or silently publish) is the correct outcome. No unrelated code is touched.

No files require special attention. The `npm.ts` refactor is the highest-risk site but the tests and the explicit comment around the `try/catch` boundary make the intent clear.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/core/src/packageUtils.ts | Adds `isPrivatePackageJson` helper: returns true only for boolean true, throws a clear error for non-boolean values, and returns false for absent/null/undefined. |
| packages/core/src/index.ts | Exports the new `isPrivatePackageJson` from the core package index. |
| packages/config/src/packageFiltering.ts | Replaces truthy `if (pkg.packageJson.private)` with `isPrivatePackageJson` in the no-config-targets path; behavior is now strict and throws on non-boolean values. |
| packages/publish/src/registry/npm.ts | Moves the `private` check outside the parse try/catch so a quoted `"private": "true"` throws instead of being swallowed and allowing an accidental publish. |
| packages/version/src/core/versionEngine.ts | Replaces the strict `!== true` check with `isPrivatePackageJson`, so `"private": "true"` (string) now throws instead of silently being treated as releasable. |
| packages/core/test/unit/packageUtils.spec.ts | Comprehensive unit tests for `isPrivatePackageJson` covering boolean true/false, absent, null, undefined, and all error-throwing cases with exact message assertions. |
| packages/config/test/unit/packageFiltering.spec.ts | Updated mock to use real `isPrivatePackageJson` for integration-style test; adds a throw assertion for `"private": "true"` string in the no-targets path. |
| packages/publish/test/unit/registry/npm.spec.ts | New test file exercising `precheckSkip` against real temp package.json files; covers skip, publish, and throw cases without mocking the JSON I/O. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[package.json read] --> B{private field value}
    B -- "boolean true" --> C[isPrivate = true\nSkip publish]
    B -- "boolean false\nor absent/null" --> D[isPrivate = false\nProceed with publish]
    B -- "non-boolean\ne.g. string 'true', number 1" --> E[throw Error\nwith pkgJsonPath + type + value]

    subgraph "Call Sites"
      F[packageFiltering.ts\nconfigTargets.length === 0]
      G[npm.ts precheckSkip\noutside try/catch]
      H[versionEngine.ts\n!includePrivate filter]
    end

    F --> A
    G --> A
    H --> A

    E --> I[Release aborts\nwith actionable message]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[package.json read] --> B{private field value}
    B -- "boolean true" --> C[isPrivate = true\nSkip publish]
    B -- "boolean false\nor absent/null" --> D[isPrivate = false\nProceed with publish]
    B -- "non-boolean\ne.g. string 'true', number 1" --> E[throw Error\nwith pkgJsonPath + type + value]

    subgraph "Call Sites"
      F[packageFiltering.ts\nconfigTargets.length === 0]
      G[npm.ts precheckSkip\noutside try/catch]
      H[versionEngine.ts\n!includePrivate filter]
    end

    F --> A
    G --> A
    H --> A

    E --> I[Release aborts\nwith actionable message]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(core): route all package.json privat..."](https://github.com/goosewobbler/releasekit/commit/f4e05732ffa7b4d97d8d69082f7d8a5f0885801e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40654782)</sub>

<!-- /greptile_comment -->