### PR TITLE
fix(release): use #### headings for standing-PR changelog sections (blockquote spacing)

### DIFF
--- a/packages/release/src/standing-pr/changelog-region.ts
+++ b/packages/release/src/standing-pr/changelog-region.ts
@@ -144,7 +144,10 @@ function renderGrouped(deduped: DedupedEntry[], refOpts: RefRenderOptions): stri
   const emit = (label: string): void => {
     const list = byLabel.get(label);
     if (!list?.length) return;
-    lines.push(`**${label}**`, '');
+    // `#### `, not bold `**…**`: inside the blockquote (#506) GitHub gives a heading paragraph-level
+    // top margin, so consecutive sections stay visually separated — bold text collapses to near-zero
+    // spacing there (#508). Matches the preview surface, which already uses `#### ` headings.
+    lines.push(`#### ${label}`, '');
     for (const d of list) lines.push(entryLine(d, attribution, refOpts));
     lines.push('');
   };

--- a/packages/release/test/unit/changelog-region.spec.ts
+++ b/packages/release/test/unit/changelog-region.spec.ts
@@ -20,9 +20,9 @@ describe('changelog-region', () => {
       // One <details> covering both packages, grouped by Keep-a-Changelog type. The disclosure tags stay
       // un-quoted (raw HTML); only the inner content is blockquoted (`> `), indented to nest under its row.
       expect(block).toContain('  <details><summary>Changelog (2 entries)</summary>');
-      expect(block).toContain('  > **Added**');
+      expect(block).toContain('  > #### Added');
       expect(block).toContain('  > - App feature');
-      expect(block).toContain('  > **Fixed**');
+      expect(block).toContain('  > #### Fixed');
       expect(block).toContain('  > - Lib fix');
       expect(block).toContain('  </details>');
       // Multi-package unit → inline attribution per line.
@@ -102,9 +102,9 @@ describe('changelog-region', () => {
           sharedEntries: [{ type: 'fix', description: 'CI tweak' }],
         }),
       );
-      expect(footer).toContain('**Added**');
+      expect(footer).toContain('#### Added');
       expect(footer).toContain('- Package feature');
-      expect(footer).toContain('**Fixed**');
+      expect(footer).toContain('#### Fixed');
       expect(footer).toContain('- CI tweak');
       expect(footer).toContain('Show all changes (2 changes, de-duplicated)');
     });
@@ -254,7 +254,7 @@ describe('changelog-region', () => {
       expect(footer).toContain('<details><summary>Show all changes (1 change, de-duplicated)</summary>');
       expect(footer).not.toContain('> <details>');
       expect(footer).not.toContain('> </details>');
-      expect(footer).toContain('> **Added**');
+      expect(footer).toContain('> #### Added');
       expect(footer).toContain('> - A feature');
       const fl = footer.split('\n');
       expect(fl[0]).toBe('<details><summary>Show all changes (1 change, de-duplicated)</summary>');
@@ -272,7 +272,7 @@ describe('changelog-region', () => {
       // Disclosure tags carry only the indent; the inner content is `  > `-prefixed.
       expect(bl[0]).toBe('  <details><summary>Changelog (1 entry)</summary>');
       expect(bl[bl.length - 1]).toBe('  </details>');
-      expect(block).toContain('  > **Added**');
+      expect(block).toContain('  > #### Added');
       expect(block).toContain('  > - Solo feature');
     });
   });

