### PR TITLE
feat(standing-pr): in-progress banner + collapse rapid checkbox toggles

### DIFF
--- a/packages/release/docs/ci-setup.md
+++ b/packages/release/docs/ci-setup.md
@@ -524,7 +524,7 @@ jobs:
           case "$BODY" in
             *'<!-- releasekit-processing -->'*) echo "Banner already present — skipping"; exit 0 ;;
           esac
-          BANNER=$'<!-- releasekit-processing -->\n> 🔄 **Updating the release PR** to reflect your change… ([run details]('"$RUN_URL"'))\n<!-- releasekit-processing-end -->'
+          BANNER=$'<!-- releasekit-processing -->\n> 🔄 **Updating the release PR** to reflect your change… ([run details]('"$RUN_URL"$'))\n<!-- releasekit-processing-end -->'
           NEWBODY=$(printf '%s\n\n%s' "$BANNER" "$BODY")
           gh api --method PATCH "repos/$REPO/pulls/$PR" -f body="$NEWBODY" >/dev/null
 
@@ -557,10 +557,11 @@ jobs:
           # ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           # OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
 
-      # On success the regenerated body already omits the banner; only a run that died before the
+      # On success the regenerated body already omits the banner; only a run that ended before the
       # rebuild leaves it behind. Strip the marker region so it doesn't linger as a false "in progress".
-      - name: Clear the in-progress banner on failure
-        if: failure() && github.event_name == 'pull_request'
+      # `cancelled()` too — a manual cancel (or a superseded reactive run) also skips the rebuild.
+      - name: Clear the in-progress banner if the update didn't finish
+        if: (failure() || cancelled()) && github.event_name == 'pull_request'
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}

--- a/packages/release/docs/ci-setup.md
+++ b/packages/release/docs/ci-setup.md
@@ -465,8 +465,14 @@ on:
     - cron: '0 * * * *'  # Hourly — re-evaluates minAge status check as time passes
 
 concurrency:
-  group: standing-release-pr
-  cancel-in-progress: false
+  # Rapid checkbox toggles each fire a separate `edited` event — route a maintainer's edits to a
+  # per-PR group that cancels in-progress runs, so a flurry of ticks collapses to one rebuild of the
+  # latest selection. Everything else — push / schedule / merge, AND the bot's own body edits (the
+  # processing banner + the rebuilt body, which are `edited` from a Bot sender) — stays on the stable
+  # shared group with cancelling OFF, so a bot edit never cancels the run doing the work and a queued
+  # publish dispatch is never dropped. The `sender.type != 'Bot'` guard is what keeps the two apart.
+  group: ${{ (github.event_name == 'pull_request' && github.event.action == 'edited' && github.event.sender.type != 'Bot') && format('standing-release-pr-edit-{0}', github.event.pull_request.number) || 'standing-release-pr' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action == 'edited' && github.event.sender.type != 'Bot' }}
 
 permissions:
   contents: write
@@ -500,6 +506,28 @@ jobs:
       )
     runs-on: ubuntu-latest
     steps:
+      # Post an instant "updating…" banner so a maintainer who just ticked a checkbox (or changed a
+      # label) knows the change was received while the slower rebuild runs. Reactive events only; runs
+      # BEFORE checkout so it lands within seconds. `standing-pr update` regenerates the body from
+      # scratch, so the banner self-clears on success; the failure step below strips it if the run dies
+      # first. Idempotent — skips if a banner is already present.
+      - name: Acknowledge the update in progress
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          BODY=$(gh api "repos/$REPO/pulls/$PR" --jq '.body // ""')
+          case "$BODY" in
+            *'<!-- releasekit-processing -->'*) echo "Banner already present — skipping"; exit 0 ;;
+          esac
+          BANNER=$'<!-- releasekit-processing -->\n> 🔄 **Updating the release PR** to reflect your change… ([run details]('"$RUN_URL"'))\n<!-- releasekit-processing-end -->'
+          NEWBODY=$(printf '%s\n\n%s' "$BANNER" "$BODY")
+          gh api --method PATCH "repos/$REPO/pulls/$PR" -f body="$NEWBODY" >/dev/null
+
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
@@ -528,6 +556,20 @@ jobs:
           # OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           # ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           # OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
+
+      # On success the regenerated body already omits the banner; only a run that died before the
+      # rebuild leaves it behind. Strip the marker region so it doesn't linger as a false "in progress".
+      - name: Clear the in-progress banner on failure
+        if: failure() && github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          BODY=$(gh api "repos/$REPO/pulls/$PR" --jq '.body // ""')
+          CLEANED=$(printf '%s' "$BODY" | sed '/<!-- releasekit-processing -->/,/<!-- releasekit-processing-end -->/d')
+          gh api --method PATCH "repos/$REPO/pulls/$PR" -f body="$CLEANED" >/dev/null
 
   publish-release:
     name: Publish Release
