### PR TITLE
feat(version): per-package release channel — advance prereleases on their own line by default

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -41,11 +41,13 @@ export {
   SELECTION_MARKER_END,
   wrapSelectionRegion,
 } from './selectionRegion.js';
-export type {
-  VersionAction,
-  VersionChangelogEntry,
-  VersionOutput,
-  VersionPackageChangelog,
-  VersionPackageUpdate,
+export {
+  deriveReleaseChannel,
+  type ReleaseChannel,
+  type VersionAction,
+  type VersionChangelogEntry,
+  type VersionOutput,
+  type VersionPackageChangelog,
+  type VersionPackageUpdate,
 } from './types.js';
 export { sanitizePackageName } from './utils.js';

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -52,6 +52,27 @@ export interface VersionPackageChangelog {
 export type VersionAction = 'first-release' | 'graduated' | 'bumped';
 
 /**
+ * The release channel a version sits on (#485). Derived per-package and purely from the resolved
+ * version: `'prerelease'` when the version carries a semver prerelease segment (`…-<preid>.N`), else
+ * `'stable'`. A standing PR with permanently-mixed maturity carries both at once — some `'stable'`
+ * packages, some `'prerelease'` — each advancing along its own line. #486 (per-package graduation)
+ * and #487 (channel-grouped rendering) build on this.
+ */
+export type ReleaseChannel = 'stable' | 'prerelease';
+
+/**
+ * Derive a version's {@link ReleaseChannel}. Pure and dependency-free (core cannot import semver): a
+ * semver prerelease is the hyphen-introduced segment that precedes any build-metadata `+`, so a
+ * version is `'prerelease'` exactly when that leading segment contains a `-`. Consumers that only
+ * hold a version string (and a manifest predating the persisted {@link VersionPackageUpdate.channel}
+ * field) re-derive the channel with this.
+ */
+export function deriveReleaseChannel(version: string): ReleaseChannel {
+  const core = version.split('+', 1)[0] ?? version;
+  return core.includes('-') ? 'prerelease' : 'stable';
+}
+
+/**
  * The complete JSON output of @releasekit/version --json.
  * This is the primary interchange format between version and notes.
  */
@@ -132,4 +153,13 @@ export interface VersionPackageUpdate {
   action?: VersionAction;
   /** Short human-readable reason for {@link action} (e.g. `Graduated 1.0.0-next.1 → 1.0.0 (bump ignored).`). Optional, same back-compat rule as {@link action}. */
   actionReason?: string;
+  /**
+   * The release channel this package's new version sits on (#485): `'prerelease'` when `newVersion`
+   * carries a semver prerelease segment, else `'stable'`. Derived from the resolved version via
+   * {@link deriveReleaseChannel}; a mixed standing PR carries both, each package advancing on its own
+   * line. Purely additive observability — it never affects which version resolves. Optional for
+   * backwards compatibility: standing-PR manifests written before this field existed omit it, so every
+   * consumer must tolerate its absence (re-derive from `newVersion`). #486/#487 build on it.
+   */
+  channel?: ReleaseChannel;
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -68,7 +68,8 @@ export type ReleaseChannel = 'stable' | 'prerelease';
  * field) re-derive the channel with this.
  */
 export function deriveReleaseChannel(version: string): ReleaseChannel {
-  const core = version.split('+', 1)[0] ?? version;
+  const buildIdx = version.indexOf('+');
+  const core = buildIdx === -1 ? version : version.slice(0, buildIdx);
   return core.includes('-') ? 'prerelease' : 'stable';
 }
 

--- a/packages/core/test/unit/types.spec.ts
+++ b/packages/core/test/unit/types.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { deriveReleaseChannel } from '../../src/types.js';
+
+describe('deriveReleaseChannel (#485)', () => {
+  it('should classify clean semver as the stable channel', () => {
+    expect(deriveReleaseChannel('1.0.0')).toBe('stable');
+    expect(deriveReleaseChannel('10.2.0')).toBe('stable');
+    expect(deriveReleaseChannel('0.1.0')).toBe('stable');
+  });
+
+  it('should classify a prerelease version as the prerelease channel', () => {
+    expect(deriveReleaseChannel('1.0.0-next.1')).toBe('prerelease');
+    expect(deriveReleaseChannel('2.0.0-beta.0')).toBe('prerelease');
+    expect(deriveReleaseChannel('1.0.0-0')).toBe('prerelease');
+  });
+
+  it('should ignore build metadata when deriving the channel', () => {
+    // A `+build` segment is not a prerelease — only the hyphen-introduced segment is.
+    expect(deriveReleaseChannel('1.0.0+build.5')).toBe('stable');
+    expect(deriveReleaseChannel('1.0.0-next.1+build.5')).toBe('prerelease');
+  });
+});

--- a/packages/publish/test/unit/utils/semver.spec.ts
+++ b/packages/publish/test/unit/utils/semver.spec.ts
@@ -37,5 +37,13 @@ describe('semver utils', () => {
     it('should use custom default tag', () => {
       expect(getDistTag('1.0.0', 'stable')).toBe('stable');
     });
+
+    it('should resolve the dist-tag per package in a mixed (stable + prerelease) release (#485)', () => {
+      // A standing PR with permanently-mixed maturity publishes each package on its own channel.
+      // getDistTag is per-version, so the same run yields `latest` for the stable packages and the
+      // prerelease identifier for the `-next` ones with no extra wiring.
+      const versions = ['10.2.0', '1.1.0-next.0', '2.0.0', '0.3.0-beta.4'];
+      expect(versions.map((v) => getDistTag(v, 'latest'))).toEqual(['latest', 'next', 'latest', 'beta']);
+    });
   });
 });

