### PR TITLE
feat(release): per-package graduation via graduate:<package> label

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -110,7 +110,7 @@ How the bump type is determined. Configure under `ci.releaseTrigger`.
 
 **`label`** (default) — A PR label (`bump:patch`, `bump:minor`, or `bump:major`) must be present for a release to fire. The label controls the bump type. PRs without a release label are silently skipped, giving reviewers direct control over when and at what level a release ships.
 
-Both modes support `bump:major` as an override, `channel:prerelease` as a channel modifier, and `release:graduate` to graduate a prerelease to its stable base version.
+Both modes support `bump:major` as an override, `channel:prerelease` as a channel modifier, and `release:graduate` to graduate a prerelease to its stable base version. In standing-PR mode a `graduate:<package>` label graduates a single prerelease package (and, atomically, any `fixed`/`linked` group it belongs to) while the rest stay on their own line.
 
 | | Commit trigger | Label trigger |
 |---|---|---|

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -396,6 +396,7 @@ PR label names used for release control. Override to match your repository's lab
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `graduate` | string | `"release:graduate"` | Label that graduates a prerelease to its stable base version (e.g. 1.0.0-next.6 → 1.0.0). A standalone release trigger in label/direct mode; in standing-pr mode it sets the next merge to graduate. |
+| `graduatePackagePrefix` | string | `"graduate:"` | Prefix for per-package graduate labels on the standing PR. A `graduate:<package>` label graduates just that prerelease package (and, atomically, any fixed/linked group it belongs to) to its stable base version on the next update, while other prerelease packages stay on their line. The whole-batch `graduate` label still graduates everything. Standing-pr mode only. |
 | `prerelease` | string | `"channel:prerelease"` | Label to create a prerelease |
 | `skip` | string | `"release:skip"` | Label to suppress a release on this PR |
 | `immediate` | string | `"release:immediate"` | Label to bypass the standing PR for one merge — triggers a direct release. Standing-pr mode only. |

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -508,6 +508,12 @@ export const CILabelsConfigSchema = z.object({
     .describe(
       'Label that graduates a prerelease to its stable base version (e.g. 1.0.0-next.6 → 1.0.0). A standalone release trigger in label/direct mode; in standing-pr mode it sets the next merge to graduate.',
     ),
+  graduatePackagePrefix: z
+    .string()
+    .default('graduate:')
+    .describe(
+      'Prefix for per-package graduate labels on the standing PR. A `graduate:<package>` label graduates just that prerelease package (and, atomically, any fixed/linked group it belongs to) to its stable base version on the next update, while other prerelease packages stay on their line. The whole-batch `graduate` label still graduates everything. Standing-pr mode only.',
+    ),
   prerelease: z.string().default('channel:prerelease').describe('Label to create a prerelease'),
   skip: z.string().default('release:skip').describe('Label to suppress a release on this PR'),
   immediate: z
@@ -656,6 +662,7 @@ export const CIConfigSchema = z.object({
     ),
   labels: CILabelsConfigSchema.default({
     graduate: 'release:graduate',
+    graduatePackagePrefix: 'graduate:',
     prerelease: 'channel:prerelease',
     skip: 'release:skip',
     immediate: 'release:immediate',

--- a/packages/config/test/unit/schema.spec.ts
+++ b/packages/config/test/unit/schema.spec.ts
@@ -466,6 +466,7 @@ describe('CIConfigSchema', () => {
     expect(result.prPreview).toEqual({ enabled: true, refreshAfterRelease: false });
     expect(result.labels).toEqual({
       graduate: 'release:graduate',
+      graduatePackagePrefix: 'graduate:',
       prerelease: 'channel:prerelease',
       skip: 'release:skip',
       immediate: 'release:immediate',

--- a/packages/release/docs/ci-setup.md
+++ b/packages/release/docs/ci-setup.md
@@ -655,7 +655,8 @@ A maintainer can edit labels directly on the standing PR (via the GitHub UI or `
 |---|---|
 | `bump:patch` / `bump:minor` / `bump:major` | Forces that bump magnitude, overriding what conventional commits would otherwise produce. |
 | `scope:foo` (per `ci.scopeLabels`) | Limits the release to scoped packages on the next update. |
-| `release:graduate` | Graduates a prerelease to stable. |
+| `release:graduate` | Graduates **every** queued prerelease to its stable base version. |
+| `graduate:<package>` | Graduates **just that** prerelease package (and, atomically, any `fixed`/`linked` group it belongs to) to stable on the next update — other prerelease packages keep advancing their line. The label is per-package (`graduate:@scope/core`); ReleaseKit seeds one for every package currently on a prerelease line so it appears in the GitHub label picker. Prefix configurable via `ci.labels.graduatePackagePrefix`. |
 | `channel:prerelease` | Switches the standing PR to prerelease versioning. |
 
 Conflicts (e.g. both `bump:patch` and `bump:major`) surface as a `pending` `releasekit/standing-pr` status check on the release branch and a workflow warning. The override is dropped (falls back to commit-driven) until the conflict is resolved by removing one of the labels.
@@ -751,7 +752,8 @@ Standing-pr mode handles both batched and one-off releases through a single work
 | Routine feature — batch with others | Merge PR without a label. Bumps come from conventional commits. |
 | Critical fix that needs to ship now | Add `release:immediate` (optionally `+ bump:patch`) to the PR. |
 | Adjust the standing PR's bump magnitude | Add `bump:major` (etc.) to the standing PR itself; the next update applies it. |
-| Promote accumulated prereleases to stable | Add `release:graduate` to the standing PR and merge it. |
+| Promote **all** accumulated prereleases to stable | Add `release:graduate` to the standing PR and merge it. |
+| Promote **one** prerelease package to stable (others stay prerelease) | Add `graduate:<package>` to the standing PR (e.g. `graduate:@scope/core`); others keep advancing their line. |
 | Retry a publish that failed partway | Add `release:retry` to the **merged** standing PR. |
 
 ---

--- a/packages/release/src/label-definitions.ts
+++ b/packages/release/src/label-definitions.ts
@@ -1,6 +1,6 @@
 import type { CIConfig } from '@releasekit/config';
 import type { Forge } from '@releasekit/forge';
-import { DEFAULT_LABELS } from './label-utils.js';
+import { DEFAULT_LABELS, graduatePackageLabel } from './label-utils.js';
 
 /**
  * Canonical definition of a label ReleaseKit relies on. `name` honours `ci.labels` renames
@@ -25,8 +25,16 @@ const COLOR_STANDING = 'ededed'; // grey — standing PR markers (matches legacy
  * labels. Honours `ci.labels` renames and `ci.scopeLabels`. The result is deduped by name —
  * if a rename collides with another label (or a scope label reuses a reserved name) the first
  * definition wins, so we never emit two definitions for the same label name.
+ *
+ * `graduatablePackages` (#486) seeds the per-package `graduate:<package>` labels — GitHub can only
+ * apply labels that already exist, so the standing-PR update passes the names of packages currently
+ * on a prerelease line so a maintainer can pick one from the label picker. Callers without that
+ * context (the label-sync command) omit it; those labels are then minted lazily on the next update.
  */
-export function deriveLabelDefinitions(ciConfig: CIConfig | undefined): LabelDefinition[] {
+export function deriveLabelDefinitions(
+  ciConfig: CIConfig | undefined,
+  graduatablePackages: string[] = [],
+): LabelDefinition[] {
   const labels = ciConfig?.labels ?? DEFAULT_LABELS;
   const scopeLabels = ciConfig?.scopeLabels ?? {};
   const standingPrLabels = ciConfig?.standingPr?.labels ?? ['release'];
@@ -73,6 +81,17 @@ export function deriveLabelDefinitions(ciConfig: CIConfig | undefined): LabelDef
       name: scopeLabel,
       color: COLOR_SCOPE,
       description: 'ReleaseKit: scope the release to a subset of packages',
+    });
+  }
+
+  // Per-package graduate labels (#486): one `graduate:<package>` per package currently on a
+  // prerelease line, so a maintainer can graduate just that package (and its lockstep group) to
+  // stable from the GitHub label picker. Channel-blue like the prerelease label — they steer channel.
+  for (const pkg of graduatablePackages) {
+    definitions.push({
+      name: graduatePackageLabel(pkg, labels),
+      color: COLOR_CHANNEL,
+      description: 'ReleaseKit: graduate this prerelease package to its stable base version',
     });
   }
 

--- a/packages/release/src/label-utils.ts
+++ b/packages/release/src/label-utils.ts
@@ -1,5 +1,7 @@
 export interface LabelConfig {
   graduate: string;
+  /** Prefix for per-package graduate labels (`graduate:<package>`); see #486. */
+  graduatePackagePrefix: string;
   prerelease: string;
   skip: string;
   immediate: string;
@@ -13,6 +15,7 @@ export interface LabelConfig {
 
 export const DEFAULT_LABELS: LabelConfig = {
   graduate: 'release:graduate',
+  graduatePackagePrefix: 'graduate:',
   prerelease: 'channel:prerelease',
   skip: 'release:skip',
   immediate: 'release:immediate',
@@ -23,6 +26,40 @@ export const DEFAULT_LABELS: LabelConfig = {
   patch: 'bump:patch',
   withPrerequisites: 'release:with-prerequisites',
 };
+
+/**
+ * The configured per-package graduate prefix, falling back to the default when a (possibly partial)
+ * config omits it — an empty/absent prefix would otherwise match every label or crash on `startsWith`.
+ */
+function graduatePrefix(labels: Partial<LabelConfig> | undefined): string {
+  return labels?.graduatePackagePrefix || DEFAULT_LABELS.graduatePackagePrefix;
+}
+
+/**
+ * The per-package graduate label for a package (#486), e.g. `graduate:@scope/pkg`. Adding it to the
+ * standing PR graduates that one prerelease package (and its fixed/linked group) to stable.
+ */
+export function graduatePackageLabel(packageName: string, labels?: Partial<LabelConfig>): string {
+  return `${graduatePrefix(labels)}${packageName}`;
+}
+
+/**
+ * Whether a label is a per-package graduate label (#486). The prefix alone (no package suffix) is not
+ * a valid per-package graduate, so it doesn't match. Comparison is case-insensitive to mirror
+ * GitHub's case-insensitive label uniqueness.
+ */
+export function isGraduatePackageLabel(label: string, labels?: Partial<LabelConfig>): boolean {
+  const prefix = graduatePrefix(labels);
+  return label.length > prefix.length && label.toLowerCase().startsWith(prefix.toLowerCase());
+}
+
+/**
+ * The package name carried by a per-package graduate label (#486), or `undefined` when the label
+ * isn't one. `graduate:@scope/pkg` → `@scope/pkg`.
+ */
+export function graduatedPackageFromLabel(label: string, labels?: Partial<LabelConfig>): string | undefined {
+  return isGraduatePackageLabel(label, labels) ? label.slice(graduatePrefix(labels).length) : undefined;
+}
 
 export interface LabelConflictResult {
   bumpConflict: boolean;

--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -1,7 +1,7 @@
 import * as fs from 'node:fs';
 import { type CIConfig, loadConfig as loadReleaseKitConfig } from '@releasekit/config';
-import type { VersionOutput } from '@releasekit/core';
-import { error, info, markerData, success, warn } from '@releasekit/core';
+import type { VersionOutput, VersionPackageUpdate } from '@releasekit/core';
+import { deriveReleaseChannel, error, info, markerData, success, warn } from '@releasekit/core';
 import { type Forge, forgeErrorStatus, type PullRequestDetails } from '@releasekit/forge';
 import { createGitCli } from '@releasekit/git';
 import { PipelineError } from '@releasekit/publish';
@@ -12,7 +12,7 @@ import { detectUnresolvedFailure, postFailureReport, resolveFailureReportIfPrese
 import { getGitHubContext, getHeadCommitMessage, matchesSkipPattern } from '../git.js';
 import { forgeFor } from '../github.js';
 import { deriveLabelDefinitions, syncLabels } from '../label-definitions.js';
-import { DEFAULT_LABELS } from '../label-utils.js';
+import { DEFAULT_LABELS, graduatedPackageFromLabel, isGraduatePackageLabel } from '../label-utils.js';
 import { refreshFeederPreviews } from '../preview/refresh.js';
 import { runNotesStep, runPublishStep, runVersionStep } from '../steps.js';
 import type { ReleaseOptions, ReleaseOutput } from '../types.js';
@@ -97,6 +97,15 @@ export interface StandingPRManifest {
    * manifests written before this field existed.
    */
   deselected?: string[];
+  /**
+   * Packages graduated from prerelease to stable on this update (#486), driven by `graduate:<package>`
+   * labels (or the whole-batch `release:graduate`). Group-atomic — a graduated fixed/linked group lists
+   * every releasing member. Recorded for provenance and so consumers (#487's channel-grouped render)
+   * can flag a row as graduated; the resolved stable versions already live in `versionOutput`. Optional:
+   * absent when nothing graduated, and on manifests written before this field existed (consumers
+   * re-derive from each update's `channel` / `action`).
+   */
+  graduated?: string[];
 }
 
 async function getHeadSha(cwd: string): Promise<string> {
@@ -521,11 +530,17 @@ interface StandingPrOverrides {
   prerelease?: boolean;
   /** Also release the targeted packages' changed prerequisites (the `release:with-prerequisites` label). */
   withPrerequisites?: boolean;
+  /**
+   * Per-package graduation (#486): package names parsed from `graduate:<package>` labels — graduate
+   * just these prereleases to stable, leaving others on their line. Empty when none. Ignored when
+   * `stable` (the whole-batch `release:graduate`) is set, which graduates everything.
+   */
+  graduate?: string[];
   /** Human-readable conflict descriptions (used for the pending status check). Empty when no conflict. */
   conflicts: string[];
 }
 
-/** The release-control label names (bump/channel/scope/with-prerequisites) — those that drive output. */
+/** The fixed release-control label names (bump/channel/scope/with-prerequisites) — those that drive output. */
 function relevantOverrideLabelNames(ciConfig: CIConfig | undefined): Set<string> {
   const labels = ciConfig?.labels ?? DEFAULT_LABELS;
   const scopeLabels = ciConfig?.scopeLabels ?? {};
@@ -541,14 +556,56 @@ function relevantOverrideLabelNames(ciConfig: CIConfig | undefined): Set<string>
 }
 
 /**
- * The override-relevant labels (bump/channel/scope) present on a PR, sorted and de-duplicated.
+ * Whether a label steers the next release, so it must be tracked by the manifest's `overrideLabels`
+ * (staleness guard, #337) and the label-authorization reconcile (#402). Covers the fixed control
+ * labels plus the dynamic per-package `graduate:<package>` labels (#486), whose names aren't known up
+ * front but still drive output and so can't be left for an unauthorized actor to add unchecked.
+ */
+function isRelevantOverrideLabel(label: string, ciConfig: CIConfig | undefined): boolean {
+  return relevantOverrideLabelNames(ciConfig).has(label) || isGraduatePackageLabel(label, ciConfig?.labels);
+}
+
+/**
+ * The override-relevant labels (bump/channel/scope/graduate) present on a PR, sorted and de-duplicated.
  * This is the set that actually drives the next release, so it's what the manifest records and what
  * publish compares against the merged PR to detect a stale manifest (#337). The standing-PR marker
  * label and any unrelated labels (area:*, etc.) are deliberately excluded — they don't affect output.
  */
 function extractOverrideLabels(prLabels: string[], ciConfig: CIConfig | undefined): string[] {
-  const relevant = relevantOverrideLabelNames(ciConfig);
-  return [...new Set(prLabels.filter((l) => relevant.has(l)))].sort();
+  return [...new Set(prLabels.filter((l) => isRelevantOverrideLabel(l, ciConfig)))].sort();
+}
+
+/** A package update's channel — the persisted `channel` (#485), else re-derived from its version. */
+function updateChannel(update: VersionPackageUpdate): ReturnType<typeof deriveReleaseChannel> {
+  return update.channel ?? deriveReleaseChannel(update.newVersion);
+}
+
+/**
+ * Publishable packages currently on a prerelease line (#486) — the candidates a maintainer can
+ * graduate. Used to seed the per-package `graduate:<package>` labels so they exist in the picker.
+ */
+function prereleasePackageNames(versionOutput: VersionOutput): string[] {
+  return publishableUpdates(versionOutput)
+    .filter((u) => updateChannel(u) === 'prerelease')
+    .map((u) => u.packageName);
+}
+
+/**
+ * Packages graduated from prerelease to stable on this run (#486), for the manifest's `graduated`
+ * provenance field. Sourced from each update's resolved `action` (`'graduated'`), then widened for
+ * group atomicity: a fixed/linked group where any member graduated lists every releasing member, even
+ * one whose own action read `'bumped'` because it adopted the group version from a different baseline.
+ */
+function graduatedPackageNames(versionOutput: VersionOutput): string[] {
+  const updates = publishableUpdates(versionOutput);
+  const graduatedGroups = new Set(
+    updates.filter((u) => u.action === 'graduated' && u.group).map((u) => u.group as string),
+  );
+  const names = new Set<string>();
+  for (const u of updates) {
+    if (u.action === 'graduated' || (u.group && graduatedGroups.has(u.group))) names.add(u.packageName);
+  }
+  return [...names].sort();
 }
 
 function resolveStandingPrLabelOverrides(prLabels: string[], ciConfig: CIConfig | undefined): StandingPrOverrides {
@@ -583,6 +640,19 @@ function resolveStandingPrLabelOverrides(prLabels: string[], ciConfig: CIConfig 
     if (hasPrerelease) prerelease = true;
   }
 
+  // Per-package graduation (#486): each `graduate:<package>` label graduates that one prerelease to
+  // stable. The whole-batch `release:graduate` (stable) supersedes them — it graduates everything, so
+  // a per-package subset would only narrow it; drop the per-package set then. `channel:prerelease`
+  // forces a prerelease line, which directly contradicts graduating, so flag it as a conflict.
+  const graduate = stable
+    ? []
+    : prLabels.map((l) => graduatedPackageFromLabel(l, labels)).filter((p): p is string => p !== undefined);
+  if (graduate.length > 0 && hasPrerelease) {
+    conflicts.push(
+      `Conflicting release-type labels on standing PR (per-package graduate and ${labels.prerelease}) — a package can't graduate and stay prerelease`,
+    );
+  }
+
   // Scope: first matching configured scope label wins
   let target: string | undefined;
   for (const [labelName, pattern] of Object.entries(scopeLabels)) {
@@ -607,7 +677,15 @@ function resolveStandingPrLabelOverrides(prLabels: string[], ciConfig: CIConfig 
   // when there is a target (the engine derives prerequisites from the targeted set).
   const withPrerequisites = prLabels.includes(labels.withPrerequisites) || undefined;
 
-  return { bump: composedBump, target, stable, prerelease, withPrerequisites, conflicts };
+  return {
+    bump: composedBump,
+    target,
+    stable,
+    prerelease,
+    withPrerequisites,
+    graduate: graduate.length > 0 ? graduate : undefined,
+    conflicts,
+  };
 }
 
 interface BuildOptionsExtras {
@@ -618,6 +696,8 @@ interface BuildOptionsExtras {
   stable?: boolean;
   prerelease?: boolean;
   includePrerequisites?: boolean;
+  /** Per-package graduation (#486): package patterns to graduate to stable; others stay on their line. */
+  graduate?: string[];
   /** Packages to hold back from the release (standing-PR ad-hoc deselection). Exact name match. */
   exclude?: string[];
 }
@@ -636,6 +716,7 @@ function buildBaseReleaseOptions(
     includePrerequisites: extras?.includePrerequisites,
     exclude: extras?.exclude,
     stable: extras?.stable,
+    graduate: extras?.graduate,
     prerelease: extras?.prerelease ? true : undefined,
     skipNotes: true,
     skipPublish: true,
@@ -814,9 +895,9 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
     const actor = getEventActor();
     const isLabelEvent = actor.action === 'labeled' || actor.action === 'unlabeled';
     if (isLabelEvent && !(await authorizedOrWarn(forgeFor(githubContext), actor, authz))) {
-      const relevant = relevantOverrideLabelNames(ciConfig);
-      const authorizedOverrides = (existingManifest?.overrideLabels ?? []).filter((l) => relevant.has(l));
-      const reconciled = [...new Set([...effectiveLabels.filter((l) => !relevant.has(l)), ...authorizedOverrides])];
+      const isRelevant = (l: string) => isRelevantOverrideLabel(l, ciConfig);
+      const authorizedOverrides = (existingManifest?.overrideLabels ?? []).filter(isRelevant);
+      const reconciled = [...new Set([...effectiveLabels.filter((l) => !isRelevant(l)), ...authorizedOverrides])];
       // Tell the unauthorized labeller their change was ignored — parity with the selection gate
       // (the label removal is also visible in the timeline, but the comment says why). Idempotent.
       if (!setsEqual(new Set(effectiveLabels), new Set(reconciled))) {
@@ -845,6 +926,7 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
   if (overrides.bump) info(`Standing PR label override: bump=${overrides.bump}`);
   if (overrides.target) info(`Standing PR label override: target=${overrides.target}`);
   if (overrides.stable) info(`Standing PR label override: ${overrideLabelNames.graduate}`);
+  if (overrides.graduate) info(`Standing PR label override: graduate [${overrides.graduate.join(', ')}]`);
   if (overrides.prerelease) info(`Standing PR label override: ${overrideLabelNames.prerelease}`);
   for (const conflict of overrides.conflicts) warn(conflict);
 
@@ -857,6 +939,10 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
   // the CLI flag OR the `release:with-prerequisites` label, either way.
   const cliTarget = options.target ?? overrides.target;
   const includePrerequisites = options.includePrerequisites || overrides.withPrerequisites;
+  // Per-package graduation (#486) is a non-sync concept — a sync release moves as one atomic unit
+  // (no selection region, single shared version), so `graduate:<package>` has no meaning there; the
+  // whole-batch `release:graduate` still graduates the synced unit. Drop the per-package set for sync.
+  const graduate = sync ? undefined : overrides.graduate;
   const buildExtras: BuildOptionsExtras = overrides.conflicts.length
     ? { sync, target: cliTarget, includePrerequisites }
     : {
@@ -865,6 +951,7 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
         target: cliTarget,
         stable: overrides.stable,
         prerelease: overrides.prerelease,
+        graduate,
         includePrerequisites,
       };
 
@@ -1127,7 +1214,9 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
   // retry label is created but NOT applied — a maintainer applies it on demand after merge to
   // retry a failed publish (issue #245). Best-effort: a sync failure must not block the update.
   try {
-    await syncLabels(forge, deriveLabelDefinitions(ciConfig));
+    // Seed a `graduate:<package>` label for every package currently on a prerelease line (#486) so a
+    // maintainer can pick one from GitHub's label list — labels must exist before they can be applied.
+    await syncLabels(forge, deriveLabelDefinitions(ciConfig, prereleasePackageNames(versionOutput)));
   } catch (err) {
     warn(`Could not ensure ReleaseKit labels exist: ${err instanceof Error ? err.message : String(err)}`);
   }
@@ -1153,6 +1242,11 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
     firstUpdatedAt = existingManifest.firstUpdatedAt ?? existingManifest.createdAt;
   }
 
+  // Packages that graduated to stable this run (#486), recorded in the manifest below for provenance
+  // and for the channel-grouped render (#487). Derived from what actually resolved, so it reflects
+  // group atomicity and the whole-batch graduate as well as the per-package labels.
+  const graduatedPackages = graduatedPackageNames(versionOutput);
+
   // Store manifest as a bot comment. `releaseNotes` is intentionally omitted — publishFromManifest
   // regenerates LLM-enhanced release notes against the merged commit set, so caching them here
   // would waste LLM calls and risk drift if the standing PR sits open while new commits land.
@@ -1170,6 +1264,9 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
     // Record any packages held back via the selection region (provenance; the release set in
     // `versionOutput` is already narrowed). Omitted when nothing was deselected.
     deselected: effectiveDeselected.size > 0 ? [...effectiveDeselected].sort() : undefined,
+    // Record which packages graduated to stable this run (#486) so the state survives re-runs and
+    // consumers (#487) can flag a graduated row. Omitted when nothing graduated.
+    graduated: graduatedPackages.length > 0 ? graduatedPackages : undefined,
   };
 
   const manifestBody = serializeManifest(manifest);

--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -644,12 +644,18 @@ function resolveStandingPrLabelOverrides(prLabels: string[], ciConfig: CIConfig 
   // stable. The whole-batch `release:graduate` (stable) supersedes them — it graduates everything, so
   // a per-package subset would only narrow it; drop the per-package set then. `channel:prerelease`
   // forces a prerelease line, which directly contradicts graduating, so flag it as a conflict.
+  const graduateLabels = stable ? [] : prLabels.filter((l) => isGraduatePackageLabel(l, labels));
   const graduate = stable
     ? []
-    : prLabels.map((l) => graduatedPackageFromLabel(l, labels)).filter((p): p is string => p !== undefined);
+    : graduateLabels.map((l) => graduatedPackageFromLabel(l, labels)).filter((p): p is string => p !== undefined);
   if (graduate.length > 0 && hasPrerelease) {
+    // Name the offending graduate label(s) up front so the (140-char-truncated) status check tells the
+    // maintainer exactly what to remove — the alternative is an opaque "release-type labels conflict".
+    // Calling out that a graduate label lingers after its package graduated also points at the likely
+    // cause: a leftover `graduate:<package>` colliding with a newly-added prerelease channel.
     conflicts.push(
-      `Conflicting release-type labels on standing PR (per-package graduate and ${labels.prerelease}) — a package can't graduate and stay prerelease`,
+      `Conflicting release-type labels: ${graduateLabels.map((l) => `\`${l}\``).join(', ')} graduate to stable while ` +
+        `\`${labels.prerelease}\` forces a prerelease — remove one. (A graduate label lingers after its package graduates, so it may be a stale leftover.)`,
     );
   }
 

--- a/packages/release/src/steps.ts
+++ b/packages/release/src/steps.ts
@@ -20,6 +20,7 @@ export async function runVersionStep(options: ReleaseOptions): Promise<VersionOu
     bump: options.bump as import('semver').ReleaseType | undefined,
     prerelease: options.prerelease,
     stable: options.stable,
+    graduate: options.graduate,
     allowFirstBump: options.allowFirstBump,
     dryRun: options.dryRun,
     sync: options.sync,

--- a/packages/release/src/types.ts
+++ b/packages/release/src/types.ts
@@ -7,6 +7,9 @@ export interface ReleaseOptions {
   bump?: string;
   prerelease?: string | boolean;
   stable?: boolean;
+  /** Per-package graduation (#486): package name patterns to graduate to stable, leaving other
+   *  prereleases on their line. Distinct from `stable`, which graduates ALL prereleases. */
+  graduate?: string[];
   /** Acknowledge a first-release bump on an already-stable manifest (silences the #388 overshoot guard). */
   allowFirstBump?: boolean;
   sync: boolean;

--- a/packages/release/test/unit/label-definitions.spec.ts
+++ b/packages/release/test/unit/label-definitions.spec.ts
@@ -90,6 +90,27 @@ describe('deriveLabelDefinitions', () => {
     const releaseCount = names(defs).filter((n) => n === 'release').length;
     expect(releaseCount).toBe(1);
   });
+
+  it('should seed a graduate:<package> label for each graduatable package (#486)', () => {
+    const defs = deriveLabelDefinitions(ciConfig(), ['@scope/a', '@scope/b']);
+    expect(names(defs)).toContain('graduate:@scope/a');
+    expect(names(defs)).toContain('graduate:@scope/b');
+    // The fixed whole-batch graduate label is still present and distinct.
+    expect(names(defs)).toContain('release:graduate');
+  });
+
+  it('should emit no per-package graduate labels when no graduatable packages are passed (#486)', () => {
+    const defs = deriveLabelDefinitions(ciConfig());
+    expect(names(defs).some((n) => n.startsWith('graduate:'))).toBe(false);
+  });
+
+  it('should honour a renamed graduatePackagePrefix when seeding per-package graduate labels (#486)', () => {
+    const config = ciConfig({
+      labels: { ...DEFAULT_LABELS_CONFIG, graduatePackagePrefix: 'promote/' },
+    } as Partial<CIConfig>);
+    const defs = deriveLabelDefinitions(config, ['@scope/a']);
+    expect(names(defs)).toContain('promote/@scope/a');
+  });
 });
 
 describe('syncLabels', () => {

--- a/packages/release/test/unit/label-utils.spec.ts
+++ b/packages/release/test/unit/label-utils.spec.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { composeBumpFromLabels, DEFAULT_LABELS } from '../../src/label-utils.js';
+import {
+  composeBumpFromLabels,
+  DEFAULT_LABELS,
+  graduatedPackageFromLabel,
+  graduatePackageLabel,
+  isGraduatePackageLabel,
+} from '../../src/label-utils.js';
 
 describe('composeBumpFromLabels', () => {
   it('should return the magnitude when only a bump label is present', () => {
@@ -41,5 +47,43 @@ describe('composeBumpFromLabels', () => {
   it('should honour renamed labels from a custom LabelConfig', () => {
     const labels = { ...DEFAULT_LABELS, major: 'bump/major', prerelease: 'release:prerelease' };
     expect(composeBumpFromLabels(['bump/major', 'release:prerelease'], labels)).toBe('premajor');
+  });
+});
+
+describe('per-package graduate labels (#486)', () => {
+  it('should build a graduate:<package> label from a package name', () => {
+    expect(graduatePackageLabel('@scope/pkg')).toBe('graduate:@scope/pkg');
+  });
+
+  it('should recognise a per-package graduate label', () => {
+    expect(isGraduatePackageLabel('graduate:@scope/pkg')).toBe(true);
+    expect(isGraduatePackageLabel('graduate:core')).toBe(true);
+  });
+
+  it('should not treat the bare prefix, the whole-batch graduate, or unrelated labels as per-package', () => {
+    expect(isGraduatePackageLabel('graduate:')).toBe(false);
+    expect(isGraduatePackageLabel('release:graduate')).toBe(false);
+    expect(isGraduatePackageLabel('bump:major')).toBe(false);
+  });
+
+  it('should extract the package name from a per-package graduate label, undefined otherwise', () => {
+    expect(graduatedPackageFromLabel('graduate:@scope/pkg')).toBe('@scope/pkg');
+    expect(graduatedPackageFromLabel('release:graduate')).toBeUndefined();
+    expect(graduatedPackageFromLabel('graduate:')).toBeUndefined();
+  });
+
+  it('should honour a renamed graduatePackagePrefix', () => {
+    const labels = { ...DEFAULT_LABELS, graduatePackagePrefix: 'promote/' };
+    expect(graduatePackageLabel('@scope/pkg', labels)).toBe('promote/@scope/pkg');
+    expect(isGraduatePackageLabel('promote/@scope/pkg', labels)).toBe(true);
+    expect(graduatedPackageFromLabel('promote/@scope/pkg', labels)).toBe('@scope/pkg');
+    // The default prefix no longer matches when renamed.
+    expect(isGraduatePackageLabel('graduate:@scope/pkg', labels)).toBe(false);
+  });
+
+  it('should fall back to the default prefix when a partial config omits it', () => {
+    const partial = { graduate: 'release:graduate' };
+    expect(graduatePackageLabel('core', partial)).toBe('graduate:core');
+    expect(isGraduatePackageLabel('graduate:core', partial)).toBe(true);
   });
 });

--- a/packages/release/test/unit/standing-pr.spec.ts
+++ b/packages/release/test/unit/standing-pr.spec.ts
@@ -271,6 +271,17 @@ describe('serializeManifest / parseManifest', () => {
     const parsed = parseManifest(serializeManifest(baseManifest));
     expect(parsed.overrideLabels).toBeUndefined();
   });
+
+  it('should round-trip graduated packages (#486)', () => {
+    const m = { ...baseManifest, schemaVersion: 2 as const, graduated: ['@scope/a', '@scope/b'] };
+    const parsed = parseManifest(serializeManifest(m));
+    expect(parsed.graduated).toEqual(['@scope/a', '@scope/b']);
+  });
+
+  it('should accept a manifest without graduated (backward compat)', () => {
+    const parsed = parseManifest(serializeManifest(baseManifest));
+    expect(parsed.graduated).toBeUndefined();
+  });
 });
 
 describe('runStandingPRUpdate', () => {
@@ -1858,6 +1869,106 @@ describe('runStandingPRUpdate', () => {
       await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
 
       expect(runVersionStepMock.mock.calls[0]?.[0]).toMatchObject({ sync: true });
+    });
+  });
+
+  describe('per-package graduation (#486)', () => {
+    // A mixed async standing PR: @scope/a stays on its stable line, @scope/b is a prerelease.
+    const mixedOutput = (graduatedName?: string) => ({
+      dryRun: false,
+      strategy: 'async' as const,
+      updates: [
+        {
+          packageName: '@scope/a',
+          newVersion: graduatedName === '@scope/a' ? '1.0.0' : '1.0.1',
+          filePath: 'packages/a/package.json',
+          channel: 'stable' as const,
+          action: graduatedName === '@scope/a' ? ('graduated' as const) : ('bumped' as const),
+        },
+        {
+          packageName: '@scope/b',
+          newVersion: graduatedName === '@scope/b' ? '2.0.0' : '2.0.0-next.2',
+          filePath: 'packages/b/package.json',
+          channel: graduatedName === '@scope/b' ? ('stable' as const) : ('prerelease' as const),
+          action: graduatedName === '@scope/b' ? ('graduated' as const) : ('bumped' as const),
+        },
+      ],
+      changelogs: [],
+      tags: [],
+      commitMessage: 'chore: release',
+      sharedEntries: [],
+    });
+
+    async function setupGraduation(labels: string[], graduatedName?: string) {
+      const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
+      const output = mixedOutput(graduatedName);
+      vi.mocked(runVersionStep)
+        .mockResolvedValueOnce(output as unknown as Awaited<ReturnType<typeof runVersionStep>>)
+        .mockResolvedValueOnce(output as unknown as Awaited<ReturnType<typeof runVersionStep>>);
+      vi.mocked(runNotesStep).mockResolvedValue({ packageNotes: {}, releaseNotes: {}, files: [] });
+      const forge = await mockForge({ standingPR: openStandingPR(99, labels) });
+      return { forge, runVersionStepMock: vi.mocked(runVersionStep) };
+    }
+
+    it('should pass a graduate:<package> label as the graduate set into both version runs', async () => {
+      const { runVersionStepMock } = await setupGraduation(['release', 'graduate:@scope/b'], '@scope/b');
+
+      await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
+
+      expect(runVersionStepMock.mock.calls[0]?.[0]).toMatchObject({ graduate: ['@scope/b'] });
+      expect(runVersionStepMock.mock.calls[1]?.[0]).toMatchObject({ graduate: ['@scope/b'] });
+      // Per-package graduation is NOT the whole-batch graduate — `stable` stays unset.
+      expect(runVersionStepMock.mock.calls[0]?.[0]?.stable).toBeUndefined();
+    });
+
+    it('should record the graduated package in the manifest', async () => {
+      const { forge } = await setupGraduation(['release', 'graduate:@scope/b'], '@scope/b');
+
+      await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
+
+      const writes = [...forge.createdComments.map((c) => c.body), ...forge.updatedComments.map((c) => c.body)];
+      const manifestWrite = writes.find((b) => b.includes(MANIFEST_MARKER));
+      const manifest = parseManifest(manifestWrite as string);
+      expect(manifest.graduated).toEqual(['@scope/b']);
+    });
+
+    it('should record the graduate:<package> label in the manifest overrideLabels (staleness guard)', async () => {
+      const { forge } = await setupGraduation(['release', 'graduate:@scope/b'], '@scope/b');
+
+      await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
+
+      const writes = [...forge.createdComments.map((c) => c.body), ...forge.updatedComments.map((c) => c.body)];
+      const manifest = parseManifest(writes.find((b) => b.includes(MANIFEST_MARKER)) as string);
+      expect(manifest.overrideLabels).toContain('graduate:@scope/b');
+    });
+
+    it('should let the whole-batch release:graduate win over per-package graduate labels', async () => {
+      const { runVersionStepMock } = await setupGraduation(['release', 'release:graduate', 'graduate:@scope/b']);
+
+      await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
+
+      expect(runVersionStepMock.mock.calls[0]?.[0]).toMatchObject({ stable: true });
+      expect(runVersionStepMock.mock.calls[0]?.[0]?.graduate).toBeUndefined();
+    });
+
+    it('should create a graduate:<package> label for each prerelease package so it can be applied', async () => {
+      const { forge } = await setupGraduation(['release']);
+
+      await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
+
+      // @scope/b is on a prerelease line → its graduate label is seeded; @scope/a is stable → no label.
+      expect(forge.createdLabels.some((l) => l.name === 'graduate:@scope/b')).toBe(true);
+      expect(forge.createdLabels.some((l) => l.name === 'graduate:@scope/a')).toBe(false);
+    });
+
+    it('should flag a conflict when a per-package graduate meets channel:prerelease', async () => {
+      const { forge } = await setupGraduation(['release', 'graduate:@scope/b', 'channel:prerelease'], '@scope/b');
+
+      await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
+
+      const lastStatus = forge.commitStatuses.at(-1);
+      expect(lastStatus?.state).toBe('pending');
+      expect(lastStatus?.description).toMatch(/graduate/i);
     });
   });
 

--- a/packages/release/test/unit/standing-pr.spec.ts
+++ b/packages/release/test/unit/standing-pr.spec.ts
@@ -1961,14 +1961,17 @@ describe('runStandingPRUpdate', () => {
       expect(forge.createdLabels.some((l) => l.name === 'graduate:@scope/a')).toBe(false);
     });
 
-    it('should flag a conflict when a per-package graduate meets channel:prerelease', async () => {
+    it('should name the offending graduate label in the conflict when it meets channel:prerelease', async () => {
       const { forge } = await setupGraduation(['release', 'graduate:@scope/b', 'channel:prerelease'], '@scope/b');
 
       await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
 
       const lastStatus = forge.commitStatuses.at(-1);
       expect(lastStatus?.state).toBe('pending');
-      expect(lastStatus?.description).toMatch(/graduate/i);
+      // The specific stale graduate label is surfaced (not an opaque "release-type labels conflict")
+      // so the maintainer knows exactly what to remove — and it survives the 140-char status truncation.
+      expect(lastStatus?.description).toContain('graduate:@scope/b');
+      expect(lastStatus?.description).toContain('channel:prerelease');
     });
   });
 

--- a/packages/version/src/core/groupStrategy.ts
+++ b/packages/version/src/core/groupStrategy.ts
@@ -158,6 +158,19 @@ interface GroupComputation {
 }
 
 /**
+ * Whether this whole group is graduating to stable on this run (#486). A fixed/linked group shares
+ * one version and channel, so graduation is all-or-nothing: graduating ANY member graduates the
+ * group. True when `stableOnly` is set and either there's no per-package `graduateScope` (the global
+ * `release:graduate` path → every group graduates) or some member falls inside that scope.
+ */
+function isGroupGraduating(group: ResolvedGroup, config: Config): boolean {
+  if (!config.stableOnly) return false;
+  const scope = config.graduateScope;
+  if (!scope || scope.length === 0) return true;
+  return group.members.some((m) => shouldMatchPackageTargets(m.packageJson.name, scope));
+}
+
+/**
  * Compute the group version and the set of releasing members from each member's independent plan.
  */
 function computeGroup(group: ResolvedGroup, plans: MemberPlan[], config: Config): GroupComputation {
@@ -174,6 +187,24 @@ function computeGroup(group: ResolvedGroup, plans: MemberPlan[], config: Config)
   }
 
   const maxBaseline = plans.map((p) => p.baseline).sort(semver.rcompare)[0];
+
+  // Group graduation (#486): drop the prerelease segment of the highest baseline so the whole
+  // fixed/linked group lands on its stable base (e.g. 1.2.0-next.3 → 1.2.0), atomically — every
+  // member adopts it regardless of which one carried the graduate label, and the bump magnitude is
+  // ignored (graduation is bump-less). Only when the group is actually on a prerelease line; an
+  // already-stable group falls through to the normal bump path (graduating it would be a no-op
+  // write). The never-regress guard below still pulls the version up to any member's own stable next.
+  if (isGroupGraduating(group, config) && semver.prerelease(maxBaseline)) {
+    const parsed = semver.parse(maxBaseline);
+    let groupVersion = parsed ? `${parsed.major}.${parsed.minor}.${parsed.patch}` : maxBaseline;
+    for (const plan of changedPlans) {
+      if (semver.valid(plan.ownNext) && semver.gt(plan.ownNext, groupVersion)) {
+        groupVersion = plan.ownNext;
+      }
+    }
+    const releasing = group.sync === 'fixed' ? plans : changedPlans;
+    return { groupVersion, releasing, hasChange: true };
+  }
   const maxRank = Math.max(...changedPlans.map(memberBumpRank));
   const bumpType = RANK_TO_TYPE[maxRank] ?? 'patch';
 

--- a/packages/version/src/core/versionCalculator.ts
+++ b/packages/version/src/core/versionCalculator.ts
@@ -61,19 +61,28 @@ export function applyOverrideScope(
   config: Config,
   options: VersionOptions,
 ): { config: Config; options: VersionOptions } {
-  const { overrideScope } = config;
+  const { overrideScope, graduateScope } = config;
+  let scoped: { config: Config; options: VersionOptions } = { config, options };
   // `type` / `isPrerelease` / `stableOnly` are the engine's runtime override fields (folded from
   // runOptions bump/prerelease/stable) — none is a static config-file setting, so clearing them to
   // their "not specified" sentinel reverts an out-of-scope package to commit-driven calculation.
   // When `options.name` is absent (a single-package repo) there's nothing to match against, so the
   // override applies — scoping is only meaningful across multiple packages.
   if (overrideScope?.length && options.name && !shouldMatchPackageTargets(options.name, overrideScope)) {
-    return {
-      config: { ...config, type: undefined, isPrerelease: undefined, stableOnly: undefined },
-      options: { ...options, type: undefined },
+    scoped = {
+      config: { ...scoped.config, type: undefined, isPrerelease: undefined, stableOnly: undefined },
+      options: { ...scoped.options, type: undefined },
     };
   }
-  return { config, options };
+  // Per-package graduation (#486): graduate only the packages in `graduateScope`; every other
+  // prerelease keeps its line. Gate ONLY the `stableOnly` graduation here — unlike `overrideScope`,
+  // a graduate is bump-less, so leave any bump/prerelease the run also carries untouched. An empty
+  // `graduateScope` with `stableOnly` set means "graduate everything" (the global release:graduate
+  // path), so this clause is a no-op then.
+  if (graduateScope?.length && options.name && !shouldMatchPackageTargets(options.name, graduateScope)) {
+    scoped = { ...scoped, config: { ...scoped.config, stableOnly: undefined } };
+  }
+  return scoped;
 }
 
 /**

--- a/packages/version/src/core/versionCalculator.ts
+++ b/packages/version/src/core/versionCalculator.ts
@@ -74,13 +74,19 @@ export function applyOverrideScope(
       options: { ...scoped.options, type: undefined },
     };
   }
-  // Per-package graduation (#486): graduate only the packages in `graduateScope`; every other
-  // prerelease keeps its line. Gate ONLY the `stableOnly` graduation here — unlike `overrideScope`,
-  // a graduate is bump-less, so leave any bump/prerelease the run also carries untouched. An empty
-  // `graduateScope` with `stableOnly` set means "graduate everything" (the global release:graduate
-  // path), so this clause is a no-op then.
-  if (graduateScope?.length && options.name && !shouldMatchPackageTargets(options.name, graduateScope)) {
-    scoped = { ...scoped, config: { ...scoped.config, stableOnly: undefined } };
+  // Per-package graduation (#486): `graduateScope` membership is AUTHORITATIVE for `stableOnly`. A
+  // package in scope graduates — re-assert `stableOnly` even when the `overrideScope` clearing above
+  // stripped it, because a graduate target can be a transitive prerequisite that sits OUTSIDE
+  // `overrideScope` when `release:with-prerequisites` is also active; without this re-assert the
+  // explicit graduation would be silently lost. A package out of scope keeps its line — clear
+  // `stableOnly`. Gate ONLY `stableOnly` (graduation is bump-less, so any `type`/`isPrerelease` the
+  // overrideScope branch cleared stays cleared — that's fine, graduation ignores them). `graduateScope`
+  // is only ever set together with `stableOnly: true` (the engine folds them from `runOptions.graduate`),
+  // so re-asserting `true` here can't fabricate a graduation the run didn't ask for. An empty
+  // `graduateScope` with `stableOnly` set means "graduate everything" (global release:graduate) — no-op.
+  if (graduateScope?.length && options.name) {
+    const inGraduateScope = shouldMatchPackageTargets(options.name, graduateScope);
+    scoped = { ...scoped, config: { ...scoped.config, stableOnly: inGraduateScope ? true : undefined } };
   }
   return scoped;
 }

--- a/packages/version/src/core/versionEngine.ts
+++ b/packages/version/src/core/versionEngine.ts
@@ -58,6 +58,14 @@ export class VersionEngine {
         effective.isPrerelease = true;
       }
       if (runOptions.stable) effective.stableOnly = true;
+      // Per-package graduation (#486): graduate only the named packages, leaving other prereleases on
+      // their line. Sets stableOnly + graduateScope; applyOverrideScope clears stableOnly for any
+      // package outside the scope. The global `stable` flag wins — when it's set we graduate ALL
+      // prereleases, so a per-package scope would only narrow it (don't set graduateScope then).
+      if (!runOptions.stable && runOptions.graduate?.length) {
+        effective.stableOnly = true;
+        effective.graduateScope = runOptions.graduate;
+      }
       if (runOptions.allowFirstBump) effective.allowFirstBump = true;
       if (runOptions.targets?.length) this.runtimeTargets = runOptions.targets;
       if (runOptions.baseRef) effective.baseRef = runOptions.baseRef;

--- a/packages/version/src/types.ts
+++ b/packages/version/src/types.ts
@@ -23,6 +23,14 @@ export interface VersionRunOptions {
   /** Graduate prerelease packages to stable; skip already-stable packages
    *  unless bump is also set, in which case bump applies to stable packages. */
   stable?: boolean;
+  /**
+   * Per-package graduation (#486): package name patterns to graduate to stable on this run, leaving
+   * every other prerelease package on its own line. Drives `stableOnly` scoped to just these packages
+   * (see {@link Config.graduateScope}). Distinct from the global `stable` flag, which graduates ALL
+   * prereleases. When both are set, `stable` wins (graduate everything). Empty/undefined → no
+   * per-package graduation.
+   */
+  graduate?: string[];
   /** Acknowledge a first-release bump on a stable manifest, silencing the #388 overshoot guard. */
   allowFirstBump?: boolean;
   dryRun?: boolean;
@@ -119,6 +127,11 @@ export interface Config extends VersionConfigBase {
   /** Runtime override: package patterns the forced bump/prerelease/stable applies to. When set,
    *  non-matching packages ignore the override and compute commit-driven. See VersionRunOptions.overrideScope. */
   overrideScope?: string[];
+  /** Runtime override (#486): package patterns to graduate to stable. Set together with `stableOnly`
+   *  by per-package graduation; a package outside this scope keeps `stableOnly` cleared and advances
+   *  along its own line. `undefined`/empty with `stableOnly` set means "graduate every prerelease"
+   *  (the global `release:graduate` path). See VersionRunOptions.graduate. */
+  graduateScope?: string[];
   /** Runtime (engine-populated): the FULL discovered workspace — every package's name+dir, before
    *  the release-set filters (targets/exclude/config.packages). The repo-level changelog classifier
    *  uses this so a commit touching a non-releasing package's dir is attributed to that package, not

--- a/packages/version/test/unit/core/applyOverrideScope.spec.ts
+++ b/packages/version/test/unit/core/applyOverrideScope.spec.ts
@@ -112,3 +112,41 @@ describe('applyOverrideScope — graduateScope (#486)', () => {
     expect(input.stableOnly).toBe(true);
   });
 });
+
+// `release:with-prerequisites` scopes the bump override to the explicit targets (overrideScope), while
+// `graduate:<pkg>` can target a transitive prerequisite that sits OUTSIDE that overrideScope. The two
+// scopes interact: graduateScope must win for stableOnly so the explicit graduation isn't lost (#486).
+const comboCfg = (): Config =>
+  ({
+    tagTemplate: '${prefix}${version}',
+    preset: 'conventional',
+    sync: false,
+    packages: [],
+    versionPrefix: 'v',
+    stableOnly: true,
+    overrideScope: ['@scope/target'],
+    graduateScope: ['@scope/prereq'],
+  }) as Config;
+
+describe('applyOverrideScope — graduateScope + overrideScope combo (#486)', () => {
+  it('should keep stableOnly for a graduated prerequisite outside overrideScope', () => {
+    // @scope/prereq is outside overrideScope (so block 1 strips its bump override) but inside
+    // graduateScope — it must still graduate (stableOnly survives the overrideScope clearing).
+    const { config } = applyOverrideScope(comboCfg(), opts('@scope/prereq'));
+    expect(config.stableOnly).toBe(true);
+    // The bump override is gone (it's outside overrideScope) — graduation is bump-less, so that's fine.
+    expect(config.type).toBeUndefined();
+    expect(config.isPrerelease).toBeUndefined();
+  });
+
+  it('should clear stableOnly for a non-graduated prerequisite outside both scopes (stays on its line)', () => {
+    const { config } = applyOverrideScope(comboCfg(), opts('@scope/other-prereq'));
+    expect(config.stableOnly).toBeUndefined();
+  });
+
+  it('should clear stableOnly for an in-overrideScope target that was not graduated', () => {
+    // The explicit target keeps its bump override but does NOT graduate — it wasn't asked to.
+    const { config } = applyOverrideScope(comboCfg(), opts('@scope/target'));
+    expect(config.stableOnly).toBeUndefined();
+  });
+});

--- a/packages/version/test/unit/core/applyOverrideScope.spec.ts
+++ b/packages/version/test/unit/core/applyOverrideScope.spec.ts
@@ -66,3 +66,49 @@ describe('applyOverrideScope', () => {
     expect(config.type).toBe('major');
   });
 });
+
+// Per-package graduation (#486): `graduateScope` gates ONLY the `stableOnly` graduation, leaving any
+// bump/prerelease the run also carries intact. A graduate config carries stableOnly (no other override).
+const gradCfg = (graduateScope?: string[]): Config =>
+  ({
+    tagTemplate: '${prefix}${version}',
+    preset: 'conventional',
+    sync: false,
+    packages: [],
+    versionPrefix: 'v',
+    stableOnly: true,
+    graduateScope,
+  }) as Config;
+
+describe('applyOverrideScope — graduateScope (#486)', () => {
+  it('should keep stableOnly for a package inside graduateScope', () => {
+    const { config } = applyOverrideScope(gradCfg(['@scope/a']), opts('@scope/a'));
+    expect(config.stableOnly).toBe(true);
+  });
+
+  it('should clear stableOnly for a package outside graduateScope so it stays on its line', () => {
+    const { config } = applyOverrideScope(gradCfg(['@scope/a']), opts('@other/b'));
+    expect(config.stableOnly).toBeUndefined();
+  });
+
+  it('should graduate every package when graduateScope is undefined (global graduate)', () => {
+    const { config } = applyOverrideScope(gradCfg(undefined), opts('@other/b'));
+    expect(config.stableOnly).toBe(true);
+  });
+
+  it('should leave a bump override intact when gating an out-of-scope package (graduate is bump-less)', () => {
+    // stableOnly + graduateScope + a forced bump: the out-of-scope package loses graduation but keeps
+    // the bump, so it advances along its line rather than graduating.
+    const config = { ...gradCfg(['@scope/a']), type: 'minor' } as Config;
+    const { config: scoped, options } = applyOverrideScope(config, opts('@other/b'));
+    expect(scoped.stableOnly).toBeUndefined();
+    expect(scoped.type).toBe('minor');
+    expect(options.type).toBe('major'); // options.type from opts() is untouched by graduateScope gating
+  });
+
+  it('should not mutate the input config', () => {
+    const input = gradCfg(['@scope/a']);
+    applyOverrideScope(input, opts('@other/b'));
+    expect(input.stableOnly).toBe(true);
+  });
+});

--- a/packages/version/test/unit/core/groupStrategy.spec.ts
+++ b/packages/version/test/unit/core/groupStrategy.spec.ts
@@ -637,6 +637,125 @@ describe('createGroupStrategy', () => {
     });
   });
 
+  describe('per-package graduation (#486) — group atomicity', () => {
+    it('should graduate a whole fixed group to stable when ONE member is in graduateScope', async () => {
+      const core = mkPackage('@wdio/native-core', '1.0.0-next.5');
+      const utils = mkPackage('@wdio/native-utils', '1.0.0-next.5');
+
+      // Only native-core is in graduateScope → its calculator returns the stable base; native-utils
+      // is out of scope so (per applyOverrideScope, simulated here) it advances its prerelease line.
+      vi.mocked(calculator.calculateVersion).mockImplementation(async (_cfg, opts) => {
+        if (opts.name === '@wdio/native-core') return '1.0.0';
+        return '1.0.0-next.6';
+      });
+
+      const strategy = createGroupStrategy(
+        baseConfig({
+          groups: { native: { packages: ['@wdio/native-*'], sync: 'fixed' } },
+          stableOnly: true,
+          graduateScope: ['@wdio/native-core'],
+        }),
+      );
+      await strategy(workspace([core, utils]));
+
+      // The whole group graduates to 1.0.0 — native-utils does NOT stay on its -next line.
+      expect(packageManagement.updatePackageVersion).toHaveBeenCalledWith(
+        '/ws/packages/wdio-native-core/package.json',
+        '1.0.0',
+        undefined,
+      );
+      expect(packageManagement.updatePackageVersion).toHaveBeenCalledWith(
+        '/ws/packages/wdio-native-utils/package.json',
+        '1.0.0',
+        undefined,
+      );
+    });
+
+    it('should graduate a whole linked group to stable when one changed member is graduated', async () => {
+      const core = mkPackage('@wdio/native-core', '2.0.0-next.2');
+      const utils = mkPackage('@wdio/native-utils', '2.0.0-next.2');
+
+      // Both members changed; native-core is the graduate target. Linked releases only changed members,
+      // all at the shared graduated version.
+      vi.mocked(calculator.calculateVersion).mockImplementation(async (_cfg, opts) => {
+        if (opts.name === '@wdio/native-core') return '2.0.0';
+        return '2.0.0-next.3';
+      });
+
+      const strategy = createGroupStrategy(
+        baseConfig({
+          groups: { native: { packages: ['@wdio/native-*'], sync: 'linked' } },
+          stableOnly: true,
+          graduateScope: ['@wdio/native-utils'],
+        }),
+      );
+      await strategy(workspace([core, utils]));
+
+      expect(packageManagement.updatePackageVersion).toHaveBeenCalledWith(
+        '/ws/packages/wdio-native-core/package.json',
+        '2.0.0',
+        undefined,
+      );
+      expect(packageManagement.updatePackageVersion).toHaveBeenCalledWith(
+        '/ws/packages/wdio-native-utils/package.json',
+        '2.0.0',
+        undefined,
+      );
+    });
+
+    it('should NOT graduate a group when no member is in graduateScope', async () => {
+      const core = mkPackage('@wdio/native-core', '1.0.0-next.5');
+      const utils = mkPackage('@wdio/native-utils', '1.0.0-next.5');
+
+      // stableOnly is set for the run, but graduateScope targets a package in another group, so this
+      // group keeps advancing its prerelease line (simulated calculator output).
+      vi.mocked(calculator.calculateVersion).mockResolvedValue('1.0.0-next.6');
+
+      const strategy = createGroupStrategy(
+        baseConfig({
+          groups: { native: { packages: ['@wdio/native-*'], sync: 'fixed' } },
+          stableOnly: true,
+          graduateScope: ['@other/thing'],
+        }),
+      );
+      await strategy(workspace([core, utils]));
+
+      expect(packageManagement.updatePackageVersion).toHaveBeenCalledWith(
+        '/ws/packages/wdio-native-core/package.json',
+        '1.0.0-next.6',
+        undefined,
+      );
+      expect(packageManagement.updatePackageVersion).not.toHaveBeenCalledWith(
+        expect.anything(),
+        '1.0.0',
+        expect.anything(),
+      );
+    });
+
+    it('should graduate every group under the whole-batch graduate (stableOnly, no graduateScope)', async () => {
+      const a = mkPackage('@app/a', '3.1.0-next.4');
+      const b = mkPackage('@app/b', '3.1.0-next.4');
+
+      vi.mocked(calculator.calculateVersion).mockResolvedValue('3.1.0');
+
+      const strategy = createGroupStrategy(
+        baseConfig({ groups: { app: { packages: ['@app/*'], sync: 'fixed' } }, stableOnly: true }),
+      );
+      await strategy(workspace([a, b]));
+
+      expect(packageManagement.updatePackageVersion).toHaveBeenCalledWith(
+        '/ws/packages/app-a/package.json',
+        '3.1.0',
+        undefined,
+      );
+      expect(packageManagement.updatePackageVersion).toHaveBeenCalledWith(
+        '/ws/packages/app-b/package.json',
+        '3.1.0',
+        undefined,
+      );
+    });
+  });
+
   describe('ungrouped packages', () => {
     it('should version ungrouped packages independently at their own computed version', async () => {
       const core = mkPackage('@wdio/native-core', '2.3.0');

--- a/packages/version/test/unit/core/versionChannel.spec.ts
+++ b/packages/version/test/unit/core/versionChannel.spec.ts
@@ -149,6 +149,39 @@ describe('Per-package release channel — advance along the current line (#485)'
     });
   });
 
+  describe('per-package graduation via graduateScope (#486)', () => {
+    it('should graduate a package inside graduateScope to its stable base', async () => {
+      baselineAt('1.0.0-next.5');
+      // stableOnly + graduateScope covering this package → graduate (bump ignored).
+      const config = { ...baseConfig, stableOnly: true, graduateScope: ['my-pkg'] } as Config;
+      const next = await calculateVersion(config, options({ name: 'my-pkg' }));
+      expect(next).toBe('1.0.0');
+    });
+
+    it('should leave a package outside graduateScope on its prerelease line', async () => {
+      baselineAt('1.0.0-next.5');
+      inferredBump('patch');
+      // stableOnly is set, but graduateScope excludes this package → it advances its line, not graduates.
+      const config = { ...baseConfig, stableOnly: true, graduateScope: ['other-pkg'] } as Config;
+      const next = await calculateVersion(config, options({ name: 'my-pkg' }));
+      expect(next).toBe('1.0.0-next.6');
+    });
+
+    it('should graduate one package and advance another in a mixed run (some stay prerelease)', async () => {
+      const config = { ...baseConfig, stableOnly: true, graduateScope: ['graduating-pkg'] } as Config;
+
+      baselineAt('1.0.0-next.5');
+      const graduated = await calculateVersion(config, options({ name: 'graduating-pkg' }));
+
+      baselineAt('2.3.0-next.1');
+      inferredBump('minor');
+      const staysPre = await calculateVersion(config, options({ name: 'staying-pkg', latestTag: 'v2.3.0-next.1' }));
+
+      expect(graduated).toBe('1.0.0');
+      expect(staysPre).toBe('2.4.0-next.0');
+    });
+  });
+
   describe('explicit channel:prerelease (isPrerelease) is unchanged by this default', () => {
     it('should create a fresh prerelease from a stable package (10.1.0 + minor -> 10.2.0-next.0)', async () => {
       baselineAt('10.1.0');

--- a/releasekit.schema.json
+++ b/releasekit.schema.json
@@ -1063,6 +1063,11 @@
               "default": "release:graduate",
               "description": "Label that graduates a prerelease to its stable base version (e.g. 1.0.0-next.6 → 1.0.0). A standalone release trigger in label/direct mode; in standing-pr mode it sets the next merge to graduate."
             },
+            "graduatePackagePrefix": {
+              "type": "string",
+              "default": "graduate:",
+              "description": "Prefix for per-package graduate labels on the standing PR. A `graduate:<package>` label graduates just that prerelease package (and, atomically, any fixed/linked group it belongs to) to its stable base version on the next update, while other prerelease packages stay on their line. The whole-batch `graduate` label still graduates everything. Standing-pr mode only."
+            },
             "prerelease": {
               "type": "string",
               "default": "channel:prerelease",


### PR DESCRIPTION
Closes #486.

## What

Graduating a prerelease package to stable is a per-package decision. Until now the only lever was the global `release:graduate`, which graduates the whole PR. This adds a per-package `graduate:<package>` label so a maintainer can promote one prerelease unit to stable while the rest keep advancing their `-next` line.

## How

- **Label:** `graduate:<package>` (prefix configurable via `ci.labels.graduatePackagePrefix`, default `graduate:`). ReleaseKit seeds one label per currently-prerelease package each standing-PR update so it shows up in GitHub's label picker.
- **Version engine:** new `graduate` run option → scoped `stableOnly` + `graduateScope`. `applyOverrideScope` clears `stableOnly` for out-of-scope packages (they advance along their line); a graduated package drops its prerelease suffix to the stable base.
- **Group atomicity:** graduating any member of a `fixed`/`linked` group graduates the whole group — enforced in the group strategy's `computeGroup`, which also fixes a latent over-bump where global `release:graduate` + groups mis-derived the bump.
- **Manifest:** new optional `graduated` field records what graduated (survives re-runs); `graduate:*` labels join `overrideLabels` so they're covered by the publish staleness guard and the unauthorized-label reconcile.
- `release:graduate` still graduates every queued prerelease.

Out of scope: no changes to the standing-PR selection-region rendering (#487).

## Tests

Unit/integration: single-package graduation in a mixed standing PR (one goes stable + correct channel, others stay prerelease), manifest round-trip, override-label/staleness wiring, fixed & linked group atomicity, label helpers, and the whole-batch-wins precedence.

`pnpm turbo run lint typecheck test` — all 32 tasks green; `schema:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds per-package graduation for prerelease packages in standing-PR mode. A maintainer can now apply a `graduate:<package>` label to promote one package (and, atomically, any `fixed`/`linked` group it belongs to) to its stable base version while other prerelease packages keep advancing their line.

- **Label & config**: new `graduate:<package>` label shape with a configurable `ci.labels.graduatePackagePrefix` (default `"graduate:"`); ReleaseKit seeds one label per currently-prerelease package on each update so the GitHub label picker stays up to date.
- **Version engine**: `VersionRunOptions.graduate` sets `stableOnly + graduateScope` in the engine; `applyOverrideScope` is extended so `graduateScope` authoritatively controls `stableOnly` per-package, fixing a latent bug where a graduate target that was also a transitive prerequisite (outside `overrideScope`) could silently lose its graduation.
- **Group atomicity**: `computeGroup` grows a graduation path that fires when any member is in `graduateScope` and the group's max baseline is prerelease; the whole group drops to the stable base in one shot, and `graduatedPackageNames` widens the manifest's new `graduated` field to every releasing group member.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge. The per-package graduation logic is correctly isolated from the existing global graduation path and all shared edge cases are covered by unit tests.

The two scope-interaction invariants that matter most — re-asserting stableOnly for a graduate target that sits outside overrideScope, and gating the group graduation path on semver.prerelease(maxBaseline) — are both correctly implemented and covered by dedicated test suites. The never-regress guard inside the group graduation path is safe because semver places prerelease versions below their stable counterpart. No logic gaps found beyond the stale-label UX limitation already flagged in prior review threads.

No files require special attention. The stale graduate label cleanup after graduation is a known open UX issue tracked in prior threads and does not affect correctness.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/version/src/core/versionCalculator.ts | applyOverrideScope extended to handle graduateScope: re-asserts stableOnly for packages inside the scope, clearing it for those outside. Correctly handles the prerequisite-outside-overrideScope edge case via sequential application of both scope checks. |
| packages/version/src/core/groupStrategy.ts | New isGroupGraduating helper and graduation path in computeGroup. Group atomicity is enforced: when any member is in graduateScope and the group's max baseline is prerelease, all releasing members adopt the stable base. Never-regress guard correctly keeps prerelease ownNext values from superseding the stable groupVersion. |
| packages/version/src/core/versionEngine.ts | Folds runOptions.graduate into stableOnly + graduateScope when the global stable flag is not set. Global stable correctly wins over per-package graduate. |
| packages/release/src/standing-pr/standing-pr.ts | Core orchestration: resolveStandingPrLabelOverrides parses graduate: labels with correct stable-wins precedence and conflict detection; prereleasePackageNames seeds per-package labels for the next picker update; graduatedPackageNames captures group-atomic graduation for the manifest's new graduated field. |
| packages/release/src/label-utils.ts | Adds graduatePackageLabel, isGraduatePackageLabel, and graduatedPackageFromLabel helpers. graduatePrefix safely falls back to the default when the config omits graduatePackagePrefix, preventing empty-prefix footguns. |
| packages/release/src/label-definitions.ts | deriveLabelDefinitions extended to accept graduatablePackages and seed per-package graduate: labels; callers without prerelease context omit the arg, so labels are minted lazily. |
| packages/version/src/types.ts | Adds graduate to VersionRunOptions and graduateScope to Config, both documented as runtime-only overrides that are always set together via the engine. |
| packages/config/src/schema.ts | graduatePackagePrefix added to CILabelsConfigSchema with default "graduate:" and matching default in the CIConfigSchema.labels default object. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Standing PR update triggered] --> B{Parse PR labels}
    B --> C{release:graduate present?}
    C -- Yes --> D[stable = true global graduation]
    C -- No --> E{graduate pkg labels present?}
    E -- Yes --> F[graduate = pkg names from labels]
    E -- No --> G[No graduation]
    D --> H{channel:prerelease also set?}
    F --> H
    H -- Yes --> I[CONFLICT pending status drop graduation]
    H -- No --> J[buildBaseReleaseOptions]
    J --> K[VersionEngine run]
    K --> L{graduate set and not stable?}
    L -- Yes --> M[stableOnly = true graduateScope = pkg names]
    L -- No --> N[stableOnly = true no scope]
    M --> O[applyOverrideScope per package]
    N --> O
    O --> P{package in graduateScope?}
    P -- Yes --> Q[stableOnly = true returns stable base]
    P -- No --> R[stableOnly = undefined advances prerelease]
    P -- empty scope --> S[stableOnly = true for all]
    Q --> T{Fixed or Linked group?}
    R --> T
    T -- Yes --> U[isGroupGraduating check]
    U -- Yes --> V[groupVersion = stable base all members adopt]
    U -- No --> W[Normal group bump]
    T -- No --> X[Per-package stable base]
    V --> Y[action graduated]
    X --> Y
    W --> Z[action bumped]
    Y --> AA[manifest.graduated recorded]
    AA --> AB[syncLabels seed graduate labels for remaining prerelease packages]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Standing PR update triggered] --> B{Parse PR labels}
    B --> C{release:graduate present?}
    C -- Yes --> D[stable = true global graduation]
    C -- No --> E{graduate pkg labels present?}
    E -- Yes --> F[graduate = pkg names from labels]
    E -- No --> G[No graduation]
    D --> H{channel:prerelease also set?}
    F --> H
    H -- Yes --> I[CONFLICT pending status drop graduation]
    H -- No --> J[buildBaseReleaseOptions]
    J --> K[VersionEngine run]
    K --> L{graduate set and not stable?}
    L -- Yes --> M[stableOnly = true graduateScope = pkg names]
    L -- No --> N[stableOnly = true no scope]
    M --> O[applyOverrideScope per package]
    N --> O
    O --> P{package in graduateScope?}
    P -- Yes --> Q[stableOnly = true returns stable base]
    P -- No --> R[stableOnly = undefined advances prerelease]
    P -- empty scope --> S[stableOnly = true for all]
    Q --> T{Fixed or Linked group?}
    R --> T
    T -- Yes --> U[isGroupGraduating check]
    U -- Yes --> V[groupVersion = stable base all members adopt]
    U -- No --> W[Normal group bump]
    T -- No --> X[Per-package stable base]
    V --> Y[action graduated]
    X --> Y
    W --> Z[action bumped]
    Y --> AA[manifest.graduated recorded]
    AA --> AB[syncLabels seed graduate labels for remaining prerelease packages]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(release): harden per-package graduat..."](https://github.com/goosewobbler/releasekit/commit/0fa6f2452afed8406df22a02dbce1e4f4836c1c2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40669578)</sub>

<!-- /greptile_comment -->