### PR TITLE
fix(version): harden Cargo.lock resolution and add real-cargo sync coverage

### DIFF
--- a/.github/workflows/_ci-integration.reusable.yml
+++ b/.github/workflows/_ci-integration.reusable.yml
@@ -34,5 +34,9 @@ jobs:
           name: releasekit-build
           cache_key: ${{ inputs.cache_key }}
 
+      # Provides cargo for the Cargo.lock self-version sync integration test (#496). The test is
+      # skipped when cargo is absent, so this toolchain is what makes it actually run in CI.
+      - uses: dtolnay/rust-toolchain@stable
+
       - name: Run integration tests
         run: pnpm --filter @releasekit/integration-tests test

--- a/packages/core/src/cargo.ts
+++ b/packages/core/src/cargo.ts
@@ -1,21 +1,45 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
+/** A `Cargo.toml` declares a workspace when it has a `[workspace]` (or `[workspace.*]`) table. */
+function isWorkspaceManifest(cargoTomlPath: string): boolean {
+  try {
+    return /^\s*\[workspace[\].]/m.test(fs.readFileSync(cargoTomlPath, 'utf8'));
+  } catch {
+    return false;
+  }
+}
+
 /**
- * Find the `Cargo.lock` that governs a crate at `startDir` by walking up to the nearest ancestor
- * that has one — for a workspace member the lock lives at the workspace root, not the member dir.
+ * Find the `Cargo.lock` that governs a crate at `startDir` — the one `cargo update --workspace`
+ * rewrites — by walking up from `startDir`:
  *
- * Returns `undefined` when no committed lock exists above `startDir`. That is deliberate: libraries
- * commonly don't commit a lock, and we must never *create* one as a side effect of a version bump —
- * only sync an existing committed lock so it doesn't drift.
+ * - If an ancestor `Cargo.toml` declares a `[workspace]`, that's the workspace root and its
+ *   `Cargo.lock` is authoritative. A workspace member's own (stray) lock is ignored by cargo, so we
+ *   must not target it — only the root lock actually moves.
+ * - Otherwise (a standalone crate, no workspace) the nearest committed `Cargo.lock` governs.
+ *
+ * Returns `undefined` when no committed lock governs the crate. That is deliberate: libraries
+ * commonly don't commit a lock, and a version bump must never *create* one as a side effect — only
+ * sync an existing committed lock so it doesn't drift.
  */
 export function findCargoLockfile(startDir: string): string | undefined {
   let dir = path.resolve(startDir);
+  let nearestLock: string | undefined;
   while (true) {
     const lockPath = path.join(dir, 'Cargo.lock');
-    if (fs.existsSync(lockPath)) return lockPath;
+    const hasLock = fs.existsSync(lockPath);
+    if (hasLock && !nearestLock) nearestLock = lockPath;
+
+    const cargoToml = path.join(dir, 'Cargo.toml');
+    if (fs.existsSync(cargoToml) && isWorkspaceManifest(cargoToml)) {
+      // Workspace root: its lock is the one cargo updates (or none, if no lock is committed).
+      return hasLock ? lockPath : undefined;
+    }
+
     const parent = path.dirname(dir);
-    if (parent === dir) return undefined; // reached the filesystem root
+    if (parent === dir) break; // reached the filesystem root
     dir = parent;
   }
+  return nearestLock;
 }

--- a/packages/core/test/unit/cargo.spec.ts
+++ b/packages/core/test/unit/cargo.spec.ts
@@ -50,4 +50,28 @@ describe('findCargoLockfile', () => {
     fs.mkdirSync(member, { recursive: true });
     expect(findCargoLockfile(member)).toBeUndefined();
   });