--- a/packages/release/test/unit/standing-pr.spec.ts
+++ b/packages/release/test/unit/standing-pr.spec.ts
@@ -1086,9 +1086,9 @@ describe('runStandingPRUpdate', () => {
     const perRowIdx = body.indexOf('<details><summary>Changelog (2 entries)</summary>');
     expect(rowIdx).toBeGreaterThanOrEqual(0);
     expect(perRowIdx).toBeGreaterThan(rowIdx);
-    expect(body).toContain('**Added**');
+    expect(body).toContain('#### Added');
     expect(body).toContain('Add new widget');
-    expect(body).toContain('**Fixed**');
+    expect(body).toContain('#### Fixed');
     expect(body).toContain('Fix broken export');
     // Combined footer: a single flat, de-duplicated block (default-on), below the selection region.
     expect(body).toContain('<details><summary>Show all changes (2 changes, de-duplicated)</summary>');


### PR DESCRIPTION
Closes #508 (follow-up to #506).

## Problem
#506 wrapped the standing-PR / combined-footer changelog content in a Markdown blockquote for visual distinction. But inside a blockquote GitHub collapses **bold-text** section labels to near-zero vertical spacing, so the `**Added**` / `**Fixed**` / `**Changed**` sections read as one cramped block:

```
> **Added**
>
> - migrate to shared …
>
> **Fixed**
>
> - clear errors …
```

## Fix
Switch the section labels from bold `**Label**` to `#### Label` headings. GitHub gives a heading a paragraph-level top margin that it *still applies inside a blockquote*, so consecutive sections separate again.

This also makes the standing-PR consistent with the **preview** surface, which already renders `#### ` headings inside its own blockquote (`format.ts`) and was never reported as cramped — direct evidence that a heading (not bold text) is the treatment GitHub spaces correctly in a blockquote.

One-line change in `renderGrouped` (covers both the combined footer and the per-row panes); tests updated to assert `#### Added` / `#### Fixed`.

## Verification
Full gate green (32/32). The live render will be visible on the dogfooded standing PR (`release/next`) after the next update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a blockquote spacing issue in the standing-PR changelog by switching section labels from bold (`**Added**`) to `#### ` headings. GitHub applies paragraph-level top margin to headings inside blockquotes but collapses bold text to near-zero spacing, causing sections to run together visually.

- **`changelog-region.ts`**: One-line change in `renderGrouped` — `**${label}**` → `#### ${label}` — with an inline comment explaining the GitHub rendering difference and the parallel to the existing preview surface.
- **Tests** (`changelog-region.spec.ts`, `standing-pr.spec.ts`): All affected assertions updated from `**Added**`/`**Fixed**` to `#### Added`/`#### Fixed` to match the new output.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is isolated to one formatting string and all tests pass with the updated assertions.

The source change is a single string interpolation swap with no behavioural side effects beyond rendered Markdown output. All 32 tests are green, existing coverage for both the per-row block and the combined footer is updated, and the heading syntax used here already matches the preview surface, so there is no new rendering risk.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/release/src/standing-pr/changelog-region.ts | Single-line fix in renderGrouped: swaps bold label syntax for h4 heading syntax with a clear explanatory comment; no logic changes. |
| packages/release/test/unit/changelog-region.spec.ts | Four assertion strings updated from **Added**/**Fixed** to #### Added/#### Fixed to match the new heading output; coverage is complete. |
| packages/release/test/unit/standing-pr.spec.ts | Two assertions updated to #### headings to keep the integration-level test suite in sync with the source change. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[renderGrouped called] --> B[Group DedupedEntries by label]
    B --> C[emit label in LABEL_ORDER]
    C --> D{"list?.length > 0?"}
    D -- No --> E[skip]
    D -- Yes --> F["push '#### label' heading"]
    F --> G[push empty line]
    G --> H[push entry lines]
    H --> I[push trailing empty line]
    I --> C
    C --> J[emit any remaining labels not in LABEL_ORDER]
    J --> K[return joined lines]
    K --> L["Rendered inside blockquote\n(> #### Added\n> - item)"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[renderGrouped called] --> B[Group DedupedEntries by label]
    B --> C[emit label in LABEL_ORDER]
    C --> D{"list?.length > 0?"}
    D -- No --> E[skip]
    D -- Yes --> F["push '#### label' heading"]
    F --> G[push empty line]
    G --> H[push entry lines]
    H --> I[push trailing empty line]
    I --> C
    C --> J[emit any remaining labels not in LABEL_ORDER]
    J --> K[return joined lines]
    K --> L["Rendered inside blockquote\n(> #### Added\n> - item)"]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(release): use #### headings for stan..."](https://github.com/goosewobbler/releasekit/commit/f704bcbb85fd02db700e413327ae8cca0dc979af) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41056325)</sub>

<!-- /greptile_comment -->