### PR TITLE
fix(release): show days in standing-PR "open …" age

### DIFF
--- a/packages/release/src/duration.ts
+++ b/packages/release/src/duration.ts
@@ -20,9 +20,11 @@ export function parseDuration(str: string): number | null {
 }
 
 export function formatDuration(ms: number): string {
-  const hours = Math.floor(ms / 3_600_000);
+  const days = Math.floor(ms / 86_400_000);
+  const hours = Math.floor((ms % 86_400_000) / 3_600_000);
   const minutes = Math.floor((ms % 3_600_000) / 60_000);
   const parts: string[] = [];
+  if (days > 0) parts.push(`${days}d`);
   if (hours > 0) parts.push(`${hours}h`);
   if (minutes > 0) parts.push(`${minutes}m`);
   if (parts.length === 0) parts.push(`${Math.ceil(ms / 1000)}s`);

--- a/packages/release/test/unit/duration.spec.ts
+++ b/packages/release/test/unit/duration.spec.ts
@@ -56,6 +56,18 @@ describe('formatDuration', () => {
     expect(formatDuration(3 * 3_600_000)).toBe('3h');
   });
 
+  it('should format days, omitting a zero hours component', () => {
+    expect(formatDuration(624 * 3_600_000 + 36 * 60_000)).toBe('26d 36m');
+  });
+
+  it('should format days and hours, omitting a zero minutes component', () => {
+    expect(formatDuration(26 * 3_600_000)).toBe('1d 2h');
+  });
+
+  it('should format days only for a whole number of days', () => {
+    expect(formatDuration(2 * 86_400_000)).toBe('2d');
+  });
+
   it('should format minutes only', () => {
     expect(formatDuration(45 * 60_000)).toBe('45m');
   });


### PR DESCRIPTION
## What

Add a day component to `formatDuration` (`packages/release/src/duration.ts`) so the standing-PR preview's open-age no longer renders as an unreadable hour count.

- `624h 36m` → `26d 36m`
- `26h` → `1d 2h`
- exactly 2 days → `2d`

## Why

A long-lived standing PR previously read `open 624h 36m`. `formatDuration` computed hours straight from the millisecond total and never produced a day unit, even though `parseDuration` in the same file already understood `d`. This makes the two symmetric and keeps the existing zero-omission behavior intact (`3h`, not `3h 0m`).

The shared call sites (`Waiting … for minAge` gate reason) read sensibly with the change; days are effectively unreachable there since minAge is sub-day, and no snapshot/fixture crosses 24h.

Closes #535

## Verification

`pnpm turbo run lint typecheck test --force` — all 32 tasks pass; `pnpm lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes `formatDuration` in `packages/release/src/duration.ts` to decompose millisecond totals into days before hours, matching the existing `parseDuration` support for the `d` unit. Previously a 26-day-old PR displayed as `open 624h 36m`; it now renders as `26d 36m`.

- `formatDuration` now computes days first (`ms / 86_400_000`), then hours modulo a day (`ms % 86_400_000 / 3_600_000`), preserving the existing zero-omission behavior.
- Three new unit tests cover the day+minutes, day+hours, and whole-day cases.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a small, self-contained fix to a pure formatting utility with no side effects on the rest of the codebase.

The arithmetic decomposition is correct for all cases (days+hours+minutes, days+minutes, days only, sub-day durations), the existing zero-omission logic is preserved, and the three new tests directly cover the changed code paths. No regressions are introduced for the sub-day call sites.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/release/src/duration.ts | Adds day-level decomposition to formatDuration, making it symmetric with parseDuration. Logic is correct. |
| packages/release/test/unit/duration.spec.ts | Adds three new test cases covering the new day formatting: days+minutes only, days+hours, and whole-day. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["formatDuration(ms)"] --> B["days = ⌊ms / 86_400_000⌋"]
    B --> C["hours = ⌊(ms % 86_400_000) / 3_600_000⌋"]
    C --> D["minutes = ⌊(ms % 3_600_000) / 60_000⌋"]
    D --> E{days > 0?}
    E -- yes --> F["push '{days}d'"]
    E -- no --> G{hours > 0?}
    F --> G
    G -- yes --> H["push '{hours}h'"]
    G -- no --> I{minutes > 0?}
    H --> I
    I -- yes --> J["push '{minutes}m'"]
    I -- no --> K{parts empty?}
    J --> K
    K -- yes --> L["push '⌈ms/1000⌉s'"]
    K -- no --> M["return parts.join(' ')"]
    L --> M
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["formatDuration(ms)"] --> B["days = ⌊ms / 86_400_000⌋"]
    B --> C["hours = ⌊(ms % 86_400_000) / 3_600_000⌋"]
    C --> D["minutes = ⌊(ms % 3_600_000) / 60_000⌋"]
    D --> E{days > 0?}
    E -- yes --> F["push '{days}d'"]
    E -- no --> G{hours > 0?}
    F --> G
    G -- yes --> H["push '{hours}h'"]
    G -- no --> I{minutes > 0?}
    H --> I
    I -- yes --> J["push '{minutes}m'"]
    I -- no --> K{parts empty?}
    J --> K
    K -- yes --> L["push '⌈ms/1000⌉s'"]
    K -- no --> M["return parts.join(' ')"]
    L --> M
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(release): show days in standing-PR &quot;..."](https://github.com/goosewobbler/releasekit/commit/ccd511061d6f91f064cadcab75100533d5493298) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45322366)</sub>

<!-- /greptile_comment -->