+
+  it('should target the workspace-root lock, not a member’s own stray lock', () => {
+    const root = tmp();
+    fs.writeFileSync(path.join(root, 'Cargo.toml'), '[workspace]\nmembers = ["crates/foo"]\n');
+    const rootLock = path.join(root, 'Cargo.lock');
+    fs.writeFileSync(rootLock, '');
+    const member = path.join(root, 'crates', 'foo');
+    fs.mkdirSync(member, { recursive: true });
+    fs.writeFileSync(path.join(member, 'Cargo.toml'), '[package]\nname = "foo"\nversion = "1.0.0"\n');
+    // A stray lock in the member dir is ignored by cargo — the workspace-root lock is the one that moves.
+    fs.writeFileSync(path.join(member, 'Cargo.lock'), '');
+    expect(findCargoLockfile(member)).toBe(rootLock);
+  });
+
+  it('should return undefined when the workspace root has no committed lock', () => {
+    const root = tmp();
+    fs.writeFileSync(path.join(root, 'Cargo.toml'), '[workspace]\nmembers = ["crates/foo"]\n');
+    const member = path.join(root, 'crates', 'foo');
+    fs.mkdirSync(member, { recursive: true });
+    fs.writeFileSync(path.join(member, 'Cargo.toml'), '[package]\nname = "foo"\nversion = "1.0.0"\n');
+    // No lock at the workspace root → nothing to sync (don't fall back to a stray member lock).
+    fs.writeFileSync(path.join(member, 'Cargo.lock'), '');
+    expect(findCargoLockfile(member)).toBeUndefined();
+  });
 });

--- a/packages/core/test/unit/cargo.spec.ts
+++ b/packages/core/test/unit/cargo.spec.ts
@@ -34,7 +34,9 @@ describe('findCargoLockfile', () => {
     expect(findCargoLockfile(member)).toBe(lock);
   });
 
-  it('should return the nearest lock when both a member and an ancestor have one', () => {
+  it('should return the nearest lock for a standalone (non-workspace) crate when both a member and an ancestor have one', () => {
+    // No [workspace] manifest anywhere → the standalone fallback (nearest lock wins). With a
+    // workspace root present, the root lock would win instead — see the workspace-root test below.
     const root = tmp();
     fs.writeFileSync(path.join(root, 'Cargo.lock'), '');
     const member = path.join(root, 'crates', 'foo');

--- a/packages/publish/src/utils/cargo.ts
+++ b/packages/publish/src/utils/cargo.ts
@@ -32,9 +32,16 @@ export async function syncCargoLockfile(crateDir: string): Promise<string | unde
     });
     return lockPath;
   } catch (error) {
-    const stderr = (error as { stderr?: string }).stderr;
-    const detail = stderr?.trim() || (error instanceof Error ? error.message : String(error));
-    warn(`Failed to refresh Cargo.lock at ${lockPath}: ${detail}. The committed lock may drift from the bump.`);
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      warn(
+        `cargo not found on PATH — Cargo.lock at ${lockPath} may drift from the bumped version. ` +
+          'Install the Rust toolchain in the release environment, or disable cargo handling.',
+      );
+    } else {
+      const stderr = (error as { stderr?: string }).stderr;
+      const detail = stderr?.trim() || (error instanceof Error ? error.message : String(error));
+      warn(`Failed to refresh Cargo.lock at ${lockPath}: ${detail}. The committed lock may drift from the bump.`);
+    }
     return undefined;
   }
 }