--- a/packages/release/docs/ci-setup.md
+++ b/packages/release/docs/ci-setup.md
@@ -97,9 +97,9 @@ In CI, add `--check`: it exits non-zero on a missing label, catching the silent 
 | `bump:patch` | `1.0.0` | `1.0.1` |
 | `bump:minor` | `1.0.0` | `1.1.0` |
 | `bump:major` | `1.0.0` | `2.0.0` |
-| `bump:patch` | `1.0.0-next.6` | `1.0.1` — graduates prerelease to stable patch |
-| `bump:minor` | `1.0.0-next.6` | `1.1.0` — graduates prerelease to stable minor |
-| `bump:major` | `1.0.0-next.6` | `2.0.0` — graduates prerelease to stable major |
+| `bump:patch` | `1.0.0-next.6` | `1.0.0-next.7` — advances the prerelease (no graduation) |
+| `bump:minor` | `1.0.0-next.6` | `1.1.0-next.0` — escalates the prerelease base (no graduation) |
+| `bump:major` | `1.0.0-next.6` | `2.0.0-next.0` — escalates the prerelease base (no graduation) |
 | `channel:prerelease` + `bump:patch` | `1.0.0` | `1.0.1-next.0` |
 | `channel:prerelease` + `bump:minor` | `1.0.0` | `1.1.0-next.0` |
 | `channel:prerelease` + `bump:major` | `1.0.0` | `2.0.0-next.0` |
@@ -111,6 +111,14 @@ In CI, add `--check`: it exits non-zero on a missing label, catching the silent 
 | `release:graduate` alone | `1.0.0` | No release — already at stable version |
 | `release:graduate` + any `bump:*` | `1.0.0-next.6` | `1.0.0` — bump label is ignored during stable promotion |
 | `release:graduate` + `bump:minor` | `1.0.0` | `1.1.0` — bump applies to already-stable packages |
+
+> **Each package's channel is derived from its *current* version, and the default advances along it
+> — a `-next` package never graduates to stable without an explicit `release:graduate`.** A standing
+> PR with permanently-mixed maturity (mature stable packages alongside incubating `-next` ones) is
+> normal: each package walks its own line, so the same merge can ship `10.2.0` (stable) and
+> `1.1.0-next.0` (prerelease) at once. A `bump:*` label sets the *magnitude* but not the channel — on
+> a prerelease it escalates within the line (above), it does not promote. Use `release:graduate` to
+> promote, `channel:prerelease` to drag a stable package onto a prerelease line.
 
 > **`channel:prerelease` + `bump:*` escalates — it starts a *fresh* prerelease line at the chosen
 > magnitude, even when the package is already on a prerelease.** So `bump:major` + `channel:prerelease`

