### PR TITLE
feat(notes): neutralise GitHub auto-linked refs and mentions in changelogs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -256,6 +256,7 @@ Set to `false` to disable.
 |-----|------|---------|-------------|
 | `mode` | `"root"` \| `"packages"` \| `"both"` | — | Where to write changelog files. root: repo root only. packages: per-package (monorepos). both: repo root and per-package. When omitted entirely (no changelog config), defaults to root. |
 | `file` | string | — | Changelog file name override (default: CHANGELOG.md) |
+| `refs` | `"strip"` \| `"escape"` \| `"link"` | `"link"` | How bare `#NNN` issue/PR refs in the changelog are rendered. 'link' (default): a canonical Markdown link [#NNN](<repo>/issues/NNN) — clickable and keeps the hovercard, but no longer a bare token GitHub re-scans (falls back to 'escape' for non-GitHub repos). 'escape': plain text \\#NNN (no link, no hovercard). 'strip': refs are removed entirely. Scoped-package / @user mentions in entry text are always neutralised regardless of this setting. |
 
 **`notes.changelog.templates`** — Template configuration for changelog.
 

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -310,6 +310,12 @@ export const ChangelogConfigSchema = z
     ),
     file: z.string().optional().describe('Changelog file name override (default: CHANGELOG.md)'),
     templates: TemplateConfigSchema.optional().describe('Template configuration for changelog'),
+    refs: z
+      .enum(['strip', 'escape', 'link'])
+      .default('link')
+      .describe(
+        "How bare `#NNN` issue/PR refs in the changelog are rendered. 'link' (default): a canonical Markdown link [#NNN](<repo>/issues/NNN) — clickable and keeps the hovercard, but no longer a bare token GitHub re-scans (falls back to 'escape' for non-GitHub repos). 'escape': plain text \\#NNN (no link, no hovercard). 'strip': refs are removed entirely. Scoped-package / @user mentions in entry text are always neutralised regardless of this setting.",
+      ),
   })
   .describe('Changelog file configuration');
 

--- a/packages/core/src/changelogRefs.ts
+++ b/packages/core/src/changelogRefs.ts
@@ -65,9 +65,14 @@ export function renderIssueRefs(issueIds: string[], mode: ChangelogRefsMode, rep
 // A GitHub mention is a word-boundary `@name` or `@org/team` (npm scoped package names share the
 // `@scope/pkg` shape). Match those, but not when `@` is preceded by a word char, `/`, `@`, or `\`
 // (a backslash means it's already escaped) — so emails (`foo@bar.com`) and mid-word `@` are left
-// alone. An inline-code span is matched first and returned untouched: GitHub does not linkify a
-// mention inside code, so escaping there would just surface a stray backslash.
-const CODE_SPAN_OR_MENTION = /(`+)[\s\S]*?\1|(?<![0-9A-Za-z_@\\/])@[A-Za-z0-9][A-Za-z0-9-]*(?:\/[A-Za-z0-9._-]+)?/g;
+// alone. A (single-backtick) inline-code span is matched first and returned untouched: GitHub does
+// not linkify a mention inside code, so escaping there would just surface a stray backslash.
+//
+// The code-span half deliberately matches only single-backtick spans (`` `[^`]*` ``) rather than a
+// variable-length ```(`+)…\1```: the backreference form backtracks polynomially on adversarial
+// backtick runs (ReDoS). Single backticks cover inline code in changelog text; a mention inside a
+// rare multi-backtick span just gets a harmless literal backslash.
+const CODE_SPAN_OR_MENTION = /`[^`]*`|(?<![0-9A-Za-z_@\\/])@[A-Za-z0-9][A-Za-z0-9-]*(?:\/[A-Za-z0-9._-]+)?/g;
 
 /**
  * Backslash-escape `@`-mentions in changelog entry text so GitHub renders them as literal text with
@@ -76,5 +81,6 @@ const CODE_SPAN_OR_MENTION = /(`+)[\s\S]*?\1|(?<![0-9A-Za-z_@\\/])@[A-Za-z0-9][A
  * outside inline code are touched.
  */
 export function escapeChangelogMentions(text: string): string {
-  return text.replace(CODE_SPAN_OR_MENTION, (match, codeTicks) => (codeTicks ? match : `\\${match}`));
+  // A code-span match starts with a backtick — leave it untouched; everything else is a mention.
+  return text.replace(CODE_SPAN_OR_MENTION, (match) => (match.startsWith('`') ? match : `\\${match}`));
 }

--- a/packages/core/src/changelogRefs.ts
+++ b/packages/core/src/changelogRefs.ts
@@ -1,0 +1,80 @@
+/**
+ * Neutralising bare GitHub-autolinked tokens in changelog output. GitHub auto-links a bare `#NNN`
+ * issue/PR ref (with a hovercard) and treats a bare `@scope/pkg` / `@user` as a mention (a stray
+ * link that can ping/subscribe a real org or team on every release PR). Both render surfaces — the
+ * notes Markdown (`CHANGELOG.md`, GitHub release body) and the standing-PR body — share these two
+ * pure helpers so the treatment stays identical (#499).
+ */
+
+/** How bare `#NNN` issue/PR refs in a changelog are rendered. */
+export type ChangelogRefsMode = 'strip' | 'escape' | 'link';
+
+/**
+ * Parse a GitHub repo URL into `{ owner, repo }`. Handles HTTPS
+ * (`https://github.com/owner/repo[.git]`) and SCP-style SSH (`git@github.com:owner/repo[.git]`);
+ * github.com only. Returns `null` for any other host or an unparseable input.
+ */
+export function parseGitHubOwnerRepo(repoUrl: string): { owner: string; repo: string } | null {
+  const scpMatch = repoUrl.match(/^git@github\.com:([^/]+)\/(.+?)(?:\.git)?$/);
+  if (scpMatch) return { owner: scpMatch[1]!, repo: scpMatch[2]! };
+
+  try {
+    const url = new URL(repoUrl);
+    if (url.hostname !== 'github.com') return null;
+    const parts = url.pathname
+      .replace(/^\//, '')
+      .replace(/\.git$/, '')
+      .split('/');
+    if (parts.length >= 2 && parts[0] && parts[1]) return { owner: parts[0], repo: parts[1] };
+  } catch {
+    // not a parseable URL
+  }
+  return null;
+}
+
+/**
+ * Render the trailing issue/PR refs for a changelog entry per `mode`. Returns the comma-joined refs
+ * WITHOUT any surrounding punctuation — callers wrap (the Markdown surface in `(…)`, the standing-PR
+ * surface with a leading space). Returns `''` when there are no refs or `mode` is `'strip'`.
+ *
+ * `link` emits a canonical Markdown link `[#NNN](<repo>/issues/NNN)` — clickable, keeps the
+ * hovercard, but no longer a bare token GitHub re-scans. It always points at `/issues/NNN`: GitHub
+ * redirects issues↔pulls, so the emitter needn't know which. A non-GitHub / unparseable `repoUrl`
+ * has no canonical URL to build, so `link` degrades to `escape` for that entry. `escape` renders a
+ * literal `\#NNN` (no link, no hovercard); `strip` drops the refs entirely.
+ *
+ * Tokens may arrive as `#NNN` (the producer's format) or a bare `NNN`; the leading `#` is normalised.
+ */
+export function renderIssueRefs(issueIds: string[], mode: ChangelogRefsMode, repoUrl: string | null): string {
+  if (mode === 'strip' || issueIds.length === 0) return '';
+
+  const ownerRepo = mode === 'link' && repoUrl ? parseGitHubOwnerRepo(repoUrl) : null;
+
+  return issueIds
+    .map((raw) => {
+      const num = raw.replace(/^#/, '');
+      if (ownerRepo) {
+        return `[#${num}](https://github.com/${ownerRepo.owner}/${ownerRepo.repo}/issues/${num})`;
+      }
+      // escape mode, or link mode with no resolvable GitHub repo → literal `#NNN`.
+      return `\\#${num}`;
+    })
+    .join(', ');
+}
+
+// A GitHub mention is a word-boundary `@name` or `@org/team` (npm scoped package names share the
+// `@scope/pkg` shape). Match those, but not when `@` is preceded by a word char, `/`, `@`, or `\`
+// (a backslash means it's already escaped) — so emails (`foo@bar.com`) and mid-word `@` are left
+// alone. An inline-code span is matched first and returned untouched: GitHub does not linkify a
+// mention inside code, so escaping there would just surface a stray backslash.
+const CODE_SPAN_OR_MENTION = /(`+)[\s\S]*?\1|(?<![0-9A-Za-z_@\\/])@[A-Za-z0-9][A-Za-z0-9-]*(?:\/[A-Za-z0-9._-]+)?/g;
+
+/**
+ * Backslash-escape `@`-mentions in changelog entry text so GitHub renders them as literal text with
+ * no mention link (and never pings/subscribes a real user, org, or team on a release PR). Always
+ * applied, independent of the `refs` mode. Conservative by design — only word-boundary mentions
+ * outside inline code are touched.
+ */
+export function escapeChangelogMentions(text: string): string {
+  return text.replace(CODE_SPAN_OR_MENTION, (match, codeTicks) => (codeTicks ? match : `\\${match}`));
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,10 @@
 export { findCargoLockfile } from './cargo.js';
+export {
+  type ChangelogRefsMode,
+  escapeChangelogMentions,
+  parseGitHubOwnerRepo,
+  renderIssueRefs,
+} from './changelogRefs.js';
 export { readPackageVersion } from './cli.js';
 export {
   buildDependencyGraph,

--- a/packages/core/test/unit/changelogRefs.spec.ts
+++ b/packages/core/test/unit/changelogRefs.spec.ts
@@ -95,4 +95,13 @@ describe('escapeChangelogMentions', () => {
   it('should escape a real mention while leaving a code-span mention alone', () => {
     expect(escapeChangelogMentions('ping @octocat about `@wdio/foo`')).toBe('ping \\@octocat about `@wdio/foo`');
   });
+
+  it('should handle adversarial backtick input in linear time (no catastrophic backtracking)', () => {
+    // A long run of unmatched backticks would hang a backreference-based code-span regex (ReDoS).
+    // The single-backtick pattern is linear, so this returns effectively instantly.
+    const start = Date.now();
+    const out = escapeChangelogMentions('`'.repeat(100_000));
+    expect(out).toContain('`');
+    expect(Date.now() - start).toBeLessThan(1000);
+  });
 });

