### PR TITLE
feat(notes): label PR vs closed issues in changelog refs; blockquote PR-comment changelogs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -256,7 +256,7 @@ Set to `false` to disable.
 |-----|------|---------|-------------|
 | `mode` | `"root"` \| `"packages"` \| `"both"` | — | Where to write changelog files. root: repo root only. packages: per-package (monorepos). both: repo root and per-package. When omitted entirely (no changelog config), defaults to root. |
 | `file` | string | — | Changelog file name override (default: CHANGELOG.md) |
-| `refs` | `"strip"` \| `"escape"` \| `"link"` | `"link"` | How bare `#NNN` issue/PR refs in the changelog are rendered. 'link' (default): a canonical Markdown link [#NNN](<repo>/issues/NNN) — clickable and keeps the hovercard, but no longer a bare token GitHub re-scans (falls back to 'escape' for non-GitHub repos). 'escape': plain text \\#NNN (no link, no hovercard). 'strip': refs are removed entirely. Scoped-package / @user mentions in entry text are always neutralised regardless of this setting. |
+| `refs` | `"strip"` \| `"escape"` \| `"link"` | `"link"` | How `#NNN` issue/PR refs in the changelog are rendered. 'link' (default): the PR and the issues it closed are labelled as `(PR #503 · closes #500)`, where the PR links to its canonical /pull/ URL with `PR #503` as the visible text — this keeps the GitHub hovercard but stops the bare-token rich inline card that duplicated the entry; closed issues link to /issues/. An entry with no identifiable PR (a non-squash commit, or a non-GitHub repo) falls back to a plain ref list. 'escape': plain text \\#NNN (no link, no hovercard, no PR/closes labelling). 'strip': refs are removed entirely. Scoped-package / @user mentions in entry text are always neutralised regardless of this setting. |
 
 **`notes.changelog.templates`** — Template configuration for changelog.
 

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -314,7 +314,7 @@ export const ChangelogConfigSchema = z
       .enum(['strip', 'escape', 'link'])
       .default('link')
       .describe(
-        "How bare `#NNN` issue/PR refs in the changelog are rendered. 'link' (default): a canonical Markdown link [#NNN](<repo>/issues/NNN) — clickable and keeps the hovercard, but no longer a bare token GitHub re-scans (falls back to 'escape' for non-GitHub repos). 'escape': plain text \\#NNN (no link, no hovercard). 'strip': refs are removed entirely. Scoped-package / @user mentions in entry text are always neutralised regardless of this setting.",
+        "How `#NNN` issue/PR refs in the changelog are rendered. 'link' (default): the PR and the issues it closed are labelled as `(PR #503 · closes #500)`, where the PR links to its canonical /pull/ URL with `PR #503` as the visible text — this keeps the GitHub hovercard but stops the bare-token rich inline card that duplicated the entry; closed issues link to /issues/. An entry with no identifiable PR (a non-squash commit, or a non-GitHub repo) falls back to a plain ref list. 'escape': plain text \\#NNN (no link, no hovercard, no PR/closes labelling). 'strip': refs are removed entirely. Scoped-package / @user mentions in entry text are always neutralised regardless of this setting.",
       ),
   })
   .describe('Changelog file configuration');

