### PR TITLE
fix(version): sync Cargo.lock self-version when bumping a crate

### DIFF
--- a/packages/core/src/cargo.ts
+++ b/packages/core/src/cargo.ts
@@ -1,0 +1,21 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Find the `Cargo.lock` that governs a crate at `startDir` by walking up to the nearest ancestor
+ * that has one — for a workspace member the lock lives at the workspace root, not the member dir.
+ *
+ * Returns `undefined` when no committed lock exists above `startDir`. That is deliberate: libraries
+ * commonly don't commit a lock, and we must never *create* one as a side effect of a version bump —
+ * only sync an existing committed lock so it doesn't drift.
+ */
+export function findCargoLockfile(startDir: string): string | undefined {
+  let dir = path.resolve(startDir);
+  while (true) {
+    const lockPath = path.join(dir, 'Cargo.lock');
+    if (fs.existsSync(lockPath)) return lockPath;
+    const parent = path.dirname(dir);
+    if (parent === dir) return undefined; // reached the filesystem root
+    dir = parent;
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,4 @@
+export { findCargoLockfile } from './cargo.js';
 export { readPackageVersion } from './cli.js';
 export {
   buildDependencyGraph,

--- a/packages/core/test/unit/cargo.spec.ts
+++ b/packages/core/test/unit/cargo.spec.ts
@@ -1,0 +1,53 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { findCargoLockfile } from '../../src/cargo.js';
+
+describe('findCargoLockfile', () => {
+  const tmpDirs: string[] = [];
+
+  function tmp(): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'rk-cargo-lock-'));
+    tmpDirs.push(dir);
+    return fs.realpathSync(dir);
+  }
+
+  afterEach(() => {
+    for (const dir of tmpDirs) fs.rmSync(dir, { recursive: true, force: true });
+    tmpDirs.length = 0;
+  });
+
+  it('should return the lock in the start dir when present', () => {
+    const dir = tmp();
+    const lock = path.join(dir, 'Cargo.lock');
+    fs.writeFileSync(lock, '');
+    expect(findCargoLockfile(dir)).toBe(lock);
+  });
+
+  it('should walk up to the nearest ancestor lock for a workspace member', () => {
+    const root = tmp();
+    const lock = path.join(root, 'Cargo.lock');
+    fs.writeFileSync(lock, '');
+    const member = path.join(root, 'crates', 'foo');
+    fs.mkdirSync(member, { recursive: true });
+    expect(findCargoLockfile(member)).toBe(lock);
+  });
+
+  it('should return the nearest lock when both a member and an ancestor have one', () => {
+    const root = tmp();
+    fs.writeFileSync(path.join(root, 'Cargo.lock'), '');
+    const member = path.join(root, 'crates', 'foo');
+    fs.mkdirSync(member, { recursive: true });
+    const memberLock = path.join(member, 'Cargo.lock');
+    fs.writeFileSync(memberLock, '');
+    expect(findCargoLockfile(member)).toBe(memberLock);
+  });
+
+  it('should return undefined when no lock exists above the start dir', () => {
+    const dir = tmp();
+    const member = path.join(dir, 'crates', 'foo');
+    fs.mkdirSync(member, { recursive: true });
+    expect(findCargoLockfile(member)).toBeUndefined();
+  });
+});

--- a/packages/publish/src/stages/prepare.ts
+++ b/packages/publish/src/stages/prepare.ts
@@ -1,6 +1,6 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { debug, info } from '@releasekit/core';
+import { debug, findCargoLockfile, info } from '@releasekit/core';
 import { createPublishError, PublishErrorCode } from '../errors/index.js';
 import type { PipelineContext } from '../types.js';
 import { updateCargoVersion } from '../utils/cargo.js';