--- a/packages/core/test/unit/changelogRefs.spec.ts
+++ b/packages/core/test/unit/changelogRefs.spec.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+import { escapeChangelogMentions, parseGitHubOwnerRepo, renderIssueRefs } from '../../src/changelogRefs.js';
+
+describe('parseGitHubOwnerRepo', () => {
+  it('should parse an HTTPS GitHub URL', () => {
+    expect(parseGitHubOwnerRepo('https://github.com/owner/repo')).toEqual({ owner: 'owner', repo: 'repo' });
+  });
+
+  it('should strip a trailing .git suffix', () => {
+    expect(parseGitHubOwnerRepo('https://github.com/owner/repo.git')).toEqual({ owner: 'owner', repo: 'repo' });
+  });
+
+  it('should parse an SCP-style SSH URL', () => {
+    expect(parseGitHubOwnerRepo('git@github.com:owner/repo.git')).toEqual({ owner: 'owner', repo: 'repo' });
+  });
+
+  it('should return null for a non-GitHub host', () => {
+    expect(parseGitHubOwnerRepo('https://gitlab.com/owner/repo')).toBeNull();
+  });
+
+  it('should return null for an unparseable input', () => {
+    expect(parseGitHubOwnerRepo('not a url')).toBeNull();
+  });
+});
+
+describe('renderIssueRefs', () => {
+  const repo = 'https://github.com/octocat/hello';
+
+  it('should render a canonical /issues/ link in link mode', () => {
+    expect(renderIssueRefs(['#481'], 'link', repo)).toBe('[#481](https://github.com/octocat/hello/issues/481)');
+  });
+
+  it('should join multiple refs with a comma in link mode', () => {
+    expect(renderIssueRefs(['#1', '#2'], 'link', repo)).toBe(
+      '[#1](https://github.com/octocat/hello/issues/1), [#2](https://github.com/octocat/hello/issues/2)',
+    );
+  });
+
+  it('should normalise a bare numeric token without a leading #', () => {
+    expect(renderIssueRefs(['481'], 'link', repo)).toBe('[#481](https://github.com/octocat/hello/issues/481)');
+  });
+
+  it('should fall back to escape when the repo URL is null in link mode', () => {
+    expect(renderIssueRefs(['#481'], 'link', null)).toBe('\\#481');
+  });
+
+  it('should fall back to escape when the repo URL is non-GitHub in link mode', () => {
+    expect(renderIssueRefs(['#481'], 'link', 'https://gitlab.com/o/r')).toBe('\\#481');
+  });
+
+  it('should render literal escaped refs in escape mode (no link even with a repo URL)', () => {
+    expect(renderIssueRefs(['#481', '#7'], 'escape', repo)).toBe('\\#481, \\#7');
+  });
+
+  it('should return an empty string in strip mode', () => {
+    expect(renderIssueRefs(['#481'], 'strip', repo)).toBe('');
+  });
+
+  it('should return an empty string when there are no refs', () => {
+    expect(renderIssueRefs([], 'link', repo)).toBe('');
+  });
+});
+
+describe('escapeChangelogMentions', () => {
+  it('should escape a leading @user mention', () => {
+    expect(escapeChangelogMentions('Thanks @octocat for the fix')).toBe('Thanks \\@octocat for the fix');
+  });
+
+  it('should escape a scoped-package @org/team mention', () => {
+    expect(escapeChangelogMentions('Bump @wdio/native-cdp-bridge')).toBe('Bump \\@wdio/native-cdp-bridge');
+  });
+
+  it('should escape a mention at the start of the text', () => {
+    expect(escapeChangelogMentions('@octocat opened this')).toBe('\\@octocat opened this');
+  });
+
+  it('should not mangle an email address', () => {
+    expect(escapeChangelogMentions('Contact support@example.com please')).toBe('Contact support@example.com please');
+  });
+
+  it('should not touch a mid-word @ (foo@bar)', () => {
+    expect(escapeChangelogMentions('handle foo@bar inline')).toBe('handle foo@bar inline');
+  });
+
+  it('should not double-escape an already-escaped mention', () => {
+    expect(escapeChangelogMentions('see \\@octocat')).toBe('see \\@octocat');
+  });
+
+  it('should leave a mention inside an inline code span untouched', () => {
+    expect(escapeChangelogMentions('install `@wdio/native-cdp-bridge` now')).toBe(
+      'install `@wdio/native-cdp-bridge` now',
+    );
+  });
+
+  it('should escape a real mention while leaving a code-span mention alone', () => {
+    expect(escapeChangelogMentions('ping @octocat about `@wdio/foo`')).toBe('ping \\@octocat about `@wdio/foo`');
+  });
+});

--- a/packages/notes/src/core/pipeline.ts
+++ b/packages/notes/src/core/pipeline.ts
@@ -1,6 +1,6 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { debug, info, success, warn } from '@releasekit/core';
+import { debug, info, parseGitHubOwnerRepo, success, warn } from '@releasekit/core';
 import { parseVersionOutput } from '../input/version-output.js';
 import { withContentHashCache } from '../llm/cache.js';
 import { fetchPullRequestContext, parseIssueNumbers, resolveGitHubToken } from '../llm/context/prFetcher.js';
@@ -32,25 +32,6 @@ import type {
   TemplateContext,
   TemplateEngine,
 } from './types.js';