--- a/packages/version/src/core/versionCalculator.ts
+++ b/packages/version/src/core/versionCalculator.ts
@@ -21,6 +21,38 @@ import {
 } from '../utils/versionUtils.js';
 
 /**
+ * Map a standard bump magnitude to the prerelease increment that advances an *existing* prerelease
+ * along its own channel instead of graduating it to a stable release (#485):
+ *  - `patch` → `prerelease` — advance the counter   (1.0.0-next.1 → 1.0.0-next.2)
+ *  - `minor` → `preminor`   — escalate the base      (1.0.0-next.1 → 1.1.0-next.0)
+ *  - `major` → `premajor`   — escalate the base      (1.0.0-next.1 → 2.0.0-next.0)
+ * Any non-standard type (already a `pre*` / `prerelease` form) passes through unchanged.
+ */
+function toPrereleaseLineBump(bumpType: ReleaseType): ReleaseType {
+  switch (bumpType) {
+    case 'major':
+      return 'premajor';
+    case 'minor':
+      return 'preminor';
+    case 'patch':
+      return 'prerelease';
+    default:
+      return bumpType;
+  }
+}
+
+/**
+ * The prerelease identifier embedded in a version (e.g. `1.0.0-next.1` → `next`), or undefined when
+ * the version is stable or its prerelease segment carries no string identifier. Advancing along a
+ * channel keeps the *current* line's identifier, so this is preferred over the configured default
+ * (a config change is a deliberate line switch, out of scope for the advance-along-line default) (#485).
+ */
+function prereleaseIdOf(version: string): string | undefined {
+  const pre = semver.prerelease(version);
+  return pre && typeof pre[0] === 'string' ? pre[0] : undefined;
+}
+
+/**
  * Strip the forced `bump` / `prerelease` / `stable` override for a package outside `overrideScope`,
  * so it falls through to commit-driven calculation. Returns the (possibly scoped) config + options.
  * Scoping changes *who* the override applies to, never the composed-bump formula.
@@ -262,6 +294,25 @@ async function calculateVersionInner(config: Config, options: VersionOptions): P
         'debug',
       );
 
+      // Per-package channel default (#485): a package whose current version is a prerelease advances
+      // along its own prerelease line rather than graduating to stable — UNLESS an explicit channel
+      // action is in play (`--stable` / release:graduate sets stableOnly and graduates above;
+      // `--prerelease` / channel:prerelease sets isPrerelease, handled by the existing branch below).
+      // The magnitude maps to the matching pre-increment so a minor/major escalates the base while a
+      // patch just advances the prerelease counter. This is the keystone that removes the global
+      // auto-graduate: no routine bump silently promotes a `-next` package to a production release.
+      if (
+        isCurrentPrerelease &&
+        !config.stableOnly &&
+        !explicitlyRequestedPrerelease &&
+        STANDARD_BUMP_TYPES.includes(specifiedType as 'major' | 'minor' | 'patch')
+      ) {
+        const channelId = prereleaseIdOf(currentVersion) ?? normalizedPrereleaseId;
+        const channelType = toPrereleaseLineBump(specifiedType as ReleaseType);
+        log(`Advancing prerelease ${currentVersion} along its channel via ${channelType} (id: ${channelId})`, 'debug');
+        return bumpVersion(currentVersion, channelType, channelId);
+      }
+
       if (
         STANDARD_BUMP_TYPES.includes(specifiedType as 'major' | 'minor' | 'patch') &&
         (isCurrentPrerelease || explicitlyRequestedPrerelease)
@@ -376,6 +427,22 @@ async function calculateVersionInner(config: Config, options: VersionOptions): P
       if ((config.zeroMajor ?? 'spec') === 'spec' && isPre1 && releaseTypeFromCommits === 'major') {
         effectiveReleaseType = 'minor';
         log("Pre-1.0 breaking change: downgrading inferred 'major' to 'minor' (zeroMajor: 'spec')", 'info');
+      }
+
+      // Per-package channel default (#485): advance an existing prerelease along its own line rather
+      // than graduating it, unless an explicit channel action is in play. Mirrors the specified-type
+      // branch above; here the magnitude is the commit-inferred (zeroMajor-adjusted) bump. See the
+      // keystone examples in #485 — patch advances the counter, minor/major escalate the base.
+      if (
+        semver.prerelease(currentVersion) !== null &&
+        !config.stableOnly &&
+        !config.isPrerelease &&
+        STANDARD_BUMP_TYPES.includes(effectiveReleaseType as 'major' | 'minor' | 'patch')
+      ) {
+        const channelId = prereleaseIdOf(currentVersion) ?? normalizedPrereleaseId;
+        const channelType = toPrereleaseLineBump(effectiveReleaseType);
+        log(`Advancing prerelease ${currentVersion} along its channel via ${channelType} (id: ${channelId})`, 'debug');
+        return bumpVersion(currentVersion, channelType, channelId);
       }
 
       const isPrereleaseBumpType = ['prerelease', 'premajor', 'preminor', 'prepatch'].includes(effectiveReleaseType);

--- a/packages/version/src/utils/jsonOutput.ts
+++ b/packages/version/src/utils/jsonOutput.ts
@@ -5,7 +5,13 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import type { VersionAction, VersionChangelogEntry, VersionOutput, VersionPackageChangelog } from '@releasekit/core';
+import {
+  deriveReleaseChannel,
+  type VersionAction,
+  type VersionChangelogEntry,
+  type VersionOutput,
+  type VersionPackageChangelog,
+} from '@releasekit/core';
 
 /** @deprecated Use {@link VersionOutput} from `@releasekit/core` instead. */
 export type JsonOutputData = VersionOutput;