@@ -48,6 +48,11 @@ export async function runPrepareStage(ctx: PipelineContext): Promise<void> {
 
   // Update Cargo.toml versions for cargo packages
   if (config.cargo.enabled) {
+    // Cargo.lock files to stage alongside the manifests (#496). The version step already synced each
+    // crate's lock self-entry to the bumped version; here we surface it so the direct-commit flow
+    // (git-commit, which stages an explicit file list rather than `git add -A`) includes it. The
+    // standing-PR flow stages the lock via its own `git add -A`, so this is a no-op there.
+    const lockfiles = new Set<string>();
     for (const update of input.updates) {
       const pkgDir = path.dirname(path.resolve(cwd, update.filePath));
       const cargoPath = path.join(pkgDir, 'Cargo.toml');
@@ -63,6 +68,15 @@ export async function runPrepareStage(ctx: PipelineContext): Promise<void> {
 
       updateCargoVersion(cargoPath, update.newVersion);
       debug(`Updated ${cargoPath} to version ${update.newVersion}`);
+
+      const lockPath = findCargoLockfile(pkgDir);
+      if (lockPath) lockfiles.add(lockPath);
+    }
+
+    if (lockfiles.size > 0) {
+      const existing = new Set(ctx.additionalFiles ?? []);
+      for (const lock of lockfiles) existing.add(lock);
+      ctx.additionalFiles = [...existing];
     }
   }
 }

--- a/packages/publish/src/stages/prepare.ts
+++ b/packages/publish/src/stages/prepare.ts
@@ -1,9 +1,9 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { debug, findCargoLockfile, info } from '@releasekit/core';
+import { debug, info } from '@releasekit/core';
 import { createPublishError, PublishErrorCode } from '../errors/index.js';
 import type { PipelineContext } from '../types.js';
-import { updateCargoVersion } from '../utils/cargo.js';
+import { syncCargoLockfile, updateCargoVersion } from '../utils/cargo.js';
 
 export async function runPrepareStage(ctx: PipelineContext): Promise<void> {
   const { input, config, cliOptions, cwd } = ctx;
@@ -48,10 +48,11 @@ export async function runPrepareStage(ctx: PipelineContext): Promise<void> {
 
   // Update Cargo.toml versions for cargo packages
   if (config.cargo.enabled) {
-    // Cargo.lock files to stage alongside the manifests (#496). The version step already synced each
-    // crate's lock self-entry to the bumped version; here we surface it so the direct-commit flow
-    // (git-commit, which stages an explicit file list rather than `git add -A`) includes it. The
-    // standing-PR flow stages the lock via its own `git add -A`, so this is a no-op there.
+    // Cargo.lock files to stage alongside the manifests (#496), deduped — crates in one workspace
+    // share a single workspace-root lock. We re-sync the lock here (rather than trust the version
+    // step) so the direct-commit flow — git-commit stages an explicit file list, not `git add -A` —
+    // is self-sufficient and correct even run in isolation. The standing-PR flow stages the lock via
+    // its own `git add -A`, with git-commit skipped, so this re-sync is a harmless no-op there.
     const lockfiles = new Set<string>();
     for (const update of input.updates) {
       const pkgDir = path.dirname(path.resolve(cwd, update.filePath));
@@ -69,7 +70,7 @@ export async function runPrepareStage(ctx: PipelineContext): Promise<void> {
       updateCargoVersion(cargoPath, update.newVersion);
       debug(`Updated ${cargoPath} to version ${update.newVersion}`);
 
-      const lockPath = findCargoLockfile(pkgDir);
+      const lockPath = await syncCargoLockfile(pkgDir);
       if (lockPath) lockfiles.add(lockPath);
     }
 

--- a/packages/publish/src/utils/cargo.ts
+++ b/packages/publish/src/utils/cargo.ts
@@ -1,11 +1,43 @@
 import * as fs from 'node:fs';
+import * as path from 'node:path';
 import type { CargoManifest } from '@releasekit/config';
 import { parseCargoToml } from '@releasekit/config';
+import { findCargoLockfile, warn } from '@releasekit/core';
 import * as TOML from 'smol-toml';
 import { createPublishError, PublishErrorCode } from '../errors/index.js';
+import { execCommand } from './exec.js';
 
 export type { CargoManifest };
 export { parseCargoToml };
+
+/**
+ * Refresh a crate's `Cargo.lock` self-version entry after its `Cargo.toml` was bumped, so the
+ * committed lock doesn't drift (#496). `cargo update --workspace --offline` moves only workspace
+ * members' own lock entries to match their manifests — registry dependencies are never re-resolved.
+ *
+ * Returns the lock path (so the caller can stage it) or `undefined` when there's no committed lock,
+ * or the refresh fails. A failure is logged, never thrown: a lockfile fix-up must not abort a publish
+ * that would otherwise succeed. This mirrors the version step's sync (which covers the standing-PR
+ * flow's `git add -A`); doing it here too keeps the direct-commit flow self-sufficient rather than
+ * depending on the version step having run and succeeded first.
+ */
+export async function syncCargoLockfile(crateDir: string): Promise<string | undefined> {
+  const lockPath = findCargoLockfile(crateDir);
+  if (!lockPath) return undefined;
+
+  try {
+    await execCommand('cargo', ['update', '--workspace', '--offline'], {
+      cwd: crateDir,
+      label: `cargo update --workspace --offline (${path.basename(crateDir)})`,
+    });
+    return lockPath;
+  } catch (error) {
+    const stderr = (error as { stderr?: string }).stderr;
+    const detail = stderr?.trim() || (error instanceof Error ? error.message : String(error));
+    warn(`Failed to refresh Cargo.lock at ${lockPath}: ${detail}. The committed lock may drift from the bump.`);
+    return undefined;
+  }
+}
 
 export const CRATES_IO_USER_AGENT = 'releasekit/publish (https://github.com/goosewobbler/releasekit)';
 export const CRATES_IO_API_TIMEOUT_MS = 30_000;

--- a/packages/publish/test/unit/stages/prepare.spec.ts
+++ b/packages/publish/test/unit/stages/prepare.spec.ts
@@ -6,6 +6,12 @@ import { getDefaultConfig } from '../../../src/config.js';
 import { runPrepareStage } from '../../../src/stages/prepare.js';
 import type { PipelineContext } from '../../../src/types.js';
 
+// Don't shell out to a real cargo for the lockfile sync — assert the staging behaviour, not cargo.
+vi.mock('../../../src/utils/exec.js', async () => {
+  const actual = await vi.importActual<typeof import('../../../src/utils/exec.js')>('../../../src/utils/exec.js');
+  return { ...actual, execCommand: vi.fn().mockResolvedValue({ stdout: '', stderr: '', exitCode: 0 }) };
+});
+
 function createContext(overrides?: Partial<PipelineContext>): PipelineContext {
   return {
     input: {
@@ -188,7 +194,7 @@ describe('prepare stage', () => {
         verbose: false,
       },
       input: {
-        dryRun: false,
+        dryRun: true,
         updates: [{ packageName: 'foo', newVersion: '1.1.0', filePath: 'crates/foo/Cargo.toml' }],
         changelogs: [],
         tags: [],

--- a/packages/publish/test/unit/stages/prepare.spec.ts
+++ b/packages/publish/test/unit/stages/prepare.spec.ts
@@ -138,6 +138,68 @@ describe('prepare stage', () => {
     expect(fs.existsSync(path.join(pkgDir, 'LICENSE'))).toBe(false);
   });
 
+  it('should stage the workspace Cargo.lock alongside a bumped crate', async () => {
+    const dir = createTmpDir();
+    const crateDir = path.join(dir, 'crates', 'foo');
+    fs.mkdirSync(crateDir, { recursive: true });
+    fs.writeFileSync(path.join(crateDir, 'Cargo.toml'), '[package]\nname = "foo"\nversion = "1.0.0"\n');
+    const lockPath = path.join(dir, 'Cargo.lock');
+    fs.writeFileSync(lockPath, '');
+
+    const config = getDefaultConfig();
+    config.cargo.enabled = true;
+    const ctx = createContext({
+      cwd: dir,
+      config,
+      input: {
+        dryRun: false,
+        updates: [{ packageName: 'foo', newVersion: '1.1.0', filePath: 'crates/foo/Cargo.toml' }],
+        changelogs: [],
+        tags: [],
+      },
+    });
+
+    await runPrepareStage(ctx);
+
+    expect(ctx.additionalFiles).toContain(lockPath);
+  });
+
+  it('should not stage a Cargo.lock in dry-run mode', async () => {
+    const dir = createTmpDir();
+    const crateDir = path.join(dir, 'crates', 'foo');
+    fs.mkdirSync(crateDir, { recursive: true });
+    fs.writeFileSync(path.join(crateDir, 'Cargo.toml'), '[package]\nname = "foo"\nversion = "1.0.0"\n');
+    fs.writeFileSync(path.join(dir, 'Cargo.lock'), '');
+
+    const config = getDefaultConfig();
+    config.cargo.enabled = true;
+    const ctx = createContext({
+      cwd: dir,
+      config,
+      cliOptions: {
+        registry: 'all',
+        npmAuth: 'auto',
+        dryRun: true,
+        skipGit: false,
+        skipPublish: false,
+        skipGithubRelease: false,
+        skipVerification: false,
+        json: false,
+        verbose: false,
+      },
+      input: {
+        dryRun: false,
+        updates: [{ packageName: 'foo', newVersion: '1.1.0', filePath: 'crates/foo/Cargo.toml' }],
+        changelogs: [],
+        tags: [],
+      },
+    });
+
+    await runPrepareStage(ctx);
+
+    expect(ctx.additionalFiles ?? []).not.toContain(path.join(dir, 'Cargo.lock'));
+  });
+
   it('should skip copy when source and destination are the same directory', async () => {
     const dir = createTmpDir();
     fs.writeFileSync(path.join(dir, 'LICENSE'), 'MIT License');

--- a/packages/version/src/cargo/cargoLock.ts
+++ b/packages/version/src/cargo/cargoLock.ts
@@ -1,0 +1,53 @@
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+import { findCargoLockfile } from '@releasekit/core';
+import { log } from '../utils/logging.js';
+
+/**
+ * Sync a crate's `Cargo.lock` self-version entry after its `Cargo.toml` version was bumped, so a
+ * committed lock doesn't drift from the manifest (which breaks `cargo build --locked`/`--frozen` and
+ * leaks a spurious lock diff into later builds). The bump only rewrites `Cargo.toml`, so without this
+ * the lock's own `[[package]]` entry stays at the old version.
+ *
+ * The refresh is surgical and offline: `cargo update --workspace --offline` moves only the workspace
+ * members' own lock entries to match their manifests, never re-resolving registry dependencies, so it
+ * can't reintroduce a dependency-cascade. We never create a lock that wasn't already committed.
+ *
+ * Returns the lock path when it was refreshed (so the caller can stage it), or `undefined` when there
+ * is no committed lock, under dry-run, or when cargo is unavailable / the refresh fails. A failure is
+ * logged but never thrown: the version bump itself already succeeded and must not be blocked by a
+ * lockfile fix-up — surfacing the drift loudly is enough.
+ */
+export function syncCargoLockfile(cargoTomlPath: string, dryRun = false): string | undefined {
+  const crateDir = path.dirname(cargoTomlPath);
+  const lockPath = findCargoLockfile(crateDir);
+  if (!lockPath) {
+    log(`No Cargo.lock found above ${crateDir}; nothing to sync`, 'debug');
+    return undefined;
+  }
+
+  if (dryRun) {
+    log(`[DRY RUN] Would refresh Cargo.lock at ${lockPath}`, 'info');
+    return undefined;
+  }
+
+  try {
+    execFileSync('cargo', ['update', '--workspace', '--offline'], { cwd: crateDir, stdio: 'pipe' });
+    log(`Synced Cargo.lock at ${lockPath}`, 'success');
+    return lockPath;
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT') {
+      log(
+        `cargo not found on PATH — Cargo.lock at ${lockPath} may drift from the bumped version. ` +
+          'Install the Rust toolchain in the release environment, or set version.cargo.enabled to false.',
+        'warning',
+      );
+    } else {
+      const stderr = (error as { stderr?: Buffer | string }).stderr;
+      const detail = stderr ? stderr.toString().trim() : error instanceof Error ? error.message : String(error);
+      log(`Failed to refresh Cargo.lock at ${lockPath}: ${detail}`, 'warning');
+    }
+    return undefined;
+  }
+}

--- a/packages/version/src/core/versionStrategies.ts
+++ b/packages/version/src/core/versionStrategies.ts
@@ -7,6 +7,7 @@ import * as path from 'node:path';
 import type { Package } from '@manypkg/get-packages';
 import type { VersionChangelogEntry } from '@releasekit/core';
 import { shouldMatchPackageTargets, shouldProcessPackage as shouldProcessPackageUtil } from '@releasekit/core';
+import { syncCargoLockfile } from '../cargo/cargoLock.js';
 import { extractChangelogEntriesFromCommits } from '../changelog/commitParser.js';
 import { BaseVersionError } from '../errors/baseError.js';
 import { StrictReachableError } from '../errors/strictReachableError.js';
@@ -76,21 +77,29 @@ function updateCargoFiles(packageDir: string, version: string, cargoConfig: Conf
 
   const cargoPaths = cargoConfig?.paths;
 
+  // After rewriting a Cargo.toml version, sync its Cargo.lock self-entry so the committed lock
+  // doesn't drift (#496). The returned lock path is staged alongside the manifest; deduped because
+  // crates in one workspace share a single workspace-root lock.
+  const stageCargo = (cargoTomlPath: string): void => {
+    updatePackageVersion(cargoTomlPath, version, dryRun);
+    updatedFiles.push(cargoTomlPath);
+    const lockPath = syncCargoLockfile(cargoTomlPath, dryRun);
+    if (lockPath && !updatedFiles.includes(lockPath)) updatedFiles.push(lockPath);
+  };
+
   if (cargoPaths && cargoPaths.length > 0) {
     // If paths are specified, only include those Cargo.toml files
     for (const cargoPath of cargoPaths) {
       const resolvedCargoPath = path.resolve(packageDir, cargoPath, 'Cargo.toml');
       if (fs.existsSync(resolvedCargoPath)) {
-        updatePackageVersion(resolvedCargoPath, version, dryRun);
-        updatedFiles.push(resolvedCargoPath);
+        stageCargo(resolvedCargoPath);
       }
     }
   } else {
     // Default behaviour: check for Cargo.toml in the root package directory
     const cargoTomlPath = path.join(packageDir, 'Cargo.toml');
     if (fs.existsSync(cargoTomlPath)) {
-      updatePackageVersion(cargoTomlPath, version, dryRun);
-      updatedFiles.push(cargoTomlPath);
+      stageCargo(cargoTomlPath);
     }
   }
 

--- a/packages/version/test/unit/cargo/cargoLock.spec.ts
+++ b/packages/version/test/unit/cargo/cargoLock.spec.ts
@@ -1,0 +1,72 @@
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+import { findCargoLockfile } from '@releasekit/core';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { syncCargoLockfile } from '../../../src/cargo/cargoLock.js';
+import { log } from '../../../src/utils/logging.js';
+
+vi.mock('node:child_process', () => ({ execFileSync: vi.fn() }));
+vi.mock('@releasekit/core', () => ({ findCargoLockfile: vi.fn() }));
+vi.mock('../../../src/utils/logging.js', () => ({ log: vi.fn() }));
+
+const crateDir = path.join('/repo', 'crates', 'foo');
+const cargoToml = path.join(crateDir, 'Cargo.toml');
+const lockPath = path.join('/repo', 'Cargo.lock');
+
+describe('syncCargoLockfile', () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it('should run an offline workspace-scoped cargo update and return the lock path', () => {
+    vi.mocked(findCargoLockfile).mockReturnValue(lockPath);
+
+    const result = syncCargoLockfile(cargoToml);
+
+    expect(result).toBe(lockPath);
+    expect(execFileSync).toHaveBeenCalledWith('cargo', ['update', '--workspace', '--offline'], {
+      cwd: crateDir,
+      stdio: 'pipe',
+    });
+  });
+
+  it('should skip the refresh and not run cargo under dry-run', () => {
+    vi.mocked(findCargoLockfile).mockReturnValue(lockPath);
+
+    const result = syncCargoLockfile(cargoToml, true);
+
+    expect(result).toBeUndefined();
+    expect(execFileSync).not.toHaveBeenCalled();
+  });
+
+  it('should do nothing when there is no committed lock above the crate', () => {
+    vi.mocked(findCargoLockfile).mockReturnValue(undefined);
+
+    const result = syncCargoLockfile(cargoToml);
+
+    expect(result).toBeUndefined();
+    expect(execFileSync).not.toHaveBeenCalled();
+  });
+
+  it('should warn and return undefined when cargo is not on PATH', () => {
+    vi.mocked(findCargoLockfile).mockReturnValue(lockPath);
+    vi.mocked(execFileSync).mockImplementation(() => {
+      throw Object.assign(new Error('spawn cargo ENOENT'), { code: 'ENOENT' });
+    });
+
+    const result = syncCargoLockfile(cargoToml);
+
+    expect(result).toBeUndefined();
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('cargo not found on PATH'), 'warning');
+  });
+
+  it('should warn with the cargo error and return undefined when the refresh fails', () => {
+    vi.mocked(findCargoLockfile).mockReturnValue(lockPath);
+    vi.mocked(execFileSync).mockImplementation(() => {
+      throw Object.assign(new Error('exit 101'), { stderr: Buffer.from('error: version conflict') });
+    });
+
+    const result = syncCargoLockfile(cargoToml);
+
+    expect(result).toBeUndefined();
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('error: version conflict'), 'warning');
+  });
+});


### PR DESCRIPTION
## What

Closes #496. Bumping a Rust crate rewrote `Cargo.toml`'s `version` but never updated the committed `Cargo.lock`, so the lock's own `[[package]]` entry drifted (e.g. crate released at `1.2.0`, lock still pinning itself at `1.1.0`). That:

- breaks `cargo build --locked` / `--frozen` — the mode consumers use *because* the lock is committed;
- leaks a spurious lock diff into later, unrelated builds;
- slips through the release itself under `cargo publish --no-verify` (the default), which skips build-verify — so only later builds go red.

## Fix

After each `Cargo.toml` version write, run a **surgical, offline** refresh — `cargo update --workspace --offline` — which moves only the workspace members' own lock entries to match their manifests and **never re-resolves registry dependencies** (no dependency-cascade). The lock is then staged with the version commit.

- **Never creates a lock** — only an already-committed `Cargo.lock` is synced (found by walking up to the nearest ancestor, since a workspace member's lock lives at the workspace root). Libraries that don't commit a lock are untouched.
- **Best-effort, never fatal** — a missing `cargo` or a failed refresh warns loudly (so the drift is visible) but does not abort the bump, which already succeeded.
- Honors `version.cargo` (gated with the existing Cargo.toml handling) and dry-run (logs "would refresh" without writing).

## Where it lives (two commit paths)

The issue suggested the version engine, but git staging moved to publish since then, so the fix spans both paths:

- **Version step** (`versionStrategies.ts` → new `cargo/cargoLock.ts`) writes the synced lock. The **standing-PR flow** stages it automatically via its `git add -A`.
- **Publish prepare** (`prepare.ts`) surfaces the lock into `additionalFiles` so the **direct-commit flow** (`git-commit`, which stages an explicit file list, not `git add -A`) includes it.
- The shared "find the governing lock" locator lives in **core** (`findCargoLockfile`), used by both.

## Tests

- `core`: `findCargoLockfile` — start-dir, workspace-member walk-up, nearest-wins, none-found.
- `version`: `syncCargoLockfile` — offline workspace-scoped update + returns lock path; dry-run skips cargo; no-lock skips; cargo-missing (`ENOENT`) and refresh-failure both warn + return undefined.
- `publish`: `prepare` stages the workspace `Cargo.lock` into `additionalFiles`; dry-run does not.

Full gate green (`lint typecheck test`, 32/32).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Fixes a lock-drift bug (#496) where bumping a Rust crate's version in `Cargo.toml` left the committed `Cargo.lock` still pinned to the old self-version, breaking `cargo build --locked`. The fix runs `cargo update --workspace --offline` after each manifest write — surgical, registry-dependency-safe, and best-effort (failures warn loudly but never abort the bump).

- **New `findCargoLockfile` in `@releasekit/core`** walks up the directory tree to locate a workspace-root lock without creating one if it doesn't exist; shared by both the version and publish packages.
- **`syncCargoLockfile` in the version package** (`cargoLock.ts`) covers the standing-PR flow (uses `execFileSync`, has a `dryRun` param, has a specific ENOENT branch); a parallel async implementation in the publish package covers the direct-commit flow and adds the refreshed lock path to `additionalFiles`.
- **`prepare.ts`** deduplicates lock paths across crates that share a workspace-root lock so it's staged exactly once per workspace.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the fix is self-contained, never creates a lock that wasn't already committed, and failures degrade gracefully to a warning rather than aborting the release.

All changed paths are additive or wrap existing logic; the lock sync is best-effort and cannot break a release that would otherwise succeed. Tests cover the happy path, dry-run, no-lock, cargo-absent, and cargo-error cases. The only divergence from ideal is the publish syncCargoLockfile missing an ENOENT-specific message and a theoretical path-resolution edge case for members with their own Cargo.lock, neither of which affects correctness in any standard workspace layout.

No files require special attention. packages/publish/src/utils/cargo.ts has a minor usability gap in its error path, but it does not affect correctness.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/core/src/cargo.ts | New findCargoLockfile helper that walks up the directory tree looking for the nearest Cargo.lock; correctly terminates at the filesystem root and never creates a lock. |
| packages/core/src/index.ts | Re-exports findCargoLockfile from the new cargo.ts module; one-line addition. |
| packages/version/src/cargo/cargoLock.ts | New synchronous syncCargoLockfile that runs cargo update --workspace --offline after a Cargo.toml version bump; handles ENOENT, general cargo errors, and dry-run gracefully without aborting the bump. |
| packages/version/src/core/versionStrategies.ts | Extracts Cargo.toml update + lock sync into a stageCargo helper and calls it for both the path-specified and default cases; deduplication of the lock path is correct. |
| packages/publish/src/utils/cargo.ts | Adds async syncCargoLockfile for the publish pipeline; unlike the version step's implementation it has no dryRun parameter and gives a less specific error message when cargo is absent (no ENOENT branch). |
| packages/publish/src/stages/prepare.ts | Wires lock syncing into the prepare stage for the direct-commit flow; dry-run is correctly guarded at the caller level, and deduplication of lock paths across multi-crate workspaces is correct. |
| packages/core/test/unit/cargo.spec.ts | Four integration tests using real temp directories cover start-dir hit, workspace walk-up, nearest-wins, and no-lock; cleanup via afterEach is correct. |
| packages/version/test/unit/cargo/cargoLock.spec.ts | Five unit tests with mocked execFileSync and findCargoLockfile cover the happy path, dry-run, no-lock, ENOENT, and general cargo failure; all expectations look correct. |
| packages/publish/test/unit/stages/prepare.spec.ts | Two new tests cover happy-path staging and dry-run skip; execCommand is mocked at the module level while findCargoLockfile uses the real implementation against actual temp directories. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant VS as versionStrategies.ts
    participant CL as cargoLock.ts (version)
    participant PR as prepare.ts (publish)
    participant CU as cargo.ts (publish utils)
    participant Core as findCargoLockfile (core)
    participant Cargo as cargo CLI

    note over VS,Cargo: Standing-PR flow
    VS->>VS: updatePackageVersion(cargoTomlPath)
    VS->>CL: syncCargoLockfile(cargoTomlPath, dryRun)
    CL->>Core: findCargoLockfile(crateDir)
    Core-->>CL: /workspace/Cargo.lock
    CL->>Cargo: cargo update --workspace --offline
    Cargo-->>CL: exit 0
    CL-->>VS: /workspace/Cargo.lock
    VS->>VS: updatedFiles.push(lockPath)
    note over VS: git add -A stages lock

    note over PR,Cargo: Direct-commit flow
    PR->>PR: updateCargoVersion(cargoPath)
    PR->>CU: syncCargoLockfile(pkgDir)
    CU->>Core: findCargoLockfile(pkgDir)
    Core-->>CU: /workspace/Cargo.lock
    CU->>Cargo: cargo update --workspace --offline
    Cargo-->>CU: exit 0
    CU-->>PR: /workspace/Cargo.lock
    PR->>PR: "ctx.additionalFiles <- lockPath"
    note over PR: git-commit stages explicit file list
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant VS as versionStrategies.ts
    participant CL as cargoLock.ts (version)
    participant PR as prepare.ts (publish)
    participant CU as cargo.ts (publish utils)
    participant Core as findCargoLockfile (core)
    participant Cargo as cargo CLI

    note over VS,Cargo: Standing-PR flow
    VS->>VS: updatePackageVersion(cargoTomlPath)
    VS->>CL: syncCargoLockfile(cargoTomlPath, dryRun)
    CL->>Core: findCargoLockfile(crateDir)
    Core-->>CL: /workspace/Cargo.lock
    CL->>Cargo: cargo update --workspace --offline
    Cargo-->>CL: exit 0
    CL-->>VS: /workspace/Cargo.lock
    VS->>VS: updatedFiles.push(lockPath)
    note over VS: git add -A stages lock

    note over PR,Cargo: Direct-commit flow
    PR->>PR: updateCargoVersion(cargoPath)
    PR->>CU: syncCargoLockfile(pkgDir)
    CU->>Core: findCargoLockfile(pkgDir)
    Core-->>CU: /workspace/Cargo.lock
    CU->>Cargo: cargo update --workspace --offline
    Cargo-->>CU: exit 0
    CU-->>PR: /workspace/Cargo.lock
    PR->>PR: "ctx.additionalFiles <- lockPath"
    note over PR: git-commit stages explicit file list
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(publish): make prepare self-sufficie..."](https://github.com/goosewobbler/releasekit/commit/7b3d51ab64b250cffbd85debcbfcff914a62c3b9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40704377)</sub>

<!-- /greptile_comment -->