### PR TITLE
fix(version): increment the prerelease counter instead of escalating the base

### DIFF
--- a/packages/release/docs/ci-setup.md
+++ b/packages/release/docs/ci-setup.md
@@ -97,7 +97,10 @@ In CI, add `--check`: it exits non-zero on a missing label, catching the silent 
 | `bump:patch` | `1.0.0` | `1.0.1` |
 | `bump:minor` | `1.0.0` | `1.1.0` |
 | `bump:major` | `1.0.0` | `2.0.0` |
-| `bump:patch` / `:minor` / `:major` | `1.0.0-next.6` | `1.0.0-next.7` — advances the prerelease counter; the magnitude does **not** escalate the base, which is a fixed target until graduation (#500) |
+| _(no `bump:*` label — commit-driven)_ | `1.0.0-next.6` | `1.0.0-next.7` — increments the counter; the magnitude does **not** escalate the base, a fixed target until graduation (#500) |
+| `bump:patch` | `1.0.0-next.6` | `1.0.0-next.7` — advances the prerelease counter (no graduation) |
+| `bump:minor` | `1.0.0-next.6` | `1.1.0-next.0` — explicit magnitude: escalates the prerelease base (no graduation) |
+| `bump:major` | `1.0.0-next.6` | `2.0.0-next.0` — explicit magnitude: escalates the prerelease base (no graduation) |
 | `channel:prerelease` + `bump:patch` | `1.0.0` | `1.0.1-next.0` |
 | `channel:prerelease` + `bump:minor` | `1.0.0` | `1.1.0-next.0` |
 | `channel:prerelease` + `bump:major` | `1.0.0` | `2.0.0-next.0` |
@@ -114,16 +117,18 @@ In CI, add `--check`: it exits non-zero on a missing label, catching the silent 
 > — a `-next` package never graduates to stable without an explicit `release:graduate`.** A standing
 > PR with permanently-mixed maturity (mature stable packages alongside incubating `-next` ones) is
 > normal: each package walks its own line, so the same merge can ship `10.2.0` (stable) and
-> `1.1.0-next.0` (prerelease) at once. A `bump:*` label sets the *magnitude* but not the channel — on
-> a prerelease it advances the counter (the base is a fixed target until graduation), it does not
-> escalate the base or promote. Use `release:graduate` to promote, `channel:prerelease` to drag a
-> stable package onto a prerelease line (or re-target an in-flight prerelease's base — below).
+> `1.1.0-next.0` (prerelease) at once. The commit-driven default on a prerelease just **increments
+> the counter** (the base is a fixed target until graduation, #500). An explicit `bump:*` label is a
+> deliberate magnitude declaration, so it's honoured — on a prerelease a `bump:minor`/`bump:major`
+> **escalates the base** to a fresh line (above). Use `release:graduate` to promote, `channel:prerelease`
+> to drag a stable package onto a prerelease line.
 
 > **`channel:prerelease` + `bump:*` escalates — it starts a *fresh* prerelease line at the chosen
 > magnitude, even when the package is already on a prerelease.** So `bump:major` + `channel:prerelease`
 > on `1.1.1-next.1` yields `2.0.0-next.0`, not `1.1.1-next.2`. To *iterate* an existing prerelease
-> counter (`2.0.0-next.0` → `2.0.0-next.1`), just don't add `channel:prerelease` — a `bump:*` label
-> (or a commit-driven bump) on a prerelease advances the counter and leaves the base alone (#500).
+> counter (`2.0.0-next.0` → `2.0.0-next.1`), let the bump come from commits with **no** `bump:*`
+> label — the commit-driven default advances the counter and leaves the base alone (#500). (An
+> explicit `bump:*` label declares a magnitude and escalates the base instead.)
 
 > **`channel:prerelease` is a channel modifier, never a standalone release trigger.** It does
 > nothing without a `bump:*` label in label/direct mode (it can't pick a magnitude on its own), and

--- a/packages/release/docs/ci-setup.md
+++ b/packages/release/docs/ci-setup.md
@@ -97,9 +97,7 @@ In CI, add `--check`: it exits non-zero on a missing label, catching the silent 
 | `bump:patch` | `1.0.0` | `1.0.1` |
 | `bump:minor` | `1.0.0` | `1.1.0` |
 | `bump:major` | `1.0.0` | `2.0.0` |
-| `bump:patch` | `1.0.0-next.6` | `1.0.0-next.7` — advances the prerelease (no graduation) |
-| `bump:minor` | `1.0.0-next.6` | `1.1.0-next.0` — escalates the prerelease base (no graduation) |
-| `bump:major` | `1.0.0-next.6` | `2.0.0-next.0` — escalates the prerelease base (no graduation) |
+| `bump:patch` / `:minor` / `:major` | `1.0.0-next.6` | `1.0.0-next.7` — advances the prerelease counter; the magnitude does **not** escalate the base, which is a fixed target until graduation (#500) |
 | `channel:prerelease` + `bump:patch` | `1.0.0` | `1.0.1-next.0` |
 | `channel:prerelease` + `bump:minor` | `1.0.0` | `1.1.0-next.0` |
 | `channel:prerelease` + `bump:major` | `1.0.0` | `2.0.0-next.0` |
@@ -117,15 +115,15 @@ In CI, add `--check`: it exits non-zero on a missing label, catching the silent 
 > PR with permanently-mixed maturity (mature stable packages alongside incubating `-next` ones) is
 > normal: each package walks its own line, so the same merge can ship `10.2.0` (stable) and
 > `1.1.0-next.0` (prerelease) at once. A `bump:*` label sets the *magnitude* but not the channel — on
-> a prerelease it escalates within the line (above), it does not promote. Use `release:graduate` to
-> promote, `channel:prerelease` to drag a stable package onto a prerelease line.
+> a prerelease it advances the counter (the base is a fixed target until graduation), it does not
+> escalate the base or promote. Use `release:graduate` to promote, `channel:prerelease` to drag a
+> stable package onto a prerelease line (or re-target an in-flight prerelease's base — below).
 
 > **`channel:prerelease` + `bump:*` escalates — it starts a *fresh* prerelease line at the chosen
 > magnitude, even when the package is already on a prerelease.** So `bump:major` + `channel:prerelease`
 > on `1.1.1-next.1` yields `2.0.0-next.0`, not `1.1.1-next.2`. To *iterate* an existing prerelease
-> counter (`2.0.0-next.0` → `2.0.0-next.1`) without escalating, drop the `bump:*` label and let the
-> bump come from commits with the prerelease channel applied — e.g. in standing-pr mode, put
-> `channel:prerelease` alone on the standing PR.
+> counter (`2.0.0-next.0` → `2.0.0-next.1`), just don't add `channel:prerelease` — a `bump:*` label
+> (or a commit-driven bump) on a prerelease advances the counter and leaves the base alone (#500).
 
 > **`channel:prerelease` is a channel modifier, never a standalone release trigger.** It does
 > nothing without a `bump:*` label in label/direct mode (it can't pick a magnitude on its own), and

--- a/packages/version/src/core/versionCalculator.ts
+++ b/packages/version/src/core/versionCalculator.ts
@@ -21,6 +21,29 @@ import {
 } from '../utils/versionUtils.js';
 
 /**
+ * Map a standard bump magnitude to the prerelease form that ESCALATES an existing prerelease's base
+ * to a new line — used only when a maintainer explicitly declares the magnitude via a `bump:*` label
+ * (#485). The commit-inferred default does NOT escalate; it increments the counter (the base is a
+ * fixed target until graduation, #500).
+ *  - `patch` → `prerelease` — advance the counter   (1.0.0-next.1 → 1.0.0-next.2)
+ *  - `minor` → `preminor`   — escalate the base      (1.0.0-next.1 → 1.1.0-next.0)
+ *  - `major` → `premajor`   — escalate the base      (1.0.0-next.1 → 2.0.0-next.0)
+ * Any non-standard type (already a `pre*` / `prerelease` form) passes through unchanged.
+ */
+function toPrereleaseLineBump(bumpType: ReleaseType): ReleaseType {
+  switch (bumpType) {
+    case 'major':
+      return 'premajor';
+    case 'minor':
+      return 'preminor';
+    case 'patch':
+      return 'prerelease';
+    default:
+      return bumpType;
+  }
+}
+
+/**
  * The prerelease identifier embedded in a version (e.g. `1.0.0-next.1` → `next`), or undefined when
  * the version is stable or its prerelease segment carries no string identifier. Advancing along a
  * channel keeps the *current* line's identifier, so this is preferred over the configured default
@@ -292,11 +315,11 @@ async function calculateVersionInner(config: Config, options: VersionOptions): P
       // along its own prerelease line rather than graduating to stable — UNLESS an explicit channel
       // action is in play (`--stable` / release:graduate sets stableOnly and graduates above;
       // `--prerelease` / channel:prerelease sets isPrerelease, handled by the existing branch below).
-      // Advancing always INCREMENTS the prerelease counter regardless of the change magnitude
-      // (`semver.inc(v, 'prerelease')`, #500): while the base is unreleased it is a fixed target, so a
-      // minor/major does NOT escalate the base (1.0.0-next.3 → 1.0.0-next.4, not 1.1.0-next.0). The
-      // base only advances on graduation; re-targeting an in-flight prerelease's base to a new line is
-      // the explicit channel:prerelease action below. Keystone that removes the global auto-graduate.
+      // This is the EXPLICIT-bump path (a `bump:*` label set `type`): the maintainer declared a
+      // magnitude, so honour it — a minor/major escalates the base to a fresh line (1.0.0-next.6 →
+      // 1.1.0-next.0), a patch advances the counter. The commit-inferred DEFAULT instead always
+      // increments the counter (the base is a fixed target until graduation, #500) — see the
+      // conventional-commits branch below. Keystone that removes the global auto-graduate.
       if (
         isCurrentPrerelease &&
         !config.stableOnly &&
@@ -304,8 +327,9 @@ async function calculateVersionInner(config: Config, options: VersionOptions): P
         STANDARD_BUMP_TYPES.includes(specifiedType as 'major' | 'minor' | 'patch')
       ) {
         const channelId = prereleaseIdOf(currentVersion) ?? normalizedPrereleaseId;
-        log(`Advancing prerelease ${currentVersion} along its channel (increment, id: ${channelId})`, 'debug');
-        return bumpVersion(currentVersion, 'prerelease', channelId);
+        const channelType = toPrereleaseLineBump(specifiedType as ReleaseType);
+        log(`Advancing prerelease ${currentVersion} along its channel via ${channelType} (id: ${channelId})`, 'debug');
+        return bumpVersion(currentVersion, channelType, channelId);
       }
 
       if (
@@ -425,9 +449,10 @@ async function calculateVersionInner(config: Config, options: VersionOptions): P
       }
 
       // Per-package channel default (#485): advance an existing prerelease along its own line rather
-      // than graduating it, unless an explicit channel action is in play. Mirrors the specified-type
-      // branch above — the advance increments the prerelease counter regardless of the commit-inferred
-      // magnitude, because the base is a fixed target until graduation (#500).
+      // than graduating it, unless an explicit channel action is in play. This is the COMMIT-INFERRED
+      // default (no `bump:*` label) — it always increments the prerelease counter regardless of the
+      // inferred magnitude, because the base is a fixed target until graduation (#500). An explicit
+      // `bump:*` label takes the specified-type branch above and escalates the base instead.
       if (
         semver.prerelease(currentVersion) !== null &&
         !config.stableOnly &&

--- a/packages/version/src/core/versionCalculator.ts
+++ b/packages/version/src/core/versionCalculator.ts
@@ -21,27 +21,6 @@ import {
 } from '../utils/versionUtils.js';
 
 /**
- * Map a standard bump magnitude to the prerelease increment that advances an *existing* prerelease
- * along its own channel instead of graduating it to a stable release (#485):
- *  - `patch` → `prerelease` — advance the counter   (1.0.0-next.1 → 1.0.0-next.2)
- *  - `minor` → `preminor`   — escalate the base      (1.0.0-next.1 → 1.1.0-next.0)
- *  - `major` → `premajor`   — escalate the base      (1.0.0-next.1 → 2.0.0-next.0)
- * Any non-standard type (already a `pre*` / `prerelease` form) passes through unchanged.
- */
-function toPrereleaseLineBump(bumpType: ReleaseType): ReleaseType {
-  switch (bumpType) {
-    case 'major':
-      return 'premajor';
-    case 'minor':
-      return 'preminor';
-    case 'patch':
-      return 'prerelease';
-    default:
-      return bumpType;
-  }
-}
-
-/**
  * The prerelease identifier embedded in a version (e.g. `1.0.0-next.1` → `next`), or undefined when
  * the version is stable or its prerelease segment carries no string identifier. Advancing along a
  * channel keeps the *current* line's identifier, so this is preferred over the configured default
@@ -313,9 +292,11 @@ async function calculateVersionInner(config: Config, options: VersionOptions): P
       // along its own prerelease line rather than graduating to stable — UNLESS an explicit channel
       // action is in play (`--stable` / release:graduate sets stableOnly and graduates above;
       // `--prerelease` / channel:prerelease sets isPrerelease, handled by the existing branch below).
-      // The magnitude maps to the matching pre-increment so a minor/major escalates the base while a
-      // patch just advances the prerelease counter. This is the keystone that removes the global
-      // auto-graduate: no routine bump silently promotes a `-next` package to a production release.
+      // Advancing always INCREMENTS the prerelease counter regardless of the change magnitude
+      // (`semver.inc(v, 'prerelease')`, #500): while the base is unreleased it is a fixed target, so a
+      // minor/major does NOT escalate the base (1.0.0-next.3 → 1.0.0-next.4, not 1.1.0-next.0). The
+      // base only advances on graduation; re-targeting an in-flight prerelease's base to a new line is
+      // the explicit channel:prerelease action below. Keystone that removes the global auto-graduate.
       if (
         isCurrentPrerelease &&
         !config.stableOnly &&
@@ -323,9 +304,8 @@ async function calculateVersionInner(config: Config, options: VersionOptions): P
         STANDARD_BUMP_TYPES.includes(specifiedType as 'major' | 'minor' | 'patch')
       ) {
         const channelId = prereleaseIdOf(currentVersion) ?? normalizedPrereleaseId;
-        const channelType = toPrereleaseLineBump(specifiedType as ReleaseType);
-        log(`Advancing prerelease ${currentVersion} along its channel via ${channelType} (id: ${channelId})`, 'debug');
-        return bumpVersion(currentVersion, channelType, channelId);
+        log(`Advancing prerelease ${currentVersion} along its channel (increment, id: ${channelId})`, 'debug');
+        return bumpVersion(currentVersion, 'prerelease', channelId);
       }
 
       if (
@@ -446,8 +426,8 @@ async function calculateVersionInner(config: Config, options: VersionOptions): P
 
       // Per-package channel default (#485): advance an existing prerelease along its own line rather
       // than graduating it, unless an explicit channel action is in play. Mirrors the specified-type
-      // branch above; here the magnitude is the commit-inferred (zeroMajor-adjusted) bump. See the
-      // keystone examples in #485 — patch advances the counter, minor/major escalate the base.
+      // branch above — the advance increments the prerelease counter regardless of the commit-inferred
+      // magnitude, because the base is a fixed target until graduation (#500).
       if (
         semver.prerelease(currentVersion) !== null &&
         !config.stableOnly &&
@@ -455,9 +435,8 @@ async function calculateVersionInner(config: Config, options: VersionOptions): P
         STANDARD_BUMP_TYPES.includes(effectiveReleaseType as 'major' | 'minor' | 'patch')
       ) {
         const channelId = prereleaseIdOf(currentVersion) ?? normalizedPrereleaseId;
-        const channelType = toPrereleaseLineBump(effectiveReleaseType);
-        log(`Advancing prerelease ${currentVersion} along its channel via ${channelType} (id: ${channelId})`, 'debug');
-        return bumpVersion(currentVersion, channelType, channelId);
+        log(`Advancing prerelease ${currentVersion} along its channel (increment, id: ${channelId})`, 'debug');
+        return bumpVersion(currentVersion, 'prerelease', channelId);
       }
 
       const isPrereleaseBumpType = ['prerelease', 'premajor', 'preminor', 'prepatch'].includes(effectiveReleaseType);

--- a/packages/version/test/unit/core/versionChannel.spec.ts
+++ b/packages/version/test/unit/core/versionChannel.spec.ts
@@ -127,19 +127,19 @@ describe('Per-package release channel — advance along the current line (#485)'
   });
 
   describe('explicit bump magnitude (release:major/minor/patch) without a channel action', () => {
-    // A bump LABEL sets the magnitude but not the channel; a prerelease package stays on its line and
-    // advances the counter (the bump is not a graduate action, and the base is a fixed target until
-    // graduation — #500). To re-target the base of an in-flight prerelease, use channel:prerelease.
-    it('should increment the counter under an explicit minor bump, not escalate (1.0.0-next.1 -> 1.0.0-next.2)', async () => {
+    // A bump LABEL is a deliberate magnitude declaration, so it is honoured: on a prerelease it
+    // escalates the base to a fresh line (unlike the commit-inferred default, which increments the
+    // counter — the base is a fixed target until graduation, #500). It still doesn't graduate.
+    it('should escalate the base under an explicit minor bump (1.0.0-next.1 -> 1.1.0-next.0)', async () => {
       baselineAt('1.0.0-next.1');
       const next = await calculateVersion(baseConfig as Config, options({ type: 'minor' }));
-      expect(next).toBe('1.0.0-next.2');
+      expect(next).toBe('1.1.0-next.0');
     });
 
-    it('should increment the counter under an explicit major bump, not escalate (1.0.0-next.1 -> 1.0.0-next.2)', async () => {
+    it('should escalate the base under an explicit major bump (1.0.0-next.1 -> 2.0.0-next.0)', async () => {
       baselineAt('1.0.0-next.1');
       const next = await calculateVersion(baseConfig as Config, options({ type: 'major' }));
-      expect(next).toBe('1.0.0-next.2');
+      expect(next).toBe('2.0.0-next.0');
     });
 
     it('should keep a prerelease on its line under an explicit patch bump (1.0.0-next.1 -> 1.0.0-next.2)', async () => {

--- a/packages/version/test/unit/core/versionChannel.spec.ts
+++ b/packages/version/test/unit/core/versionChannel.spec.ts
@@ -68,18 +68,26 @@ describe('Per-package release channel — advance along the current line (#485)'
       expect(next).toBe('1.0.0-next.2');
     });
 
-    it('should escalate the base for a minor-level change (1.0.0-next.1 -> 1.1.0-next.0)', async () => {
+    it('should increment the counter for a minor-level change, not escalate the base (1.0.0-next.1 -> 1.0.0-next.2)', async () => {
+      // The base is a fixed target until graduation (#500) — a minor doesn't move it to 1.1.0-next.0.
       baselineAt('1.0.0-next.1');
       inferredBump('minor');
       const next = await calculateVersion(baseConfig as Config, options());
-      expect(next).toBe('1.1.0-next.0');
+      expect(next).toBe('1.0.0-next.2');
     });
 
-    it('should escalate the base for a major-level change (1.0.0-next.1 -> 2.0.0-next.0)', async () => {
+    it('should increment the counter for a major-level change, not escalate the base (1.0.0-next.1 -> 1.0.0-next.2)', async () => {
       baselineAt('1.0.0-next.1');
       inferredBump('major');
       const next = await calculateVersion(baseConfig as Config, options());
-      expect(next).toBe('2.0.0-next.0');
+      expect(next).toBe('1.0.0-next.2');
+    });
+
+    it('should increment a higher prerelease counter without resetting it (#500: 1.0.0-next.3 -> 1.0.0-next.4)', async () => {
+      baselineAt('1.0.0-next.3');
+      inferredBump('minor');
+      const next = await calculateVersion(baseConfig as Config, options({ latestTag: 'v1.0.0-next.3' }));
+      expect(next).toBe('1.0.0-next.4');
     });
 
     it('should preserve the existing prerelease identifier rather than the config default', async () => {
@@ -119,18 +127,19 @@ describe('Per-package release channel — advance along the current line (#485)'
   });
 
   describe('explicit bump magnitude (release:major/minor/patch) without a channel action', () => {
-    // A bump LABEL sets the magnitude but not the channel; a prerelease package must still stay on
-    // its line (the bump is not a graduate action).
-    it('should keep a prerelease on its line under an explicit minor bump (1.0.0-next.1 -> 1.1.0-next.0)', async () => {
+    // A bump LABEL sets the magnitude but not the channel; a prerelease package stays on its line and
+    // advances the counter (the bump is not a graduate action, and the base is a fixed target until
+    // graduation — #500). To re-target the base of an in-flight prerelease, use channel:prerelease.
+    it('should increment the counter under an explicit minor bump, not escalate (1.0.0-next.1 -> 1.0.0-next.2)', async () => {
       baselineAt('1.0.0-next.1');
       const next = await calculateVersion(baseConfig as Config, options({ type: 'minor' }));
-      expect(next).toBe('1.1.0-next.0');
+      expect(next).toBe('1.0.0-next.2');
     });
 
-    it('should keep a prerelease on its line under an explicit major bump (1.0.0-next.1 -> 2.0.0-next.0)', async () => {
+    it('should increment the counter under an explicit major bump, not escalate (1.0.0-next.1 -> 1.0.0-next.2)', async () => {
       baselineAt('1.0.0-next.1');
       const next = await calculateVersion(baseConfig as Config, options({ type: 'major' }));
-      expect(next).toBe('2.0.0-next.0');
+      expect(next).toBe('1.0.0-next.2');
     });
 
     it('should keep a prerelease on its line under an explicit patch bump (1.0.0-next.1 -> 1.0.0-next.2)', async () => {
@@ -178,7 +187,7 @@ describe('Per-package release channel — advance along the current line (#485)'
       const staysPre = await calculateVersion(config, options({ name: 'staying-pkg', latestTag: 'v2.3.0-next.1' }));
 
       expect(graduated).toBe('1.0.0');
-      expect(staysPre).toBe('2.4.0-next.0');
+      expect(staysPre).toBe('2.3.0-next.2');
     });
   });
 
@@ -207,7 +216,7 @@ describe('Per-package release channel — advance along the current line (#485)'
         options({ name: 'stable-pkg', latestTag: 'v10.1.0' }),
       );
 
-      expect(pre).toBe('1.1.0-next.0');
+      expect(pre).toBe('1.0.0-next.2');
       expect(stable).toBe('10.2.0');
     });
   });


### PR DESCRIPTION
Closes #500.

## Problem
A package on a prerelease whose base is still unreleased advanced by **escalating the base + resetting the counter** on a routine (commit-driven) bump. A feat on `1.0.0-next.3` produced `1.1.0-next.0` (so three packages at `next.3` / `next.1` / `next.0` all collapsed to the same `1.1.0-next.0`) rather than `1.0.0-next.4`.

## Fix
The **commit-inferred default** now **increments the prerelease counter** (`semver.inc(v,'prerelease')`) regardless of the inferred magnitude — the base is a fixed target until graduation.

| current | commit-driven feat → before | → after |
|---|---|---|
| `1.0.0-next.3` | `1.1.0-next.0` | **`1.0.0-next.4`** |
| `1.0.0-next.1` | `1.1.0-next.0` | **`1.0.0-next.2`** |
| `1.0.0-next.0` | `1.1.0-next.0` | **`1.0.0-next.1`** |

## Explicit `bump:*` labels are unchanged (honored)
An explicit `bump:minor`/`bump:major` is a deliberate magnitude declaration, so it's respected — on a prerelease it **escalates the base** to a fresh line (`1.0.0-next.6 → 1.1.0-next.0`), exactly as before. Only the automatic/commit-driven path changes. (Distinguishing "automatic accumulation" from "deliberate declaration" is the crux — thanks for the steer in review.)

So, on a prerelease:
- **no label (commit-driven)** → increment the counter (`next.N+1`) — the #500 fix
- **`bump:minor`/`major`** → escalate the base (`1.1.0-next.0`)
- **`channel:prerelease` + bump** → fresh prerelease line (also relevant for promoting a *stable* package to prerelease)
- **`release:graduate`** → stable

## Tests + docs
- `versionChannel.spec.ts`: commit-inferred default asserts increment (+ a `1.0.0-next.3 → 1.0.0-next.4` regression); explicit-bump tests assert escalate. Full version suite green (696).
- `ci-setup.md`: separate rows for the commit-driven default (increment) vs explicit `bump:*` (escalate), prose updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where a prerelease package on a dist-tag (e.g. `1.0.0-next.3`) would have its base version escalated by commit-inferred bumps instead of simply incrementing the prerelease counter. The commit-inferred code path in `versionCalculator.ts` now unconditionally calls `bumpVersion(currentVersion, 'prerelease', channelId)` rather than routing through `toPrereleaseLineBump`, which was mapping `minor` → `preminor` and `major` → `premajor`.

- **Core fix**: the commit-inferred (no `bump:*` label) path now always increments the prerelease counter regardless of inferred magnitude; `1.0.0-next.3 + inferred minor → 1.0.0-next.4` instead of the buggy `1.1.0-next.0`.
- **Explicit-bump path unchanged**: an explicit `bump:minor`/`bump:major` label still calls `toPrereleaseLineBump` and escalates the base (`1.0.0-next.6 → 1.1.0-next.0`), consistent with the updated docs and tests.
- **Docs and tests** are internally consistent with the code; the regression case from #500 is covered by a new dedicated test.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is surgical, well-tested, and documented.

The only modified execution path is the commit-inferred prerelease branch, which now calls bumpVersion with the fixed 'prerelease' type instead of routing through toPrereleaseLineBump. The explicit-bump path is intentionally unchanged. The regression case (1.0.0-next.3 → 1.0.0-next.4) is directly tested, and all three changed files are internally consistent with each other.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/version/src/core/versionCalculator.ts | Commit-inferred prerelease branch changed from toPrereleaseLineBump() to always 'prerelease' (counter increment); explicit-bump branch is intentionally unchanged and still escalates via toPrereleaseLineBump(). Comment-only update for the function doc and both branch comments. |
| packages/version/test/unit/core/versionChannel.spec.ts | Two inferred-bump assertions updated from escalation expectations to counter-increment expectations; a dedicated regression test for #500 (1.0.0-next.3 → 1.0.0-next.4) added; mixed-run and per-package tests updated to match new behavior. |
| packages/release/docs/ci-setup.md | Added a commit-driven prerelease row to the label table; updated prose to distinguish commit-driven (always-increment) from explicit-bump (escalate-base) behavior. Accurate to the implementation. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[calculateVersion called] --> B{specifiedType set?\nbump:* label present}
    B -- Yes --> C{isCurrentPrerelease\n&& !stableOnly\n&& !isPrerelease}
    C -- Yes --> D[toPrereleaseLineBump\npatch→prerelease\nminor→preminor\nmajor→premajor]
    D --> E[bumpVersion with channelType\ne.g. 1.0.0-next.1 + minor\n→ 1.1.0-next.0 ESCALATE]
    C -- No --> F[Normal bump / isPrerelease path]
    B -- No --> G[Conventional-commits bumper\ninfers releaseType]
    G --> H{isCurrentPrerelease\n&& !stableOnly\n&& !isPrerelease}
    H -- Yes --> I[bumpVersion with 'prerelease'\nALWAYS increment counter\ne.g. 1.0.0-next.3 + minor\n→ 1.0.0-next.4 FIX #500]
    H -- No --> J[Normal semver bump]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[calculateVersion called] --> B{specifiedType set?\nbump:* label present}
    B -- Yes --> C{isCurrentPrerelease\n&& !stableOnly\n&& !isPrerelease}
    C -- Yes --> D[toPrereleaseLineBump\npatch→prerelease\nminor→preminor\nmajor→premajor]
    D --> E[bumpVersion with channelType\ne.g. 1.0.0-next.1 + minor\n→ 1.1.0-next.0 ESCALATE]
    C -- No --> F[Normal bump / isPrerelease path]
    B -- No --> G[Conventional-commits bumper\ninfers releaseType]
    G --> H{isCurrentPrerelease\n&& !stableOnly\n&& !isPrerelease}
    H -- Yes --> I[bumpVersion with 'prerelease'\nALWAYS increment counter\ne.g. 1.0.0-next.3 + minor\n→ 1.0.0-next.4 FIX #500]
    H -- No --> J[Normal semver bump]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(version): honor explicit bump label ..."](https://github.com/goosewobbler/releasekit/commit/3bec4dbb4fc7d8adb7730a21c6ed059c322d016a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40783113)</sub>

<!-- /greptile_comment -->