### PR TITLE
fix(release): label independent-group members "bundled", not "coupled"

### DIFF
--- a/packages/release/src/standing-pr/selection-region.ts
+++ b/packages/release/src/standing-pr/selection-region.ts
@@ -117,6 +117,10 @@ export interface ReleaseUnit {
   primaryName: string;
   primaryUpdate?: Update;
   children: Update[];
+  /** Sync mode of the primary's `version.group` (`fixed`/`linked`/`independent`), when it has one.
+   *  Drives the members' wording: `fixed`/`linked` members share a version (`coupled`), `independent`
+   *  members version on their own lines but ship atomically (`bundled`, #509). */
+  groupSync?: string;
 }
 
 export interface SelectionHierarchy {
@@ -171,7 +175,9 @@ export function computeHierarchy(updates: Update[], cfg: PrimaryConfig): Selecti
     const children = childrenOf(primaryName);
     const primaryUpdate = updateByName.get(primaryName);
     if (!primaryUpdate && children.length === 0) continue; // declared but nothing in its unit changed
-    units.push({ primaryName, primaryUpdate, children });
+    const group = groupOfPrimary(primaryName);
+    const groupSync = group ? groups[group]?.sync : undefined;
+    units.push({ primaryName, primaryUpdate, children, groupSync });
     for (const child of children) {
       childOwners.set(child.packageName, [...(childOwners.get(child.packageName) ?? []), primaryName]);
       claimed.add(child.packageName);
@@ -244,10 +250,17 @@ function primaryRow(unit: ReleaseUnit, selected: boolean): string {
   return `- ${checkbox(selected)} **\`${unit.primaryName}\`** ${label} ${rkSelMarker(unit.primaryName)}`;
 }
 
+/** How a unit's members relate to its primary: `independent`-group members version on their own
+ *  commit-driven lines but ship atomically (`bundled`); `fixed`/`linked` members share a version
+ *  (`coupled`). Prerequisites and un-grouped members keep `coupled` — the existing wording (#509). */
+function couplingWord(groupSync?: string): string {
+  return groupSync === 'independent' ? 'bundled' : 'coupled';
+}
+
 /** A streamlined child: a plain bullet (never a task item, so GitHub can't make it interactive and
  *  fight the cascade) and intentionally markerless — its state is derived from its primary each run. */
-function childBullet(child: Update): string {
-  return `  - \`${child.packageName}\` → ${versionDisplay(child)} · coupled`;
+function childBullet(child: Update, groupSync?: string): string {
+  return `  - \`${child.packageName}\` → ${versionDisplay(child)} · ${couplingWord(groupSync)}`;
 }
 
 /**
@@ -337,8 +350,8 @@ function renderUnit(
     if (unit.children.length > 0) {
       // Children inside a collapsed pane as plain bullets — a blank line after <summary> lets GitHub
       // render the nested markdown list.
-      lines.push(`  <details><summary>ships ${unit.children.length} coupled</summary>`, '');
-      for (const child of unit.children) lines.push(childBullet(child));
+      lines.push(`  <details><summary>ships ${unit.children.length} ${couplingWord(unit.groupSync)}</summary>`, '');
+      for (const child of unit.children) lines.push(childBullet(child, unit.groupSync));
       lines.push('  </details>');
     }
     // The streamlined unit ships primary + coupled members together, so its changelog aggregates

--- a/packages/release/src/standing-pr/selection-region.ts
+++ b/packages/release/src/standing-pr/selection-region.ts
@@ -250,17 +250,30 @@ function primaryRow(unit: ReleaseUnit, selected: boolean): string {
   return `- ${checkbox(selected)} **\`${unit.primaryName}\`** ${label} ${rkSelMarker(unit.primaryName)}`;
 }
 
-/** How a unit's members relate to its primary: `independent`-group members version on their own
+/** How a group's members relate to their primary: `independent`-group members version on their own
  *  commit-driven lines but ship atomically (`bundled`); `fixed`/`linked` members share a version
- *  (`coupled`). Prerequisites and un-grouped members keep `coupled` — the existing wording (#509). */
+ *  (`coupled`). Un-grouped members fall through to `coupled` — the existing wording (#509). */
 function couplingWord(groupSync?: string): string {
   return groupSync === 'independent' ? 'bundled' : 'coupled';
+}
+
+/** The relationship word for one child of a unit. A prerequisite ships with the unit but isn't a
+ *  group member, so it keeps the neutral `coupled` wording; only true group members reflect the
+ *  group's sync mode (`bundled` for independent). */
+function childWord(child: Update, groupSync?: string): string {
+  return child.role === 'prerequisite' ? 'coupled' : couplingWord(groupSync);
+}
+
+/** The summary word for a unit's collapsed pane: `bundled` when it carries any bundled group member,
+ *  else `coupled` — so the header never claims `bundled` over a pane of only prerequisites. */
+function unitWord(unit: ReleaseUnit): string {
+  return unit.children.some((c) => childWord(c, unit.groupSync) === 'bundled') ? 'bundled' : 'coupled';
 }
 
 /** A streamlined child: a plain bullet (never a task item, so GitHub can't make it interactive and
  *  fight the cascade) and intentionally markerless — its state is derived from its primary each run. */
 function childBullet(child: Update, groupSync?: string): string {
-  return `  - \`${child.packageName}\` → ${versionDisplay(child)} · ${couplingWord(groupSync)}`;
+  return `  - \`${child.packageName}\` → ${versionDisplay(child)} · ${childWord(child, groupSync)}`;
 }
 
 /**
@@ -350,12 +363,12 @@ function renderUnit(
     if (unit.children.length > 0) {
       // Children inside a collapsed pane as plain bullets — a blank line after <summary> lets GitHub
       // render the nested markdown list.
-      lines.push(`  <details><summary>ships ${unit.children.length} ${couplingWord(unit.groupSync)}</summary>`, '');
+      lines.push(`  <details><summary>ships ${unit.children.length} ${unitWord(unit)}</summary>`, '');
       for (const child of unit.children) lines.push(childBullet(child, unit.groupSync));
       lines.push('  </details>');
     }
-    // The streamlined unit ships primary + coupled members together, so its changelog aggregates
-    // them all — a shared prerequisite re-appears under every owning unit (self-contained by design).
+    // The streamlined unit ships primary + its members together (coupled or bundled), so its changelog
+    // aggregates them all — a shared prerequisite re-appears under every owning unit (self-contained).
     attachChangelog(
       lines,
       rowChangelog,

--- a/packages/release/test/unit/selection-region.spec.ts
+++ b/packages/release/test/unit/selection-region.spec.ts
@@ -338,6 +338,30 @@ describe('selection-region', () => {
         expect(region).not.toContain('· coupled');
       });
 
+      it('should keep an independent primary’s prerequisite as "coupled", not "bundled" (#509)', () => {
+        // A prerequisite ships with the unit but isn't a group member — it has no version-bundle with
+        // the independent group, so it keeps `coupled` even while the true group member shows `bundled`.
+        const independent = { tauri: { sync: 'independent' as const, packages: ['@wdio/tauri-*', 'tauri-plugin-*'] } };
+        const updates: Update[] = [
+          { packageName: '@wdio/tauri-service', newVersion: '1.4.0', filePath: '', group: 'tauri' },
+          { packageName: '@wdio/tauri-plugin', newVersion: '1.4.0', filePath: '', group: 'tauri' },
+          {
+            packageName: '@scope/prereq',
+            newVersion: '2.0.0',
+            filePath: '',
+            role: 'prerequisite',
+            prerequisiteOf: ['@wdio/tauri-service'],
+          },
+        ];
+        const region = renderSelectionRegion(
+          updates,
+          new Set(),
+          cfg({ groups: independent, allPackageNames: [...tauriAll, '@scope/prereq'] }),
+        );
+        expect(region).toContain('  - `@wdio/tauri-plugin` → 1.4.0 · bundled');
+        expect(region).toContain('  - `@scope/prereq` → 2.0.0 · coupled');
+      });
+
       it('should render an unchanged primary as "— no change" but still toggleable', () => {
         const pluginOnly: Update[] = [
           { packageName: '@wdio/tauri-plugin', newVersion: '1.4.0', filePath: '', group: 'tauri' },

--- a/packages/release/test/unit/selection-region.spec.ts
+++ b/packages/release/test/unit/selection-region.spec.ts
@@ -327,6 +327,17 @@ describe('selection-region', () => {
         expect(region).not.toContain('rk-sel:@wdio/tauri-plugin');
       });
 
+      it('should label independent-group members "bundled" rather than "coupled" (#509)', () => {
+        // independent members version on their own commit-driven lines but ship atomically with the
+        // unit — "coupled" implies a shared version they don't have; "bundled" conveys atomic shipping.
+        const independent = { tauri: { sync: 'independent' as const, packages: ['@wdio/tauri-*', 'tauri-plugin-*'] } };
+        const region = renderSelectionRegion(tauriUpdates, new Set(), cfg({ groups: independent }));
+        expect(region).toContain('  <details><summary>ships 2 bundled</summary>');
+        expect(region).toContain('  - `@wdio/tauri-plugin` → 1.4.0 · bundled');
+        expect(region).toContain('  - `tauri-plugin-wdio-webdriver` → 1.4.0 · bundled');
+        expect(region).not.toContain('· coupled');
+      });
+
       it('should render an unchanged primary as "— no change" but still toggleable', () => {
         const pluginOnly: Update[] = [
           { packageName: '@wdio/tauri-plugin', newVersion: '1.4.0', filePath: '', group: 'tauri' },


### PR DESCRIPTION
Closes #509.

## Problem
In streamlined mode a primary's group-mates render as `· coupled` bullets under a `ships N coupled` summary:

```
<details><summary>ships 3 coupled</summary>
- `@wdio/dioxus-bridge` → 1.0.0-next.4 · coupled
- `wdio-dioxus-driver`  → 1.0.0-next.4 · coupled
```

That's accurate for **fixed** / **linked** groups (members share a version), but misleading for **independent** groups: each member versions on its *own* commit-driven line — they aren't version-coupled, they just **ship atomically** with the unit. "coupled" implies a version link that doesn't exist. (The read-only rendering itself is correct — the unit is atomic — only the *word* is wrong.)

## Fix
`computeHierarchy` already resolves each primary's `version.group`; carry that group's sync mode onto the `ReleaseUnit` (`groupSync`) and word the members from it:

- `fixed` / `linked` → `coupled` / `ships N coupled` (unchanged)
- `independent` → `bundled` / `ships N bundled`

Prerequisites and un-grouped members keep `coupled` (existing wording — the issue is scoped to independent groups).

## Verification
Full gate green (32/32). New test asserts an independent group renders `ships 2 bundled` / `· bundled`; the existing `linked`-group tests still assert `coupled`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes misleading "coupled" labelling for members of `independent` release groups in streamlined mode. Instead of changing the read-only rendering (which is correct), it threads the group's sync mode (`groupSync`) onto `ReleaseUnit` and introduces three small helpers to pick the right word per child and per summary header.

- **`ReleaseUnit.groupSync`** is resolved in `computeHierarchy` and used by `childWord`/`unitWord` to emit `bundled` for `independent`-group members and `coupled` for `fixed`/`linked` members and prerequisites.
- **Prerequisites are explicitly guarded**: `childWord` checks `child.role === 'prerequisite'` first, so a prerequisite of an independent-group primary keeps the `coupled` label — matching the stated design intent.
- **Two new tests** cover the happy path (`independent` → `bundled`) and the prerequisite edge case (`independent` primary + prerequisite → mixed `bundled`/`coupled`); the existing `linked`-group tests are untouched.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is narrowly scoped to display wording and carries no runtime risk; all existing behaviour for fixed/linked groups and prerequisites is preserved.

The logic is straightforward: a single field added to a data structure, three small pure helpers, and two new tests that cover both the success path and the prerequisite edge case. The previous review concerns (prerequisite mis-labelling, stale inline comment) were addressed in this revision. The only remaining note is a one-word stale JSDoc on renderUnit, which has no effect on correctness.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/release/src/standing-pr/selection-region.ts | Adds `groupSync` to `ReleaseUnit`, introduces `couplingWord`/`childWord`/`unitWord` helpers to differentiate "bundled" (independent groups) from "coupled" (fixed/linked/prerequisites), and threads the new word through `childBullet` and `renderUnit`. Logic is correct; prerequisites are properly kept as "coupled" via the `child.role` guard. Minor stale JSDoc on `renderUnit` itself. |
| packages/release/test/unit/selection-region.spec.ts | Adds two new tests: one asserting independent-group members render as `bundled` (with a strong `not.toContain('· coupled')` guard), and one asserting a prerequisite of an independent-group primary stays `coupled`. Both cases are well-specified and the existing `linked`-group tests remain unmodified, confirming backward compatibility. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[child of a ReleaseUnit] --> B{child.role === 'prerequisite'?}
    B -- Yes --> C["coupled"]
    B -- No --> D{unit.groupSync === 'independent'?}
    D -- Yes --> E["bundled"]
    D -- No --> F["coupled"]

    G[ReleaseUnit summary header] --> H{any child returns 'bundled'?}
    H -- Yes --> I["ships N bundled"]
    H -- No --> J["ships N coupled"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[child of a ReleaseUnit] --> B{child.role === 'prerequisite'?}
    B -- Yes --> C["coupled"]
    B -- No --> D{unit.groupSync === 'independent'?}
    D -- Yes --> E["bundled"]
    D -- No --> F["coupled"]

    G[ReleaseUnit summary header] --> H{any child returns 'bundled'?}
    H -- Yes --> I["ships N bundled"]
    H -- No --> J["ships N coupled"]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(release): keep a prerequisite of an ..."](https://github.com/goosewobbler/releasekit/commit/d0471fff52ecd00944c71c71d156d7c2665a0879) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41058751)</sub>

<!-- /greptile_comment -->