-
-function parseOwnerRepo(repoUrl: string): { owner: string; repo: string } | null {
-  // SCP-style SSH: git@github.com:owner/repo.git — only github.com
-  const scpMatch = repoUrl.match(/^git@github\.com:([^/]+)\/(.+?)(?:\.git)?$/);
-  if (scpMatch) return { owner: scpMatch[1]!, repo: scpMatch[2]! };
-
-  try {
-    const url = new URL(repoUrl);
-    if (url.hostname !== 'github.com') return null;
-    const parts = url.pathname
-      .replace(/^\//, '')
-      .replace(/\.git$/, '')
-      .split('/');
-    if (parts.length >= 2) return { owner: parts[0]!, repo: parts[1]! };
-  } catch {
-    // invalid URL
-  }
-  return null;
-}
 
 /**
  * For dash-format compound tags (e.g. "scope-pkg-1.2.3" or "scope-pkg-1.2.3-next.1"),
@@ -401,7 +382,7 @@ export async function runPipeline(
 
     const examplesCount = llmConfig.examples ?? 3;
     const repoUrl = contexts[0]?.repoUrl ?? input.metadata?.repoUrl;
-    const ownerRepo = repoUrl ? parseOwnerRepo(repoUrl) : null;
+    const ownerRepo = repoUrl ? parseGitHubOwnerRepo(repoUrl) : null;
     const examplesByPackage = new Map<string, Example[]>();
 
     if (examplesCount > 0 && ownerRepo) {
@@ -470,6 +451,7 @@ export async function runPipeline(
     categoryOrder: llmConfig?.categoryOrder,
     links: releaseNotesConfig?.links,
     firstRelease: releaseNotesConfig?.firstRelease,
+    refs: (changelogConfig !== false ? changelogConfig.refs : undefined) ?? 'link',
   };
 
   if (!pipelineOptions?.skipChangelogs && changelogConfig !== false && changelogConfig.mode) {

--- a/packages/notes/src/core/pipeline.ts
+++ b/packages/notes/src/core/pipeline.ts
@@ -1,6 +1,6 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { debug, info, parseGitHubOwnerRepo, success, warn } from '@releasekit/core';
+import { type ChangelogRefsMode, debug, info, parseGitHubOwnerRepo, success, warn } from '@releasekit/core';
 import { parseVersionOutput } from '../input/version-output.js';
 import { withContentHashCache } from '../llm/cache.js';
 import { fetchPullRequestContext, parseIssueNumbers, resolveGitHubToken } from '../llm/context/prFetcher.js';
@@ -477,7 +477,13 @@ export async function runPipeline(
       }
 
       if (mode === 'packages' || mode === 'both') {
-        const monoFiles = await writeMonorepoFiles(contexts, config, dryRun, changelogConfig.file ?? 'CHANGELOG.md');
+        const monoFiles = await writeMonorepoFiles(
+          contexts,
+          config,
+          dryRun,
+          changelogConfig.file ?? 'CHANGELOG.md',
+          fmtOpts.refs ?? 'link',
+        );
         files.push(...monoFiles);
       }
     } catch (error) {
@@ -579,6 +585,7 @@ async function writeMonorepoFiles(
   config: Config,
   dryRun: boolean,
   fileName: string,
+  refs: ChangelogRefsMode,
 ): Promise<string[]> {
   const { detectMonorepo, writeMonorepoChangelogs } = await import('../monorepo/aggregator.js');
   const cwd = process.cwd();
@@ -596,6 +603,7 @@ async function writeMonorepoFiles(
     },
     config,
     dryRun,
+    refs,
   );
 
   return monoFiles;

--- a/packages/notes/src/core/types.ts
+++ b/packages/notes/src/core/types.ts
@@ -1,4 +1,5 @@
 import type { MonorepoConfig } from '@releasekit/config';
+import type { ChangelogRefsMode } from '@releasekit/core';
 import type { RetryOptions } from '../utils/retry.js';
 
 export type { RetryOptions };
@@ -188,6 +189,8 @@ export interface ChangelogConfig {
   mode?: LocationMode;
   file?: string;
   templates?: TemplateConfig;
+  /** How bare `#NNN` issue/PR refs render in the changelog (#499). Default `'link'` when unset. */
+  refs?: ChangelogRefsMode;
 }
 
 export interface LinksConfig {

--- a/packages/notes/src/monorepo/aggregator.ts
+++ b/packages/notes/src/monorepo/aggregator.ts
@@ -1,6 +1,6 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { debug, info, success } from '@releasekit/core';
+import { type ChangelogRefsMode, debug, info, success } from '@releasekit/core';
 import type { TemplateContext } from '../core/types.js';
 import { formatVersion, prependVersion, renderMarkdown } from '../output/markdown.js';
 import { splitByPackage } from './splitter.js';
@@ -59,13 +59,14 @@ export function writeMonorepoChangelogs(
   options: MonorepoOptions,
   config: { updateStrategy?: 'prepend' | 'regenerate' },
   dryRun: boolean,
+  refs: ChangelogRefsMode = 'link',
 ): string[] {
   const files: string[] = [];
 
   if (options.mode === 'root' || options.mode === 'both') {
     const rootPath = path.join(options.rootPath, options.fileName ?? 'CHANGELOG.md');
     // Root changelog includes package names since it aggregates multiple packages
-    const fmtOpts = { includePackageName: true };
+    const fmtOpts = { includePackageName: true, refs };
 
     info(`Writing root changelog to ${rootPath}`);
     let rootContent: string;
@@ -101,8 +102,8 @@ export function writeMonorepoChangelogs(
         info(`Writing changelog for ${packageName} to ${changelogPath}`);
         const pkgContent =
           config.updateStrategy !== 'regenerate' && fs.existsSync(changelogPath)
-            ? prependVersion(changelogPath, ctx)
-            : renderMarkdown([ctx]);
+            ? prependVersion(changelogPath, ctx, { refs })
+            : renderMarkdown([ctx], { refs });
         if (writeFile(changelogPath, pkgContent, dryRun)) {
           files.push(changelogPath);
         }

--- a/packages/notes/src/output/markdown.ts
+++ b/packages/notes/src/output/markdown.ts
@@ -59,20 +59,24 @@ interface EntryRefOptions {
 
 function formatEntry(entry: ChangelogEntry, opts?: EntryRefOptions): string {
   // GitHub treats a bare `@scope/pkg` / `@user` in prose as a mention (stray link, can ping a real
-  // org/team on a release PR) — always neutralise it, regardless of the refs mode.
+  // org/team on a release PR) — always neutralise it, regardless of the refs mode. The scope and
+  // lead-in are interpolated as bold prose too (a scoped package name like `@wdio/native-cdp-bridge`
+  // would mention `@wdio`), so escape all three, not just the description.
   const description = escapeChangelogMentions(entry.description);
+  const scope = entry.scope ? escapeChangelogMentions(entry.scope) : undefined;
+  const leadIn = entry.leadIn ? escapeChangelogMentions(entry.leadIn) : undefined;
   let line: string;
 
-  if (entry.leadIn && entry.breaking) {
-    line = `- **BREAKING** **${entry.leadIn}**: ${description}`;
-  } else if (entry.leadIn) {
-    line = `- **${entry.leadIn}**: ${description}`;
-  } else if (entry.breaking && entry.scope && !opts?.hideScope) {
-    line = `- **BREAKING** **${entry.scope}**: ${description}`;
+  if (leadIn && entry.breaking) {
+    line = `- **BREAKING** **${leadIn}**: ${description}`;
+  } else if (leadIn) {
+    line = `- **${leadIn}**: ${description}`;
+  } else if (entry.breaking && scope && !opts?.hideScope) {
+    line = `- **BREAKING** **${scope}**: ${description}`;
   } else if (entry.breaking) {
     line = `- **BREAKING** ${description}`;
-  } else if (entry.scope && !opts?.hideScope) {
-    line = `- **${entry.scope}**: ${description}`;
+  } else if (scope && !opts?.hideScope) {
+    line = `- **${scope}**: ${description}`;
   } else {
     line = `- ${description}`;
   }
@@ -122,7 +126,7 @@ function formatCategorySection(name: string, entries: ChangelogEntry[], refOpts:
       if (entry.scope && groupedScopes.has(entry.scope)) {
         if (!renderedScopes.has(entry.scope)) {
           renderedScopes.add(entry.scope);
-          lines.push(`**${entry.scope}**:`);
+          lines.push(`**${escapeChangelogMentions(entry.scope)}**:`);
           for (const e of byScope.get(entry.scope) ?? []) {
             lines.push(formatEntry(e, { ...refOpts, hideScope: true }));
           }

--- a/packages/notes/src/output/markdown.ts
+++ b/packages/notes/src/output/markdown.ts
@@ -1,6 +1,6 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { info, success } from '@releasekit/core';
+import { type ChangelogRefsMode, escapeChangelogMentions, info, renderIssueRefs, success } from '@releasekit/core';
 import type {
   ChangelogEntry,
   Config,
@@ -49,31 +49,43 @@ function groupEntriesByType(entries: ChangelogEntry[]): Map<ChangelogEntry['type
   return grouped;
 }
 
-function formatEntry(entry: ChangelogEntry, opts?: { hideScope?: boolean }): string {
+interface EntryRefOptions {
+  hideScope?: boolean;
+  /** How bare `#NNN` issue/PR refs are rendered (default `'link'`). */
+  refs?: ChangelogRefsMode;
+  /** Repo URL used to build canonical issue links in `link` mode. */
+  repoUrl?: string | null;
+}
+
+function formatEntry(entry: ChangelogEntry, opts?: EntryRefOptions): string {
+  // GitHub treats a bare `@scope/pkg` / `@user` in prose as a mention (stray link, can ping a real
+  // org/team on a release PR) — always neutralise it, regardless of the refs mode.
+  const description = escapeChangelogMentions(entry.description);
   let line: string;
 
   if (entry.leadIn && entry.breaking) {
-    line = `- **BREAKING** **${entry.leadIn}**: ${entry.description}`;
+    line = `- **BREAKING** **${entry.leadIn}**: ${description}`;
   } else if (entry.leadIn) {
-    line = `- **${entry.leadIn}**: ${entry.description}`;
+    line = `- **${entry.leadIn}**: ${description}`;
   } else if (entry.breaking && entry.scope && !opts?.hideScope) {
-    line = `- **BREAKING** **${entry.scope}**: ${entry.description}`;
+    line = `- **BREAKING** **${entry.scope}**: ${description}`;
   } else if (entry.breaking) {
-    line = `- **BREAKING** ${entry.description}`;
+    line = `- **BREAKING** ${description}`;
   } else if (entry.scope && !opts?.hideScope) {
-    line = `- **${entry.scope}**: ${entry.description}`;
+    line = `- **${entry.scope}**: ${description}`;
   } else {
-    line = `- ${entry.description}`;
+    line = `- ${description}`;
   }
 
-  if (entry.issueIds && entry.issueIds.length > 0) {
-    line += ` (${entry.issueIds.join(', ')})`;
+  const refs = renderIssueRefs(entry.issueIds ?? [], opts?.refs ?? 'link', opts?.repoUrl ?? null);
+  if (refs) {
+    line += ` (${refs})`;
   }
 
   return line;
 }
 
-function formatCategorySection(name: string, entries: ChangelogEntry[]): string[] {
+function formatCategorySection(name: string, entries: ChangelogEntry[], refOpts: EntryRefOptions): string[] {
   const lines: string[] = [];
   lines.push(`### ${name}`);
 
@@ -90,7 +102,7 @@ function formatCategorySection(name: string, entries: ChangelogEntry[]): string[
   if (groupedScopes.size === 0) {
     // No scope grouping — render flat
     for (const entry of entries) {
-      lines.push(formatEntry(entry));
+      lines.push(formatEntry(entry, refOpts));
     }
   } else {
     // Scope groups are expanded at the position of their first member.
@@ -112,12 +124,12 @@ function formatCategorySection(name: string, entries: ChangelogEntry[]): string[
           renderedScopes.add(entry.scope);
           lines.push(`**${entry.scope}**:`);
           for (const e of byScope.get(entry.scope) ?? []) {
-            lines.push(formatEntry(e, { hideScope: true }));
+            lines.push(formatEntry(e, { ...refOpts, hideScope: true }));
           }
         }
         // Remaining entries in this group already rendered above — skip
       } else {
-        lines.push(formatEntry(entry));
+        lines.push(formatEntry(entry, refOpts));
       }
     }
   }
@@ -242,10 +254,13 @@ export interface FormatVersionOptions {
   links?: LinksConfig;
   /** First-release placeholder intro config, or `false` to suppress it. */
   firstRelease?: FirstReleaseConfig | false;
+  /** How bare `#NNN` issue/PR refs are rendered (`changelog.refs`; default `'link'`). */
+  refs?: ChangelogRefsMode;
 }
 
 export function formatVersion(context: TemplateContext, options?: FormatVersionOptions): string {
   const lines: string[] = [];
+  const refOpts: EntryRefOptions = { refs: options?.refs ?? 'link', repoUrl: context.repoUrl };
 
   const versionLabel =
     options?.includePackageName && context.packageName ? `${context.packageName}@${context.version}` : context.version;
@@ -277,7 +292,7 @@ export function formatVersion(context: TemplateContext, options?: FormatVersionO
 
     for (const category of categories) {
       if (category.entries.length === 0) continue;
-      lines.push(...formatCategorySection(category.name, category.entries));
+      lines.push(...formatCategorySection(category.name, category.entries, refOpts));
     }
 
     const links = resolveLinks(context.entries, options?.links);
@@ -297,7 +312,7 @@ export function formatVersion(context: TemplateContext, options?: FormatVersionO
 
       lines.push(`### ${TYPE_LABELS[type]}`);
       for (const entry of entries) {
-        lines.push(formatEntry(entry));
+        lines.push(formatEntry(entry, refOpts));
       }
       lines.push('');
     }

--- a/packages/notes/test/integration/pipeline-config.spec.ts
+++ b/packages/notes/test/integration/pipeline-config.spec.ts
@@ -139,6 +139,7 @@ describe('Pipeline: mode both does not double-write root', () => {
       expect.objectContaining({ mode: 'packages' }),
       expect.anything(),
       false,
+      expect.anything(),
     );
     expect(writeMonorepoChangelogs).not.toHaveBeenCalledWith(
       expect.anything(),
@@ -160,6 +161,7 @@ describe('Pipeline: mode both does not double-write root', () => {
       expect.objectContaining({ fileName: 'CHANGES.md' }),
       expect.anything(),
       false,
+      expect.anything(),
     );
   });
 
@@ -179,6 +181,23 @@ describe('Pipeline: mode both does not double-write root', () => {
       expect.objectContaining({ fileName: 'CHANGELOG.md' }),
       expect.anything(),
       false,
+      expect.anything(),
+    );
+  });
+
+  it('should forward the configured refs mode to per-package monorepo changelogs (#503)', async () => {
+    const { writeMonorepoChangelogs } = await import('../../src/monorepo/aggregator.js');
+    const { runPipeline } = await import('../../src/core/pipeline.js');
+
+    const config: Config = { changelog: { mode: 'packages', refs: 'strip' } };
+    await runPipeline(sampleInput, config, false);
+
+    expect(writeMonorepoChangelogs).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      false,
+      'strip',
     );
   });
 });

--- a/packages/notes/test/integration/pipeline.spec.ts
+++ b/packages/notes/test/integration/pipeline.spec.ts
@@ -64,7 +64,8 @@ describe('Pipeline: version output → markdown', () => {
     expect(markdown).toContain('### Added');
     expect(markdown).toContain('- **api**: Add streaming support');
     expect(markdown).toContain('### Fixed');
-    expect(markdown).toContain('- Null pointer in parser (#88)');
+    // Bare `#88` is rendered as a canonical Markdown link by default (link mode, #499).
+    expect(markdown).toContain('- Null pointer in parser ([#88](https://github.com/acme/my-lib/issues/88))');
     expect(markdown).toContain('### Changed');
     expect(markdown).toContain('- Simplify config loading');
   });

--- a/packages/notes/test/unit/output/markdown.spec.ts
+++ b/packages/notes/test/unit/output/markdown.spec.ts
@@ -588,6 +588,72 @@ describe('formatVersion: non-LLM path', () => {
 });
 
 // ---------------------------------------------------------------------------
+// formatVersion — issue refs + mention escaping (#499)
+// ---------------------------------------------------------------------------
+
+describe('formatVersion: issue refs', () => {
+  const refsCtx = () =>
+    makeContext({
+      repoUrl: 'https://github.com/octocat/hello',
+      entries: [{ type: 'added', description: 'New thing', issueIds: ['#481'] }],
+    });
+
+  it('should render a canonical issue link by default (link mode)', async () => {
+    const { formatVersion } = await import('../../../src/output/markdown.js');
+    const result = formatVersion(refsCtx());
+    expect(result).toContain('- New thing ([#481](https://github.com/octocat/hello/issues/481))');
+  });
+
+  it('should render an escaped ref in escape mode', async () => {
+    const { formatVersion } = await import('../../../src/output/markdown.js');
+    const result = formatVersion(refsCtx(), { refs: 'escape' });
+    expect(result).toContain('- New thing (\\#481)');
+    expect(result).not.toContain('issues/481');
+  });
+
+  it('should drop the refs entirely in strip mode', async () => {
+    const { formatVersion } = await import('../../../src/output/markdown.js');
+    const result = formatVersion(refsCtx(), { refs: 'strip' });
+    expect(result).toContain('- New thing');
+    expect(result).not.toContain('#481');
+    expect(result).not.toContain('()');
+  });
+
+  it('should fall back to escape in link mode when the repo URL is not GitHub', async () => {
+    const { formatVersion } = await import('../../../src/output/markdown.js');
+    const ctx = makeContext({
+      repoUrl: null,
+      entries: [{ type: 'added', description: 'New thing', issueIds: ['#481'] }],
+    });
+    const result = formatVersion(ctx, { refs: 'link' });
+    expect(result).toContain('- New thing (\\#481)');
+  });
+});
+
+describe('formatVersion: mention escaping', () => {
+  it('should always neutralise a scoped-package mention in the description regardless of refs mode', async () => {
+    const { formatVersion } = await import('../../../src/output/markdown.js');
+    const ctx = makeContext({
+      entries: [{ type: 'added', description: 'Support @wdio/native-cdp-bridge' }],
+    });
+    for (const refs of ['link', 'escape', 'strip'] as const) {
+      const result = formatVersion(ctx, { refs });
+      expect(result).toContain('- Support \\@wdio/native-cdp-bridge');
+    }
+  });
+
+  it('should neutralise mentions in the LLM-categorised path too', async () => {
+    const { formatVersion } = await import('../../../src/output/markdown.js');
+    const ctx = makeContext({
+      enhanced: {
+        categories: [{ name: 'New', entries: [{ type: 'added', description: 'Thanks @octocat' }] }],
+      },
+    });
+    expect(formatVersion(ctx)).toContain('- Thanks \\@octocat');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // formatVersion — first-release intro
 // ---------------------------------------------------------------------------
 

--- a/packages/notes/test/unit/output/markdown.spec.ts
+++ b/packages/notes/test/unit/output/markdown.spec.ts
@@ -651,6 +651,37 @@ describe('formatVersion: mention escaping', () => {
     });
     expect(formatVersion(ctx)).toContain('- Thanks \\@octocat');
   });
+
+  it('should neutralise a scoped-package mention in the bold scope prefix', async () => {
+    const { formatVersion } = await import('../../../src/output/markdown.js');
+    const ctx = makeContext({
+      entries: [{ type: 'fixed', description: 'a fix', scope: '@wdio/native-cdp-bridge' }],
+    });
+    const result = formatVersion(ctx);
+    expect(result).toContain('- **\\@wdio/native-cdp-bridge**: a fix');
+    expect(result).not.toContain('**@wdio/native-cdp-bridge**');
+  });
+
+  it('should neutralise a mention in the leadIn prefix', async () => {
+    const { formatVersion } = await import('../../../src/output/markdown.js');
+    const ctx = makeContext({
+      entries: [{ type: 'added', description: 'a feature', leadIn: '@octocat' }],
+    });
+    expect(formatVersion(ctx)).toContain('- **\\@octocat**: a feature');
+  });
+
+  it('should neutralise a scoped-package mention in the grouped scope header', async () => {
+    const { formatVersion } = await import('../../../src/output/markdown.js');
+    const ctx = makeContext({
+      entries: [
+        { type: 'fixed', description: 'fix one', scope: '@wdio/native-cdp-bridge' },
+        { type: 'fixed', description: 'fix two', scope: '@wdio/native-cdp-bridge' },
+      ],
+    });
+    const result = formatVersion(ctx);
+    expect(result).toContain('**\\@wdio/native-cdp-bridge**:');
+    expect(result).not.toContain('**@wdio/native-cdp-bridge**:');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/release/src/standing-pr/changelog-region.ts
+++ b/packages/release/src/standing-pr/changelog-region.ts
@@ -1,4 +1,10 @@
-import type { VersionChangelogEntry, VersionOutput } from '@releasekit/core';
+import {
+  type ChangelogRefsMode,
+  escapeChangelogMentions,
+  renderIssueRefs,
+  type VersionChangelogEntry,
+  type VersionOutput,
+} from '@releasekit/core';
 import type { RowChangelogRenderer } from './selection-region.js';
 
 /**
@@ -98,16 +104,26 @@ function shortName(pkg: string): string {
   return slash === -1 ? pkg : pkg.slice(slash + 1);
 }
 
-function entryLine(d: DedupedEntry, attribution: boolean): string {
+/** How bare `#NNN` refs render plus the repo to resolve canonical issue links against (#499). */
+interface RefRenderOptions {
+  refs: ChangelogRefsMode;
+  repoUrl: string | null;
+}
+
+function entryLine(d: DedupedEntry, attribution: boolean, refOpts: RefRenderOptions): string {
   const { entry, pkgs } = d;
+  // GitHub treats a bare `@scope/pkg` / `@user` in the description as a mention (stray link, can ping
+  // a real org/team on the standing PR) — always neutralise it, regardless of the refs mode.
+  const description = escapeChangelogMentions(entry.description);
   const scope = entry.scope ? ` (\`${entry.scope}\`)` : '';
-  const issues = entry.issueIds?.length ? ` ${entry.issueIds.join(', ')}` : '';
+  const refs = renderIssueRefs(entry.issueIds ?? [], refOpts.refs, refOpts.repoUrl);
+  const issues = refs ? ` ${refs}` : '';
   const attr = attribution && pkgs.size > 0 ? ` _(${[...pkgs].map(shortName).sort().join(', ')})_` : '';
-  return `- ${entry.description}${scope}${issues}${attr}`;
+  return `- ${description}${scope}${issues}${attr}`;
 }
 
 /** Render the deduped entries as flat, type-grouped Markdown (no per-package sections). */
-function renderGrouped(deduped: DedupedEntry[]): string[] {
+function renderGrouped(deduped: DedupedEntry[], refOpts: RefRenderOptions): string[] {
   const distinct = new Set<string>();
   for (const d of deduped) for (const p of d.pkgs) distinct.add(p);
   // Attribution only earns its place when the list spans more than one package.
@@ -129,7 +145,7 @@ function renderGrouped(deduped: DedupedEntry[]): string[] {
     const list = byLabel.get(label);
     if (!list?.length) return;
     lines.push(`**${label}**`, '');
-    for (const d of list) lines.push(entryLine(d, attribution));
+    for (const d of list) lines.push(entryLine(d, attribution, refOpts));
     lines.push('');
   };
   const rendered = new Set<string>();
@@ -153,6 +169,12 @@ function pluralEntries(n: number): string {
   return `${n} ${n === 1 ? 'entry' : 'entries'}`;
 }
 
+/** Every package in a standing PR lives in the same repo, so any changelog's `repoUrl` resolves
+ *  canonical issue links for the whole render. Pick the first present one. */
+function repoUrlOf(changelogs: VersionOutput['changelogs']): string | null {
+  return changelogs.find((cl) => cl.repoUrl)?.repoUrl ?? null;
+}
+
 /**
  * Build the per-row changelog renderer for a set of package changelogs. The returned function takes
  * the package names a checkbox gates (a streamlined unit aggregates primary + coupled members +
@@ -161,10 +183,15 @@ function pluralEntries(n: number): string {
  * when those packages have no real changelog entries.
  *
  * #487 regroups *where* rows are placed; it reuses this renderer unchanged to keep *how* changelogs
- * attach to a row identical.
+ * attach to a row identical. `refs` (`changelog.refs`, default `'link'`) controls how bare `#NNN`
+ * refs render (#499).
  */
-export function makeRowChangelogRenderer(changelogs: VersionOutput['changelogs']): RowChangelogRenderer {
+export function makeRowChangelogRenderer(
+  changelogs: VersionOutput['changelogs'],
+  refs: ChangelogRefsMode = 'link',
+): RowChangelogRenderer {
   const byPkg = new Map(changelogs.map((cl) => [cl.packageName, cl]));
+  const refOpts: RefRenderOptions = { refs, repoUrl: repoUrlOf(changelogs) };
   return (packageNames, heldBack, indent) => {
     const attributed: AttributedEntry[] = [];
     for (const name of packageNames) {
@@ -177,7 +204,7 @@ export function makeRowChangelogRenderer(changelogs: VersionOutput['changelogs']
     const summary = heldBack
       ? `<s>Changelog (${pluralEntries(deduped.length)})</s> — held back, won’t publish`
       : `Changelog (${pluralEntries(deduped.length)})`;
-    return wrapDetails(summary, renderGrouped(deduped), indent);
+    return wrapDetails(summary, renderGrouped(deduped, refOpts), indent);
   };
 }
 
@@ -191,7 +218,10 @@ export function makeRowChangelogRenderer(changelogs: VersionOutput['changelogs']
  * It's how the caller keeps shared entries visible when the maintainer disables the full footer: the
  * redundant per-package summary is dropped (it's covered per-row), but project-wide changes survive.
  */
-export function renderCombinedFooter(versionOutput: VersionOutput, opts: { sharedOnly?: boolean } = {}): string {
+export function renderCombinedFooter(
+  versionOutput: VersionOutput,
+  opts: { sharedOnly?: boolean; refs?: ChangelogRefsMode } = {},
+): string {
   const attributed: AttributedEntry[] = [];
   if (!opts.sharedOnly) {
     for (const cl of versionOutput.changelogs) {
@@ -205,5 +235,6 @@ export function renderCombinedFooter(versionOutput: VersionOutput, opts: { share
   const summary = opts.sharedOnly
     ? `Show project-wide changes (${n} ${n === 1 ? 'change' : 'changes'})`
     : `Show all changes (${n} ${n === 1 ? 'change' : 'changes'}, de-duplicated)`;
-  return wrapDetails(summary, renderGrouped(deduped), '');
+  const refOpts: RefRenderOptions = { refs: opts.refs ?? 'link', repoUrl: repoUrlOf(versionOutput.changelogs) };
+  return wrapDetails(summary, renderGrouped(deduped, refOpts), '');
 }

--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -791,6 +791,13 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
 
   const branch = standingPrConfig?.branch ?? 'release/next';
   const base = releaseKitConfig.git?.branch ?? 'main';
+  // How bare `#NNN` refs render in the PR-body changelogs (#499). The setting lives under
+  // notes.changelog; when that's disabled (`changelog: false`) the standing PR still renders
+  // changelogs, so fall back to the 'link' default.
+  // `changelog` is `false` (disabled), a config object, or absent; `false` and `undefined` are both
+  // falsy, so a plain truthy check narrows to the object.
+  const changelogConfig = releaseKitConfig.notes?.changelog;
+  const changelogRefsMode = (changelogConfig ? changelogConfig.refs : undefined) ?? 'link';
   const skipPatterns = releaseKitConfig.release?.ci?.skipPatterns ?? ['chore: release '];
 
   // Label-triggered runs (a maintainer added/removed an override label on the standing PR, #336)
@@ -1179,7 +1186,7 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
     const warningSuffix = warnings.length > 0 ? `\n\n${warnings.map((w) => `> ⚠️ ${w.reason}`).join('\n')}` : '';
     // Per-row changelogs are sourced from the DRY changelogs (the full changed set) so a held-back
     // row still shows its greyed changelog — the write output omits held-back packages entirely.
-    const rowChangelog = makeRowChangelogRenderer(versionOutputDry.changelogs);
+    const rowChangelog = makeRowChangelogRenderer(versionOutputDry.changelogs, changelogRefsMode);
     renderSelectionBlock = (withChangelogs) =>
       renderSelectionRegion(dryUpdates, effectiveDeselected, primaryConfig, withChangelogs ? rowChangelog : undefined) +
       warningSuffix;
@@ -1193,8 +1200,8 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
   const footerEnabled = standingPrConfig?.combinedChangelogFooter !== false;
   const footer =
     footerEnabled || versionOutput.strategy === 'sync'
-      ? renderCombinedFooter(versionOutput)
-      : renderCombinedFooter(versionOutput, { sharedOnly: true });
+      ? renderCombinedFooter(versionOutput, { refs: changelogRefsMode })
+      : renderCombinedFooter(versionOutput, { sharedOnly: true, refs: changelogRefsMode });
 
   const body = renderPrBody(versionOutput, { supersedeWarning, notesRegion, renderSelectionBlock, footer });
 

--- a/packages/release/test/unit/changelog-region.spec.ts
+++ b/packages/release/test/unit/changelog-region.spec.ts
@@ -5,8 +5,8 @@ import { type PrimaryConfig, renderSelectionRegion } from '../../src/standing-pr
 
 type Changelog = VersionOutput['changelogs'][number];
 
-function cl(packageName: string, entries: Changelog['entries']): Changelog {
-  return { packageName, version: '1.0.0', previousVersion: '0.9.0', revisionRange: '', repoUrl: null, entries };
+function cl(packageName: string, entries: Changelog['entries'], repoUrl: string | null = null): Changelog {
+  return { packageName, version: '1.0.0', previousVersion: '0.9.0', revisionRange: '', repoUrl, entries };
 }
 
 describe('changelog-region', () => {
@@ -131,6 +131,75 @@ describe('changelog-region', () => {
         { sharedOnly: true },
       );
       expect(footer).toBe('');
+    });
+  });
+
+  describe('issue refs + mention escaping (#499)', () => {
+    const repo = 'https://github.com/octocat/hello';
+
+    function output(over: Partial<VersionOutput>): VersionOutput {
+      return { dryRun: false, updates: [], changelogs: [], tags: [], ...over };
+    }
+
+    it('should render a canonical issue link in the per-row pane by default (link mode)', () => {
+      const render = makeRowChangelogRenderer([
+        cl('@scope/app', [{ type: 'feat', description: 'App feature', issueIds: ['#481'] }], repo),
+      ]);
+      const block = render(['@scope/app'], false, '');
+      expect(block).toContain('- App feature [#481](https://github.com/octocat/hello/issues/481)');
+    });
+
+    it('should escape refs in escape mode', () => {
+      const render = makeRowChangelogRenderer(
+        [cl('@scope/app', [{ type: 'feat', description: 'App feature', issueIds: ['#481'] }], repo)],
+        'escape',
+      );
+      const block = render(['@scope/app'], false, '');
+      expect(block).toContain('- App feature \\#481');
+      expect(block).not.toContain('issues/481');
+    });
+
+    it('should drop refs in strip mode', () => {
+      const render = makeRowChangelogRenderer(
+        [cl('@scope/app', [{ type: 'feat', description: 'App feature', issueIds: ['#481'] }], repo)],
+        'strip',
+      );
+      const block = render(['@scope/app'], false, '');
+      expect(block).toContain('- App feature');
+      expect(block).not.toContain('#481');
+    });
+
+    it('should fall back to escape in link mode when no GitHub repo URL is present', () => {
+      const render = makeRowChangelogRenderer([
+        cl('@scope/app', [{ type: 'feat', description: 'App feature', issueIds: ['#481'] }], null),
+      ]);
+      const block = render(['@scope/app'], false, '');
+      expect(block).toContain('- App feature \\#481');
+    });
+
+    it('should always neutralise a scoped-package mention in the description', () => {
+      const render = makeRowChangelogRenderer([
+        cl('@scope/app', [{ type: 'feat', description: 'Bump @wdio/native-cdp-bridge' }], repo),
+      ]);
+      const block = render(['@scope/app'], false, '');
+      expect(block).toContain('- Bump \\@wdio/native-cdp-bridge');
+    });
+
+    it('should render refs and escape mentions in the combined footer', () => {
+      const footer = renderCombinedFooter(
+        output({
+          changelogs: [cl('@scope/a', [{ type: 'fix', description: 'Fix @octocat case', issueIds: ['#7'] }], repo)],
+        }),
+      );
+      expect(footer).toContain('- Fix \\@octocat case [#7](https://github.com/octocat/hello/issues/7)');
+    });
+
+    it('should honour escape mode in the combined footer', () => {
+      const footer = renderCombinedFooter(
+        output({ changelogs: [cl('@scope/a', [{ type: 'fix', description: 'Patch', issueIds: ['#7'] }], repo)] }),
+        { refs: 'escape' },
+      );
+      expect(footer).toContain('- Patch \\#7');
     });
   });
 

--- a/releasekit.schema.json
+++ b/releasekit.schema.json
@@ -613,6 +613,16 @@
                     }
                   },
                   "description": "Template configuration for changelog"
+                },
+                "refs": {
+                  "type": "string",
+                  "enum": [
+                    "strip",
+                    "escape",
+                    "link"
+                  ],
+                  "default": "link",
+                  "description": "How bare `#NNN` issue/PR refs in the changelog are rendered. 'link' (default): a canonical Markdown link [#NNN](<repo>/issues/NNN) — clickable and keeps the hovercard, but no longer a bare token GitHub re-scans (falls back to 'escape' for non-GitHub repos). 'escape': plain text \\#NNN (no link, no hovercard). 'strip': refs are removed entirely. Scoped-package / @user mentions in entry text are always neutralised regardless of this setting."
                 }
               },
               "description": "Changelog file configuration"


### PR DESCRIPTION
## What

Changelog output (the standing-PR body, `CHANGELOG.md`, and the GitHub release body) contains bare tokens GitHub auto-links:

- **Issue/PR refs** (`#481`) — auto-linked with hovercard previews, clutter in expanded changelogs.
- **Scoped package names / mentions** (`@wdio/native-cdp-bridge`, `@user`) — parsed as `@org/team` mentions → stray links that can **ping or subscribe a real org/team on every release PR**.

## Changes

- New `notes.changelog.refs` config — `strip` | `escape` | `link` (default `link`):
  - `link`: `[#NNN](https://github.com/owner/repo/issues/NNN)` — clickable, keeps the hovercard, no longer a bare token. Always points at `/issues/NNN` (GitHub redirects issues↔pulls). Falls back to `escape` for a missing/non-GitHub repo URL.
  - `escape`: literal `\#NNN` (no link, no hovercard).
  - `strip`: refs removed entirely.
- `@scope/pkg` / `@user` mentions in entry descriptions are **always** backslash-escaped, regardless of `refs`. Conservative: emails (`foo@bar.com`), mid-word `@`, and mentions inside inline code spans are left untouched.
- Two shared pure helpers (`renderIssueRefs`, `escapeChangelogMentions`) in `@releasekit/core` drive both the notes Markdown and standing-PR surfaces, so the treatment is identical. The GitHub release body (built via `renderMarkdown`) inherits link-mode refs + mention escaping for free.
- Config schema + generated docs regenerated.

## Out of scope (follow-up)
A **third** render surface — `packages/release/src/preview/format.ts` (the feeder-PR / preview comment) — has the same bare-`#NNN` + un-escaped-`@` problem but isn't in this issue's named scope and needs `repoUrl`/`refs` threaded through the preview pipeline. Left untouched; worth a follow-up issue.

## Tests

Core helper (all three modes incl. unparseable-repoUrl fallback; mention escaping incl. email and code-span cases), notes Markdown rendering, and standing-PR changelog-region rendering. Full gate green (32/32); `schema:check` clean.

Closes #499

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR neutralises the two GitHub auto-linking hazards in changelog output — bare `#NNN` refs and `@scope/user` mentions — across all three render surfaces (root/per-package `CHANGELOG.md`, standing-PR body, and GitHub release body). A new `notes.changelog.refs` config (`link` | `escape` | `strip`, default `link`) controls how issue refs are rendered; `@`-mention escaping is unconditional.

- Two pure helpers (`renderIssueRefs`, `escapeChangelogMentions`) are added to `@releasekit/core` and plumbed through `markdown.ts`, `aggregator.ts`, `changelog-region.ts`, and `standing-pr.ts`; the previous P1 gaps (unescaped scope/leadIn/scope-header fields, `refs` not forwarded to per-package monorepo changelogs) addressed in earlier review rounds are correctly closed.
- The `escapeChangelogMentions` regex uses a single-backtick code-span guard to avoid polynomial backtracking on adversarial backtick runs (ReDoS) — this is verified by a dedicated test.
- The `context.enhanced?.summary` LLM prose field is not passed through `escapeChangelogMentions`; the PR description explicitly scopes to "entry descriptions", so this is a known gap rather than a regression.
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge — the `refs` config is correctly threaded through all named render surfaces, mention escaping covers scope/leadIn/scope-header fields, and the ReDoS concern is explicitly guarded and tested.

The core helpers are pure functions with thorough unit tests including edge cases (emails, mid-word @, already-escaped tokens, code spans, adversarial backtick runs). The `refs` setting is correctly forwarded through the changelog file writer, the monorepo aggregator, and both standing-PR render functions. The only gap — `enhanced.summary` not being escaped — is explicitly scoped out in the PR description and is pre-existing LLM-generated prose, not changelog entries.

No files require special attention. The one P2 observation about `context.enhanced?.summary` in `markdown.ts` is a known coverage gap documented in the PR description, not a regression introduced here.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/core/src/changelogRefs.ts | New module housing two pure helpers: `renderIssueRefs` (three-mode ref rendering with GitHub URL parsing) and `escapeChangelogMentions` (lookbehind regex guards emails, mid-word @, already-escaped, and backtick spans). ReDoS concern is explicitly addressed via single-backtick code-span pattern. |
| packages/notes/src/output/markdown.ts | Adds `refs`/`repoUrl` threading through `EntryRefOptions`, applies `escapeChangelogMentions` to `entry.description`, `entry.scope`, and `entry.leadIn` in `formatEntry`, and escapes the grouped-scope header. Both LLM-categorised and non-LLM entry paths now receive `refOpts`. |
| packages/notes/src/core/pipeline.ts | Replaces local `parseOwnerRepo` with the shared `parseGitHubOwnerRepo`, builds `fmtOpts.refs` from `changelogConfig.refs ?? 'link'`, and forwards `refs` down to `writeMonorepoFiles`/`writeMonorepoChangelogs` so per-package changelogs honour the setting. |
| packages/release/src/standing-pr/changelog-region.ts | Introduces `RefRenderOptions`, escapes `entry.description` via `escapeChangelogMentions`, replaces bare `issueIds.join` with `renderIssueRefs`, and propagates `refOpts` through `entryLine`/`renderGrouped`/`renderCombinedFooter`/`makeRowChangelogRenderer`. The existing backtick-wrapped scope field is left as-is (safe by design). |
| packages/release/src/standing-pr/standing-pr.ts | Reads `changelogConfig.refs` (with truthy-check fallback to `'link'` for `false`/absent configs) and passes `changelogRefsMode` into both `makeRowChangelogRenderer` and both `renderCombinedFooter` call sites. |
| packages/notes/src/monorepo/aggregator.ts | Accepts `refs: ChangelogRefsMode = 'link'` parameter, threads it into `fmtOpts` for the root changelog and into `prependVersion`/`renderMarkdown` calls for per-package changelogs. |

</details>


<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["changelog.refs config\n('link' | 'escape' | 'strip')"] --> B["pipeline.ts: fmtOpts.refs"]

    B --> C["writeMarkdown (root CHANGELOG.md)"]
    B --> D["writeMonorepoFiles → aggregator.ts"]
    D --> E["renderMarkdown / prependVersion\n(per-package CHANGELOG.md)"]

    B --> F["formatVersion (release notes file)"]

    G["standing-pr.ts: changelogRefsMode"] --> H["makeRowChangelogRenderer\n(per-row details pane)"]
    G --> I["renderCombinedFooter\n(combined footer)"]

    J["renderIssueRefs(issueIds, mode, repoUrl)"]
    K["escapeChangelogMentions(text)"]

    C --> J
    E --> J
    F --> J
    H --> J
    I --> J

    C --> K
    E --> K
    F --> K
    H --> K
    I --> K

    L["repoUrl"] --> J
    M["parseGitHubOwnerRepo(url)"] --> J
    L --> M
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["changelog.refs config\n('link' | 'escape' | 'strip')"] --> B["pipeline.ts: fmtOpts.refs"]

    B --> C["writeMarkdown (root CHANGELOG.md)"]
    B --> D["writeMonorepoFiles → aggregator.ts"]
    D --> E["renderMarkdown / prependVersion\n(per-package CHANGELOG.md)"]

    B --> F["formatVersion (release notes file)"]

    G["standing-pr.ts: changelogRefsMode"] --> H["makeRowChangelogRenderer\n(per-row details pane)"]
    G --> I["renderCombinedFooter\n(combined footer)"]

    J["renderIssueRefs(issueIds, mode, repoUrl)"]
    K["escapeChangelogMentions(text)"]

    C --> J
    E --> J
    F --> J
    H --> J
    I --> J

    C --> K
    E --> K
    F --> K
    H --> K
    I --> K

    L["repoUrl"] --> J
    M["parseGitHubOwnerRepo(url)"] --> J
    L --> M
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `packages/notes/src/output/markdown.ts`, line 120-125 ([link](https://github.com/goosewobbler/releasekit/blob/7e1c4945b72cd27ca6992cfd94e92ac05fb1dc4a/packages/notes/src/output/markdown.ts#L120-L125)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Scope group header also emits unescaped `@` mentions**

   When multiple entries share the same scoped-package scope, a group header line `**${entry.scope}**:` is emitted here. If the scope is `@wdio/native-cdp-bridge`, the resulting `**@wdio/native-cdp-bridge**:` header will trigger the same GitHub org-mention as a bare `@wdio` in prose. `escapeChangelogMentions(entry.scope)` needs to be applied before this interpolation as well.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fnotes%2Fsrc%2Foutput%2Fmarkdown.ts%0ALine%3A%20120-125%0A%0AComment%3A%0A**Scope%20group%20header%20also%20emits%20unescaped%20%60%40%60%20mentions**%0A%0AWhen%20multiple%20entries%20share%20the%20same%20scoped-package%20scope%2C%20a%20group%20header%20line%20%60**%24%7Bentry.scope%7D**%3A%60%20is%20emitted%20here.%20If%20the%20scope%20is%20%60%40wdio%2Fnative-cdp-bridge%60%2C%20the%20resulting%20%60**%40wdio%2Fnative-cdp-bridge**%3A%60%20header%20will%20trigger%20the%20same%20GitHub%20org-mention%20as%20a%20bare%20%60%40wdio%60%20in%20prose.%20%60escapeChangelogMentions%28entry.scope%29%60%20needs%20to%20be%20applied%20before%20this%20interpolation%20as%20well.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=goosewobbler%2Freleasekit&pr=503&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fnotes%2Fsrc%2Foutput%2Fmarkdown.ts%0ALine%3A%20120-125%0A%0AComment%3A%0A**Scope%20group%20header%20also%20emits%20unescaped%20%60%40%60%20mentions**%0A%0AWhen%20multiple%20entries%20share%20the%20same%20scoped-package%20scope%2C%20a%20group%20header%20line%20%60**%24%7Bentry.scope%7D**%3A%60%20is%20emitted%20here.%20If%20the%20scope%20is%20%60%40wdio%2Fnative-cdp-bridge%60%2C%20the%20resulting%20%60**%40wdio%2Fnative-cdp-bridge**%3A%60%20header%20will%20trigger%20the%20same%20GitHub%20org-mention%20as%20a%20bare%20%60%40wdio%60%20in%20prose.%20%60escapeChangelogMentions%28entry.scope%29%60%20needs%20to%20be%20applied%20before%20this%20interpolation%20as%20well.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=503&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

2. `packages/notes/src/core/pipeline.ts`, line 479-481 ([link](https://github.com/goosewobbler/releasekit/blob/c9c1cf96f7b6634d286c4440656b1dddf3c2a341/packages/notes/src/core/pipeline.ts#L479-L481)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`refs` config silently ignored for per-package monorepo changelogs**

   `writeMonorepoFiles` does not receive `fmtOpts` (which carries `refs`), so when `changelog.mode` is `'packages'` or `'both'`, every per-package `CHANGELOG.md` is always rendered with `link` mode regardless of the user's configured `refs` value. `writeMonorepoChangelogs` in `aggregator.ts` also hard-codes its own `{ includePackageName: true }` options and calls both `prependVersion` and `renderMarkdown` without forwarding any format options. A user who sets `notes.changelog.refs: 'strip'` would see the root changelog correctly strip refs (since `writeMarkdown` at line 474 does receive `fmtOpts`) but every per-package file would still emit full Markdown issue links.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fnotes%2Fsrc%2Fcore%2Fpipeline.ts%0ALine%3A%20479-481%0A%0AComment%3A%0A**%60refs%60%20config%20silently%20ignored%20for%20per-package%20monorepo%20changelogs**%0A%0A%60writeMonorepoFiles%60%20does%20not%20receive%20%60fmtOpts%60%20%28which%20carries%20%60refs%60%29%2C%20so%20when%20%60changelog.mode%60%20is%20%60'packages'%60%20or%20%60'both'%60%2C%20every%20per-package%20%60CHANGELOG.md%60%20is%20always%20rendered%20with%20%60link%60%20mode%20regardless%20of%20the%20user's%20configured%20%60refs%60%20value.%20%60writeMonorepoChangelogs%60%20in%20%60aggregator.ts%60%20also%20hard-codes%20its%20own%20%60%7B%20includePackageName%3A%20true%20%7D%60%20options%20and%20calls%20both%20%60prependVersion%60%20and%20%60renderMarkdown%60%20without%20forwarding%20any%20format%20options.%20A%20user%20who%20sets%20%60notes.changelog.refs%3A%20'strip'%60%20would%20see%20the%20root%20changelog%20correctly%20strip%20refs%20%28since%20%60writeMarkdown%60%20at%20line%20474%20does%20receive%20%60fmtOpts%60%29%20but%20every%20per-package%20file%20would%20still%20emit%20full%20Markdown%20issue%20links.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=goosewobbler%2Freleasekit&pr=503&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fnotes%2Fsrc%2Fcore%2Fpipeline.ts%0ALine%3A%20479-481%0A%0AComment%3A%0A**%60refs%60%20config%20silently%20ignored%20for%20per-package%20monorepo%20changelogs**%0A%0A%60writeMonorepoFiles%60%20does%20not%20receive%20%60fmtOpts%60%20%28which%20carries%20%60refs%60%29%2C%20so%20when%20%60changelog.mode%60%20is%20%60'packages'%60%20or%20%60'both'%60%2C%20every%20per-package%20%60CHANGELOG.md%60%20is%20always%20rendered%20with%20%60link%60%20mode%20regardless%20of%20the%20user's%20configured%20%60refs%60%20value.%20%60writeMonorepoChangelogs%60%20in%20%60aggregator.ts%60%20also%20hard-codes%20its%20own%20%60%7B%20includePackageName%3A%20true%20%7D%60%20options%20and%20calls%20both%20%60prependVersion%60%20and%20%60renderMarkdown%60%20without%20forwarding%20any%20format%20options.%20A%20user%20who%20sets%20%60notes.changelog.refs%3A%20'strip'%60%20would%20see%20the%20root%20changelog%20correctly%20strip%20refs%20%28since%20%60writeMarkdown%60%20at%20line%20474%20does%20receive%20%60fmtOpts%60%29%20but%20every%20per-package%20file%20would%20still%20emit%20full%20Markdown%20issue%20links.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=503&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["fix(notes): forward refs mode to per-pac..."](https://github.com/goosewobbler/releasekit/commit/481fcae16dc446177d31dd683bcb3ec0aaf3e369) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40793020)</sub>

<!-- /greptile_comment -->