### PR TITLE
docs(ci-setup): guide exempting the standing PR from consumer build CI

### DIFF
--- a/packages/release/docs/ci-setup.md
+++ b/packages/release/docs/ci-setup.md
@@ -642,6 +642,27 @@ Use `release:graduate` and `channel:prerelease` labels on **the standing PR itse
   Each main-branch SHA gets its own group (so nothing is cancelled), while PR runs still cancel on new pushes.
 - **Status check `releasekit/standing-pr`:** posted on the release branch HEAD after each update. States: `success` (ready to merge), `pending` (one or more gates not yet satisfied — typically `minAge`). Configure as a required check in branch protection on the standing PR's base branch if you want gates enforced at merge time.
 
+### Keeping CI off the standing PR
+
+Every `standing-pr update` force-pushes the release branch (`release/next`), which is a `pull_request: synchronize` on the open standing PR. If your build/test CI triggers on `pull_request` (the usual `[opened, synchronize, reopened]`), **it re-runs the whole matrix on every update** — each feeder merge, and each checkbox toggle that changes the selection. On a large cross-platform matrix that's dozens of jobs per update, all wasted: the release branch only ever carries version bumps and regenerated changelogs on top of `main`, whose code was already validated on each feeder PR and is validated again on push to `main` when the standing PR merges.
+
+Path or change-detection filters won't save you — a release commit touches version files and changelogs across **every** releasing package, so it reads as "everything changed" and fans the matrix out regardless.
+
+`[skip ci]` is **not** the lever: the standing PR's single prep commit deliberately omits it. A squash-merge inherits that commit's message onto `main`, where `[skip ci]` would suppress the publish workflow — so the skip has to live in your CI's triggers, not the commit. Exempt the branch with a head-ref guard:
+
+```yaml
+# In your build/test workflow (e.g. ci.yml)
+jobs:
+  build:
+    # Skip the standing PR — its branch only carries release bumps, already CI'd on the feeder PRs.
+    if: ${{ !startsWith(github.head_ref, 'release/') }}
+    # ...
+```
+
+`github.head_ref` is set only for `pull_request` events (it's empty on `push: main`), so your main-branch CI is unaffected. Apply the guard wherever it gates the rest of the run — a single change-detection / entry job that everything else `needs` is the cleanest single point; otherwise guard each job or the workflow's own `on:` filter. (`release/` matches the default `ci.standingPr.branch` of `release/next`; adjust the prefix if you changed it.)
+
+Skipping entirely is the recommended default — the merge to `main` re-runs CI anyway. If you want a cheap safety net on the release branch, keep a fast lint/typecheck job and guard only the heavy build/e2e legs.
+
 ### Label semantics in standing-pr mode
 
 Labels behave differently in standing-pr mode than in direct mode. There are two surfaces.
@@ -729,6 +750,7 @@ This is a standing-pr-only feature — it needs a durable pre-publish artifact (
 | `error: too many arguments for 'preview'` | Pre-fix releasekit where `standing-pr` was missing from `cli.ts`. Upgrade `@releasekit/release`. |
 | Standing PR never appears despite merges | Check, in order: (1) the GitHub repo setting; (2) the head commit doesn't match `release.ci.skipPatterns`; (3) there are releasable conventional commits (`feat:`, `fix:`) since the last tag; (4) the `update-release-pr` job logs — they print the dry-run version output. |
 | Standing PR keeps closing immediately | `minPackages` is set higher than the current change count. Either lower the threshold or wait for more package changes to accumulate. |
+| Every standing-PR update re-runs my whole build matrix | Your CI triggers on `pull_request` and isn't exempting the release branch. Add a head-ref guard — see [Keeping CI off the standing PR](#keeping-ci-off-the-standing-pr). `[skip ci]` can't be used here (it would suppress publish on merge). |
 | Standing PR ignores my `bump:*` label on a feeder PR | By design — feeder labels are advisory in standing-pr mode. Add the label to the standing PR itself, or use `release:immediate` to bypass the queue. |
 | Standing PR shows `pending` status `Conflicting bump labels…` | Two conflicting labels on the standing PR (e.g. `bump:patch` + `bump:major`). Remove one and re-run `standing-pr update`. |
 | Added `release:preview-notes` but no notes appear | The region is written on the next `standing-pr update` (push to `main`, the hourly `schedule`, or a manual re-run) — not the instant the label is applied. Also confirm `notes.releaseNotes.llm` is set and the provider secret reaches the `update-release-pr` job. |

--- a/packages/release/docs/ci-setup.md
+++ b/packages/release/docs/ci-setup.md
@@ -659,7 +659,7 @@ jobs:
     # ...
 ```
 
-`github.head_ref` is set only for `pull_request` events (it's empty on `push: main`), so your main-branch CI is unaffected. Apply the guard wherever it gates the rest of the run — a single change-detection / entry job that everything else `needs` is the cleanest single point; otherwise guard each job or the workflow's own `on:` filter. (`release/` matches the default `ci.standingPr.branch` of `release/next`; adjust the prefix if you changed it.)
+`github.head_ref` is set only for `pull_request` events (it's empty on `push: main`), so your main-branch CI is unaffected. Apply the guard wherever it gates the rest of the run — a single change-detection / entry job that everything else `needs` is the cleanest single point; otherwise guard each job. There's no `on:`-level lever for this: `on.pull_request.branches` filters by the PR's **base** branch (the merge target, `main`), not its head, so a job-level `if` is the only way to target the release branch. (`release/` matches the default `ci.standingPr.branch` of `release/next`; adjust the prefix if you changed it.)
 
 Skipping entirely is the recommended default — the merge to `main` re-runs CI anyway. If you want a cheap safety net on the release branch, keep a fast lint/typecheck job and guard only the heavy build/e2e legs.
 

--- a/templates/workflows/standing-pr.yml
+++ b/templates/workflows/standing-pr.yml
@@ -7,6 +7,9 @@
 #
 # Without it, the first `standing-pr update` run will fail with HTTP 403.
 # See packages/release/docs/ci-setup.md → Standing Release PR for the full guide.
+#
+# Tip: exempt this PR's branch (release/*) from your build/test CI, or every update
+# re-runs your whole matrix. See ci-setup.md → "Keeping CI off the standing PR".
 
 name: Standing Release PR
 


### PR DESCRIPTION
Closes #515.

## What
New `packages/release/docs/ci-setup.md` subsection **"Keeping CI off the standing PR"** under Standing Release PR, plus a Troubleshooting row and a tip in the standing-pr template header.

## Why
Every `standing-pr update` force-pushes `release/next` → `pull_request: synchronize` on the open standing PR → the consumer's build/test matrix re-runs on **every** update (each feeder merge, each checkbox toggle). Verified on `webdriverio/desktop-mobile` #456: one update fired **65 jobs** (full cross-platform build matrix). Change-detection doesn't help — the all-package release commit reads as "everything changed" — and `[skip ci]` is forbidden (a squash-merge inherits it onto `main` and would suppress the publish workflow).

## Guidance
Head-ref guard at the change-detection / entry job (or workflow-wide):

```yaml
jobs:
  build:
    if: ${{ !startsWith(github.head_ref, 'release/') }}
```

`github.head_ref` is empty on `push: main`, so main CI is unaffected. Recommends skip-entirely (merge re-runs CI anyway) with a lint-only fallback for the cautious; explains the `[skip ci]` caveat so nobody reaches for it.

Docs-only (ci-setup.md is hand-written, not generated) + two comment lines in the template. Full gate green (32/32).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This is a docs-only PR that adds a new "Keeping CI off the standing PR" subsection to `ci-setup.md`, a corresponding troubleshooting row, and a one-line tip comment in the standing-PR workflow template.

- **New guidance section** explains why every `standing-pr update` triggers full CI re-runs (force-push → `pull_request: synchronize`), why change-detection and `[skip ci]` don't help, and recommends a job-level `if: ${{ !startsWith(github.head_ref, 'release/') }}` guard.
- **Troubleshooting row** cross-links to the new section for consumers who hit the symptom first.
- **Template comment** in `standing-pr.yml` surfaces the tip at the point where engineers first set up the workflow.
</details>

<h3>Confidence Score: 5/5</h3>

Documentation-only change; no executable code is modified. Safe to merge.

Both changed files are hand-written documentation and template comments with no generated or executable content. The github.head_ref behaviour described is technically accurate, the on:-filter concern raised in the earlier review thread is now explicitly corrected in the prose, and the YAML snippet in the guide is syntactically valid and produces the intended guard.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/release/docs/ci-setup.md | Adds "Keeping CI off the standing PR" subsection and a troubleshooting row; guidance is technically accurate, github.head_ref behaviour on push vs pull_request is correctly described, and the previous on:-filter concern from the earlier review thread is now explicitly addressed in the prose. |
| templates/workflows/standing-pr.yml | Adds two comment lines pointing consumers to the new ci-setup.md section; no logic changed. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Feeder PR merges to main] --> B[standing-pr update runs]
    B --> C[Force-push to release/next]
    C --> D{Consumer CI triggered\npull_request: synchronize}
    D -->|No head-ref guard| E[Full build matrix runs\ne.g. 65 jobs — wasted]
    D -->|With head-ref guard| F{"if: !startsWith(github.head_ref, 'release/')"}
    F -->|head_ref == 'release/next'| G[CI skipped on standing PR ✓]
    F -->|head_ref empty on push to main| H[CI runs normally on main ✓]
    G --> I[Standing PR merged to main]
    I --> H
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Feeder PR merges to main] --> B[standing-pr update runs]
    B --> C[Force-push to release/next]
    C --> D{Consumer CI triggered\npull_request: synchronize}
    D -->|No head-ref guard| E[Full build matrix runs\ne.g. 65 jobs — wasted]
    D -->|With head-ref guard| F{"if: !startsWith(github.head_ref, 'release/')"}
    F -->|head_ref == 'release/next'| G[CI skipped on standing PR ✓]
    F -->|head_ref empty on push to main| H[CI runs normally on main ✓]
    G --> I[Standing PR merged to main]
    I --> H
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["docs(ci-setup): clarify there&#39;s no on:-l..."](https://github.com/goosewobbler/releasekit/commit/27a1cffd96e88ce418f201f21c0df93c70ea0fa7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41070482)</sub>

<!-- /greptile_comment -->