--- a/packages/core/src/changelogRefs.ts
+++ b/packages/core/src/changelogRefs.ts
@@ -61,7 +61,12 @@ export function renderIssueRefs(
 ): string {
   if (mode === 'strip') return '';
   const ids = issueIds ?? [];
-  if (ids.length === 0 && !prNumber) return '';
+  // prNumber is normally already in issueIds; fold it in defensively so no path can silently drop it.
+  const allIds =
+    prNumber && !ids.some((id) => Number(id.replace(/^#/, '')) === Number(prNumber.replace(/^#/, '')))
+      ? [prNumber, ...ids]
+      : ids;
+  if (allIds.length === 0) return '';
 
   const ownerRepo = mode === 'link' && repoUrl ? parseGitHubOwnerRepo(repoUrl) : null;
 
@@ -69,13 +74,13 @@ export function renderIssueRefs(
     const { owner, repo } = ownerRepo;
     const pr = prNumber.replace(/^#/, '');
     const prPart = `PR [#${pr}](https://github.com/${owner}/${repo}/pull/${pr})`;
-    const closes = ids.map((raw) => raw.replace(/^#/, '')).filter((num) => Number(num) !== Number(pr));
+    const closes = allIds.map((raw) => raw.replace(/^#/, '')).filter((num) => Number(num) !== Number(pr));
     if (closes.length === 0) return `(${prPart})`;
     const closesPart = closes.map((num) => `[#${num}](https://github.com/${owner}/${repo}/issues/${num})`).join(', ');
     return `(${prPart} · closes ${closesPart})`;
   }
 
-  const rendered = ids
+  const rendered = allIds
     .map((raw) => {
       const num = raw.replace(/^#/, '');
       // escape mode, or link mode with no resolvable GitHub repo → literal `#NNN`.

--- a/packages/core/src/changelogRefs.ts
+++ b/packages/core/src/changelogRefs.ts
@@ -33,33 +33,58 @@ export function parseGitHubOwnerRepo(repoUrl: string): { owner: string; repo: st
 }
 
 /**
- * Render the trailing issue/PR refs for a changelog entry per `mode`. Returns the comma-joined refs
- * WITHOUT any surrounding punctuation — callers wrap (the Markdown surface in `(…)`, the standing-PR
- * surface with a leading space). Returns `''` when there are no refs or `mode` is `'strip'`.
+ * Render the trailing issue/PR refs for a changelog entry per `mode`. Returns the COMPLETE group
+ * INCLUDING its own parentheses (e.g. `(PR #503 · closes #500)` or `(#503, #499)`); callers append it
+ * after a single space. Returns `''` when there are no refs or `mode` is `'strip'`.
  *
- * `link` emits a canonical Markdown link `[#NNN](<repo>/issues/NNN)` — clickable, keeps the
- * hovercard, but no longer a bare token GitHub re-scans. It always points at `/issues/NNN`: GitHub
- * redirects issues↔pulls, so the emitter needn't know which. A non-GitHub / unparseable `repoUrl`
- * has no canonical URL to build, so `link` degrades to `escape` for that entry. `escape` renders a
- * literal `\#NNN` (no link, no hovercard); `strip` drops the refs entirely.
+ * In `link` mode with a resolvable GitHub `repoUrl` AND a known `prNumber`, the group distinguishes
+ * the PR from the issues it closed: `(PR [#503](<repo>/pull/503) · closes [#500](<repo>/issues/500))`.
+ * The PR link's visible text is `PR #503`, deliberately NOT a bare `#503`: GitHub auto-expands a bare
+ * `#503` link into a rich inline reference card (merged-PR icon + the PR title) that duplicates the
+ * entry; the `PR #503` text keeps a plain link plus the hovercard. The href is the canonical
+ * `/pull/503` URL. `closes` is `issueIds` minus the PR (compared by numeric value); it is omitted when
+ * empty, leaving `(PR #503)`.
+ *
+ * Otherwise it falls back to the plain ref list: canonical `[#NNN](<repo>/issues/NNN)` links in `link`
+ * mode (issues↔pulls redirect, so the emitter needn't know which), or literal `\#NNN` in `escape` mode
+ * and in `link` mode when `repoUrl` is non-GitHub / unparseable. The PR is never guessed — without
+ * `prNumber` every ref renders the same. `strip` drops the refs entirely; `escape`/`strip` carry no
+ * PR/closes labelling (it's a `link`-mode nicety).
  *
  * Tokens may arrive as `#NNN` (the producer's format) or a bare `NNN`; the leading `#` is normalised.
  */
-export function renderIssueRefs(issueIds: string[], mode: ChangelogRefsMode, repoUrl: string | null): string {
-  if (mode === 'strip' || issueIds.length === 0) return '';
+export function renderIssueRefs(
+  issueIds: string[],
+  mode: ChangelogRefsMode,
+  repoUrl: string | null,
+  prNumber?: string,
+): string {
+  if (mode === 'strip') return '';
+  const ids = issueIds ?? [];
+  if (ids.length === 0 && !prNumber) return '';
 
   const ownerRepo = mode === 'link' && repoUrl ? parseGitHubOwnerRepo(repoUrl) : null;
 
-  return issueIds
+  if (ownerRepo && prNumber) {
+    const { owner, repo } = ownerRepo;
+    const pr = prNumber.replace(/^#/, '');
+    const prPart = `PR [#${pr}](https://github.com/${owner}/${repo}/pull/${pr})`;
+    const closes = ids.map((raw) => raw.replace(/^#/, '')).filter((num) => Number(num) !== Number(pr));
+    if (closes.length === 0) return `(${prPart})`;
+    const closesPart = closes.map((num) => `[#${num}](https://github.com/${owner}/${repo}/issues/${num})`).join(', ');
+    return `(${prPart} · closes ${closesPart})`;
+  }
+
+  const rendered = ids
     .map((raw) => {
       const num = raw.replace(/^#/, '');
-      if (ownerRepo) {
-        return `[#${num}](https://github.com/${ownerRepo.owner}/${ownerRepo.repo}/issues/${num})`;
-      }
       // escape mode, or link mode with no resolvable GitHub repo → literal `#NNN`.
-      return `\\#${num}`;
+      return ownerRepo
+        ? `[#${num}](https://github.com/${ownerRepo.owner}/${ownerRepo.repo}/issues/${num})`
+        : `\\#${num}`;
     })
     .join(', ');
+  return rendered ? `(${rendered})` : '';
 }
 
 // A GitHub mention is a word-boundary `@name` or `@org/team` (npm scoped package names share the

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -12,6 +12,15 @@ export interface VersionChangelogEntry {
   type: string;
   description: string;
   issueIds?: string[];
+  /**
+   * The pull request this entry shipped through, taken from the trailing `(#N)` GitHub appends to a
+   * squash-merge commit subject. It marks which of the {@link issueIds} is the PR (the rest are closed
+   * issues), so the changelog can render `(PR #N · closes #M)` instead of a flat ref list. The number
+   * is also kept inside `issueIds` (the full flat list), so a consumer that ignores this field still
+   * shows the ref. Optional and additive — absent means no identifiable PR (a non-squash commit or an
+   * old manifest), and renderers fall back to the plain ref list.
+   */
+  prNumber?: string;
   scope?: string;
   originalType?: string;
   breaking?: boolean;

--- a/packages/core/test/unit/changelogRefs.spec.ts
+++ b/packages/core/test/unit/changelogRefs.spec.ts
@@ -95,6 +95,12 @@ describe('renderIssueRefs', () => {
   it('should drop the refs in strip mode even when a prNumber is given', () => {
     expect(renderIssueRefs(['#503', '#500'], 'strip', repo, '#503')).toBe('');
   });
+
+  it('should still render a prNumber that is absent from issueIds (never silently dropped)', () => {
+    // Defensive: the invariant is prNumber ∈ issueIds, but if a caller omits it the PR must not vanish.
+    expect(renderIssueRefs([], 'escape', repo, '#503')).toBe('(\\#503)');
+    expect(renderIssueRefs(['#500'], 'escape', repo, '#503')).toBe('(\\#503, \\#500)');
+  });
 });
 
 describe('escapeChangelogMentions', () => {

--- a/packages/core/test/unit/changelogRefs.spec.ts
+++ b/packages/core/test/unit/changelogRefs.spec.ts
@@ -26,30 +26,30 @@ describe('parseGitHubOwnerRepo', () => {
 describe('renderIssueRefs', () => {
   const repo = 'https://github.com/octocat/hello';
 
-  it('should render a canonical /issues/ link in link mode', () => {
-    expect(renderIssueRefs(['#481'], 'link', repo)).toBe('[#481](https://github.com/octocat/hello/issues/481)');
+  it('should render a canonical /issues/ link wrapped in parens in link mode', () => {
+    expect(renderIssueRefs(['#481'], 'link', repo)).toBe('([#481](https://github.com/octocat/hello/issues/481))');
   });
 
   it('should join multiple refs with a comma in link mode', () => {
     expect(renderIssueRefs(['#1', '#2'], 'link', repo)).toBe(
-      '[#1](https://github.com/octocat/hello/issues/1), [#2](https://github.com/octocat/hello/issues/2)',
+      '([#1](https://github.com/octocat/hello/issues/1), [#2](https://github.com/octocat/hello/issues/2))',
     );
   });
 
   it('should normalise a bare numeric token without a leading #', () => {
-    expect(renderIssueRefs(['481'], 'link', repo)).toBe('[#481](https://github.com/octocat/hello/issues/481)');
+    expect(renderIssueRefs(['481'], 'link', repo)).toBe('([#481](https://github.com/octocat/hello/issues/481))');
   });
 
   it('should fall back to escape when the repo URL is null in link mode', () => {
-    expect(renderIssueRefs(['#481'], 'link', null)).toBe('\\#481');
+    expect(renderIssueRefs(['#481'], 'link', null)).toBe('(\\#481)');
   });
 
   it('should fall back to escape when the repo URL is non-GitHub in link mode', () => {
-    expect(renderIssueRefs(['#481'], 'link', 'https://gitlab.com/o/r')).toBe('\\#481');
+    expect(renderIssueRefs(['#481'], 'link', 'https://gitlab.com/o/r')).toBe('(\\#481)');
   });
 
   it('should render literal escaped refs in escape mode (no link even with a repo URL)', () => {
-    expect(renderIssueRefs(['#481', '#7'], 'escape', repo)).toBe('\\#481, \\#7');
+    expect(renderIssueRefs(['#481', '#7'], 'escape', repo)).toBe('(\\#481, \\#7)');
   });
 
   it('should return an empty string in strip mode', () => {
@@ -58,6 +58,42 @@ describe('renderIssueRefs', () => {
 
   it('should return an empty string when there are no refs', () => {
     expect(renderIssueRefs([], 'link', repo)).toBe('');
+  });
+
+  it('should label the PR and closed issues when a prNumber is given in link mode', () => {
+    expect(renderIssueRefs(['#503', '#500'], 'link', repo, '#503')).toBe(
+      '(PR [#503](https://github.com/octocat/hello/pull/503) · closes [#500](https://github.com/octocat/hello/issues/500))',
+    );
+  });
+
+  it('should render PR-only (no `· closes`) when there are no closed issues', () => {
+    expect(renderIssueRefs(['#503'], 'link', repo, '#503')).toBe(
+      '(PR [#503](https://github.com/octocat/hello/pull/503))',
+    );
+  });
+
+  it('should list every closed issue after the PR', () => {
+    expect(renderIssueRefs(['#503', '#500', '#499'], 'link', repo, '#503')).toBe(
+      '(PR [#503](https://github.com/octocat/hello/pull/503) · closes [#500](https://github.com/octocat/hello/issues/500), [#499](https://github.com/octocat/hello/issues/499))',
+    );
+  });
+
+  it('should compare PR vs closed issues by numeric value, with or without a leading #', () => {
+    expect(renderIssueRefs(['503', '500'], 'link', repo, '503')).toBe(
+      '(PR [#503](https://github.com/octocat/hello/pull/503) · closes [#500](https://github.com/octocat/hello/issues/500))',
+    );
+  });
+
+  it('should fall back to the plain ref list when a prNumber is given but the repo is non-GitHub', () => {
+    expect(renderIssueRefs(['#503', '#500'], 'link', null, '#503')).toBe('(\\#503, \\#500)');
+  });
+
+  it('should not label the PR in escape mode even when a prNumber is given', () => {
+    expect(renderIssueRefs(['#503', '#500'], 'escape', repo, '#503')).toBe('(\\#503, \\#500)');
+  });
+
+  it('should drop the refs in strip mode even when a prNumber is given', () => {
+    expect(renderIssueRefs(['#503', '#500'], 'strip', repo, '#503')).toBe('');
   });
 });
 

--- a/packages/notes/src/core/types.ts
+++ b/packages/notes/src/core/types.ts
@@ -16,6 +16,9 @@ export interface ChangelogEntry {
   type: ChangelogType;
   description: string;
   issueIds?: string[];
+  /** The PR this entry shipped through (trailing `(#N)` of a squash-merge subject); marks which of
+   *  {@link issueIds} is the PR vs. a closed issue. Optional — absent means no identifiable PR. */
+  prNumber?: string;
   scope?: string;
   originalType?: string;
   breaking?: boolean;

--- a/packages/notes/src/input/conventional-changelog.ts
+++ b/packages/notes/src/input/conventional-changelog.ts
@@ -83,6 +83,11 @@ function parseEntry(line: string, sectionType: ChangelogEntry['type']): Changelo
     rawText = scopeMatch[2] ?? rawText;
   }
 
+  // Squash-merge convention: a lone trailing `(#N)` is the PR GitHub appended. Mark it so the renderer
+  // can label it; the number still lands in issueIds (the full flat list) via extractIssueIds.
+  const prMatch = rawText.match(/\(#(\d+)\)\s*$/);
+  const prNumber = prMatch ? `#${prMatch[1]}` : undefined;
+
   const { description, issueIds } = extractIssueIds(rawText);
 
   return {
@@ -91,6 +96,7 @@ function parseEntry(line: string, sectionType: ChangelogEntry['type']): Changelo
     scope,
     breaking: breaking || undefined,
     issueIds: issueIds.length > 0 ? issueIds : undefined,
+    prNumber,
   };
 }
 

--- a/packages/notes/src/input/conventional-changelog.ts
+++ b/packages/notes/src/input/conventional-changelog.ts
@@ -83,11 +83,9 @@ function parseEntry(line: string, sectionType: ChangelogEntry['type']): Changelo
     rawText = scopeMatch[2] ?? rawText;
   }
 
-  // Squash-merge convention: a lone trailing `(#N)` is the PR GitHub appended. Mark it so the renderer
-  // can label it; the number still lands in issueIds (the full flat list) via extractIssueIds.
-  const prMatch = rawText.match(/\(#(\d+)\)\s*$/);
-  const prNumber = prMatch ? `#${prMatch[1]}` : undefined;
-
+  // No PR detection here: this adapter parses existing/external CHANGELOG.md text, where a trailing
+  // `(#N)` is ambiguous (it could be an issue ref) and there's no commit signal to confirm. Only the
+  // commit-based parsers (commitParser.ts, git-log.ts) infer prNumber, from a real squash-merge subject.
   const { description, issueIds } = extractIssueIds(rawText);
 
   return {
@@ -96,7 +94,6 @@ function parseEntry(line: string, sectionType: ChangelogEntry['type']): Changelo
     scope,
     breaking: breaking || undefined,
     issueIds: issueIds.length > 0 ? issueIds : undefined,
-    prNumber,
   };
 }
 

--- a/packages/notes/src/input/git-log.ts
+++ b/packages/notes/src/input/git-log.ts
@@ -69,12 +69,20 @@ function parseConventionalCommit(message: string): ChangelogEntry | null {
     issueMatch = issuePattern.exec(message);
   }
 
+  // GitHub appends `(#N)` to the squash-merge subject — that's the PR. Strip it from the description
+  // and mark it so the renderer labels it; the number is still in issueIds (extracted message-wide).
+  const subject = description ?? message;
+  const prMatch = subject.match(/\s*\(#(\d+)\)\s*$/);
+  const prNumber = prMatch ? `#${prMatch[1]}` : undefined;
+  const subjectText = prMatch ? subject.slice(0, prMatch.index).trimEnd() : subject;
+
   return {
     type: typeMap[type?.toLowerCase() ?? ''] ?? 'changed',
-    description: description ?? message,
+    description: subjectText,
     scope: scope?.slice(1, -1),
     breaking: breaking === '!' || message.includes('BREAKING CHANGE'),
     issueIds: issueIds.length > 0 ? issueIds : undefined,
+    prNumber,
     originalType: type,
   };
 }

--- a/packages/notes/src/input/version-output.ts
+++ b/packages/notes/src/input/version-output.ts
@@ -38,6 +38,7 @@ export function versionOutputToChangelogInput(data: VersionOutput): ChangelogInp
       type: normalizeEntryType(entry.type),
       description: entry.description,
       issueIds: entry.issueIds,
+      prNumber: entry.prNumber,
       scope: entry.scope,
       originalType: entry.originalType,
       breaking: entry.breaking ?? entry.originalType?.includes('!') ?? false,

--- a/packages/notes/src/output/markdown.ts
+++ b/packages/notes/src/output/markdown.ts
@@ -81,9 +81,10 @@ function formatEntry(entry: ChangelogEntry, opts?: EntryRefOptions): string {
     line = `- ${description}`;
   }
 
-  const refs = renderIssueRefs(entry.issueIds ?? [], opts?.refs ?? 'link', opts?.repoUrl ?? null);
+  // renderIssueRefs returns the complete group including its own parens — append it bare, no re-wrap.
+  const refs = renderIssueRefs(entry.issueIds ?? [], opts?.refs ?? 'link', opts?.repoUrl ?? null, entry.prNumber);
   if (refs) {
-    line += ` (${refs})`;
+    line += ` ${refs}`;
   }
 
   return line;

--- a/packages/notes/test/integration/pipeline.spec.ts
+++ b/packages/notes/test/integration/pipeline.spec.ts
@@ -257,11 +257,13 @@ describe('Parser: conventional-changelog', () => {
     expect(fixedEntry?.issueIds).toContain('#38');
   });
 
-  it('should mark a trailing (#N) bullet ref as the PR', () => {
+  it('should NOT label a trailing (#N) as the PR when parsing existing changelog text', () => {
     const result = parseConventionalChangelog(sampleChangelog, 'my-lib');
-    // `- **api**: Batch operations (#42)` — the lone trailing (#42) is the squash-merge PR.
+    // `- **api**: Batch operations (#42)` — in an existing/external changelog a trailing (#42) is
+    // ambiguous (could be an issue), and there's no commit signal, so prNumber is not inferred here.
+    // It still lands in issueIds as a generic ref. PR detection only happens in the commit parsers.
     const apiEntry = result.packages[0]?.entries.find((e) => e.scope === 'api');
-    expect(apiEntry?.prNumber).toBe('#42');
+    expect(apiEntry?.prNumber).toBeUndefined();
     expect(apiEntry?.issueIds).toContain('#42');
   });
 

--- a/packages/notes/test/integration/pipeline.spec.ts
+++ b/packages/notes/test/integration/pipeline.spec.ts
@@ -257,6 +257,14 @@ describe('Parser: conventional-changelog', () => {
     expect(fixedEntry?.issueIds).toContain('#38');
   });
 
+  it('should mark a trailing (#N) bullet ref as the PR', () => {
+    const result = parseConventionalChangelog(sampleChangelog, 'my-lib');
+    // `- **api**: Batch operations (#42)` — the lone trailing (#42) is the squash-merge PR.
+    const apiEntry = result.packages[0]?.entries.find((e) => e.scope === 'api');
+    expect(apiEntry?.prNumber).toBe('#42');
+    expect(apiEntry?.issueIds).toContain('#42');
+  });
+
   it('should round-trip: parse → render → contains version', () => {
     const result = parseConventionalChangelog(sampleChangelog, 'my-lib');
     const contexts = result.packages.map(createTemplateContext);

--- a/packages/notes/test/unit/input/git-log.spec.ts
+++ b/packages/notes/test/unit/input/git-log.spec.ts
@@ -32,6 +32,20 @@ describe('parseGitLogInput', () => {
     ]);
   });
 
+  it('should treat a trailing (#N) on the subject as the PR and strip it from the description', async () => {
+    const git = createFakeGit({
+      commits: { 'v1.0.0..HEAD': 'abc123|||feat(cli): add streaming (#503)|||Alice|||2026-06-01' },
+      remoteUrls: { origin: 'https://github.com/o/r.git' },
+      nearestTag: 'v1.2.0',
+    });
+
+    const input = await parseGitLogInput('v1.0.0', 'HEAD', git);
+    const entry = input.packages[0]?.entries[0];
+    expect(entry?.description).toBe('add streaming');
+    expect(entry?.prNumber).toBe('#503');
+    expect(entry?.issueIds).toEqual(['#503']);
+  });
+
   it('should default version to 0.0.0 and repoUrl to null when there is no tag or remote', async () => {
     const git = createFakeGit({ commits: { '*': '' } });
     const input = await parseGitLogInput(undefined, 'HEAD', git);

--- a/packages/notes/test/unit/input/version-output.spec.ts
+++ b/packages/notes/test/unit/input/version-output.spec.ts
@@ -97,6 +97,21 @@ describe('versionOutputToChangelogInput', () => {
     expect(entry?.breaking).toBe(true);
   });
 
+  it('should carry the prNumber marker through to the changelog input', () => {
+    const input: VersionOutput = {
+      ...baseVersionOutput,
+      changelogs: [
+        {
+          ...baseVersionOutput.changelogs[0],
+          entries: [{ type: 'feat', description: 'Feature', issueIds: ['#503', '#500'], prNumber: '#503' }],
+        },
+      ],
+    };
+
+    const result = versionOutputToChangelogInput(input);
+    expect(result.packages[0]?.entries[0]?.prNumber).toBe('#503');
+  });
+
   it('should detect breaking from originalType containing "!" when breaking is not set', () => {
     const input: VersionOutput = {
       ...baseVersionOutput,

--- a/packages/notes/test/unit/output/markdown.spec.ts
+++ b/packages/notes/test/unit/output/markdown.spec.ts
@@ -628,6 +628,18 @@ describe('formatVersion: issue refs', () => {
     const result = formatVersion(ctx, { refs: 'link' });
     expect(result).toContain('- New thing (\\#481)');
   });
+
+  it('should label the PR and closed issues in CHANGELOG.md when an entry carries a prNumber', async () => {
+    const { formatVersion } = await import('../../../src/output/markdown.js');
+    const ctx = makeContext({
+      repoUrl: 'https://github.com/octocat/hello',
+      entries: [{ type: 'added', description: 'New thing', issueIds: ['#503', '#500'], prNumber: '#503' }],
+    });
+    const result = formatVersion(ctx);
+    expect(result).toContain(
+      '- New thing (PR [#503](https://github.com/octocat/hello/pull/503) · closes [#500](https://github.com/octocat/hello/issues/500))',
+    );
+  });
 });
 
 describe('formatVersion: mention escaping', () => {

--- a/packages/release/src/preview/format.ts
+++ b/packages/release/src/preview/format.ts
@@ -338,13 +338,18 @@ export function formatPreviewComment(result: ReleaseOutput | null, options?: For
   const syncBumpedOnly = versionOutput.updates.filter((u) => !u.isRoot && !packagesWithChangelog.has(u.packageName));
 
   if (sharedEntries || hasPackageChangelogs || syncBumpedOnly.length > 0) {
+    // The changelog body sets itself apart with a Markdown blockquote (a left vertical bar), but the
+    // <details>/<summary>/</details> disclosure tags stay un-quoted — a `> `-prefixed raw-HTML block
+    // renders unreliably on GitHub. So each disclosure renders normally and only its inner content (and
+    // the plain-markdown "Also bumped" lists) carries the quote bar. The `### Changelog` heading and the
+    // `Project-wide changes` summary are likewise un-quoted.
     lines.push('### Changelog', '');
 
     // Project-wide entries (CI, infra, shared-package commits) rendered once
     if (sharedEntries) {
       lines.push('<details>', '<summary><b>Project-wide changes</b></summary>', '');
-      lines.push(...renderEntries(sharedEntries, refs, sharedRepoUrl));
-      lines.push('</details>', '');
+      lines.push(...blockquote(renderEntries(sharedEntries, refs, sharedRepoUrl)));
+      lines.push('', '</details>', '');
     }
 
     // Per-package entries — only rendered when the package has real (non-synthetic) changes
@@ -356,6 +361,7 @@ export function formatPreviewComment(result: ReleaseOutput | null, options?: For
 
     // List sync-bumped packages that have no individual commits so they aren't invisible
     if (syncBumpedOnly.length > 0) {
+      const bumped: string[] = [];
       if (isSync) {
         // Sync mode: every package moves to the same version — say that once in the heading
         // and list bare names (the root lockstep bump is already excluded from syncBumpedOnly).
@@ -365,16 +371,15 @@ export function formatPreviewComment(result: ReleaseOutput | null, options?: For
           // packages with their own changelog entries render above and drop out of this list.
           const coversAll = syncListed.length === publishableUpdates(versionOutput).length;
           const heading = coversAll ? 'All packages' : 'Also bumped';
-          lines.push(`**${heading} → ${syncListed[0]?.newVersion}** (sync versioning)`, '');
-          for (const u of syncListed) lines.push(`- \`${u.packageName}\``);
-          lines.push('');
+          bumped.push(`**${heading} → ${syncListed[0]?.newVersion}** (sync versioning)`, '');
+          for (const u of syncListed) bumped.push(`- \`${u.packageName}\``);
         }
       } else {
-        if (hasPackageChangelogs || sharedEntries) lines.push('**Also bumped** (sync versioning)', '');
-        else lines.push('**Bumped** (sync versioning — no individual changes)', '');
-        for (const u of syncBumpedOnly) lines.push(`- \`${u.packageName}\` → ${u.newVersion}`);
-        lines.push('');
+        if (hasPackageChangelogs || sharedEntries) bumped.push('**Also bumped** (sync versioning)', '');
+        else bumped.push('**Bumped** (sync versioning — no individual changes)', '');
+        for (const u of syncBumpedOnly) bumped.push(`- \`${u.packageName}\` → ${u.newVersion}`);
       }
+      if (bumped.length > 0) lines.push(...blockquote(bumped), '');
     }
   }
 
@@ -512,15 +517,17 @@ function formatPackageChangelog(changelog: VersionPackageChangelog, refs: Change
   const prevVersion = changelog.previousVersion ? toDisplayVersion(changelog.previousVersion) : 'N/A';
   const summary = `<b>${changelog.packageName}</b> ${prevVersion} → ${changelog.version}`;
 
+  // The disclosure tags stay un-quoted (a `> `-prefixed raw-HTML block renders unreliably on GitHub);
+  // only the entry content carries the blockquote bar, after the plain blank line below the summary.
   lines.push('<details>', `<summary>${summary}</summary>`, '');
-  lines.push(...renderEntries(changelog.entries, refs, changelog.repoUrl));
-  lines.push('</details>', '');
+  lines.push(...blockquote(renderEntries(changelog.entries, refs, changelog.repoUrl)));
+  lines.push('', '</details>', '');
   return lines;
 }
 
 function formatEntryGroup(
   type: string,
-  entries: { description: string; scope?: string; issueIds?: string[] }[],
+  entries: { description: string; scope?: string; issueIds?: string[]; prNumber?: string }[],
   refs: ChangelogRefsMode,
   repoUrl: string | null,
 ): string[] {
@@ -533,7 +540,8 @@ function formatEntryGroup(
     if (entry.scope) {
       line += ` (\`${entry.scope}\`)`;
     }
-    const renderedRefs = renderIssueRefs(entry.issueIds ?? [], refs, repoUrl);
+    // renderIssueRefs returns the complete group including its own parens — append it bare.
+    const renderedRefs = renderIssueRefs(entry.issueIds ?? [], refs, repoUrl, entry.prNumber);
     if (renderedRefs) {
       line += ` ${renderedRefs}`;
     }
@@ -546,4 +554,12 @@ function formatEntryGroup(
 
 function capitalize(str: string): string {
   return str.charAt(0).toUpperCase() + str.slice(1);
+}
+
+/** Prefix each line with `> ` (blank lines keep a bare `>`) so the block renders as one contiguous
+ *  Markdown blockquote. Trailing blanks are dropped so the quote ends cleanly before the next block. */
+function blockquote(lines: string[]): string[] {
+  const trimmed = [...lines];
+  while (trimmed.length > 0 && trimmed[trimmed.length - 1] === '') trimmed.pop();
+  return trimmed.map((l) => (l.length > 0 ? `> ${l}` : '>'));
 }

--- a/packages/release/src/standing-pr/changelog-region.ts
+++ b/packages/release/src/standing-pr/changelog-region.ts
@@ -116,7 +116,7 @@ function entryLine(d: DedupedEntry, attribution: boolean, refOpts: RefRenderOpti
   // a real org/team on the standing PR) — always neutralise it, regardless of the refs mode.
   const description = escapeChangelogMentions(entry.description);
   const scope = entry.scope ? ` (\`${entry.scope}\`)` : '';
-  const refs = renderIssueRefs(entry.issueIds ?? [], refOpts.refs, refOpts.repoUrl);
+  const refs = renderIssueRefs(entry.issueIds ?? [], refOpts.refs, refOpts.repoUrl, entry.prNumber);
   const issues = refs ? ` ${refs}` : '';
   const attr = attribution && pkgs.size > 0 ? ` _(${[...pkgs].map(shortName).sort().join(', ')})_` : '';
   return `- ${description}${scope}${issues}${attr}`;
@@ -158,11 +158,18 @@ function renderGrouped(deduped: DedupedEntry[], refOpts: RefRenderOptions): stri
   return lines;
 }
 
-/** Wrap inner Markdown in a collapsed `<details>`, indenting every non-blank line so the block nests
- *  cleanly under its list-item row (`indent` is '' for the top-level footer). */
+/** Wrap inner Markdown in a collapsed `<details>`, indenting every line so the block nests cleanly
+ *  under its list-item row (`indent` is '' for the top-level footer). Both call sites are PR-comment
+ *  surfaces, so the inner CONTENT is wrapped in a Markdown blockquote (`> `) — GitHub renders a left
+ *  vertical bar that visually sets the changelog apart from the surrounding PR-comment prose. The
+ *  `<details>`/`<summary>`/`</details>` tags themselves stay un-quoted: a `> `-prefixed raw-HTML block
+ *  renders unreliably on GitHub (it can fail to recognise the HTML block or break the disclosure). A
+ *  plain blank line separates the tags from the quoted content; inner blank lines keep a bare `>` so
+ *  the quote stays one contiguous block around the nested lists. */
 function wrapDetails(summary: string, inner: string[], indent: string): string {
-  const lines = [`<details><summary>${summary}</summary>`, '', ...inner, '', '</details>'];
-  return lines.map((l) => (l.length > 0 ? `${indent}${l}` : '')).join('\n');
+  const quotedInner = inner.map((l) => (l.length > 0 ? `${indent}> ${l}` : `${indent}>`));
+  const lines = [`${indent}<details><summary>${summary}</summary>`, '', ...quotedInner, '', `${indent}</details>`];
+  return lines.join('\n');
 }
 
 function pluralEntries(n: number): string {

--- a/packages/release/test/unit/changelog-region.spec.ts
+++ b/packages/release/test/unit/changelog-region.spec.ts
@@ -17,12 +17,14 @@ describe('changelog-region', () => {
         cl('@scope/lib', [{ type: 'fix', description: 'Lib fix' }]),
       ]);
       const block = render(['@scope/app', '@scope/lib'], false, '  ');
-      // One <details> covering both packages, grouped by Keep-a-Changelog type.
+      // One <details> covering both packages, grouped by Keep-a-Changelog type. The disclosure tags stay
+      // un-quoted (raw HTML); only the inner content is blockquoted (`> `), indented to nest under its row.
       expect(block).toContain('  <details><summary>Changelog (2 entries)</summary>');
-      expect(block).toContain('  **Added**');
-      expect(block).toContain('  - App feature');
-      expect(block).toContain('  **Fixed**');
-      expect(block).toContain('  - Lib fix');
+      expect(block).toContain('  > **Added**');
+      expect(block).toContain('  > - App feature');
+      expect(block).toContain('  > **Fixed**');
+      expect(block).toContain('  > - Lib fix');
+      expect(block).toContain('  </details>');
       // Multi-package unit → inline attribution per line.
       expect(block).toContain('_(app)_');
       expect(block).toContain('_(lib)_');
@@ -146,7 +148,7 @@ describe('changelog-region', () => {
         cl('@scope/app', [{ type: 'feat', description: 'App feature', issueIds: ['#481'] }], repo),
       ]);
       const block = render(['@scope/app'], false, '');
-      expect(block).toContain('- App feature [#481](https://github.com/octocat/hello/issues/481)');
+      expect(block).toContain('- App feature ([#481](https://github.com/octocat/hello/issues/481))');
     });
 
     it('should escape refs in escape mode', () => {
@@ -155,7 +157,7 @@ describe('changelog-region', () => {
         'escape',
       );
       const block = render(['@scope/app'], false, '');
-      expect(block).toContain('- App feature \\#481');
+      expect(block).toContain('- App feature (\\#481)');
       expect(block).not.toContain('issues/481');
     });
 
@@ -174,7 +176,7 @@ describe('changelog-region', () => {
         cl('@scope/app', [{ type: 'feat', description: 'App feature', issueIds: ['#481'] }], null),
       ]);
       const block = render(['@scope/app'], false, '');
-      expect(block).toContain('- App feature \\#481');
+      expect(block).toContain('- App feature (\\#481)');
     });
 
     it('should always neutralise a scoped-package mention in the description', () => {
@@ -191,7 +193,7 @@ describe('changelog-region', () => {
           changelogs: [cl('@scope/a', [{ type: 'fix', description: 'Fix @octocat case', issueIds: ['#7'] }], repo)],
         }),
       );
-      expect(footer).toContain('- Fix \\@octocat case [#7](https://github.com/octocat/hello/issues/7)');
+      expect(footer).toContain('- Fix \\@octocat case ([#7](https://github.com/octocat/hello/issues/7))');
     });
 
     it('should honour escape mode in the combined footer', () => {
@@ -199,7 +201,79 @@ describe('changelog-region', () => {
         output({ changelogs: [cl('@scope/a', [{ type: 'fix', description: 'Patch', issueIds: ['#7'] }], repo)] }),
         { refs: 'escape' },
       );
-      expect(footer).toContain('- Patch \\#7');
+      expect(footer).toContain('- Patch (\\#7)');
+    });
+
+    it('should label the PR and closed issues in the per-row pane when prNumber is set', () => {
+      const render = makeRowChangelogRenderer([
+        cl(
+          '@scope/app',
+          [{ type: 'feat', description: 'App feature', issueIds: ['#503', '#500'], prNumber: '#503' }],
+          repo,
+        ),
+      ]);
+      const block = render(['@scope/app'], false, '');
+      expect(block).toContain(
+        '- App feature (PR [#503](https://github.com/octocat/hello/pull/503) · closes [#500](https://github.com/octocat/hello/issues/500))',
+      );
+    });
+
+    it('should render a PR-only ref (no closes) in the combined footer when there are no closed issues', () => {
+      const footer = renderCombinedFooter(
+        output({
+          changelogs: [
+            cl('@scope/a', [{ type: 'fix', description: 'Patch', issueIds: ['#503'], prNumber: '#503' }], repo),
+          ],
+        }),
+      );
+      expect(footer).toContain('- Patch (PR [#503](https://github.com/octocat/hello/pull/503))');
+    });
+
+    it('should fall back to a plain ref list for an old entry with no prNumber', () => {
+      const footer = renderCombinedFooter(
+        output({ changelogs: [cl('@scope/a', [{ type: 'fix', description: 'Patch', issueIds: ['#500'] }], repo)] }),
+      );
+      expect(footer).toContain('- Patch ([#500](https://github.com/octocat/hello/issues/500))');
+      expect(footer).not.toContain('PR [#500]');
+    });
+  });
+
+  describe('blockquote wrapping (PR-comment surface)', () => {
+    const repo = 'https://github.com/octocat/hello';
+
+    function output(over: Partial<VersionOutput>): VersionOutput {
+      return { dryRun: false, updates: [], changelogs: [], tags: [], ...over };
+    }
+
+    it('should blockquote the footer content but leave the disclosure tags un-quoted', () => {
+      const footer = renderCombinedFooter(
+        output({ changelogs: [cl('@scope/a', [{ type: 'feat', description: 'A feature' }], repo)] }),
+      );
+      // The <details>/<summary>/</details> raw-HTML tags render un-quoted; only the inner content
+      // carries the `> ` bar (blank lines keep a bare `>`), with a plain blank line separating them.
+      expect(footer).toContain('<details><summary>Show all changes (1 change, de-duplicated)</summary>');
+      expect(footer).not.toContain('> <details>');
+      expect(footer).not.toContain('> </details>');
+      expect(footer).toContain('> **Added**');
+      expect(footer).toContain('> - A feature');
+      const fl = footer.split('\n');
+      expect(fl[0]).toBe('<details><summary>Show all changes (1 change, de-duplicated)</summary>');
+      expect(fl[1]).toBe('');
+      expect(fl[fl.length - 1]).toBe('</details>');
+      expect(fl[fl.length - 2]).toBe('');
+    });
+
+    it('should blockquote the per-row pane content, nested under its row indent', () => {
+      const render = makeRowChangelogRenderer([
+        cl('@scope/app', [{ type: 'feat', description: 'Solo feature' }], repo),
+      ]);
+      const block = render(['@scope/app'], false, '  ');
+      const bl = block.split('\n');
+      // Disclosure tags carry only the indent; the inner content is `  > `-prefixed.
+      expect(bl[0]).toBe('  <details><summary>Changelog (1 entry)</summary>');
+      expect(bl[bl.length - 1]).toBe('  </details>');
+      expect(block).toContain('  > **Added**');
+      expect(block).toContain('  > - Solo feature');
     });
   });
 

--- a/packages/release/test/unit/preview-format.spec.ts
+++ b/packages/release/test/unit/preview-format.spec.ts
@@ -206,9 +206,10 @@ describe('formatPreviewComment', () => {
     expect(result).toContain('#### Added');
     expect(result).toContain('- New dry-run flag (`cli`)');
     expect(result).toContain('#### Fixed');
-    // #499: bare #NNN now renders as a canonical link by default (refs: 'link').
+    // #499: bare #NNN renders as a canonical link by default (refs: 'link'); the ref group carries
+    // its own parens (an entry with no identified PR falls back to the plain list).
     expect(result).toContain(
-      '- Fix prerelease sorting (`semver`) [#42](https://github.com/goosewobbler/releasekit/issues/42)',
+      '- Fix prerelease sorting (`semver`) ([#42](https://github.com/goosewobbler/releasekit/issues/42))',
     );
     expect(result).toContain('#### Chores');
     expect(result).toContain('- Migrate to Vitest');
@@ -216,12 +217,45 @@ describe('formatPreviewComment', () => {
 
   it('should render bare #NNN refs per the refs mode (#504)', () => {
     expect(formatPreviewComment(releaseOutput, { refs: 'escape' })).toContain(
-      '- Fix prerelease sorting (`semver`) \\#42',
+      '- Fix prerelease sorting (`semver`) (\\#42)',
     );
     const stripped = formatPreviewComment(releaseOutput, { refs: 'strip' });
     expect(stripped).toContain('- Fix prerelease sorting (`semver`)');
     expect(stripped).not.toContain('#42');
     expect(stripped).not.toContain('[#42]');
+  });
+
+  it('should label the PR and closed issues when an entry carries a prNumber', () => {
+    const withPr = structuredClone(releaseOutput);
+    const firstChangelog = withPr.versionOutput.changelogs[0];
+    if (firstChangelog) {
+      firstChangelog.entries = [
+        {
+          type: 'fixed',
+          description: 'Fix prerelease sorting',
+          scope: 'semver',
+          issueIds: ['#503', '#500'],
+          prNumber: '#503',
+        },
+      ];
+    }
+    const result = formatPreviewComment(withPr);
+    expect(result).toContain(
+      '- Fix prerelease sorting (`semver`) (PR [#503](https://github.com/goosewobbler/releasekit/pull/503) · closes [#500](https://github.com/goosewobbler/releasekit/issues/500))',
+    );
+  });
+
+  it('should blockquote the changelog entry content but leave the disclosure tags un-quoted', () => {
+    const result = formatPreviewComment(releaseOutput);
+    // The `### Changelog` heading and the <details>/<summary> tags stay un-quoted (raw HTML renders
+    // unreliably under `> `); only the entry content inside carries the blockquote bar.
+    expect(result).toContain('### Changelog');
+    expect(result).toContain('<details>');
+    expect(result).not.toContain('> <details>');
+    expect(result).not.toContain('> </details>');
+    expect(result).toContain('<summary><b>@releasekit/version</b> 0.3.0 → 0.3.1</summary>');
+    expect(result).toContain('> #### Added');
+    expect(result).toContain('> - New dry-run flag (`cli`)');
   });
 
   it('should always neutralise @-mentions in preview descriptions (#504)', () => {

--- a/packages/version/src/changelog/commitParser.ts
+++ b/packages/version/src/changelog/commitParser.ts
@@ -284,11 +284,22 @@ function parseCommitMessage(message: string): ChangelogEntry | null {
       return null;
     }
 
-    // Extract issue IDs from footer (assuming format like "Fixes #123")
-    const issueIds = extractIssueIds(body);
+    // GitHub appends `(#N)` to the squash-merge subject — that's the PR. Pull it off the subject so it
+    // renders as a labelled PR ref instead of a bare inline autolink GitHub expands into a rich card,
+    // and record the number so the changelog can tell PR from closed issue.
+    const subjectRaw = subject ?? '';
+    const prMatch = subjectRaw.match(/\s*\(#(\d+)\)\s*$/);
+    const prNumber = prMatch ? `#${prMatch[1]}` : undefined;
+    const subjectText = prMatch ? subjectRaw.slice(0, prMatch.index).trimEnd() : subjectRaw;
+
+    // Extract issue IDs from footer (assuming format like "Fixes #123"). issueIds is the full flat
+    // list: the PR (when present) plus the closed issues, so a consumer that ignores prNumber still
+    // shows every ref.
+    const bodyIssueIds = extractIssueIds(body);
+    const issueIds = prNumber ? [prNumber, ...bodyIssueIds] : bodyIssueIds;
 
     // Format description, adding BREAKING prefix if needed
-    let description = subject;
+    let description = subjectText;
     if (hasBreakingChange) {
       description = `**BREAKING** ${description}`;
     }
@@ -298,6 +309,7 @@ function parseCommitMessage(message: string): ChangelogEntry | null {
       description,
       scope: scope || undefined,
       issueIds: issueIds.length > 0 ? issueIds : undefined,
+      prNumber,
       originalType: type, // Store original type for custom formatting
     };
   }

--- a/packages/version/test/unit/changelog/commitParser.spec.ts
+++ b/packages/version/test/unit/changelog/commitParser.spec.ts
@@ -86,6 +86,42 @@ describe('Commit Parser', () => {
     expect(featureEntry?.issueIds).toContain('#789');
   });
 
+  it('should treat a trailing (#N) on the subject as the PR and strip it from the description', async () => {
+    const mockGitOutput = ['feat(release): hierarchical selection (#471)'].join('---COMMIT_DELIMITER---');
+
+    const entries = await extractChangelogEntriesFromCommits('/test', RANGE, gitWithLog(mockGitOutput));
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0].description).toBe('hierarchical selection');
+    expect(entries[0].prNumber).toBe('#471');
+    // The PR number is also kept in the full flat issueIds list.
+    expect(entries[0].issueIds).toEqual(['#471']);
+  });
+
+  it('should separate the squash-merge PR from the issues its body closes', async () => {
+    const mockGitOutput = ['fix(api): patch serializer (#503)\n\nCloses #500\nFixes #499'].join(
+      '---COMMIT_DELIMITER---',
+    );
+
+    const entries = await extractChangelogEntriesFromCommits('/test', RANGE, gitWithLog(mockGitOutput));
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0].description).toBe('patch serializer');
+    expect(entries[0].prNumber).toBe('#503');
+    // PR first, then the closed issues in body order — the full flat list.
+    expect(entries[0].issueIds).toEqual(['#503', '#500', '#499']);
+  });
+
+  it('should leave prNumber undefined when the subject has no trailing (#N)', async () => {
+    const mockGitOutput = ['fix(api): fix bug\n\nFixes #123'].join('---COMMIT_DELIMITER---');
+
+    const entries = await extractChangelogEntriesFromCommits('/test', RANGE, gitWithLog(mockGitOutput));
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0].prNumber).toBeUndefined();
+    expect(entries[0].issueIds).toEqual(['#123']);
+  });
+
   it('should handle non-conventional commits', async () => {
     const mockGitOutput = ['Add new feature', 'Fix bug in login', 'Merge pull request #123', 'v1.0.0'].join(
       '---COMMIT_DELIMITER---',

--- a/releasekit.schema.json
+++ b/releasekit.schema.json
@@ -622,7 +622,7 @@
                     "link"
                   ],
                   "default": "link",
-                  "description": "How bare `#NNN` issue/PR refs in the changelog are rendered. 'link' (default): a canonical Markdown link [#NNN](<repo>/issues/NNN) — clickable and keeps the hovercard, but no longer a bare token GitHub re-scans (falls back to 'escape' for non-GitHub repos). 'escape': plain text \\#NNN (no link, no hovercard). 'strip': refs are removed entirely. Scoped-package / @user mentions in entry text are always neutralised regardless of this setting."
+                  "description": "How `#NNN` issue/PR refs in the changelog are rendered. 'link' (default): the PR and the issues it closed are labelled as `(PR #503 · closes #500)`, where the PR links to its canonical /pull/ URL with `PR #503` as the visible text — this keeps the GitHub hovercard but stops the bare-token rich inline card that duplicated the entry; closed issues link to /issues/. An entry with no identifiable PR (a non-squash commit, or a non-GitHub repo) falls back to a plain ref list. 'escape': plain text \\#NNN (no link, no hovercard, no PR/closes labelling). 'strip': refs are removed entirely. Scoped-package / @user mentions in entry text are always neutralised regardless of this setting."
                 }
               },
               "description": "Changelog file configuration"


### PR DESCRIPTION
Two changelog-rendering improvements (from design discussion on the standing-PR look).

## 1. Label PR vs closed issues; drop the inline rich card, keep the hovercard

`link`-mode refs now render **`(PR #503 · closes #500)`**:
- The PR link's visible text is `PR #503` (not a bare `#503`) on the canonical `/pull/503` URL. The non-bare text stops GitHub auto-expanding it into the inline rich-reference card (which duplicated the entry description); the canonical href keeps the hovercard.
- Closed issues render `closes [#500](…/issues/500), …` (omitted when none → `(PR #503)`).
- The PR is derived from the trailing `(#N)` of the squash-merge subject and stored as a new optional, additive `VersionChangelogEntry.prNumber` (it also stays in `issueIds`, so old manifests / unaware consumers render every ref via the fallback). **The PR is never guessed** — entries with no identifiable PR (non-squash, old manifest, non-GitHub repo) keep the prior `(#503, #499)` rendering. `escape`/`strip` modes and `@`-mention escaping are unchanged.

```
- Add thing (PR #503 · closes #500)
```

Wired through every producer (version commit parser → standing-PR + preview; notes git-log / conventional-changelog / version-output adapters → CHANGELOG.md) and all three render surfaces via the shared `renderIssueRefs` (which now returns the complete parens group; `markdown.ts` no longer double-wraps).

## 2. Blockquote the PR-comment changelogs

The standing-PR (per-row + combined footer) and preview-comment changelogs wrap their **content** in a Markdown blockquote for a left vertical bar that sets the changelog apart. The `<details>`/`<summary>` wrapper stays un-quoted so GitHub renders the disclosure reliably (a `> <details>` raw-HTML block renders unreliably); only the body is quoted. `CHANGELOG.md` (archival file) is left un-quoted.

```
<details><summary>Show all changes (2 changes, de-duplicated)</summary>

> **Added**
>
> - Add thing (PR #503 · closes #500)

</details>
```

## Verify on the live standing PR
Two things only GitHub's visual render can confirm (both degrade gracefully): that `PR [#503](…/pull/503)` keeps the hovercard while dropping the inline card, and that the blockquoted body nests cleanly inside the `<details>` (incl. the indented per-row pane). Since the standing PR dogfoods from `main`, the next update shows the real render.

## Tests
Parser PR-vs-issue extraction; `renderIssueRefs` (PR+closes / PR-only / fallback / escape / strip); blockquote wrapping on the standing-PR + preview surfaces. Full gate green (32/32); `schema:check` + root `biome check .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds two changelog-rendering improvements: (1) `renderIssueRefs` now returns the complete `(…)` group including parentheses and distinguishes the PR from closed issues with a `(PR #N · closes #M)` label when a `prNumber` is known; and (2) the body content inside `<details>` blocks on PR-comment surfaces (standing-PR and preview) is wrapped in a Markdown blockquote to visually set the changelog apart, while the `<details>`/`<summary>` HTML tags remain un-quoted to avoid GitHub rendering instability.

- **`prNumber` field** is added to `VersionChangelogEntry` and `ChangelogEntry` types, populated by the commit parsers (`commitParser.ts`, `git-log.ts`) when a squash-merge trailing `(#N)` is detected; `conventional-changelog.ts` deliberately omits it since its input is ambiguous.
- **`renderIssueRefs` API** now returns a self-contained parens group; all three call sites (`markdown.ts`, `changelog-region.ts`, `format.ts`) are updated to append the result bare rather than double-wrapping.
- **Blockquote helpers** (`blockquote()` in `format.ts`, inline in `wrapDetails()` in `changelog-region.ts`) prefix each non-blank inner line with `> ` and blank lines with `>` to keep one contiguous blockquote block.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the changes are additive, backward-compatible, and thoroughly tested across all three render surfaces.

The `prNumber` field is optional and purely additive; old manifests and unaware consumers fall back to the existing flat-ref-list path. The `renderIssueRefs` API change (now returning the full parens group) is correctly propagated to every call site. Both blockquote helpers are straightforward string-prefix operations with no mutable state or async concerns. The 32-test gate is green and covers the key edge cases: PR-only, PR+closes, no-PR fallback, escape/strip modes, non-GitHub repos, and the defensive fold when `prNumber` is absent from `issueIds`.

No files require special attention. The parallel implementations of blockquote logic in `format.ts` and `changelog-region.ts` are minor duplication across package boundaries but present no functional risk.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/core/src/changelogRefs.ts | Core API change: `renderIssueRefs` now returns a self-contained `(…)` group and accepts an optional `prNumber` to produce `(PR #N · closes #M)` output; defensive `allIds` fold ensures a `prNumber` absent from `issueIds` is never silently dropped. |
| packages/core/src/types.ts | Additive `prNumber?: string` field on `VersionChangelogEntry`; well-documented as optional/backward-compatible. |
| packages/version/src/changelog/commitParser.ts | Extracts trailing `(#N)` from the squash-merge subject as `prNumber`, prepends it to `bodyIssueIds` in `issueIds`, and strips it from the description; clean and well-tested. |
| packages/notes/src/input/git-log.ts | Mirrors `commitParser.ts` PR-extraction logic: issue IDs are already present (extracted message-wide), so only the subject strip and `prNumber` field assignment are added. |
| packages/notes/src/input/conventional-changelog.ts | Deliberately skips `prNumber` inference; a clear comment documents why — trailing `(#N)` in existing CHANGELOG text is ambiguous without a commit signal. |
| packages/release/src/preview/format.ts | Introduces `blockquote()` helper and applies it to the changelog body in `formatPackageChangelog` and the sync-bumped list; `<details>`/`<summary>` tags stay unquoted; caller sites updated to drop manual paren-wrapping of `renderIssueRefs`. |
| packages/release/src/standing-pr/changelog-region.ts | `wrapDetails` updated to inline the blockquote logic (`${indent}> ` / `${indent}>`) and receive `prNumber` through `entryLine`; disclosure tags stay indent-prefixed but unquoted. |
| packages/notes/src/output/markdown.ts | Correctly removes the manual `(${refs})` wrap now that `renderIssueRefs` returns the full parens group; passes `entry.prNumber` through. |
| packages/notes/src/input/version-output.ts | One-line additive change: forwards `prNumber` from the version-output entry through to the changelog input. |
| packages/core/test/unit/changelogRefs.spec.ts | Tests updated to expect the new self-contained parens group; new cases cover PR+closes, PR-only, fallback, escape, strip, and the defensive prNumber-absent-from-issueIds invariant. |
| packages/release/test/unit/changelog-region.spec.ts | Comprehensive new coverage for blockquote wrapping (footer and per-row pane) and PR-labeled refs in both single-package and multi-package scenarios. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Commit message] --> B{Squash-merge trailing N in subject?}
    B -- Yes --> C[Extract prNumber\nStrip N from subject text]
    B -- No --> D[prNumber = undefined]
    C --> E[issueIds = prNumber + body Closes refs]
    D --> F[issueIds = body refs only]
    E --> G[VersionChangelogEntry with prNumber and issueIds]
    F --> G

    G --> H[renderIssueRefs called with issueIds, mode, repoUrl, prNumber]
    H --> I{mode = strip?}
    I -- Yes --> J[Returns empty string]
    I -- No --> K{GitHub repoUrl AND prNumber set?}
    K -- Yes --> L[Returns PR-labeled group e.g. PR #503 closes #500]
    K -- No --> M{GitHub repoUrl resolvable?}
    M -- Yes --> N[Returns plain link group]
    M -- No or escape mode --> O[Returns escaped group]

    L --> P[Caller appends result bare after space]
    N --> P
    O --> P

    P --> Q{Output surface?}
    Q -- CHANGELOG.md --> R[Plain output no blockquote]
    Q -- PR comment surface --> S[Content wrapped in blockquote inside unquoted HTML details block]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Commit message] --> B{Squash-merge trailing N in subject?}
    B -- Yes --> C[Extract prNumber\nStrip N from subject text]
    B -- No --> D[prNumber = undefined]
    C --> E[issueIds = prNumber + body Closes refs]
    D --> F[issueIds = body refs only]
    E --> G[VersionChangelogEntry with prNumber and issueIds]
    F --> G

    G --> H[renderIssueRefs called with issueIds, mode, repoUrl, prNumber]
    H --> I{mode = strip?}
    I -- Yes --> J[Returns empty string]
    I -- No --> K{GitHub repoUrl AND prNumber set?}
    K -- Yes --> L[Returns PR-labeled group e.g. PR #503 closes #500]
    K -- No --> M{GitHub repoUrl resolvable?}
    M -- Yes --> N[Returns plain link group]
    M -- No or escape mode --> O[Returns escaped group]

    L --> P[Caller appends result bare after space]
    N --> P
    O --> P

    P --> Q{Output surface?}
    Q -- CHANGELOG.md --> R[Plain output no blockquote]
    Q -- PR comment surface --> S[Content wrapped in blockquote inside unquoted HTML details block]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(notes): don&#39;t infer PR from ambiguou..."](https://github.com/goosewobbler/releasekit/commit/ad9557b12ff664ee33e717fc809eeb15f0143243) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40855047)</sub>

<!-- /greptile_comment -->