### PR TITLE
fix(release): register gate, refresh-after-release, backfill in dispatcher (#519)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -6,8 +6,8 @@ ReleaseKit ships a unified `releasekit` command plus three standalone binaries. 
 
 | Binary | Provided by | Commands |
 |---|---|---|
-| `releasekit` | `@releasekit/release` | `preview` (default), `release`, `standing-pr`, `init`, `version`, `notes`, `publish` |
-| `releasekit-release` | `@releasekit/release` | `preview` (default), `release`, `standing-pr`, [`gate`](#releasekit-release-gate) |
+| `releasekit` | `@releasekit/release` | `preview` (default), `release`, `gate`, `standing-pr`, `refresh-after-release`, `backfill`, `init`, `labels`, `version`, `notes`, `publish` |
+| `releasekit-release` | `@releasekit/release` | `preview` (default), `release`, [`gate`](#releasekit-release-gate), `standing-pr`, `refresh-after-release`, [`backfill`](#releasekit-release-backfill) |
 | `releasekit-version` | `@releasekit/version` | `version` |
 | `releasekit-notes` | `@releasekit/notes` | `notes` |
 | `releasekit-publish` | `@releasekit/publish` | `publish` |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -330,7 +330,7 @@ releasekit version --json | releasekit publish --dry-run
 
 ## `releasekit-release gate`
 
-The standalone `releasekit-release` binary (also from `@releasekit/release`) exposes an extra `gate` command used by the GitHub Action's `gate` mode. It checks whether a release should proceed based on PR labels and config.
+The `gate` command — used by the GitHub Action's `gate` mode — checks whether a release should proceed based on PR labels and config. It is exposed on both the `releasekit` and `releasekit-release` binaries (from `@releasekit/release`).
 
 | Flag | Type | Default | Description |
 |---|---|---|---|
@@ -342,14 +342,14 @@ The standalone `releasekit-release` binary (also from `@releasekit/release`) exp
 | `--project-dir <path>` | string | `cwd` | Project directory |
 
 ```bash
-releasekit-release gate --json
+releasekit gate --json            # or, equivalently: releasekit-release gate --json
 ```
 
 > Most users run `gate` through the [GitHub Action](./action.md) (`mode: gate`) rather than the CLI directly.
 
 ## `releasekit-release backfill`
 
-Regenerate release notes for **already-released** versions of one or more packages by reconstructing each version's notes from git history. Each version is rendered through the notes pipeline and written to per-version files (`notes.releaseNotes.file.dir`), to the matching GitHub release bodies (`--update-releases`), or both. Dry-run by default — pass `--apply` to write. Needs at least one output: `notes.releaseNotes.file.dir` set, `--update-releases`, or both.
+Regenerate release notes for **already-released** versions of one or more packages by reconstructing each version's notes from git history. Each version is rendered through the notes pipeline and written to per-version files (`notes.releaseNotes.file.dir`), to the matching GitHub release bodies (`--update-releases`), or both. Dry-run by default — pass `--apply` to write. Needs at least one output: `notes.releaseNotes.file.dir` set, `--update-releases`, or both. Exposed on both the `releasekit` and `releasekit-release` binaries; the examples below use `releasekit-release`, but `releasekit backfill` is equivalent.
 
 | Flag | Type | Default | Description |
 |---|---|---|---|

--- a/packages/release/src/dispatcher.ts
+++ b/packages/release/src/dispatcher.ts
@@ -6,9 +6,12 @@ import { createNotesCommand } from '@releasekit/notes';
 import { createPublishCommand } from '@releasekit/publish';
 import { createVersionCommand } from '@releasekit/version';
 import { Command } from 'commander';
+import { createBackfillCommand } from './commands/backfill-command.js';
+import { createGateCommand } from './commands/gate-command.js';
 import { createInitCommand } from './commands/init-command.js';
 import { createLabelsCommand } from './commands/labels-command.js';
 import { createPreviewCommand } from './commands/preview-command.js';
+import { createRefreshAfterReleaseCommand } from './commands/refresh-after-release-command.js';
 import { createReleaseCommand } from './commands/release-command.js';
 import { createStandingPRCommand } from './commands/standing-pr-command.js';
 
@@ -19,7 +22,10 @@ export function createDispatcherProgram(): Command {
     .version(readPackageVersion(import.meta.url));
   program.addCommand(createPreviewCommand(), { isDefault: true });
   program.addCommand(createReleaseCommand());
+  program.addCommand(createGateCommand());
   program.addCommand(createStandingPRCommand());
+  program.addCommand(createRefreshAfterReleaseCommand());
+  program.addCommand(createBackfillCommand());
   program.addCommand(createInitCommand());
   program.addCommand(createLabelsCommand());
   program.addCommand(createVersionCommand());

--- a/packages/release/test/unit/dispatcher.spec.ts
+++ b/packages/release/test/unit/dispatcher.spec.ts
@@ -110,11 +110,10 @@ describe('createDispatcherProgram', () => {
   });
 
   it('should route `refresh-after-release` to its own command, not the default preview', () => {
-    // The reported symptom (#519): with the command unregistered, the dispatcher hands the token to the
-    // default `preview` command as a positional, which rejects it with "too many arguments for 'preview'".
+    // The reported symptom (#519): an unregistered command falls through to the default `preview`, which
+    // rejects the stray positional. preview is mocked with exitOverride and refresh with a no-op action
+    // (both above), so a misroute throws instead of exiting — a clean parse proves correct routing.
     const program = createDispatcherProgram().exitOverride();
-    expect(() => program.parse(['refresh-after-release'], { from: 'user' })).not.toThrow(
-      /too many arguments for 'preview'/,
-    );
+    expect(() => program.parse(['refresh-after-release'], { from: 'user' })).not.toThrow();
   });
 });

--- a/packages/release/test/unit/dispatcher.spec.ts
+++ b/packages/release/test/unit/dispatcher.spec.ts
@@ -4,18 +4,27 @@ vi.mock('@releasekit/notes/cli');
 vi.mock('@releasekit/publish/cli');
 vi.mock('@releasekit/version/cli');
 vi.mock('../../src/commands/preview-command.js');
+vi.mock('../../src/commands/refresh-after-release-command.js');
 
 import { createNotesCommand } from '@releasekit/notes/cli';
 import { createPublishCommand } from '@releasekit/publish/cli';
 import { createVersionCommand } from '@releasekit/version/cli';
 import { Command } from 'commander';
+import { createReleaseProgram } from '../../src/cli.js';
 import { createPreviewCommand } from '../../src/commands/preview-command.js';
+import { createRefreshAfterReleaseCommand } from '../../src/commands/refresh-after-release-command.js';
 import { createDispatcherProgram } from '../../src/dispatcher.js';
 
 vi.mocked(createNotesCommand).mockReturnValue(new Command('notes').description('notes'));
 vi.mocked(createPublishCommand).mockReturnValue(new Command('publish').description('publish'));
 vi.mocked(createVersionCommand).mockReturnValue(new Command('version').description('version'));
-vi.mocked(createPreviewCommand).mockReturnValue(new Command('preview').description('preview'));
+// exitOverride so an accidental route to preview (the default command) throws a catchable error
+// instead of process.exit()-ing the test worker — see the routing smoke test below.
+vi.mocked(createPreviewCommand).mockReturnValue(new Command('preview').description('preview').exitOverride());
+// No-op action so routing to it in the smoke test doesn't run the real post-release reconcile.
+vi.mocked(createRefreshAfterReleaseCommand).mockReturnValue(
+  new Command('refresh-after-release').description('refresh-after-release').action(() => {}),
+);
 
 describe('createDispatcherProgram', () => {
   it('should be named releasekit', () => {
@@ -65,8 +74,47 @@ describe('createDispatcherProgram', () => {
     expect(cmd).toBeDefined();
   });
 
+  it('should register the gate command', () => {
+    const program = createDispatcherProgram();
+    const cmd = program.commands.find((c) => c.name() === 'gate');
+    expect(cmd).toBeDefined();
+  });
+
+  it('should register the refresh-after-release command', () => {
+    const program = createDispatcherProgram();
+    const cmd = program.commands.find((c) => c.name() === 'refresh-after-release');
+    expect(cmd).toBeDefined();
+  });
+
+  it('should register the backfill command', () => {
+    const program = createDispatcherProgram();
+    const cmd = program.commands.find((c) => c.name() === 'backfill');
+    expect(cmd).toBeDefined();
+  });
+
   it('should have preview as the default command', () => {
     const program = createDispatcherProgram();
     expect((program as unknown as { _defaultCommandName: string })._defaultCommandName).toBe('preview');
+  });
+
+  // Durable drift guard: the public `releasekit` bin (dispatcher) must expose every release-domain
+  // command the `releasekit-release` bin does, or `releasekit <cmd>` silently routes to the default
+  // `preview` command (#519). Registering a new command in cli.ts without the dispatcher trips this.
+  it('should expose every release-domain command the release CLI does', () => {
+    const dispatcher = new Set(createDispatcherProgram().commands.map((c) => c.name()));
+    const releaseCli = createReleaseProgram().commands.map((c) => c.name());
+    // No command is intentionally CLI-only today; add a name here (with a reason) only if that changes.
+    const INTENTIONALLY_CLI_ONLY = new Set<string>([]);
+    const missing = releaseCli.filter((n) => !dispatcher.has(n) && !INTENTIONALLY_CLI_ONLY.has(n));
+    expect(missing).toEqual([]);
+  });
+
+  it('should route `refresh-after-release` to its own command, not the default preview', () => {
+    // The reported symptom (#519): with the command unregistered, the dispatcher hands the token to the
+    // default `preview` command as a positional, which rejects it with "too many arguments for 'preview'".
+    const program = createDispatcherProgram().exitOverride();
+    expect(() => program.parse(['refresh-after-release'], { from: 'user' })).not.toThrow(
+      /too many arguments for 'preview'/,
+    );
   });
 });


### PR DESCRIPTION
## What

Register `gate`, `refresh-after-release`, and `backfill` in the `releasekit` dispatcher (`createDispatcherProgram`), so the public `releasekit` bin exposes the same release-domain commands as the `releasekit-release` bin.

## Why

`@releasekit/release` ships two bins: `releasekit` → dispatcher and `releasekit-release` → release CLI. The dispatcher registers `preview` as the default command but was missing `gate`, `refresh-after-release`, and `backfill`. So `releasekit refresh-after-release` was parsed as a positional argument to the default `preview` command and failed with `error: too many arguments for 'preview'` — which broke the documented post-release "Refresh standing PR" step in a real consumer release (`v0.39.0`). `gate` and `backfill` had the same latent gap.

## Changes

- **`dispatcher.ts`**: register the three missing command factories (preview stays `isDefault`).
- **`dispatcher.spec.ts`**: a durable parity guard (`should expose every release-domain command the release CLI does`) that kills the whole drift class, per-command registration tests, and a routing smoke test that reproduces the `too many arguments for 'preview'` symptom.
- **`docs/cli.md`**: correct both binaries-table rows to the actual registered command sets.

## Notes

- The issue's suggested `--help` smoke test does **not** reproduce the symptom — commander short-circuits on `--help` before the excess-argument check. The smoke test was strengthened to parse the bare `refresh-after-release` argv (with `preview` mocked `exitOverride()` and the refresh command mocked to a no-op) so it is verified **red against the pre-fix dispatcher** and green after.
- Verified red-on-old: the parity guard, the three per-command tests, and the smoke test all fail when `dispatcher.ts` is reverted.

## Verification

- `pnpm turbo run lint typecheck test --force` — all 32 tasks pass (release 806/806).
- `pnpm lint` — clean.

Closes #519

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a real-world regression where `releasekit refresh-after-release` (and `gate`/`backfill`) were silently routed to the default `preview` command because they were never registered in the dispatcher, causing `error: too many arguments for 'preview'`.

- **`dispatcher.ts`**: Adds three imports and three `addCommand` calls for `gate`, `refresh-after-release`, and `backfill` — the minimal correct fix.
- **`dispatcher.spec.ts`**: Adds per-command registration tests, a durable parity guard that compares the dispatcher's command set to the release CLI on every run (killing the whole drift class), and a routing smoke test that is red against the pre-fix dispatcher and green after. The smoke test uses `.not.toThrow()` (positive assertion) rather than a narrowly-scoped regex negative.
- **`docs/cli.md`**: Corrects the binaries table and updates the `gate`/`backfill` section prose to reflect availability on both `releasekit` and `releasekit-release`; previous comments about stale exclusivity wording are addressed.
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a targeted registration fix with no behavioural side-effects on existing commands.

The dispatcher change is three addCommand calls mirroring what the release CLI already exposes. The new parity guard test ensures the same class of drift cannot recur silently. Docs accurately reflect the updated command sets. No existing behaviour is altered.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/release/src/dispatcher.ts | Adds three missing imports and `addCommand` calls for `gate`, `refresh-after-release`, and `backfill`; minimal, correct fix. |
| packages/release/test/unit/dispatcher.spec.ts | Adds per-command registration tests, a durable parity guard against future drift, and a routing smoke test that reproduces the original bug; `.not.toThrow()` (no regex) is a positive assertion. |
| docs/cli.md | Corrects the binaries table and updates the `gate`/`backfill` section prose to reflect availability on both binaries; no factual errors remain. |

</details>


<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["releasekit <cmd>"] --> B{dispatcher}
    B -->|"preview (default)"| C[createPreviewCommand]
    B -->|"release"| D[createReleaseCommand]
    B -->|"gate NEW"| E[createGateCommand]
    B -->|"standing-pr"| F[createStandingPRCommand]
    B -->|"refresh-after-release NEW"| G[createRefreshAfterReleaseCommand]
    B -->|"backfill NEW"| H[createBackfillCommand]
    B -->|"init/labels/version/notes/publish"| I[other commands]

    style E fill:#d4edda,stroke:#28a745
    style G fill:#d4edda,stroke:#28a745
    style H fill:#d4edda,stroke:#28a745
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["releasekit <cmd>"] --> B{dispatcher}
    B -->|"preview (default)"| C[createPreviewCommand]
    B -->|"release"| D[createReleaseCommand]
    B -->|"gate NEW"| E[createGateCommand]
    B -->|"standing-pr"| F[createStandingPRCommand]
    B -->|"refresh-after-release NEW"| G[createRefreshAfterReleaseCommand]
    B -->|"backfill NEW"| H[createBackfillCommand]
    B -->|"init/labels/version/notes/publish"| I[other commands]

    style E fill:#d4edda,stroke:#28a745
    style G fill:#d4edda,stroke:#28a745
    style H fill:#d4edda,stroke:#28a745
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `docs/cli.md`, line 331-348 ([link](https://github.com/goosewobbler/releasekit/blob/1486f9b463b8523c0327ef342365a3c10352df3c/docs/cli.md#L331-L348)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Section body still describes `gate` as exclusive to `releasekit-release`**

   The opening sentence reads "The standalone `releasekit-release` binary…exposes an **extra** `gate` command" — but after this PR `gate` (and `backfill`) are also registered in the `releasekit` dispatcher. The word "extra" implies it is unique to the standalone binary, which is no longer true. The CLI example at the bottom of the section (`releasekit-release gate --json`) similarly misses the now-equivalent `releasekit gate --json` form. The `backfill` section (line 350) has the same issue.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20docs%2Fcli.md%0ALine%3A%20331-348%0A%0AComment%3A%0A**Section%20body%20still%20describes%20%60gate%60%20as%20exclusive%20to%20%60releasekit-release%60**%0A%0AThe%20opening%20sentence%20reads%20%22The%20standalone%20%60releasekit-release%60%20binary%E2%80%A6exposes%20an%20**extra**%20%60gate%60%20command%22%20%E2%80%94%20but%20after%20this%20PR%20%60gate%60%20%28and%20%60backfill%60%29%20are%20also%20registered%20in%20the%20%60releasekit%60%20dispatcher.%20The%20word%20%22extra%22%20implies%20it%20is%20unique%20to%20the%20standalone%20binary%2C%20which%20is%20no%20longer%20true.%20The%20CLI%20example%20at%20the%20bottom%20of%20the%20section%20%28%60releasekit-release%20gate%20--json%60%29%20similarly%20misses%20the%20now-equivalent%20%60releasekit%20gate%20--json%60%20form.%20The%20%60backfill%60%20section%20%28line%20350%29%20has%20the%20same%20issue.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=goosewobbler%2Freleasekit&pr=538&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20docs%2Fcli.md%0ALine%3A%20331-348%0A%0AComment%3A%0A**Section%20body%20still%20describes%20%60gate%60%20as%20exclusive%20to%20%60releasekit-release%60**%0A%0AThe%20opening%20sentence%20reads%20%22The%20standalone%20%60releasekit-release%60%20binary%E2%80%A6exposes%20an%20**extra**%20%60gate%60%20command%22%20%E2%80%94%20but%20after%20this%20PR%20%60gate%60%20%28and%20%60backfill%60%29%20are%20also%20registered%20in%20the%20%60releasekit%60%20dispatcher.%20The%20word%20%22extra%22%20implies%20it%20is%20unique%20to%20the%20standalone%20binary%2C%20which%20is%20no%20longer%20true.%20The%20CLI%20example%20at%20the%20bottom%20of%20the%20section%20%28%60releasekit-release%20gate%20--json%60%29%20similarly%20misses%20the%20now-equivalent%20%60releasekit%20gate%20--json%60%20form.%20The%20%60backfill%60%20section%20%28line%20350%29%20has%20the%20same%20issue.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=538&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["test(release): positive dispatcher routi..."](https://github.com/goosewobbler/releasekit/commit/361d417e5433c5d41e7d558d9547226276f221e4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45323165)</sub>

<!-- /greptile_comment -->