@@ -105,7 +111,15 @@ export function setVersioningStrategy(strategy: 'sync' | 'single' | 'async' | 'g
 export function addPackageUpdate(packageName: string, newVersion: string, filePath: string, isRoot?: boolean): void {
   if (!_jsonOutputMode) return;
 
-  const update = { packageName, newVersion, filePath, ...(isRoot ? { isRoot } : {}) };
+  // Channel is derived per-package from the resolved version (#485) so every consumer (preview,
+  // standing PR, #486/#487) reads a single authoritative value rather than re-deriving it.
+  const update = {
+    packageName,
+    newVersion,
+    filePath,
+    channel: deriveReleaseChannel(newVersion),
+    ...(isRoot ? { isRoot } : {}),
+  };
   // Resolve to an absolute path before keying so a mix of absolute and relative filePaths for the
   // same directory still dedupes (callers don't all pass the same path form for every manifest write).
   const dir = path.dirname(path.resolve(filePath));

--- a/packages/version/test/unit/core/versionChannel.spec.ts
+++ b/packages/version/test/unit/core/versionChannel.spec.ts
@@ -1,0 +1,181 @@
+import { Bumper, type BumperRecommendationResult } from 'conventional-recommended-bump';
+import type { ReleaseType } from 'semver';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { calculateVersion } from '../../../src/core/versionCalculator.js';
+import * as gitTags from '../../../src/git/tagsAndBranches.js';
+import type { Config, VersionOptions } from '../../../src/types.js';
+import * as manifestHelpers from '../../../src/utils/manifestHelpers.js';
+import * as versionUtils from '../../../src/utils/versionUtils.js';
+
+// Per-package release channel (#485): a package's channel is DERIVED from its current version and
+// the default (no explicit channel action) advances it ALONG that channel — a prerelease stays a
+// prerelease, a stable stays stable, and a `-next` package never graduates without an explicit
+// graduate action. These specs drive the real `calculateVersion` with real semver and a real
+// `bumpVersion`; only git tag lookups, manifest reads, and the conventional-commit bumper are stubbed
+// so the asserted version strings are the engine's genuine output, not a mock's echo (the older
+// versionCalculator.spec automocks `versionUtils`, which empties STANDARD_BUMP_TYPES and neuters this
+// exact path — see that file).
+vi.mock('../../../src/git/tagsAndBranches.js');
+vi.mock('../../../src/utils/manifestHelpers.js');
+
+/** Stub the workspace baseline: the package's current version, surfaced both as the git tag source
+ *  and the manifest version, so `getBestVersionSource` (real) resolves to it without touching git. */
+function baselineAt(version: string): void {
+  vi.spyOn(versionUtils, 'getBestVersionSource').mockResolvedValue({
+    source: 'package',
+    version,
+    reason: 'test baseline',
+  });
+  vi.spyOn(manifestHelpers, 'getVersionFromManifests').mockReturnValue({
+    version,
+    manifestFound: true,
+    manifestPath: '/repo/packages/pkg/package.json',
+    manifestType: 'package.json',
+  });
+}
+
+/** Stub the conventional-commit recommendation so the inferred magnitude is deterministic. */
+function inferredBump(releaseType: ReleaseType): void {
+  vi.spyOn(Bumper.prototype, 'loadPreset').mockReturnValue({} as Bumper);
+  vi.spyOn(Bumper.prototype, 'commits').mockReturnThis();
+  vi.spyOn(Bumper.prototype, 'bump').mockResolvedValue({ releaseType } as unknown as BumperRecommendationResult);
+}
+
+const baseConfig: Partial<Config> = { preset: 'angular', versionPrefix: 'v' };
+const options = (overrides: Partial<VersionOptions> = {}): VersionOptions => ({
+  latestTag: 'v1.0.0-next.1',
+  versionPrefix: 'v',
+  path: '/repo/packages/pkg',
+  name: 'my-pkg',
+  ...overrides,
+});
+
+beforeEach(() => {
+  vi.spyOn(gitTags, 'getCommitsLength').mockResolvedValue(3);
+  vi.spyOn(gitTags, 'refExists').mockResolvedValue(false);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('Per-package release channel — advance along the current line (#485)', () => {
+  describe('default (no explicit channel) on a prerelease package', () => {
+    it('should advance the prerelease counter for a patch-level change (1.0.0-next.1 -> 1.0.0-next.2)', async () => {
+      baselineAt('1.0.0-next.1');
+      inferredBump('patch');
+      const next = await calculateVersion(baseConfig as Config, options());
+      expect(next).toBe('1.0.0-next.2');
+    });
+
+    it('should escalate the base for a minor-level change (1.0.0-next.1 -> 1.1.0-next.0)', async () => {
+      baselineAt('1.0.0-next.1');
+      inferredBump('minor');
+      const next = await calculateVersion(baseConfig as Config, options());
+      expect(next).toBe('1.1.0-next.0');
+    });
+
+    it('should escalate the base for a major-level change (1.0.0-next.1 -> 2.0.0-next.0)', async () => {
+      baselineAt('1.0.0-next.1');
+      inferredBump('major');
+      const next = await calculateVersion(baseConfig as Config, options());
+      expect(next).toBe('2.0.0-next.0');
+    });
+
+    it('should preserve the existing prerelease identifier rather than the config default', async () => {
+      baselineAt('2.3.0-beta.4');
+      inferredBump('patch');
+      const config = { ...baseConfig, prereleaseIdentifier: 'next' } as Config;
+      const next = await calculateVersion(config, options({ latestTag: 'v2.3.0-beta.4' }));
+      // The package walks its OWN line (beta), not the configured default (next) — a line switch is
+      // a deliberate, out-of-scope action.
+      expect(next).toBe('2.3.0-beta.5');
+    });
+
+    it('should never graduate a -next package to stable without an explicit graduate action', async () => {
+      for (const magnitude of ['patch', 'minor', 'major'] as const) {
+        baselineAt('1.0.0-next.1');
+        inferredBump(magnitude);
+        const next = await calculateVersion(baseConfig as Config, options());
+        expect(next).toMatch(/-next\.\d+$/);
+      }
+    });
+  });
+
+  describe('default (no explicit channel) on a stable package', () => {
+    it('should bump a stable package normally for a minor change (10.1.0 -> 10.2.0)', async () => {
+      baselineAt('10.1.0');
+      inferredBump('minor');
+      const next = await calculateVersion(baseConfig as Config, options({ latestTag: 'v10.1.0' }));
+      expect(next).toBe('10.2.0');
+    });
+
+    it('should bump a stable package normally for a patch change (10.1.0 -> 10.1.1)', async () => {
+      baselineAt('10.1.0');
+      inferredBump('patch');
+      const next = await calculateVersion(baseConfig as Config, options({ latestTag: 'v10.1.0' }));
+      expect(next).toBe('10.1.1');
+    });
+  });
+
+  describe('explicit bump magnitude (release:major/minor/patch) without a channel action', () => {
+    // A bump LABEL sets the magnitude but not the channel; a prerelease package must still stay on
+    // its line (the bump is not a graduate action).
+    it('should keep a prerelease on its line under an explicit minor bump (1.0.0-next.1 -> 1.1.0-next.0)', async () => {
+      baselineAt('1.0.0-next.1');
+      const next = await calculateVersion(baseConfig as Config, options({ type: 'minor' }));
+      expect(next).toBe('1.1.0-next.0');
+    });
+
+    it('should keep a prerelease on its line under an explicit major bump (1.0.0-next.1 -> 2.0.0-next.0)', async () => {
+      baselineAt('1.0.0-next.1');
+      const next = await calculateVersion(baseConfig as Config, options({ type: 'major' }));
+      expect(next).toBe('2.0.0-next.0');
+    });
+
+    it('should keep a prerelease on its line under an explicit patch bump (1.0.0-next.1 -> 1.0.0-next.2)', async () => {
+      baselineAt('1.0.0-next.1');
+      const next = await calculateVersion(baseConfig as Config, options({ type: 'patch' }));
+      expect(next).toBe('1.0.0-next.2');
+    });
+  });
+
+  describe('explicit graduate action (release:graduate / --stable) still graduates', () => {
+    it('should graduate a prerelease to stable, dropping the prerelease segment', async () => {
+      baselineAt('1.0.0-next.1');
+      const config = { ...baseConfig, stableOnly: true } as Config;
+      const next = await calculateVersion(config, options());
+      expect(next).toBe('1.0.0');
+    });
+  });
+
+  describe('explicit channel:prerelease (isPrerelease) is unchanged by this default', () => {
+    it('should create a fresh prerelease from a stable package (10.1.0 + minor -> 10.2.0-next.0)', async () => {
+      baselineAt('10.1.0');
+      inferredBump('minor');
+      const config = { ...baseConfig, isPrerelease: true, prereleaseIdentifier: 'next' } as Config;
+      const next = await calculateVersion(config, options({ latestTag: 'v10.1.0' }));
+      expect(next).toBe('10.2.0-next.0');
+    });
+  });
+
+  describe('a mixed standing PR resolves each package on its own channel', () => {
+    it('should advance a prerelease and bump a stable package independently in one run', async () => {
+      // Prerelease member: stays prerelease.
+      baselineAt('1.0.0-next.1');
+      inferredBump('minor');
+      const pre = await calculateVersion(baseConfig as Config, options({ name: 'pre-pkg' }));
+
+      // Stable member: bumps normally.
+      baselineAt('10.1.0');
+      inferredBump('minor');
+      const stable = await calculateVersion(
+        baseConfig as Config,
+        options({ name: 'stable-pkg', latestTag: 'v10.1.0' }),
+      );
+
+      expect(pre).toBe('1.1.0-next.0');
+      expect(stable).toBe('10.2.0');
+    });
+  });
+});

--- a/packages/version/test/unit/utils/jsonOutput.spec.ts
+++ b/packages/version/test/unit/utils/jsonOutput.spec.ts
@@ -57,6 +57,7 @@ describe('JSON Output Utilities', () => {
         packageName: 'test-package',
         newVersion: '1.0.0',
         filePath: '/path/to/package.json',
+        channel: 'stable',
       });
       expect(updatedData.tags).toHaveLength(1);
       expect(updatedData.tags[0]).toBe('v1.0.0');
@@ -108,6 +109,7 @@ describe('JSON Output Utilities', () => {
         packageName: 'my-monorepo',
         newVersion: '1.0.0',
         filePath: '/path/to/package.json',
+        channel: 'stable',
         isRoot: true,
       });
       // isRoot is omitted (not false) so pre-existing consumers see an unchanged shape
@@ -115,6 +117,7 @@ describe('JSON Output Utilities', () => {
         packageName: 'test-package',
         newVersion: '1.0.0',
         filePath: '/path/to/packages/a/package.json',
+        channel: 'stable',
       });
     });
 
@@ -133,6 +136,7 @@ describe('JSON Output Utilities', () => {
         packageName: '@scope/x-y',
         newVersion: '1.1.0',
         filePath: '/ws/packages/x/package.json',
+        channel: 'stable',
       });
     });
 