--- a/packages/publish/src/utils/exec.ts
+++ b/packages/publish/src/utils/exec.ts
@@ -55,6 +55,9 @@ export async function execCommand(file: string, args: string[], options: ExecOpt
               stdout: stdout.toString(),
               stderr: stderr.toString(),
               exitCode: error.code ?? 1,
+              // Preserve the spawn error code (e.g. 'ENOENT' when the binary isn't on PATH) so
+              // callers can distinguish "command not found" from a non-zero exit.
+              code: (error as NodeJS.ErrnoException).code,
             }),
           );
         } else {

--- a/packages/version/src/index.ts
+++ b/packages/version/src/index.ts
@@ -1,6 +1,7 @@
 // Re-export public API
 
 export type { VersionOutput } from '@releasekit/core';
+export { syncCargoLockfile } from './cargo/cargoLock.js';
 export { extractChangelogEntriesFromCommits } from './changelog/commitParser.js';
 export { createVersionCommand } from './command.js';
 export { loadConfig } from './config.js';

--- a/test/integration/cargo-lock-sync.spec.ts
+++ b/test/integration/cargo-lock-sync.spec.ts
@@ -42,7 +42,10 @@ describe.skipIf(!cargoAvailable())('syncCargoLockfile (real cargo)', () => {
     ] as const) {
       const crateDir = join(dir, name);
       mkdirSync(join(crateDir, 'src'), { recursive: true });
-      writeFileSync(join(crateDir, 'Cargo.toml'), `[package]\nname = "${name}"\nversion = "0.1.0"\nedition = "2021"\n${deps}`);
+      writeFileSync(
+        join(crateDir, 'Cargo.toml'),
+        `[package]\nname = "${name}"\nversion = "0.1.0"\nedition = "2021"\n${deps}`,
+      );
       writeFileSync(join(crateDir, 'src', 'lib.rs'), '// test crate\n');
     }
     // Generate a real, valid committed lock at the stale versions (offline — only path deps).

--- a/test/integration/cargo-lock-sync.spec.ts
+++ b/test/integration/cargo-lock-sync.spec.ts
@@ -1,0 +1,76 @@
+/**
+ * Integration test: Cargo.lock self-version sync (#496) against REAL cargo.
+ *
+ * Unit tests mock cargo, so they can't prove the load-bearing claim — that
+ * `cargo update --workspace --offline` syncs a workspace member's self-version in the lock WITHOUT
+ * re-resolving other members/dependencies. This runs real cargo on a real workspace to verify exactly
+ * that. Skipped automatically where cargo isn't on PATH (CI installs a Rust toolchain for this job).
+ */
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { syncCargoLockfile } from '@releasekit/version';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+function cargoAvailable(): boolean {
+  try {
+    execFileSync('cargo', ['--version'], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** The version on a crate's `[[package]]` entry in a Cargo.lock. */
+function lockVersion(lockContent: string, crate: string): string | undefined {
+  const block = lockContent.split('[[package]]').find((b) => new RegExp(`^\\s*name = "${crate}"\\s*$`, 'm').test(b));
+  return block?.match(/^\s*version = "([^"]+)"/m)?.[1];
+}
+
+describe.skipIf(!cargoAvailable())('syncCargoLockfile (real cargo)', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'rk-cargo-lock-int-'));
+    // Two-member workspace: crate-a depends on crate-b by path. Bumping crate-a must move only its
+    // own lock entry — crate-b and the a→b dependency edge stay put (no dependency re-resolution).
+    writeFileSync(join(dir, 'Cargo.toml'), '[workspace]\nmembers = ["crate-a", "crate-b"]\nresolver = "2"\n');
+    for (const [name, deps] of [
+      ['crate-a', '\n[dependencies]\ncrate-b = { path = "../crate-b", version = "0.1.0" }\n'],
+      ['crate-b', ''],
+    ] as const) {
+      const crateDir = join(dir, name);
+      mkdirSync(join(crateDir, 'src'), { recursive: true });
+      writeFileSync(join(crateDir, 'Cargo.toml'), `[package]\nname = "${name}"\nversion = "0.1.0"\nedition = "2021"\n${deps}`);
+      writeFileSync(join(crateDir, 'src', 'lib.rs'), '// test crate\n');
+    }
+    // Generate a real, valid committed lock at the stale versions (offline — only path deps).
+    execFileSync('cargo', ['generate-lockfile', '--offline'], { cwd: dir, stdio: 'ignore' });
+  });
+
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it('should sync the bumped crate’s self-version in the workspace-root lock, leaving others untouched', () => {
+    // Bump crate-a's manifest (what the version step does before calling the sync).
+    writeFileSync(
+      join(dir, 'crate-a', 'Cargo.toml'),
+      '[package]\nname = "crate-a"\nversion = "0.2.0"\nedition = "2021"\n\n[dependencies]\ncrate-b = { path = "../crate-b", version = "0.1.0" }\n',
+    );
+
+    const lockPath = syncCargoLockfile(join(dir, 'crate-a', 'Cargo.toml'));
+
+    expect(lockPath).toBe(join(dir, 'Cargo.lock'));
+    const lock = readFileSync(join(dir, 'Cargo.lock'), 'utf-8');
+    expect(lockVersion(lock, 'crate-a')).toBe('0.2.0'); // self-version synced
+    expect(lockVersion(lock, 'crate-b')).toBe('0.1.0'); // other member untouched
+    expect(lock).toContain('crate-b'); // a→b dependency edge preserved (no re-resolution)
+  });
+
+  it('should not create a lock when none is committed', () => {
+    rmSync(join(dir, 'Cargo.lock'));
+    const lockPath = syncCargoLockfile(join(dir, 'crate-a', 'Cargo.toml'));
+    expect(lockPath).toBeUndefined();
+    expect(() => readFileSync(join(dir, 'Cargo.lock'))).toThrow();
+  });
+});