@@ -662,6 +704,20 @@ jobs:
 `github.head_ref` is set only for `pull_request` events (it's empty on `push: main`), so your main-branch CI is unaffected. Apply the guard wherever it gates the rest of the run — a single change-detection / entry job that everything else `needs` is the cleanest single point; otherwise guard each job. There's no `on:`-level lever for this: `on.pull_request.branches` filters by the PR's **base** branch (the merge target, `main`), not its head, so a job-level `if` is the only way to target the release branch. (`release/` matches the default `ci.standingPr.branch` of `release/next`; adjust the prefix if you changed it.)
 
 Skipping entirely is the recommended default — the merge to `main` re-runs CI anyway. If you want a cheap safety net on the release branch, keep a fast lint/typecheck job and guard only the heavy build/e2e legs.
+
+### In-progress feedback
+
+Ticking a checkbox or changing a label on the standing PR re-runs `standing-pr update`, which takes a minute or two (checkout → install → rebuild). To avoid a silent wait, the template posts an **in-progress banner** to the top of the PR body within seconds of the change:
+
+> 🔄 **Updating the release PR** to reflect your change… ([run details](#))
+
+Mechanics (all in `standing-pr.yml`, no config):
+
+- **Fast.** The banner is a plain `gh api` step that runs *before* checkout/install, so it lands ~10–15s after the runner starts (the spin-up floor — an Actions job can't react instantly the way a native GitHub App can). It's on reactive events only; push/schedule updates aren't interactive.
+- **Self-clearing.** `standing-pr update` regenerates the PR body from scratch, so a successful update drops the banner automatically. A dedicated `if: failure()` step strips it if the run dies before the rebuild, so it never lingers as a false "in progress".
+- **Idempotent.** The step skips if a banner is already present, so rapid re-triggers don't stack it.
+
+Rapid checkbox toggles are also **collapsed**: the workflow's `concurrency` routes a maintainer's `edited` events to a per-PR group with `cancel-in-progress: true`, so ticking several packages in a row cancels the superseded rebuilds and only the latest selection is applied. The group is sender-aware — the bot's *own* body edits (the banner and the rebuilt body are `edited` events too) stay on the stable non-cancelling group, so they never cancel the run doing the work; push/schedule/merge events stay there too (a cancelled publish dispatch could drop a release).
 
 ### Label semantics in standing-pr mode
 

--- a/templates/workflows/standing-pr.yml
+++ b/templates/workflows/standing-pr.yml
@@ -89,7 +89,7 @@ jobs:
           case "$BODY" in
             *'<!-- releasekit-processing -->'*) echo "Banner already present — skipping"; exit 0 ;;
           esac
-          BANNER=$'<!-- releasekit-processing -->\n> 🔄 **Updating the release PR** to reflect your change… ([run details]('"$RUN_URL"'))\n<!-- releasekit-processing-end -->'
+          BANNER=$'<!-- releasekit-processing -->\n> 🔄 **Updating the release PR** to reflect your change… ([run details]('"$RUN_URL"$'))\n<!-- releasekit-processing-end -->'
           NEWBODY=$(printf '%s\n\n%s' "$BANNER" "$BODY")
           gh api --method PATCH "repos/$REPO/pulls/$PR" -f body="$NEWBODY" >/dev/null
 
@@ -121,10 +121,12 @@ jobs:
           # ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           # OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
 
-      # On success the regenerated body already omits the banner; only a run that died before the
+      # On success the regenerated body already omits the banner; only a run that ended before the
       # rebuild leaves it behind. Strip the marker region so it doesn't linger as a false "in progress".
-      - name: Clear the in-progress banner on failure
-        if: failure() && github.event_name == 'pull_request'
+      # `cancelled()` too — a manual cancel (or a superseded reactive run) also skips the rebuild; the
+      # next update self-heals it anyway, but clearing here is immediate.
+      - name: Clear the in-progress banner if the update didn't finish
+        if: (failure() || cancelled()) && github.event_name == 'pull_request'
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}

--- a/templates/workflows/standing-pr.yml
+++ b/templates/workflows/standing-pr.yml
@@ -29,8 +29,14 @@ on:
     - cron: '0 * * * *'  # Hourly — re-evaluates minAge status check as time passes
 
 concurrency:
-  group: standing-release-pr
-  cancel-in-progress: false
+  # Rapid checkbox toggles each fire a separate `edited` event — route a maintainer's edits to a
+  # per-PR group that cancels in-progress runs, so a flurry of ticks collapses to one rebuild of the
+  # latest selection. Everything else — push / schedule / merge, AND the bot's own body edits (the
+  # processing banner + the rebuilt body, which are `edited` from a Bot sender) — stays on the stable
+  # shared group with cancelling OFF, so a bot edit never cancels the run doing the work and a queued
+  # publish dispatch is never dropped. The `sender.type != 'Bot'` guard is what keeps the two apart.
+  group: ${{ (github.event_name == 'pull_request' && github.event.action == 'edited' && github.event.sender.type != 'Bot') && format('standing-release-pr-edit-{0}', github.event.pull_request.number) || 'standing-release-pr' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action == 'edited' && github.event.sender.type != 'Bot' }}
 
 permissions:
   contents: write
@@ -64,6 +70,29 @@ jobs:
       )
     runs-on: ubuntu-latest
     steps:
+      # Post an instant "updating…" banner so a maintainer who just ticked a checkbox (or changed a
+      # label) knows the change was received while the slower rebuild runs — the Dependabot pattern.
+      # Reactive events only (push/schedule aren't interactive). Runs BEFORE checkout so it lands within
+      # seconds of the runner starting (~10-15s spin-up is the floor). The `standing-pr update` below
+      # regenerates the PR body from scratch, so the banner self-clears on success; the failure step at
+      # the end strips it if the run dies first. Idempotent — skips if a banner is already present.
+      - name: Acknowledge the update in progress
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          BODY=$(gh api "repos/$REPO/pulls/$PR" --jq '.body // ""')
+          case "$BODY" in
+            *'<!-- releasekit-processing -->'*) echo "Banner already present — skipping"; exit 0 ;;
+          esac
+          BANNER=$'<!-- releasekit-processing -->\n> 🔄 **Updating the release PR** to reflect your change… ([run details]('"$RUN_URL"'))\n<!-- releasekit-processing-end -->'
+          NEWBODY=$(printf '%s\n\n%s' "$BANNER" "$BODY")
+          gh api --method PATCH "repos/$REPO/pulls/$PR" -f body="$NEWBODY" >/dev/null
+
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
@@ -91,6 +120,20 @@ jobs:
           # OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           # ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           # OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