@@ -147,6 +151,7 @@ describe('JSON Output Utilities', () => {
         packageName: '@scope/x-y',
         newVersion: '1.1.0',
         filePath: '/ws/packages/x/package.json',
+        channel: 'stable',
       });
     });
 
@@ -160,7 +165,19 @@ describe('JSON Output Utilities', () => {
         packageName: 'pure-crate',
         newVersion: '2.0.0',
         filePath: '/ws/crates/pure/Cargo.toml',
+        channel: 'stable',
       });
+    });
+
+    it('should derive the per-package channel from the resolved version (#485)', () => {
+      enableJsonOutput();
+      addPackageUpdate('stable-pkg', '10.2.0', '/ws/packages/stable/package.json');
+      addPackageUpdate('pre-pkg', '1.0.0-next.2', '/ws/packages/pre/package.json');
+
+      const updates = getJsonData().updates;
+      // A mixed standing PR carries both channels at once, each on its own line (#485).
+      expect(updates.find((u) => u.packageName === 'stable-pkg')?.channel).toBe('stable');
+      expect(updates.find((u) => u.packageName === 'pre-pkg')?.channel).toBe('prerelease');
     });
 
     it('should dedupe a hybrid when manifest paths are not string-identical for the same directory', () => {


### PR DESCRIPTION
## What & why

Standing-PR channel handling was global: the default graduated any `-next` package to stable, and the only knobs (`channel:prerelease`, `release:graduate`) flipped the whole PR. In a monorepo with permanently mixed maturity, neither global mode fits — a routine patch silently promoted incubating `-next` packages to a "production-ready" release.

This makes the channel **per-package, derived from each package's current version**, and changes only the **default (no channel label)** to advance each package along its own line.

## Behaviour

- Prerelease package: `1.0.0-next.1 → 1.0.0-next.2` (patch), `→ 1.1.0-next.0` (minor), `→ 2.0.0-next.0` (major).
- Stable package: `10.1.0 → 10.2.0`.
- A `-next` package **never** graduates without an explicit `release:graduate`.
- A mixed standing PR (some stable, some prerelease) is normal — each package walks its own line; one merge can ship `10.2.0` and `1.1.0-next.0` together.
- `release:graduate` and `channel:prerelease` are unchanged.
- Publishing already derives dist-tags per package via `getDistTag(target.version, …)`, so `latest`/`next` come out right in a mixed release (test added).

## For #486 / #487

Adds `ReleaseChannel`, a pure `deriveReleaseChannel()` helper, and an optional additive `VersionPackageUpdate.channel` field persisted per package. Optional/back-compat: old standing-PR manifests omit it; consumers re-derive from `newVersion`. Per-package graduation (#486) and channel-grouped rendering (#487) build on this.

## Tests

New real-semver spec covering prerelease patch/minor/major, stable, explicit bump without a channel, graduate, channel:prerelease, and a mixed set; `deriveReleaseChannel` unit tests; mixed dist-tag assertion. `pnpm turbo run lint typecheck test` is green.

Closes #485

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR changes version-channel handling from global to per-package: instead of a standing-PR defaulting every prerelease package to a stable graduation, the default now advances each package along its own channel (prerelease stays prerelease, stable stays stable). It also adds a pure `deriveReleaseChannel` helper and an optional `channel` field to `VersionPackageUpdate` for downstream consumers.

- Two new intercept branches in `versionCalculator.ts` (one for explicit-type, one for commit-inferred) reroute standard bump magnitudes to their `pre*` equivalents when the current version is already a prerelease, blocking silent graduation.
- `deriveReleaseChannel` is implemented as a dependency-free string function in `core` (semver is unavailable there) that strips build metadata before checking for a `-` segment; the `channel` field it produces is stored per-update in the JSON manifest.
- Tests drive the real semver engine with only git/manifest/bumper stubs so asserted version strings are genuine output, not mock echoes.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the new intercept branches are additive guards that fire only for prerelease packages without an explicit channel action, and every other path is unchanged.

The two new branches are symmetric and narrowly scoped: they only activate when the current version is a prerelease, no explicit graduate or channel:prerelease is in play, and the bump is a standard magnitude. The deriveReleaseChannel helper is pure and dependency-free. The optional channel field is additive and backwards-compatible. Tests drive the real semver engine with only infrastructure stubs, so asserted version strings are genuine rather than mock echoes. Previously flagged dead-code and redundant-guard concerns have been addressed in the head commit.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/version/src/core/versionCalculator.ts | Adds two symmetrical intercept branches (specified-type and commit-inferred) that redirect standard bump magnitudes to their pre* equivalents when the current version is already a prerelease, preventing silent graduation. |
| packages/core/src/types.ts | Introduces ReleaseChannel type, deriveReleaseChannel pure helper, and optional channel field on VersionPackageUpdate. The indexOf/slice implementation correctly strips build metadata before checking for a prerelease segment. |
| packages/core/src/index.ts | Converts the export type block to a mixed export block to include the new deriveReleaseChannel value export alongside the existing type-only exports. |
| packages/version/src/utils/jsonOutput.ts | Derives and persists channel per-package update via deriveReleaseChannel(newVersion) inside addPackageUpdate, set before the deduplication check. |
| packages/version/test/unit/core/versionChannel.spec.ts | New real-semver spec file covering patch/minor/major on prerelease, stable, explicit bump, graduate, channel:prerelease, and mixed-set scenarios. |
| packages/core/test/unit/types.spec.ts | Unit tests for deriveReleaseChannel covering stable, prerelease, and build-metadata-only versions. |
| packages/publish/test/unit/utils/semver.spec.ts | Adds a mixed-release dist-tag assertion verifying getDistTag independently resolves latest/next/beta per version. |
| packages/release/docs/ci-setup.md | Updates the bump-matrix table rows for prerelease inputs and adds a prose callout explaining per-package channel derivation. |
| packages/version/test/unit/utils/jsonOutput.spec.ts | Existing snapshot assertions updated to include channel: stable, plus a new mixed-channel test. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[calculateVersion called] --> B{type explicitly provided?}
    B -- yes --> C[specifiedType branch]
    B -- no --> D[conventional commits branch]

    C --> E{stableOnly?}
    E -- yes + prerelease --> F[Graduate to stable base]
    E -- no --> G{isCurrentPrerelease && !isPrerelease && STANDARD type?}
    G -- yes --> H[toPrereleaseLineBump: patch→prerelease, minor→preminor, major→premajor]
    H --> I[bumpVersion with pre* type and channelId]
    G -- no --> J[existing pre/stable logic]

    D --> K{stableOnly?}
    K -- yes + prerelease --> F
    K -- no --> L[conventional commit bump + zeroMajor adjustment]
    L --> N{isCurrentPrerelease && !isPrerelease && STANDARD type?}
    N -- yes --> H
    N -- no --> O[existing pre/stable logic]

    style F fill:#f9c,stroke:#c66
    style I fill:#9cf,stroke:#69c
    style H fill:#9cf,stroke:#69c
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[calculateVersion called] --> B{type explicitly provided?}
    B -- yes --> C[specifiedType branch]
    B -- no --> D[conventional commits branch]

    C --> E{stableOnly?}
    E -- yes + prerelease --> F[Graduate to stable base]
    E -- no --> G{isCurrentPrerelease && !isPrerelease && STANDARD type?}
    G -- yes --> H[toPrereleaseLineBump: patch→prerelease, minor→preminor, major→premajor]
    H --> I[bumpVersion with pre* type and channelId]
    G -- no --> J[existing pre/stable logic]

    D --> K{stableOnly?}
    K -- yes + prerelease --> F
    K -- no --> L[conventional commit bump + zeroMajor adjustment]
    L --> N{isCurrentPrerelease && !isPrerelease && STANDARD type?}
    N -- yes --> H
    N -- no --> O[existing pre/stable logic]

    style F fill:#f9c,stroke:#c66
    style I fill:#9cf,stroke:#69c
    style H fill:#9cf,stroke:#69c
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["refactor(core): clarify build-metadata s..."](https://github.com/goosewobbler/releasekit/commit/63b4caf69b92911e4e58fc152a73a0132d8841f7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40657190)</sub>

<!-- /greptile_comment -->