### PR DESCRIPTION
Follow-up to #496/#497 — closes the review gaps and adds the real-cargo coverage that mocked unit tests can't provide.

## Fixes

- **Workspace-root lock resolution.** `findCargoLockfile` now targets the *workspace-root* `Cargo.lock` — the one `cargo update --workspace` actually rewrites — by walking up to the nearest `[workspace]` manifest, instead of returning the nearest ancestor lock. A workspace member's stray own lock is ignored by cargo, so syncing/staging it was wrong; the governing root lock is used now (or none, if the root has no committed lock). +3 core tests for the member-with-own-lock edge.
- **ENOENT message.** publish's `syncCargoLockfile` now emits an actionable "cargo not found on PATH …" message matching the version step's, now that `execCommand` preserves the spawn error `code`.

## Real-cargo coverage

The #496 unit tests mock cargo, so they can't prove the load-bearing claim — that `cargo update --workspace --offline` syncs a member's self-version **without re-resolving dependencies**.

A harness e2e turned out to be architecturally impossible: every harness path runs the version step in dry+flush (sync is a no-op) or skips publish (sync never runs). That investigation also **confirmed #496 is correct in both real flows** — standing-PR via the `dryRun:false` version write-run + `git add -A`, and direct release via publish's prepare sync.

So the coverage lands as an **integration test with real cargo** (in `@releasekit/integration-tests`, skipped where cargo is absent; the Integration Tests CI job now installs a Rust toolchain). It runs the actual `cargo update` on a two-member workspace with a committed lock and asserts the bumped crate's self-version syncs while the other member and the dependency edge stay untouched.

To support it, `syncCargoLockfile` is exported from `@releasekit/version`.

Full gate green (`lint typecheck test`, 32/32); integration test verified against real cargo (1.95) locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR hardens `findCargoLockfile` to target the workspace-root `Cargo.lock` (the one `cargo update --workspace` actually rewrites) rather than the nearest ancestor lock, fixes ENOENT propagation through `execCommand` so callers can surface an actionable "cargo not found" message, and adds an integration test that exercises the sync against real cargo on a two-member workspace.

- **`packages/core/src/cargo.ts`**: New `isWorkspaceManifest` helper drives a two-branch algorithm: if a `[workspace]` manifest is found while walking up, the root lock (or `undefined`) is returned immediately; the stray member lock is ignored. The standalone-crate fallback (nearest lock) still applies when no workspace manifest exists.
- **`packages/publish/src/utils/exec.ts`**: Preserves the raw `code` property (e.g. `'ENOENT'`) from `NodeJS.ErrnoException` on the thrown Error, allowing `cargo.ts` callers to distinguish spawn-failure from a non-zero exit and emit the correct actionable warning.
- **`test/integration/cargo-lock-sync.spec.ts`**: New integration test runs real `cargo generate-lockfile` + version bump + `syncCargoLockfile` on a two-member workspace, asserting only the bumped crate's entry moves and no registry re-resolution occurs; skipped automatically when cargo is absent.
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge — all changed paths are well-covered by new unit and integration tests, and no existing behavior is broken.

The workspace-root resolution algorithm is correct and exercised by three targeted unit tests plus a real-cargo integration test. The ENOENT propagation through execCommand is a minimal additive change that enables an existing type cast to work reliably. No logic is removed, no interfaces are broken, and the CI job now installs the Rust toolchain so the integration test runs rather than being silently skipped.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/core/src/cargo.ts | Introduces `isWorkspaceManifest` and rewrites `findCargoLockfile` to skip stray member locks and target the workspace-root lock; algorithm is correct and well-tested. |
| packages/core/test/unit/cargo.spec.ts | Adds three new test cases covering workspace-root lock targeting, stray-member lock suppression, and no-root-lock undefined return; existing test renamed to clarify standalone-crate semantics per previous review. |
| packages/publish/src/utils/exec.ts | Preserves `code` from `NodeJS.ErrnoException` on rejected errors so cargo callers can distinguish ENOENT from non-zero exit; change is minimal and correct. |
| packages/publish/src/utils/cargo.ts | Adds ENOENT branch to `syncCargoLockfile` error handler that emits a clear "cargo not found on PATH" warning, matching the version step's message; fallback detail path unchanged. |
| packages/version/src/index.ts | Exports `syncCargoLockfile` from the version package's public API to enable integration-test import; straightforward one-line change. |
| test/integration/cargo-lock-sync.spec.ts | Two-case integration test against real cargo validating self-version sync and no-lock-creation; `describe.skipIf(!cargoAvailable())` guard ensures graceful skip where cargo is absent. |
| .github/workflows/_ci-integration.reusable.yml | Adds `dtolnay/rust-toolchain@stable` step so the integration job has cargo available and the new test actually runs in CI rather than being skipped. |

