### PR TITLE
fix(release): neutralise changelog auto-links in the preview comment

### DIFF
--- a/packages/release/src/preview/format.ts
+++ b/packages/release/src/preview/format.ts
@@ -1,4 +1,10 @@
-import type { VersionChangelogEntry, VersionPackageChangelog } from '@releasekit/core';
+import {
+  type ChangelogRefsMode,
+  escapeChangelogMentions,
+  renderIssueRefs,
+  type VersionChangelogEntry,
+  type VersionPackageChangelog,
+} from '@releasekit/core';
 import { ATTRIBUTION_FOOTER } from '../attribution.js';
 import { formatDuration } from '../duration.js';
 import { MARKER } from '../github.js';
@@ -71,6 +77,8 @@ export interface FormatOptions {
    * maintainer the retry-vs-supersede choice. Populated by runPreview in standing-pr mode.
    */
   supersedeWarning?: string[];
+  /** How bare `#NNN` issue/PR refs render in the changelog (`notes.changelog.refs`, default `link`). */
+  refs?: ChangelogRefsMode;
 }
 
 function getNoChangesMessage(strategy: ReleaseStrategy): string {
@@ -310,6 +318,10 @@ export function formatPreviewComment(result: ReleaseOutput | null, options?: For
   lines.push(getIntroMessage(effectiveStrategy, options?.standingPrNumber), '');
 
   // Changelog section
+  // How bare `#NNN` refs render + always-on mention escaping (#499/#504). All packages in a release
+  // share one repo, so the first non-null changelog repoUrl governs the project-wide (shared) entries.
+  const refs = options?.refs ?? 'link';
+  const sharedRepoUrl = versionOutput.changelogs.find((cl) => cl.repoUrl)?.repoUrl ?? null;
   const sharedEntries = versionOutput.sharedEntries?.length ? versionOutput.sharedEntries : undefined;
   // A changelog whose entries are *all* synthetic `Update version to X` placeholders (a sync/
   // lockstep carry with no commits of its own) has nothing real to show — treat it like an empty
@@ -331,14 +343,14 @@ export function formatPreviewComment(result: ReleaseOutput | null, options?: For
     // Project-wide entries (CI, infra, shared-package commits) rendered once
     if (sharedEntries) {
       lines.push('<details>', '<summary><b>Project-wide changes</b></summary>', '');
-      lines.push(...renderEntries(sharedEntries));
+      lines.push(...renderEntries(sharedEntries, refs, sharedRepoUrl));
       lines.push('</details>', '');
     }
 
     // Per-package entries — only rendered when the package has real (non-synthetic) changes
     for (const changelog of versionOutput.changelogs) {
       if (hasRealEntries(changelog)) {
-        lines.push(...formatPackageChangelog(changelog));
+        lines.push(...formatPackageChangelog(changelog, refs));
       }
     }
 
@@ -472,7 +484,7 @@ function renderMergeTable(rows: MergedRow[]): string[] {
   return lines;
 }
 
-function renderEntries(entries: VersionChangelogEntry[]): string[] {
+function renderEntries(entries: VersionChangelogEntry[], refs: ChangelogRefsMode, repoUrl: string | null): string[] {
   const lines: string[] = [];
   const grouped = new Map<string, VersionChangelogEntry[]>();
   for (const entry of entries) {
@@ -483,25 +495,25 @@ function renderEntries(entries: VersionChangelogEntry[]): string[] {
   for (const type of Object.keys(TYPE_LABELS)) {
     const group = grouped.get(type);
     if (group && group.length > 0) {
-      lines.push(...formatEntryGroup(type, group));
+      lines.push(...formatEntryGroup(type, group, refs, repoUrl));
       renderedTypes.add(type);
     }
   }
   for (const [type, group] of grouped) {
     if (!renderedTypes.has(type) && group.length > 0) {
-      lines.push(...formatEntryGroup(type, group));
+      lines.push(...formatEntryGroup(type, group, refs, repoUrl));
     }
   }
   return lines;
 }
 
-function formatPackageChangelog(changelog: VersionPackageChangelog): string[] {
+function formatPackageChangelog(changelog: VersionPackageChangelog, refs: ChangelogRefsMode): string[] {
   const lines: string[] = [];
   const prevVersion = changelog.previousVersion ? toDisplayVersion(changelog.previousVersion) : 'N/A';
   const summary = `<b>${changelog.packageName}</b> ${prevVersion} → ${changelog.version}`;
 
   lines.push('<details>', `<summary>${summary}</summary>`, '');
-  lines.push(...renderEntries(changelog.entries));
+  lines.push(...renderEntries(changelog.entries, refs, changelog.repoUrl));
   lines.push('</details>', '');
   return lines;
 }
@@ -509,17 +521,21 @@ function formatPackageChangelog(changelog: VersionPackageChangelog): string[] {
 function formatEntryGroup(
   type: string,
   entries: { description: string; scope?: string; issueIds?: string[] }[],
+  refs: ChangelogRefsMode,
+  repoUrl: string | null,
 ): string[] {
   const label = TYPE_LABELS[type] ?? capitalize(type);
   const lines: string[] = [`#### ${label}`, ''];
 
   for (const entry of entries) {
-    let line = `- ${entry.description}`;
+    // Always neutralise `@`-mentions in the description; the scope is already backticked (safe).
+    let line = `- ${escapeChangelogMentions(entry.description)}`;
     if (entry.scope) {
       line += ` (\`${entry.scope}\`)`;
     }
-    if (entry.issueIds && entry.issueIds.length > 0) {
-      line += ` ${entry.issueIds.join(', ')}`;
+    const renderedRefs = renderIssueRefs(entry.issueIds ?? [], refs, repoUrl);
+    if (renderedRefs) {
+      line += ` ${renderedRefs}`;
     }
     lines.push(line);
   }

--- a/packages/release/src/preview/preview.ts
+++ b/packages/release/src/preview/preview.ts
@@ -1,7 +1,7 @@
 import * as fs from 'node:fs';
 import type { CIConfig } from '@releasekit/config';
 import { loadCIConfig, loadConfig } from '@releasekit/config';
-import { info, success, warn } from '@releasekit/core';
+import { type ChangelogRefsMode, info, success, warn } from '@releasekit/core';
 import type { Forge } from '@releasekit/forge';
 import { renderSupersedeWarning } from '../failure-report/failure-report.js';
 import { detectUnresolvedFailure } from '../failure-report/post.js';
@@ -146,9 +146,13 @@ export async function runPreview(options: PreviewOptions): Promise<void> {
 
   // Run version analysis unless release is skipped or in label mode with no bump label
   let result = null;
+  // How bare `#NNN` refs render in the preview changelog (#499/#504); resolved from config below.
+  let refs: ChangelogRefsMode = 'link';
   if (!labelContext.skip && !labelContext.noBumpLabel) {
     // Determine prerelease mode
     const releaseConfig = loadConfig({ cwd: effectiveOptions.projectDir, configPath: effectiveOptions.config });
+    const changelogConfig = releaseConfig.notes?.changelog;
+    refs = (changelogConfig ? changelogConfig.refs : undefined) ?? 'link';
     const prereleaseFlag = resolvePrerelease(
       effectiveOptions,
       releaseConfig.version?.packages ?? [],
@@ -201,6 +205,7 @@ export async function runPreview(options: PreviewOptions): Promise<void> {
     mergedRows,
     labelContext,
     supersedeWarning,
+    refs,
   });
 
   if (!context || !forge) {

--- a/packages/release/test/unit/preview-format.spec.ts
+++ b/packages/release/test/unit/preview-format.spec.ts
@@ -206,9 +206,33 @@ describe('formatPreviewComment', () => {
     expect(result).toContain('#### Added');
     expect(result).toContain('- New dry-run flag (`cli`)');
     expect(result).toContain('#### Fixed');
-    expect(result).toContain('- Fix prerelease sorting (`semver`) #42');
+    // #499: bare #NNN now renders as a canonical link by default (refs: 'link').
+    expect(result).toContain(
+      '- Fix prerelease sorting (`semver`) [#42](https://github.com/goosewobbler/releasekit/issues/42)',
+    );
     expect(result).toContain('#### Chores');
     expect(result).toContain('- Migrate to Vitest');
+  });
+
+  it('should render bare #NNN refs per the refs mode (#504)', () => {
+    expect(formatPreviewComment(releaseOutput, { refs: 'escape' })).toContain(
+      '- Fix prerelease sorting (`semver`) \\#42',
+    );
+    const stripped = formatPreviewComment(releaseOutput, { refs: 'strip' });
+    expect(stripped).toContain('- Fix prerelease sorting (`semver`)');
+    expect(stripped).not.toContain('#42');
+    expect(stripped).not.toContain('[#42]');
+  });
+
+  it('should always neutralise @-mentions in preview descriptions (#504)', () => {
+    const withMention = structuredClone(releaseOutput);
+    const firstChangelog = withMention.versionOutput.changelogs[0];
+    if (firstChangelog) {
+      firstChangelog.entries = [{ type: 'added', description: 'Support @wdio/native-cdp-bridge' }];
+    }
+    for (const refs of ['link', 'escape', 'strip'] as const) {
+      expect(formatPreviewComment(withMention, { refs })).toContain('- Support \\@wdio/native-cdp-bridge');
+    }
   });
 
   it('should wrap each package changelog in details element', () => {


### PR DESCRIPTION
Closes #504 (follow-up to #499/#503).

## What
The feeder-PR / release-preview comment (`packages/release/src/preview/format.ts`) was the **third** changelog surface still emitting:
- **bare `#NNN` refs** → GitHub hovercard clutter, and
- **un-escaped `@scope/pkg` descriptions** → stray `@org/team` mentions that can ping/subscribe a real org/team every time the preview comment is posted.

#499 fixed `CHANGELOG.md` + the release body + the standing-PR body, but the preview surface was out of its named scope.

## Fix
Reuse the shared `@releasekit/core` helpers from #499:
- `escapeChangelogMentions(description)` on every entry — always (the scope is already backticked, so it was safe).
- `renderIssueRefs(issueIds, refs, repoUrl)` for refs, honouring `notes.changelog.refs` (`strip`/`escape`/`link`, default `link`).

Threaded the `refs` mode (resolved from config in `runPreview`, mirroring `standing-pr.ts`) and a per-changelog `repoUrl` through `formatPreviewComment → renderEntries → formatEntryGroup`. Project-wide (shared) entries use the first non-null changelog `repoUrl`.

## Tests
`preview-format.spec.ts`: updated the default-render assertion to the canonical link; added refs-mode coverage (escape → `\#42`, strip → dropped) and always-on `@`-mention escaping across all three modes. Full gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Extends the `#499` fix (bare `#NNN` autolinks and stray `@`-mention pings) to the third remaining changelog surface — the feeder-PR / release-preview comment. The shared `@releasekit/core` helpers (`escapeChangelogMentions`, `renderIssueRefs`) are threaded from `runPreview` → `formatPreviewComment` → `renderEntries` → `formatEntryGroup`, mirroring the pattern already in `standing-pr.ts`.

- **`format.ts`**: `formatEntryGroup` now calls `escapeChangelogMentions` on every description (always-on) and `renderIssueRefs` with the resolved mode and per-changelog `repoUrl` instead of bare `issueIds.join`. The `sharedRepoUrl` for project-wide entries is derived from the first non-null package changelog URL, which correctly degrades to escape-mode when no GitHub remote is resolvable.
- **`preview.ts`**: `refs` is resolved from `releaseConfig.notes?.changelog.refs` inside the version-analysis branch and passed to `formatPreviewComment`; the `'link'` default is safe when `result` is null since no entries are rendered on that path.
- **`preview-format.spec.ts`**: Default assertion updated to expect the canonical link format; new tests cover all three `refs` modes and always-on mention escaping.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — all three changed files apply a focused, well-scoped fix with no regressions in existing tests.

The implementation correctly threads refs and repoUrl through the call chain, matching the established pattern from standing-pr.ts. The escapeChangelogMentions call is unconditional (as intended), renderIssueRefs handles all three modes and the null-repoUrl degradation case, and the default 'link' value is safe when result is null. New tests cover all three modes plus always-on mention escaping. No edge cases appear to be missed.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/release/src/preview/format.ts | Threads refs mode and repoUrl through formatEntryGroup → renderEntries → formatPackageChangelog; applies escapeChangelogMentions unconditionally and swaps the bare issueIds.join for renderIssueRefs. Logic is correct and mirrors the standing-pr surface. |
| packages/release/src/preview/preview.ts | Resolves refs from releaseConfig.notes?.changelog inside the version-analysis block (matching the standing-pr.ts pattern) and threads it through to formatPreviewComment. The refs default of 'link' is harmless when result is null since no entries are rendered in that path. |
| packages/release/test/unit/preview-format.spec.ts | Updates default-render assertion to canonical link format; adds explicit coverage for escape and strip modes and for always-on @-mention escaping across all three modes. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant runPreview
    participant config as releaseConfig
    participant fpc as formatPreviewComment
    participant re as renderEntries
    participant feg as formatEntryGroup
    participant core as @releasekit/core

    runPreview->>config: loadConfig()
    config-->>runPreview: notes.changelog.refs
    runPreview->>fpc: "formatPreviewComment(result, { refs, ... })"
    fpc->>fpc: "sharedRepoUrl = changelogs.find(cl => cl.repoUrl)?.repoUrl"
    fpc->>re: renderEntries(sharedEntries, refs, sharedRepoUrl)
    fpc->>re: renderEntries(changelog.entries, refs, changelog.repoUrl)
    re->>feg: formatEntryGroup(type, group, refs, repoUrl)
    feg->>core: escapeChangelogMentions(entry.description)
    core-->>feg: escaped description
    feg->>core: renderIssueRefs(entry.issueIds, refs, repoUrl)
    core-->>feg: "rendered refs (link / \#NNN / empty)"
    feg-->>re: formatted lines
    re-->>fpc: lines
    fpc-->>runPreview: commentBody
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant runPreview
    participant config as releaseConfig
    participant fpc as formatPreviewComment
    participant re as renderEntries
    participant feg as formatEntryGroup
    participant core as @releasekit/core

    runPreview->>config: loadConfig()
    config-->>runPreview: notes.changelog.refs
    runPreview->>fpc: "formatPreviewComment(result, { refs, ... })"
    fpc->>fpc: "sharedRepoUrl = changelogs.find(cl => cl.repoUrl)?.repoUrl"
    fpc->>re: renderEntries(sharedEntries, refs, sharedRepoUrl)
    fpc->>re: renderEntries(changelog.entries, refs, changelog.repoUrl)
    re->>feg: formatEntryGroup(type, group, refs, repoUrl)
    feg->>core: escapeChangelogMentions(entry.description)
    core-->>feg: escaped description
    feg->>core: renderIssueRefs(entry.issueIds, refs, repoUrl)
    core-->>feg: "rendered refs (link / \#NNN / empty)"
    feg-->>re: formatted lines
    re-->>fpc: lines
    fpc-->>runPreview: commentBody
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(release): neutralise changelog auto-..."](https://github.com/goosewobbler/releasekit/commit/35816fc7117074d4b1841e53019bf27ec3e87906) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40806293)</sub>

<!-- /greptile_comment -->