+
+      # On success the regenerated body already omits the banner; only a run that died before the
+      # rebuild leaves it behind. Strip the marker region so it doesn't linger as a false "in progress".
+      - name: Clear the in-progress banner on failure
+        if: failure() && github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          BODY=$(gh api "repos/$REPO/pulls/$PR" --jq '.body // ""')
+          CLEANED=$(printf '%s' "$BODY" | sed '/<!-- releasekit-processing -->/,/<!-- releasekit-processing-end -->/d')
+          gh api --method PATCH "repos/$REPO/pulls/$PR" -f body="$CLEANED" >/dev/null
 
   immediate-release:
     # Bypass the standing PR queue and release directly. Triggered when a feeder PR


### PR DESCRIPTION
Closes #514.

## Problem
Interacting with the standing PR is slow and silent — a checkbox toggle (`pull_request: edited`) re-runs the full update (checkout → install → build → version → notes → render → push → PATCH, 2–4 min) with **no in-PR feedback**, and rapid toggles queue serially (`cancel-in-progress: false`).

## Finding
Investigation showed `renderPrBody` rebuilds the PR body **from scratch** every update (only marker-delimited regions like notes are preserved). So a banner injected above `## Release` **auto-clears on the next successful update — no CLI change needed**. This is purely a template + docs change.

## Changes (consumer template)
**1. Processing banner.** A fast `gh api` step runs *before* checkout (~10–15s from runner start — the spin-up floor) and posts a `<!-- releasekit-processing -->` marker region:

> 🔄 **Updating the release PR** to reflect your change… ([run details](#))

Reactive events only. Self-clears on success (body regen); an `if: failure()` step strips it if the run dies first. Idempotent (skips if already present). Banner chosen over a marker comment for visibility — it sits at the top where the maintainer just clicked, not at the bottom of the timeline.

**2. Reactive concurrency.** A maintainer's `edited` events route to a per-PR group with `cancel-in-progress: true`, so ticking several packages collapses to one rebuild of the latest selection. The group is **sender-aware**: the bot's own body edits (the banner + the rebuilt body are `edited` too) and every push/schedule/merge event stay on the stable non-cancelling group — so a bot edit can't cancel the run doing the work, and a queued publish dispatch is never dropped.

## Scope
- `templates/workflows/standing-pr.yml` + the embedded copy in `packages/release/docs/ci-setup.md` (kept consistent per the AGENTS.md rule).
- New **"In-progress feedback"** docs section.
- `actionlint` clean on both workflows; full gate green (32/32). No code/CLI changes, so no unit surface.

Note: the ~10–15s runner spin-up is a hard floor for any Actions-based ack — but a visible banner in ~15s beats 2–4 min of silence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds an in-progress feedback banner and smarter concurrency to the standing-PR workflow. A fast `gh api` step posts a visible "updating…" marker before checkout, and a cleanup step (guarded by `failure() || cancelled()`) removes it if the run doesn't complete the rebuild; the concurrency group is split so maintainer `edited` events cancel each other while bot edits, pushes, and schedules share a stable non-cancelling group.

- **Banner lifecycle**: posted before checkout (~10–15s), self-cleared on successful body regen, explicitly stripped on failure or cancellation; idempotency check prevents stacking on rapid retriggers.
- **Concurrency split**: `sender.type != 'Bot'` routes maintainer edits to a per-PR cancel group while all other events (including the bot's own body edits) stay on the stable group, preventing a bot write from cancelling the run that triggered it.
- **Docs**: new "In-progress feedback" section added to `ci-setup.md`, kept in sync with the embedded workflow copy.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is additive (new banner step + concurrency rework) with no code/CLI surface, and both the template and embedded doc copy are consistent.

The banner step uses set -euo pipefail, runs idempotently, and its cleanup correctly covers both failure and cancellation. The concurrency split relies on a well-documented sender.type != Bot guard that prevents bot writes from cancelling their own parent run. The only gap is a minor prose/code inconsistency in the docs, which doesn't affect runtime behaviour.

No files require special attention. The prose in the Self-clearing bullet of ci-setup.md describes the cleanup guard as if: failure() while the actual step (in both the embedded workflow and the template) uses if: (failure() || cancelled()).

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| templates/workflows/standing-pr.yml | Adds a pre-checkout banner step and cancellation-aware cleanup step; reworks concurrency group to separate maintainer edits (cancel-enabled) from bot/push/schedule events (stable group). Logic is sound and cleanup now correctly handles both failure and cancellation. |
| packages/release/docs/ci-setup.md | Embeds the updated workflow (in sync with the template) and adds a new In-progress feedback section. Minor prose/code inconsistency: the bullet describes the cleanup guard as if: failure() while the embedded code and template both use if: (failure() || cancelled()). |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    actor Maintainer
    participant GH as GitHub Events
    participant CG as Concurrency Group
    participant Runner as Actions Runner
    participant API as GitHub API (PR body)

    Maintainer->>GH: Tick checkbox (pull_request: edited)
    GH->>CG: human-edit group (cancel-in-progress: true)
    CG-->>Runner: Cancel any prior run in group
    Runner->>API: POST banner (pre-checkout, ~15s)
    API-->>Maintainer: 🔄 Updating banner visible

    alt Rebuild succeeds
        Runner->>Runner: checkout → install → releasekit update
        Runner->>API: PATCH body (regenerated, no banner)
        Note over API: Banner auto-cleared
    else Failure or cancellation
        Runner->>API: PATCH body (sed strip banner markers)
        Note over API: Banner explicitly removed
    end

    Note over GH,CG: Bot body edits (banner + rebuilt body) → stable group (cancel-in-progress: false)
    Note over GH,CG: push / schedule / merge → stable group (cancel-in-progress: false)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    actor Maintainer
    participant GH as GitHub Events
    participant CG as Concurrency Group
    participant Runner as Actions Runner
    participant API as GitHub API (PR body)

    Maintainer->>GH: Tick checkbox (pull_request: edited)
    GH->>CG: human-edit group (cancel-in-progress: true)
    CG-->>Runner: Cancel any prior run in group
    Runner->>API: POST banner (pre-checkout, ~15s)
    API-->>Maintainer: 🔄 Updating banner visible

    alt Rebuild succeeds
        Runner->>Runner: checkout → install → releasekit update
        Runner->>API: PATCH body (regenerated, no banner)
        Note over API: Banner auto-cleared
    else Failure or cancellation
        Runner->>API: PATCH body (sed strip banner markers)
        Note over API: Banner explicitly removed
    end

    Note over GH,CG: Bot body edits (banner + rebuilt body) → stable group (cancel-in-progress: false)
    Note over GH,CG: push / schedule / merge → stable group (cancel-in-progress: false)
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(standing-pr): real newline before th..."](https://github.com/goosewobbler/releasekit/commit/5553e3778085b930f0808d1fb2a9142f746fcde7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41072322)</sub>

<!-- /greptile_comment -->