</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/core/test/unit/cargo.spec.ts`, line 37 ([link](https://github.com/goosewobbler/releasekit/blob/852105e8abf8b8b991ee676e9a78051ecf12857c/packages/core/test/unit/cargo.spec.ts#L37)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The description "should return the nearest lock when both a member and an ancestor have one" now accurately describes only the standalone/no-workspace fallback. With the new algorithm, a workspace member whose ancestor has a `[workspace]` manifest would — correctly — NOT return the nearest lock. Because this test creates no `Cargo.toml` anywhere, the workspace branch is never reached and the test passes on the fallback path. The name is fine as a standalone-crate test, but clarifying that framing prevents future contributors from reading it as the general-case rule (which it no longer is).

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fcore%2Ftest%2Funit%2Fcargo.spec.ts%0ALine%3A%2037%0A%0AComment%3A%0AThe%20description%20%22should%20return%20the%20nearest%20lock%20when%20both%20a%20member%20and%20an%20ancestor%20have%20one%22%20now%20accurately%20describes%20only%20the%20standalone%2Fno-workspace%20fallback.%20With%20the%20new%20algorithm%2C%20a%20workspace%20member%20whose%20ancestor%20has%20a%20%60%5Bworkspace%5D%60%20manifest%20would%20%E2%80%94%20correctly%20%E2%80%94%20NOT%20return%20the%20nearest%20lock.%20Because%20this%20test%20creates%20no%20%60Cargo.toml%60%20anywhere%2C%20the%20workspace%20branch%20is%20never%20reached%20and%20the%20test%20passes%20on%20the%20fallback%20path.%20The%20name%20is%20fine%20as%20a%20standalone-crate%20test%2C%20but%20clarifying%20that%20framing%20prevents%20future%20contributors%20from%20reading%20it%20as%20the%20general-case%20rule%20%28which%20it%20no%20longer%20is%29.%0A%0A%60%60%60suggestion%0A%20%20it%28'should%20return%20the%20nearest%20lock%20for%20a%20standalone%20%28non-workspace%29%20crate%20when%20both%20a%20member%20and%20an%20ancestor%20have%20one'%2C%20%28%29%20%3D%3E%20%7B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=goosewobbler%2Freleasekit&pr=498&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fcore%2Ftest%2Funit%2Fcargo.spec.ts%0ALine%3A%2037%0A%0AComment%3A%0AThe%20description%20%22should%20return%20the%20nearest%20lock%20when%20both%20a%20member%20and%20an%20ancestor%20have%20one%22%20now%20accurately%20describes%20only%20the%20standalone%2Fno-workspace%20fallback.%20With%20the%20new%20algorithm%2C%20a%20workspace%20member%20whose%20ancestor%20has%20a%20%60%5Bworkspace%5D%60%20manifest%20would%20%E2%80%94%20correctly%20%E2%80%94%20NOT%20return%20the%20nearest%20lock.%20Because%20this%20test%20creates%20no%20%60Cargo.toml%60%20anywhere%2C%20the%20workspace%20branch%20is%20never%20reached%20and%20the%20test%20passes%20on%20the%20fallback%20path.%20The%20name%20is%20fine%20as%20a%20standalone-crate%20test%2C%20but%20clarifying%20that%20framing%20prevents%20future%20contributors%20from%20reading%20it%20as%20the%20general-case%20rule%20%28which%20it%20no%20longer%20is%29.%0A%0A%60%60%60suggestion%0A%20%20it%28'should%20return%20the%20nearest%20lock%20for%20a%20standalone%20%28non-workspace%29%20crate%20when%20both%20a%20member%20and%20an%20ancestor%20have%20one'%2C%20%28%29%20%3D%3E%20%7B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=498&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["test: fix integration test format + clar..."](https://github.com/goosewobbler/releasekit/commit/8446a67c9add9c2207f36666e2747adf30b70191) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40767257)</sub>

<!-- /greptile_comment -->