### PR TITLE
docs: add themed ROADMAP.md and establish docs/adr

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,4 +97,5 @@ Fresh worktrees need `pnpm install` first. If you change dependencies, run `pnpm
 | [docs/troubleshooting.md](./docs/troubleshooting.md) | Symptom-indexed errors, failed-publish recovery |
 | [packages/release/docs/ci-setup.md](./packages/release/docs/ci-setup.md) | Consumer workflow templates, standing-PR mode, securing the standing PR |
 | [docs/action.md](./docs/action.md) | GitHub Action inputs/outputs |
-| [ROADMAP.md](./ROADMAP.md) | Direction: sequencing, settled decisions (stay TS, no MCP, change files as option), ecosystem triggers |
+| [ROADMAP.md](./ROADMAP.md) | Development sequencing by theme; ecosystem support (planned + not-planned) and prioritization criteria |
+| [docs/adr/](./docs/adr/) | Architecture Decision Records — the durable *why* behind load-bearing choices (language, agent surface, change-file input) |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,3 +97,4 @@ Fresh worktrees need `pnpm install` first. If you change dependencies, run `pnpm
 | [docs/troubleshooting.md](./docs/troubleshooting.md) | Symptom-indexed errors, failed-publish recovery |
 | [packages/release/docs/ci-setup.md](./packages/release/docs/ci-setup.md) | Consumer workflow templates, standing-PR mode, securing the standing PR |
 | [docs/action.md](./docs/action.md) | GitHub Action inputs/outputs |
+| [ROADMAP.md](./ROADMAP.md) | Direction: sequencing, settled decisions (stay TS, no MCP, change files as option), ecosystem triggers |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,65 @@
+# Roadmap
+
+Distilled from the July 2026 direction review: ~40 tools and ecosystems surveyed, with code-level analysis of changesets, release-please, semantic-release, release-plz, knope, git-cliff, melos, and sampo, plus an 11-class taxonomy of publishing models. The full research document is retained by the maintainer outside the repo; this file records the decisions, the sequence, and the triggers for revisiting them.
+
+## Positioning
+
+No surveyed tool combines releasekit's three pillars — interactive standing-PR control plane, multi-registry publishing, and LLM-enhanced notes. The nearest competitors each miss at least one: release-please doesn't publish (and Google is sunsetting it), release-plz is Rust-only, knope doesn't publish, melos has no release PR, sampo has no conventional-commit input, no OIDC, and a static release PR. The moat to widen: standing-PR depth, notes quality, trusted publishing, and the agent-safety story. The moat argument against LLM-generated bespoke release scripts: registries churn policy (npm's classic-token revocation broke every pre-Dec-2025 hand-rolled script), and the hard 20% — idempotent multi-registry retry, roll-forward recovery, OIDC quirks — is exactly what one-shot scripts get wrong.
+
+## Settled decisions
+
+| Decision | Rationale (short) | Reconsider when |
+|---|---|---|
+| **Stay TypeScript** — no Rust core, no rewrite | Workload is IO-bound (the biome/oxc rationale doesn't transfer); no official Anthropic Rust SDK for the LLM moat; sampo's own npm shim still requires Node; EJS templates and in-flight `VersionOutput` manifests would break; solo+agent velocity is TS-anchored | Measured CPU-bound hotspot; official Anthropic Rust SDK *and* evidence Node blocks adoption; multi-maintainer team. Probe binary-distribution demand with Node SEA / `bun build --compile` first — never as a language decision |
+| **No MCP server** | Inner-loop local/CI tooling; CLI-with-JSON beats MCP on tokens and equals it on success rates; Nx built one and migrated the knowledge out into skills | releasekit grows a hosted, stateful service |
+| **Change files: in, as an option** (#545) | Intercept changesets migrators who would otherwise land on sampo; knope proves commits+files unify | — (decided; conventional commits stay the default) |
+| **Ecosystem policy: depth over breadth** | Polyglot breadth without depth is knope's position; release-please died of maintenance burden; every shipped ecosystem must be maintainable by one person | Per-ecosystem triggers below |
+| **Publish-by-PR indexes, async-review stores, ML hubs: never registry targets** | Wrong model class (forge-territory, third publish state, no version coordinate — respectively) | Documented per class in the review |
+
+## Now (in order)
+
+1. **#540** LLM security pack — marker-sequence neutralization + prompt-injection hardening (P1, small)
+2. **#541** LLM model defaults — optional `model`, curated per-provider tiers, `provider` enum
+3. **#544** Agent-grade CLI contract — uniform JSON envelope, error codes, `changed`, structured plan output (foundation)
+4. **#545** Change-file support (changesets-compatible) + `migrate --from-changesets`
+5. **#546** Trusted publishing (OIDC) — doctor, crates.io OIDC, first-publish detection, provenance
+
+## Next
+
+6. **#547** pub.dev depth — graph wiring (correctness hole), constraint rewriting, Flutter build numbers
+7. **#543** LLM reliability batch + **#542** eval harness
+8. **#548** `releasekit sync` — registry reconciliation
+9. **#549** Agent surface — skill, AGENTS.md snippet, safety docs (after #544)
+10. **#550** Tag-only mode + generic updaters — GitHub Actions, Terraform, C/C++ presets
+11. **#551** Bump-verifier slot + cargo-semver-checks
+12. **#552** Prerelease escalation + stabilize preview (design; resolves the #335 class)
+
+## Later (small, slot anywhere)
+
+- Channel promotion as a first-class op (npm dist-tag move instead of republish; extends channel toggles)
+- Adopt `cargo publish --workspace` (Cargo ≥1.90) for Rust publish ordering
+- Verified bot commits via GitHub GraphQL (standing-PR commits show as Verified)
+- PR-body/comment budget management (65,536-char cap with graceful degradation)
+- Announce fan-out (generic webhook + 2–3 chat targets off the GitHub Release)
+- npm `publishConfig.registry` audit + docs page (Verdaccio / GitHub Packages / Unity UPM — likely zero code)
+- Agent-artifact lockstep: `server.json` version-sync + `mcp-publisher publish` post-step; `plugin.json`/`marketplace.json` as version-manifest targets (MCP registry API is v0.1 preview — expect churn until GA)
+- Backfill graduation — dogfood tracked in #539
+
+## Ecosystem queue (behind triggers)
+
+| Ecosystem | Trigger |
+|---|---|
+| JSR | When convenient — near-free adjacency to npm; best OIDC story of any registry |
+| Python (PyPI / uv workspaces) | Demand signal or own usage — the uv-workspace release gap is open and unowned; window may close if Astral moves |
+| .NET (NuGet) | Demand signal — strongest demand-to-cost of the traditional ecosystems; trusted publishing fresh (Sept 2025) |
+| Ruby (RubyGems) | Demand signal — cheap, OIDC-mature since 2023 |
+| Elixir + Gleam (Hex) | Hex ships trusted publishing (announced Mar 2026, unshipped); note sampo is already there |
+| Helm charts | After appVersion-sync design; k8s-monorepo fit is real |
+| Go | After Python, scoped: tag-only + subdir tags; majors hard-error; `retract` flow as differentiator |
+| PHP (Packagist) | Opportunistic — weekend-sized, weak demand |
+| Maven Central (⇒ Java, Scala, Kotlin) | Standing no — mandatory GPG, no OIDC, SNAPSHOT culture. Revisit only if Sonatype ships OIDC *and* drops/automates GPG |
+
+## Watch
+
+- **sampo** — the only tool converging on the same multi-registry pitch; racing the ecosystem queue (Hex, PyPI shipped). Its prerelease design and npm binary-carrier distribution are documented reference points; its static PR, half-built failure handling, and missing OIDC are the gaps to keep wide.
+- **Bumpy** (changesets-successor claim), **release-please migration wave** (be findable: comparison + migration docs), **OCI-as-universal-registry** (WASM components, Helm — consider an OCI transport at the fourth registry), **MCP registry GA**.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,65 +1,121 @@
 # Roadmap
 
-Distilled from the July 2026 direction review: ~40 tools and ecosystems surveyed, with code-level analysis of changesets, release-please, semantic-release, release-plz, knope, git-cliff, melos, and sampo, plus an 11-class taxonomy of publishing models. The full research document is retained by the maintainer outside the repo; this file records the decisions, the sequence, and the triggers for revisiting them.
+Development sequencing for ReleaseKit, grouped by theme. Each theme is a durable track that outlives any single ticket; the checklists within move as work lands. Architecture decisions live in [docs/adr](./docs/adr); implementation detail lives in the linked issues.
 
-## Positioning
+Status legend: 🚧 in flight · ⏭️ near-term · 📋 planned · 🔭 later.
 
-No surveyed tool combines releasekit's three pillars — interactive standing-PR control plane, multi-registry publishing, and LLM-enhanced notes. The nearest competitors each miss at least one: release-please doesn't publish (and Google is sunsetting it), release-plz is Rust-only, knope doesn't publish, melos has no release PR, sampo has no conventional-commit input, no OIDC, and a static release PR. The moat to widen: standing-PR depth, notes quality, trusted publishing, and the agent-safety story. The moat argument against LLM-generated bespoke release scripts: registries churn policy (npm's classic-token revocation broke every pre-Dec-2025 hand-rolled script), and the hard 20% — idempotent multi-registry retry, roll-forward recovery, OIDC quirks — is exactly what one-shot scripts get wrong.
+**Current focus:** hardening release notes (the differentiator) and laying the machine-readable CLI foundation, then the two competitive fronts — change-file support and trusted publishing.
 
-## Settled decisions
+---
 
-| Decision | Rationale (short) | Reconsider when |
+## Themes
+
+### Release notes & LLM enhancement 🚧
+
+The clearest differentiator — no competitor ships LLM-enhanced notes — so the bar is "novel *and* defensible".
+
+- [ ] Security hardening: neutralize `<!-- releasekit-* -->` marker sequences in LLM and edited-region output; delimit attacker-writable commit text in prompts — [#540](https://github.com/goosewobbler/releasekit/issues/540)
+- [ ] Kill model-ID rot: optional `llm.model` with curated per-provider tiers refreshed each release; enum-validate `provider` — [#541](https://github.com/goosewobbler/releasekit/issues/541)
+- [ ] Quality guardrail: eval harness (golden fixtures + cached-response replay + prompt snapshots) so the differentiator can't silently regress — [#542](https://github.com/goosewobbler/releasekit/issues/542)
+- [ ] Reliability batch: per-task soft-fail, thinking-model text path, retry classification, large-release chunking, concurrency bound — [#543](https://github.com/goosewobbler/releasekit/issues/543)
+- 🔭 Later: surface the computed summary in the standing-PR body; per-package style profiles; streaming CLI output; documented zero-config local-first (Ollama) path.
+
+### Machine-readable & agent-operable surface ⏭️
+
+One surface for humans, CI, and agents. Direction set by [ADR-0002](./docs/adr/0002-no-mcp-server-cli-is-the-agent-surface.md) (CLI + skill, not MCP).
+
+- [ ] CLI contract foundation: uniform `--json` envelope, structured error codes with retry semantics, `changed` reporting, dry-run as a structured plan — [#544](https://github.com/goosewobbler/releasekit/issues/544)
+- [ ] Ship a releasekit skill + AGENTS.md snippet + agent-safety docs (propose → approve → CI-publishes-via-OIDC) — [#549](https://github.com/goosewobbler/releasekit/issues/549)
+- 🔭 Later: agent-artifact lockstep — `server.json` version-sync + `mcp-publisher publish` as a post-publish step, `plugin.json`/`marketplace.json` as version-manifest targets (gated on the MCP registry reaching GA).
+
+### Trusted publishing & supply chain ⏭️
+
+The field's clearest differentiation window: all three current registries do OIDC, no tool owns it end-to-end, and registry policy churn is the moat argument against hand-rolled scripts.
+
+- [ ] OIDC across registries: `releasekit doctor` config check, crates.io OIDC (currently token-only), first-publish detection, pub.dev tag-pattern templates, npm provenance surfacing — [#546](https://github.com/goosewobbler/releasekit/issues/546)
+- 🔭 Later: verified bot commits via the GitHub GraphQL commit API; `publishConfig.registry` audit + a Verdaccio / GitHub Packages / Unity UPM docs page (likely zero code).
+
+### Change intent & migration 📋
+
+Direction and format set by [ADR-0003](./docs/adr/0003-optional-change-file-input.md); intercepts changesets/sampo migrators without displacing the commit-first default.
+
+- [ ] Changesets-format change-file input (unified change stream, `additive`/`only` modes) + `migrate --from-changesets` + an Action-side change-present check — [#545](https://github.com/goosewobbler/releasekit/issues/545)
+
+### Release lifecycle & recovery 📋
+
+Depth in the standing-PR control plane and the roll-forward recovery model — the areas competitors are thinnest.
+
+- [ ] Prerelease escalation + always-visible stabilize preview (resolves the [#335](https://github.com/goosewobbler/releasekit/issues/335) class where labels can't jump a prerelease to a new major line) — design in [#552](https://github.com/goosewobbler/releasekit/issues/552)
+- [ ] `releasekit sync`: reconcile local version/tag state against registries; a one-command answer for partial-publish recovery — [#548](https://github.com/goosewobbler/releasekit/issues/548)
+- [ ] Graduate backfill out of experimental (dogfood on this repo) — [#539](https://github.com/goosewobbler/releasekit/issues/539)
+- 🔭 Later: channel promotion as a first-class op (dist-tag move instead of republish); PR-body/comment budget management (graceful degradation before GitHub's char cap); announce fan-out (webhook + chat targets off the GitHub Release).
+
+---
+
+## Ecosystem Support
+
+ReleaseKit's pipeline is registry-agnostic; this section tracks which ecosystems are wired, which are queued, and which are excluded.
+
+### Supported today
+
+| Ecosystem | Publish model | Notes |
 |---|---|---|
-| **Stay TypeScript** — no Rust core, no rewrite | Workload is IO-bound (the biome/oxc rationale doesn't transfer); no official Anthropic Rust SDK for the LLM moat; sampo's own npm shim still requires Node; EJS templates and in-flight `VersionOutput` manifests would break; solo+agent velocity is TS-anchored | Measured CPU-bound hotspot; official Anthropic Rust SDK *and* evidence Node blocks adoption; multi-maintainer team. Probe binary-distribution demand with Node SEA / `bun build --compile` first — never as a language decision |
-| **No MCP server** | Inner-loop local/CI tooling; CLI-with-JSON beats MCP on tokens and equals it on success rates; Nx built one and migrated the knowledge out into skills | releasekit grows a hosted, stateful service |
-| **Change files: in, as an option** (#545) | Intercept changesets migrators who would otherwise land on sampo; knope proves commits+files unify | — (decided; conventional commits stay the default) |
-| **Ecosystem policy: depth over breadth** | Polyglot breadth without depth is knope's position; release-please died of maintenance burden; every shipped ecosystem must be maintainable by one person | Per-ecosystem triggers below |
-| **Publish-by-PR indexes, async-review stores, ML hubs: never registry targets** | Wrong model class (forge-territory, third publish state, no version coordinate — respectively) | Documented per class in the review |
+| **npm** (JS/TS) | Push API + OIDC + provenance | Reference implementation; the richest path. |
+| **crates.io** (Rust) | Push API (token today; OIDC queued in [#546](https://github.com/goosewobbler/releasekit/issues/546)) | Opt-in. |
+| **pub.dev** (Dart/Flutter) | Push API + OIDC (tag-triggered) | Opt-in; depth work below. |
 
-## Now (in order)
+### Deepening the supported three ⏭️
 
-1. **#540** LLM security pack — marker-sequence neutralization + prompt-injection hardening (P1, small)
-2. **#541** LLM model defaults — optional `model`, curated per-provider tiers, `provider` enum
-3. **#544** Agent-grade CLI contract — uniform JSON envelope, error codes, `changed`, structured plan output (foundation)
-4. **#545** Change-file support (changesets-compatible) + `migrate --from-changesets`
-5. **#546** Trusted publishing (OIDC) — doctor, crates.io OIDC, first-publish detection, provenance
+Before breadth, the existing three reach parity with their best-in-class single-ecosystem competitors:
 
-## Next
+- [ ] **pub.dev**: wire pub into the dependency graph (a current correctness hole — prerequisite derivation and publish ordering ignore Dart today), dependent-constraint rewriting in `pubspec.yaml`, Flutter `+N` build-number retention — [#547](https://github.com/goosewobbler/releasekit/issues/547)
+- [ ] **crates.io**: API-breakage detection as a pluggable bump-verifier (`max(commit-bump, API-diff-bump)`), first plugin cargo-semver-checks, with ⚠️/✓ badges in the standing PR — [#551](https://github.com/goosewobbler/releasekit/issues/551)
+- 🔭 Adopt `cargo publish --workspace` (Cargo ≥1.90) for Rust publish ordering rather than reimplementing it.
 
-6. **#547** pub.dev depth — graph wiring (correctness hole), constraint rewriting, Flutter build numbers
-7. **#543** LLM reliability batch + **#542** eval harness
-8. **#548** `releasekit sync` — registry reconciliation
-9. **#549** Agent surface — skill, AGENTS.md snippet, safety docs (after #544)
-10. **#550** Tag-only mode + generic updaters — GitHub Actions, Terraform, C/C++ presets
-11. **#551** Bump-verifier slot + cargo-semver-checks
-12. **#552** Prerelease escalation + stabilize preview (design; resolves the #335 class)
+### Breadth mechanism 📋
 
-## Later (small, slot anywhere)
+- [ ] **Tag-only registry mode + generic file updaters** — [#550](https://github.com/goosewobbler/releasekit/issues/550). One build unlocks a whole cluster (below) that needs no registry client: version-in-file (sometimes none) + tag + GitHub Release + a per-ecosystem post-step. Ships with GitHub Actions (dogfoodable on releasekit's own action), Terraform module, and C/C++ presets.
 
-- Channel promotion as a first-class op (npm dist-tag move instead of republish; extends channel toggles)
-- Adopt `cargo publish --workspace` (Cargo ≥1.90) for Rust publish ordering
-- Verified bot commits via GitHub GraphQL (standing-PR commits show as Verified)
-- PR-body/comment budget management (65,536-char cap with graceful degradation)
-- Announce fan-out (generic webhook + 2–3 chat targets off the GitHub Release)
-- npm `publishConfig.registry` audit + docs page (Verdaccio / GitHub Packages / Unity UPM — likely zero code)
-- Agent-artifact lockstep: `server.json` version-sync + `mcp-publisher publish` post-step; `plugin.json`/`marketplace.json` as version-manifest targets (MCP registry API is v0.1 preview — expect churn until GA)
-- Backfill graduation — dogfood tracked in #539
+### Planned ecosystems
 
-## Ecosystem queue (behind triggers)
+Trigger-gated, not date-gated (see [Evaluation criteria](#evaluation-criteria)). Ordered by readiness × cost-to-serve:
 
-| Ecosystem | Trigger |
+1. **Tag-only cluster** — GitHub Actions, Terraform/OpenTofu modules, C/C++, Swift, Zig. *Unblocked by [#550](https://github.com/goosewobbler/releasekit/issues/550); GitHub Actions passes the "only what I use" bar today (releasekit ships an action). No registry client, small.*
+2. **JSR** — *Near-free adjacency to npm (jsr.json is package.json-shaped); best OIDC story of any registry. Framing: one PR keeps package.json + deno.json in lockstep and publishes to npm + JSR. Do when convenient.*
+3. **Python / PyPI (uv workspaces)** — *The strongest new-ecosystem case: the uv-workspace release gap is open and unowned (PSR is monorepo-weak, release-please doesn't publish, uv ships only primitives), PyPI leads on OIDC/attestations, filename immutability matches roll-forward. Cost: a PEP 440 bridge + a dynamic-versioning policy. Trigger: a demand signal or own usage; the window may close if Astral moves.*
+4. **.NET / NuGet** — *Best demand-to-cost of the traditional ecosystems: incumbents stop at version calculation, the monorepo gap is unfilled, npm-shaped registry, trusted publishing fresh (Sept 2025). Trigger: demand signal.*
+5. **Ruby / RubyGems** — *Cheap, OIDC-mature since 2023, community already assembles this shape by hand. Capped upside (modest TAM, registry-governance noise). Trigger: demand signal.*
+6. **Elixir + Gleam / Hex** — *Demand validated (sampo shipped it wave 1); Gleam rides the same registry free. Trigger: Hex ships trusted publishing (announced Mar 2026, unshipped).*
+7. **Helm charts** — *Real k8s-monorepo fit; syncing `appVersion` to a sibling package releasekit also releases would be unique. Trigger: after the chart-`version`/`appVersion` duality is designed.*
+8. **Go** — *MVP is cheap (tag-only + subdir tags); the differentiating part (multi-module `require` rewriting with tag ordering) is the expensive part, and `/v2` majors are a source codemod against an immutable proxy. Scope: majors hard-error with guidance, `retract` flow as the novel bit. Trigger: after Python.*
+9. **PHP / Packagist** — *No publish step (webhook reads tags); a weekend-sized adapter that validates the publishless path. Weak demand and cultural fit. Opportunistic filler.*
+
+### Not planned
+
+Evaluated and excluded. Recorded so the question resolves to a lookup, not fresh research.
+
+| Ecosystem / surface | Reason |
 |---|---|
-| JSR | When convenient — near-free adjacency to npm; best OIDC story of any registry |
-| Python (PyPI / uv workspaces) | Demand signal or own usage — the uv-workspace release gap is open and unowned; window may close if Astral moves |
-| .NET (NuGet) | Demand signal — strongest demand-to-cost of the traditional ecosystems; trusted publishing fresh (Sept 2025) |
-| Ruby (RubyGems) | Demand signal — cheap, OIDC-mature since 2023 |
-| Elixir + Gleam (Hex) | Hex ships trusted publishing (announced Mar 2026, unshipped); note sampo is already there |
-| Helm charts | After appVersion-sync design; k8s-monorepo fit is real |
-| Go | After Python, scoped: tag-only + subdir tags; majors hard-error; `retract` flow as differentiator |
-| PHP (Packagist) | Opportunistic — weekend-sized, weak demand |
-| Maven Central (⇒ Java, Scala, Kotlin) | Standing no — mandatory GPG, no OIDC, SNAPSHOT culture. Revisit only if Sonatype ships OIDC *and* drops/automates GPG |
+| **Maven Central** (⇒ Java, Scala, Kotlin Multiplatform) | Mandatory GPG signing (a new support-burden class), multiple build systems, SNAPSHOT culture that fights the roll-forward model, and **no OIDC** — the one ecosystem that actively undermines the trusted-publishing strategy. Scala adds a beloved incumbent (sbt-ci-release) and tag-*derived* versioning inverted from releasekit's model. **Revisit only if** Sonatype ships OIDC *and* drops/automates GPG. |
+| **App stores & marketplaces with async review** (iOS/macOS/Play, Chrome Web Store, Mozilla Add-ons, VS Code, JetBrains, ChatGPT apps) | "Published" is not synchronously verifiable — it requires a third publish state ("submitted, pending review") the roll-forward model deliberately lacks. Owned by fastlane/EAS/vsce. Off-axis: releasekit releases library packages, not reviewed application binaries. |
+| **Publish-by-PR indexes** (Homebrew core, conda-forge, nixpkgs, winget, Flathub, deb/rpm) | Not a registry class — it's opening a PR against a shared index repo, already automated by index-side bots. If ever built, it is a post-publish *announce hook* on the existing forge layer, not a publish target. |
+| **ML model hubs** (Hugging Face, ModelScope, Kaggle, Ollama) | The repo *is* the registry (git-push-as-publish); no immutable version coordinate, and commit types don't map to weight changes. releasekit's model mismatches at every stage. |
+| **Snapcraft / binary distribution** (cargo-dist territory) | Ships application binaries, not library packages — a different product; owned by GoReleaser/JReleaser. Its channel-promotion semantics are worth borrowing (see the lifecycle theme), the target isn't. |
 
-## Watch
+---
 
-- **sampo** — the only tool converging on the same multi-registry pitch; racing the ecosystem queue (Hex, PyPI shipped). Its prerelease design and npm binary-carrier distribution are documented reference points; its static PR, half-built failure handling, and missing OIDC are the gaps to keep wide.
-- **Bumpy** (changesets-successor claim), **release-please migration wave** (be findable: comparison + migration docs), **OCI-as-universal-registry** (WASM components, Helm — consider an OCI transport at the fourth registry), **MCP registry GA**.
+## Evaluation criteria
+
+How features and ecosystems get prioritized and sequenced:
+
+1. **Widen the moat first.** Standing-PR depth, notes quality, and trusted publishing are where releasekit is differentiated and competitors are thin; these outrank breadth.
+2. **Depth over breadth for ecosystems.** Polyglot breadth without depth is a maintenance trap. Each shipped ecosystem must be maintainable by a solo maintainer; the three current ones reach best-in-class parity before new ones are added.
+3. **Ecosystem expansion is trigger-gated, not scheduled.** A queued ecosystem ships when its trigger fires — a real consumer (or the maintainer's own usage) needs it, or a blocking dependency (e.g. a registry's trusted publishing) lands. This keeps the "only ecosystems I actually use/maintain" constraint enforceable.
+4. **Registry-model fit is a gate.** A target must map onto version → notes → (optional) publish with synchronous idempotency. Async-review, publish-by-PR, and repo-is-the-registry models are excluded on this basis (see Not planned).
+5. **Prefer one general mechanism to many special cases.** The tag-only mode + generic updaters serve a whole ecosystem cluster from a single build; the bump-verifier is a pluggable slot, not a cargo special case.
+
+---
+
+## Status disclaimer
+
+Sequencing reflects current intent and shifts with real-world demand, maintainer availability, and upstream ecosystem changes (registry policies, trusted-publishing rollouts). Themes are durable; the order within and between them is not a commitment.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -70,7 +70,7 @@ ReleaseKit's pipeline is registry-agnostic; this section tracks which ecosystems
 | **crates.io** (Rust) | Push API (OIDC queued — [#546](https://github.com/goosewobbler/releasekit/issues/546)) |
 | **pub.dev** (Dart/Flutter) | Push API, OIDC (tag-triggered) |
 
-Version handling is on by default for all three; per-registry *publishing* defaults are currently asymmetric (npm on, crates.io/pub.dev opt-in) — a wrinkle under review in [#554](https://github.com/goosewobbler/releasekit/issues/554).
+Publishing defaults are currently asymmetric (npm on, crates.io/pub.dev opt-in), and npm alone has no version-handling opt-out. [#554](https://github.com/goosewobbler/releasekit/issues/554) unifies both layers to "detection enables, config opts out" — every detected ecosystem versioned and published by default, symmetric opt-outs at each layer.
 
 ### Deepening the supported three ⏭️
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -18,7 +18,10 @@ The clearest differentiator — no competitor ships LLM-enhanced notes — so th
 - [ ] Kill model-ID rot: optional `llm.model` with curated per-provider tiers refreshed each release; enum-validate `provider` — [#541](https://github.com/goosewobbler/releasekit/issues/541)
 - [ ] Quality guardrail: eval harness (golden fixtures + cached-response replay + prompt snapshots) so the differentiator can't silently regress — [#542](https://github.com/goosewobbler/releasekit/issues/542)
 - [ ] Reliability batch: per-task soft-fail, thinking-model text path, retry classification, large-release chunking, concurrency bound — [#543](https://github.com/goosewobbler/releasekit/issues/543)
-- 🔭 Later: surface the computed summary in the standing-PR body; per-package style profiles; streaming CLI output; documented zero-config local-first (Ollama) path.
+- 🔭 Surface the computed release summary in the standing-PR body (reuse the existing `summarize` output).
+- 🔭 Per-package style profiles — distinct voice for user-facing vs internal packages.
+- 🔭 Streaming provider output for CLI / backfill UX.
+- 🔭 Zero-config local-first path (Ollama) documented as the keyless default.
 
 ### Machine-readable & agent-operable surface ⏭️
 
@@ -26,14 +29,15 @@ One surface for humans, CI, and agents. Direction set by [ADR-0002](./docs/adr/0
 
 - [ ] CLI contract foundation: uniform `--json` envelope, structured error codes with retry semantics, `changed` reporting, dry-run as a structured plan — [#544](https://github.com/goosewobbler/releasekit/issues/544)
 - [ ] Ship a releasekit skill + AGENTS.md snippet + agent-safety docs (propose → approve → CI-publishes-via-OIDC) — [#549](https://github.com/goosewobbler/releasekit/issues/549)
-- 🔭 Later: agent-artifact lockstep — `server.json` version-sync + `mcp-publisher publish` as a post-publish step, `plugin.json`/`marketplace.json` as version-manifest targets (gated on the MCP registry reaching GA).
+- 🔭 Agent-artifact lockstep — keep an MCP server's npm package, its `server.json`, and any plugin/skill wrapper on one version; `server.json` sync + `mcp-publisher publish` as a post-publish step. Gated on the MCP registry reaching GA.
 
 ### Trusted publishing & supply chain ⏭️
 
 The field's clearest differentiation window: all three current registries do OIDC, no tool owns it end-to-end, and registry policy churn is the moat argument against hand-rolled scripts.
 
 - [ ] OIDC across registries: `releasekit doctor` config check, crates.io OIDC (currently token-only), first-publish detection, pub.dev tag-pattern templates, npm provenance surfacing — [#546](https://github.com/goosewobbler/releasekit/issues/546)
-- 🔭 Later: verified bot commits via the GitHub GraphQL commit API; `publishConfig.registry` audit + a Verdaccio / GitHub Packages / Unity UPM docs page (likely zero code).
+- 🔭 Verified bot commits via the GitHub GraphQL commit API (standing-PR commits show as Verified).
+- 🔭 `publishConfig.registry` audit + a Verdaccio / GitHub Packages / Unity UPM docs page (npm-protocol reuse; likely zero code).
 
 ### Change intent & migration 📋
 
@@ -48,13 +52,15 @@ Depth in the standing-PR control plane and the roll-forward recovery model — t
 - [ ] Prerelease escalation + always-visible stabilize preview (resolves the [#335](https://github.com/goosewobbler/releasekit/issues/335) class where labels can't jump a prerelease to a new major line) — design in [#552](https://github.com/goosewobbler/releasekit/issues/552)
 - [ ] `releasekit sync`: reconcile local version/tag state against registries; a one-command answer for partial-publish recovery — [#548](https://github.com/goosewobbler/releasekit/issues/548)
 - [ ] Graduate backfill out of experimental (dogfood on this repo) — [#539](https://github.com/goosewobbler/releasekit/issues/539)
-- 🔭 Later: channel promotion as a first-class op (dist-tag move instead of republish); PR-body/comment budget management (graceful degradation before GitHub's char cap); announce fan-out (webhook + chat targets off the GitHub Release).
+- 🔭 Channel promotion as a first-class op — move an npm dist-tag instead of republishing when graduating a prerelease.
+- 🔭 PR-body / comment budget management — graceful degradation before GitHub's character cap.
+- 🔭 Announce fan-out — a generic webhook plus a few chat targets (Discord/Slack/Mastodon) off the GitHub Release. First step toward the post-publish propagation in [Possible future scope](#possible-future-scope).
 
 ---
 
 ## Ecosystem Support
 
-ReleaseKit's pipeline is registry-agnostic; this section tracks which ecosystems are wired, which are queued, and which are excluded.
+ReleaseKit's pipeline is registry-agnostic; this section tracks which ecosystems are wired, which are queued, which are possible future scope, and which are excluded.
 
 ### Supported today
 
@@ -78,29 +84,37 @@ Before breadth, the existing three reach parity with their best-in-class single-
 
 ### Planned ecosystems
 
-Trigger-gated, not date-gated (see [Evaluation criteria](#evaluation-criteria)). Ordered by readiness × cost-to-serve:
+Extending the multi-ecosystem promise, these are commitments — mainstream ecosystems are a matter of when, not if. Ordered by cost-to-serve × strategic value, not by date. A concrete consumer (or the maintainer's own usage) moves an item up the order; it does not unlock it.
 
-1. **Tag-only cluster** — GitHub Actions, Terraform/OpenTofu modules, C/C++, Swift, Zig. *Unblocked by [#550](https://github.com/goosewobbler/releasekit/issues/550); GitHub Actions passes the "only what I use" bar today (releasekit ships an action). No registry client, small.*
-2. **JSR** — *Near-free adjacency to npm (jsr.json is package.json-shaped); best OIDC story of any registry. Framing: one PR keeps package.json + deno.json in lockstep and publishes to npm + JSR. Do when convenient.*
-3. **Python / PyPI (uv workspaces)** — *The strongest new-ecosystem case: the uv-workspace release gap is open and unowned (PSR is monorepo-weak, release-please doesn't publish, uv ships only primitives), PyPI leads on OIDC/attestations, filename immutability matches roll-forward. Cost: a PEP 440 bridge + a dynamic-versioning policy. Trigger: a demand signal or own usage; the window may close if Astral moves.*
-4. **.NET / NuGet** — *Best demand-to-cost of the traditional ecosystems: incumbents stop at version calculation, the monorepo gap is unfilled, npm-shaped registry, trusted publishing fresh (Sept 2025). Trigger: demand signal.*
-5. **Ruby / RubyGems** — *Cheap, OIDC-mature since 2023, community already assembles this shape by hand. Capped upside (modest TAM, registry-governance noise). Trigger: demand signal.*
-6. **Elixir + Gleam / Hex** — *Demand validated (sampo shipped it wave 1); Gleam rides the same registry free. Trigger: Hex ships trusted publishing (announced Mar 2026, unshipped).*
-7. **Helm charts** — *Real k8s-monorepo fit; syncing `appVersion` to a sibling package releasekit also releases would be unique. Trigger: after the chart-`version`/`appVersion` duality is designed.*
-8. **Go** — *MVP is cheap (tag-only + subdir tags); the differentiating part (multi-module `require` rewriting with tag ordering) is the expensive part, and `/v2` majors are a source codemod against an immutable proxy. Scope: majors hard-error with guidance, `retract` flow as the novel bit. Trigger: after Python.*
-9. **PHP / Packagist** — *No publish step (webhook reads tags); a weekend-sized adapter that validates the publishless path. Weak demand and cultural fit. Opportunistic filler.*
+1. **Tag-only cluster** — GitHub Actions, Terraform/OpenTofu modules, C/C++, Swift, Zig. Unblocked by [#550](https://github.com/goosewobbler/releasekit/issues/550); no registry client, small. GitHub Actions is dogfoodable on releasekit's own composite action.
+2. **JSR** — near-free adjacency to npm (jsr.json is package.json-shaped) and the best OIDC story of any registry. One PR keeps package.json + deno.json in lockstep across npm + JSR.
+3. **Python / PyPI (uv workspaces)** — the strongest case: the uv-workspace release gap is open and unowned (python-semantic-release is monorepo-weak, release-please doesn't publish, uv ships only primitives), PyPI leads on OIDC/attestations, and filename immutability matches the roll-forward model. Cost: a PEP 440 bridge and a dynamic-versioning (setuptools-scm / hatch-vcs) policy.
+4. **.NET / NuGet** — incumbents stop at version calculation, the monorepo/release-PR gap is unfilled, the registry is npm-shaped, and trusted publishing is fresh (Sept 2025). Cheap parser.
+5. **Ruby / RubyGems** — cheap, OIDC-mature since 2023; the one new parser class is the `version.rb` constant. Capped upside (modest reach, registry-governance noise).
+6. **Go** — the MVP is cheap (tag-only + subdir-prefixed tags), but the differentiating part — multi-module `require` rewriting with tag ordering — is the expensive part, and `/v2` majors are a source codemod against an immutable proxy. Scope: majors hard-error with migration guidance; the `retract` flow is the novel differentiator.
+7. **PHP / Packagist** — a small adapter (Packagist reads tags; no publish step). Lower priority not because PHP is small — it isn't — but because releasekit's specific value-add is thinner there: conventional-commit culture is less common, and the large multi-package frameworks (Symfony, Laravel) release via subtree-splits releasekit doesn't serve.
+
+**Gated on a prerequisite** (a genuine block, not just ordering):
+
+- **Elixir + Gleam / Hex** — demand validated (sampo shipped it in its first wave) and Gleam rides the same registry for free. Waiting on Hex trusted publishing (announced Mar 2026, not yet shipped) so it lands OIDC-first like the others.
+- **Helm charts** — real k8s-monorepo fit, and syncing `appVersion` to a sibling package releasekit also releases would be genuinely unique. Needs the chart-`version` / `appVersion` duality designed first.
+
+### Possible future scope
+
+Outside releasekit's current mission (version → notes → publish for library packages), but on a coherent growth path — the version/notes/tag half is already releasekit's. Not commitments; recorded so the boundary is a considered decision. Revisited only after the core themes mature.
+
+- **Binary / artifact distribution** — build, checksum, sign, and attach cross-platform binaries and installers to the GitHub Release releasekit already creates (the cargo-dist / GoReleaser space; cargo-dist itself is in caretaker limbo). Natural shape: a separate `@releasekit/dist`-style package, or a documented hand-off triggered by releasekit's tags — not a change to the core pipeline. Would also absorb Snapcraft and OS packaging.
+- **Post-publish propagation** — after a clean publish, open a PR to bump a Homebrew tap or a winget / nixpkgs entry, or ping an index. Reuses the existing `forge` layer (fork → branch → PR → poll-merge) and serves releasekit's actual audience (a library author who also ships a CLI). The chat-announce fan-out in the lifecycle theme is the first step on this path.
 
 ### Not planned
 
-Evaluated and excluded. Recorded so the question resolves to a lookup, not fresh research.
+Genuinely excluded — wrong model class or off-mission. A separate product could tackle some (noted); they are not releasekit.
 
 | Ecosystem / surface | Reason |
 |---|---|
 | **Maven Central** (⇒ Java, Scala, Kotlin Multiplatform) | Mandatory GPG signing (a new support-burden class), multiple build systems, SNAPSHOT culture that fights the roll-forward model, and **no OIDC** — the one ecosystem that actively undermines the trusted-publishing strategy. Scala adds a beloved incumbent (sbt-ci-release) and tag-*derived* versioning inverted from releasekit's model. **Revisit only if** Sonatype ships OIDC *and* drops/automates GPG. |
-| **App stores & marketplaces with async review** (iOS/macOS/Play, Chrome Web Store, Mozilla Add-ons, VS Code, JetBrains, ChatGPT apps) | "Published" is not synchronously verifiable — it requires a third publish state ("submitted, pending review") the roll-forward model deliberately lacks. Owned by fastlane/EAS/vsce. Off-axis: releasekit releases library packages, not reviewed application binaries. |
-| **Publish-by-PR indexes** (Homebrew core, conda-forge, nixpkgs, winget, Flathub, deb/rpm) | Not a registry class — it's opening a PR against a shared index repo, already automated by index-side bots. If ever built, it is a post-publish *announce hook* on the existing forge layer, not a publish target. |
+| **App stores & async-review marketplaces** (iOS/macOS/Play, Chrome Web Store, Mozilla Add-ons, VS Code, JetBrains, ChatGPT apps) | "Published" is not synchronously verifiable — it needs a third publish state ("submitted, pending review") the roll-forward model deliberately lacks. A dedicated tool with that state machine could serve these, but it is a different product for a different audience that fastlane / EAS / vsce already own — off releasekit's library-publishing axis. |
 | **ML model hubs** (Hugging Face, ModelScope, Kaggle, Ollama) | The repo *is* the registry (git-push-as-publish); no immutable version coordinate, and commit types don't map to weight changes. releasekit's model mismatches at every stage. |
-| **Snapcraft / binary distribution** (cargo-dist territory) | Ships application binaries, not library packages — a different product; owned by GoReleaser/JReleaser. Its channel-promotion semantics are worth borrowing (see the lifecycle theme), the target isn't. |
 
 ---
 
@@ -110,8 +124,8 @@ How features and ecosystems get prioritized and sequenced:
 
 1. **Widen the moat first.** Standing-PR depth, notes quality, and trusted publishing are where releasekit is differentiated and competitors are thin; these outrank breadth.
 2. **Depth over breadth for ecosystems.** Polyglot breadth without depth is a maintenance trap. Each shipped ecosystem must be maintainable by a solo maintainer; the three current ones reach best-in-class parity before new ones are added.
-3. **Ecosystem expansion is trigger-gated, not scheduled.** A queued ecosystem ships when its trigger fires — a real consumer (or the maintainer's own usage) needs it, or a blocking dependency (e.g. a registry's trusted publishing) lands. This keeps the "only ecosystems I actually use/maintain" constraint enforceable.
-4. **Registry-model fit is a gate.** A target must map onto version → notes → (optional) publish with synchronous idempotency. Async-review, publish-by-PR, and repo-is-the-registry models are excluded on this basis (see Not planned).
+3. **Ecosystem expansion is capacity-ordered, not demand-gated.** For a multi-ecosystem tool the mainstream ecosystems (Python, NuGet, Ruby, Go…) are a matter of when, not if; they are ordered by cost-to-serve × strategic value and shipped as solo-maintainer capacity allows. A concrete consumer or the maintainer's own usage moves an item up the order rather than unlocking it. The only hard gates are an external prerequisite (a registry's trusted publishing) or an unresolved internal design question.
+4. **Registry-model fit is a gate.** A target must map onto version → notes → (optional) publish with synchronous idempotency. Async-review and repo-is-the-registry models are excluded on this basis (see Not planned). Publish-by-PR is excluded as a *publish target* but is viable as a post-publish hook (see Possible future scope).
 5. **Prefer one general mechanism to many special cases.** The tag-only mode + generic updaters serve a whole ecosystem cluster from a single build; the bump-verifier is a pluggable slot, not a cargo special case.
 
 ---

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -64,11 +64,13 @@ ReleaseKit's pipeline is registry-agnostic; this section tracks which ecosystems
 
 ### Supported today
 
-| Ecosystem | Publish model | Notes |
-|---|---|---|
-| **npm** (JS/TS) | Push API + OIDC + provenance | Reference implementation; the richest path. |
-| **crates.io** (Rust) | Push API (token today; OIDC queued in [#546](https://github.com/goosewobbler/releasekit/issues/546)) | Opt-in. |
-| **pub.dev** (Dart/Flutter) | Push API + OIDC (tag-triggered) | Opt-in; depth work below. |
+| Ecosystem | Publish model |
+|---|---|
+| **npm** (JS/TS) | Push API, OIDC, provenance |
+| **crates.io** (Rust) | Push API (OIDC queued — [#546](https://github.com/goosewobbler/releasekit/issues/546)) |
+| **pub.dev** (Dart/Flutter) | Push API, OIDC (tag-triggered) |
+
+Version handling is on by default for all three; per-registry *publishing* defaults are currently asymmetric (npm on, crates.io/pub.dev opt-in) — a wrinkle under review in [#554](https://github.com/goosewobbler/releasekit/issues/554).
 
 ### Deepening the supported three ⏭️
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -41,7 +41,7 @@ The field's clearest differentiation window: all three current registries do OID
 
 ### Change intent & migration 📋
 
-Direction and format set by [ADR-0003](./docs/adr/0003-optional-change-file-input.md); intercepts changesets/sampo migrators without displacing the commit-first default.
+Direction and format set by [ADR-0003](./docs/adr/0003-optional-change-file-input.md); intercepts changesets migrators without displacing the commit-first default.
 
 - [ ] Changesets-format change-file input (unified change stream, `additive`/`only` modes) + `migrate --from-changesets` + an Action-side change-present check — [#545](https://github.com/goosewobbler/releasekit/issues/545)
 

--- a/docs/adr/0001-language-remains-typescript.md
+++ b/docs/adr/0001-language-remains-typescript.md
@@ -1,0 +1,34 @@
+# 1. ReleaseKit remains a TypeScript codebase
+
+Date: 2026-07-19
+
+## Status
+
+Accepted.
+
+## Context
+
+Several tools in releasekit's competitive set are written in Rust — release-plz, knope, git-cliff, and sampo (which ships a Rust core distributed to npm consumers via platform-specific binary packages). This recurringly raises the question of whether releasekit should adopt a Rust core behind bindings, or be rewritten outright, while it is still pre-1.0 and the surface is small enough to move.
+
+A dedicated investigation (July 2026) weighed stay-TypeScript against a napi-rs hybrid core, a WASM core, and a full rewrite. The salient findings:
+
+- **The workload is IO/subprocess-bound, not CPU-bound.** releasekit orchestrates git, the GitHub API, registry CLIs, and LLM calls. Node startup and JS execution are noise against multi-second network and subprocess operations. The rewrites that justify themselves — Biome, oxc, rolldown, the TypeScript-Go port — are all CPU-bound over large inputs. Turborepo's Go→Rust migration, the closest "tooling not compiler" analogue, was motivated by team/codebase alignment with a sibling Rust project, not performance. Neither rationale transfers.
+- **A Rust core would not remove the Node requirement.** Publishing npm packages requires the npm CLI (hence Node) regardless of releasekit's language; the GitHub Action runs on runners with Node preinstalled. Sampo — the exact pattern that would be copied — still declares `engines: { node: ">=22" }` on its npm wrapper. The only genuinely Node-free segment (pure-Rust/Dart repos publishing to the GitHub-hosted Action) is already served by knope and release-plz, and in Actions the objection is moot.
+- **The LLM-notes differentiator depends on official SDKs that do not exist in Rust.** Anthropic ships official SDKs for Python/TypeScript/others but not Rust; community crates are thin, low-adoption wrappers that lag API features. Rewriting would move the tool's clearest advantage onto unofficial dependencies.
+- **A rewrite breaks user-facing surfaces.** Consumer release-notes templates support three JS engines including EJS (arbitrary embedded JS — unimplementable outside a JS runtime); the `VersionOutput` contract is persisted inside standing-PR manifests in open PRs and would need byte-compatible reproduction from any new core.
+- **Solo + AI-agent velocity is the scarcest resource and is TypeScript-anchored.** The test estate, mock-harness conventions, the Zod→schema→docs pipeline, and the agent context that makes `status:agent-ready` issues workable are all TypeScript. A rewrite resets that context during exactly the window feature velocity compounds.
+
+## Decision
+
+ReleaseKit stays pure TypeScript. No Rust core, no rewrite, for the foreseeable future.
+
+Two hedges keep the door open cheaply:
+
+- The `VersionOutput` contract and the `Forge` interface stay language-agnostic (they already are — serialized JSON and an interface), so a future extracted core has a clean seam.
+- If single-binary / Node-free distribution demand ever materialises, it is probed first with Node SEA or `bun build --compile` of the existing TypeScript — a packaging change, never a language decision.
+
+## Consequences
+
+- Feature work (LLM notes depth, standing-PR ergonomics, trusted publishing) proceeds without a parity-rewrite tax.
+- releasekit accepts a cosmetic positioning gap against Rust-native competitors ("not a single binary"), judged not to affect its actual Node-having audience.
+- **Reconsider-triggers** (any one warrants revisiting): a profiled CPU-bound hotspot on a real monorepo; an official Anthropic Rust SDK *and* adoption evidence that the Node requirement blocks users; or a multi-maintainer team that changes the velocity calculus. If a hybrid is ever justified, the first extraction candidate is `packages/version` bump calculation behind the existing JSON seam via napi-rs (never UniFFI, which targets mobile bindings).

--- a/docs/adr/0002-no-mcp-server-cli-is-the-agent-surface.md
+++ b/docs/adr/0002-no-mcp-server-cli-is-the-agent-surface.md
@@ -1,0 +1,31 @@
+# 2. The agent-facing surface is the CLI, not an MCP server
+
+Date: 2026-07-19
+
+## Status
+
+Accepted.
+
+## Context
+
+As LLM coding agents become a primary way developers run release chores, the question arises of whether releasekit should ship a Model Context Protocol (MCP) server so agents can drive it as a set of tools.
+
+A survey of the 2025–26 MCP-versus-CLI landscape found a strong and consistent signal:
+
+- releasekit is **inner-loop, local/CI, in-repo tooling** — the case where benchmarks show agents succeed at equal rates via a CLI as via an MCP server, at a fraction of the context-token cost (an MCP server re-declares its whole tool surface into the context on every turn).
+- No mainstream release tool (semantic-release, changesets, release-please, git-cliff) ships an MCP server; the closest comparable devtool, Nx, *built* one and then migrated its domain knowledge out of it into agent skills, keeping MCP only for its hosted cloud service.
+- Anthropic's own engineering guidance and the wider ecosystem have converged on CLIs-with-good-JSON plus lightweight skills as the agent surface for local tooling; MCP earns its keep at cross-system, multi-user, or hosted-service boundaries — none of which releasekit has.
+
+## Decision
+
+ReleaseKit does not ship an MCP server. Its agent-facing surface is three cheaper, higher-leverage layers:
+
+1. **An agent-grade CLI contract** — a uniform `--json` envelope, structured error codes with retry semantics, `changed`-style idempotency reporting, and dry-run as a structured plan. One surface serves humans, CI, and agents.
+2. **A shipped skill + AGENTS.md snippet** for consumer repos — how to preview a release, read the standing-PR manifest and marker comments, and what an agent must never do (publish directly, move tags, edit marker lines).
+3. **A documented agent-safety boundary** — agent proposes (a PR), human approves (merge, enforced by rulesets), CI publishes via OIDC. releasekit's standing-PR mode is already this topology.
+
+## Consequences
+
+- The CLI JSON contract and the skill become roadmap items in their own right (they serve non-agent users too); no separate MCP surface needs versioning, maintenance, or a security review.
+- releasekit forgoes discoverability via MCP registries, betting instead on the skill/AGENTS.md ecosystem, which is where standardization momentum sits.
+- **Reconsider-trigger:** releasekit grows a hosted, stateful, cross-repo service (e.g. an org-wide release dashboard or manifest store). That outer-loop boundary is where an MCP server would earn its place.

--- a/docs/adr/0003-optional-change-file-input.md
+++ b/docs/adr/0003-optional-change-file-input.md
@@ -1,0 +1,35 @@
+# 3. Change files are supported as an optional input, in changesets format
+
+Date: 2026-07-19
+
+## Status
+
+Accepted. Implementation tracked in [#545](https://github.com/goosewobbler/releasekit/issues/545).
+
+## Context
+
+ReleaseKit derives version bumps and changelog content from Conventional Commits. A large and mobile population of monorepo teams instead relies on **change files** — human-authored change-intent files committed alongside a PR — via [changesets](https://github.com/changesets/changesets). Changesets' most-cited strength is "the pause": explicit, reviewable release intent decoupled from commit history.
+
+Two competitive facts make this a gap worth closing:
+
+- Teams evaluating a migration away from changesets (its prerelease handling is a long-standing weak spot, and its maintenance is contested) will not consider releasekit at all if it cannot consume their existing change files.
+- **sampo** — the closest multi-registry competitor — is changesets-format-native and courts exactly these migrators. Without change-file support, releasekit cedes them by default.
+
+knope demonstrates that Conventional Commits and change files can be unified into a single change stream rather than being mutually exclusive.
+
+## Decision
+
+ReleaseKit adds change files as an **optional** input. Conventional Commits remain the default; nothing about existing behaviour changes.
+
+- **Format: the changesets `.changeset/*.md` grammar, verbatim**, parsed as a superset (also accepting `ecosystem/name` canonical-ID keys, which additionally covers sampo migrators). A migrating repo's *pending* changesets are consumed in place with zero file moves. Non-parseable files and `README.md` are skipped with a warning (every changesets repo has `.changeset/README.md`).
+- **Aggregation: a unified change stream, max-rule.** A change file is just another producer of the same `Change` records commits produce. Two modes: `additive` (default — files and commits combine) and `only` (pure changesets emulation).
+- Group / prerequisite / strategy machinery runs after aggregation, unchanged — that layer is where releasekit already exceeds sampo, and change files compose with it for free.
+- File prose enters the notes pipeline **verbatim by default** (human-authored user-facing prose is the entire point; LLM rewrite is opt-in).
+- A `releasekit migrate --from-changesets` command maps `config.json` (fixed/linked/ignore/baseBranch/access) and defaults new configs to `mode: "only"` for day-one behavioural parity, with `additive` as the later upsell. Mid-prerelease migrations (`pre.json` present) are refused with guidance rather than half-ported.
+
+## Consequences
+
+- releasekit becomes a viable migration target for changesets and sampo users without abandoning its commit-first identity.
+- The `VersionOutput` contract gains an optional `changeFiles` field; per the manifest-compatibility invariant, it must be optional so older manifests in open PRs tolerate its absence.
+- A second change-intent source means two ways to express the same bump; the max-rule and the `additive`/`only` modes keep the resolution predictable, and no per-package "file wins over commit" special-casing is introduced (it produces unexplainable outcomes).
+- The same parsing primitive yields an Action-side "change present?" check (marker comment + status or dismissable review) that matches sampo's hosted-bot gate with no hosted infrastructure.

--- a/docs/adr/0003-optional-change-file-input.md
+++ b/docs/adr/0003-optional-change-file-input.md
@@ -10,20 +10,17 @@ Accepted. Implementation tracked in [#545](https://github.com/goosewobbler/relea
 
 ReleaseKit derives version bumps and changelog content from Conventional Commits. A large and mobile population of monorepo teams instead relies on **change files** — human-authored change-intent files committed alongside a PR — via [changesets](https://github.com/changesets/changesets). Changesets' most-cited strength is "the pause": explicit, reviewable release intent decoupled from commit history.
 
-Two competitive facts make this a gap worth closing:
+The competitive fact this addresses: teams evaluating a move away from changesets — its prerelease handling is a long-standing weak spot, and its maintenance is contested — will not consider releasekit at all if it cannot consume their existing change files. Change-file users are the largest pool of monorepo-release teams in motion, and they are unreachable without it.
 
-- Teams evaluating a migration away from changesets (its prerelease handling is a long-standing weak spot, and its maintenance is contested) will not consider releasekit at all if it cannot consume their existing change files.
-- **sampo** — the closest multi-registry competitor — is changesets-format-native and courts exactly these migrators. Without change-file support, releasekit cedes them by default.
-
-knope demonstrates that Conventional Commits and change files can be unified into a single change stream rather than being mutually exclusive.
+knope demonstrates that Conventional Commits and change files can be unified into a single change stream rather than being mutually exclusive — the approach this ADR adopts.
 
 ## Decision
 
 ReleaseKit adds change files as an **optional** input. Conventional Commits remain the default; nothing about existing behaviour changes.
 
-- **Format: the changesets `.changeset/*.md` grammar, verbatim**, parsed as a superset (also accepting `ecosystem/name` canonical-ID keys, which additionally covers sampo migrators). A migrating repo's *pending* changesets are consumed in place with zero file moves. Non-parseable files and `README.md` are skipped with a warning (every changesets repo has `.changeset/README.md`).
+- **Format: the changesets `.changeset/*.md` grammar, verbatim**, parsed as a superset (also accepting `ecosystem/name` canonical-ID keys — releasekit spans ecosystems, so a package name sometimes needs ecosystem qualification). A migrating repo's *pending* changesets are consumed in place with zero file moves. Non-parseable files and `README.md` are skipped with a warning (every changesets repo has `.changeset/README.md`).
 - **Aggregation: a unified change stream, max-rule.** A change file is just another producer of the same `Change` records commits produce. Two modes: `additive` (default — files and commits combine) and `only` (pure changesets emulation).
-- Group / prerequisite / strategy machinery runs after aggregation, unchanged — that layer is where releasekit already exceeds sampo, and change files compose with it for free.
+- Group / prerequisite / strategy machinery runs after aggregation, unchanged, and change files compose with it for free.
 - File prose enters the notes pipeline **verbatim by default** (human-authored user-facing prose is the entire point; LLM rewrite is opt-in).
 - A `releasekit migrate --from-changesets` command maps `config.json` (fixed/linked/ignore/baseBranch/access) and defaults new configs to `mode: "only"` for day-one behavioural parity, with `additive` as the later upsell. Mid-prerelease migrations (`pre.json` present) are refused with guidance rather than half-ported.
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,11 @@
+# Architecture Decision Records
+
+Each ADR records one significant, hard-to-reverse decision — the context, the decision, and its consequences — following [Michael Nygard's format](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions). ADRs are immutable once accepted; a decision is changed by adding a new ADR that supersedes an older one, not by editing it.
+
+Roadmap sequencing lives in [ROADMAP.md](../../ROADMAP.md); implementation detail lives in issues. ADRs capture only the durable *why* behind a choice.
+
+| # | Decision | Status |
+|---|---|---|
+| [0001](./0001-language-remains-typescript.md) | ReleaseKit remains a TypeScript codebase | Accepted |
+| [0002](./0002-no-mcp-server-cli-is-the-agent-surface.md) | The agent-facing surface is the CLI, not an MCP server | Accepted |
+| [0003](./0003-optional-change-file-input.md) | Change files are supported as an optional input, in changesets format | Accepted |


### PR DESCRIPTION
## Summary

Adds a root `ROADMAP.md` and establishes the repo's ADR convention under `docs/adr/`, distilled from the July 2026 direction review (~40 tools/ecosystems surveyed; full research doc kept maintainer-local).

**ROADMAP.md** — structured for durability, not a ticket list that rots as issues move:
- **Themes** — five capability tracks (release notes & LLM, agent-operable surface, trusted publishing, change intent, release lifecycle & recovery), each a checklist that outlives individual tickets, with a status legend and a single "current focus" pointer.
- **Ecosystem Support** — supported today / deepening the existing three / breadth mechanism / trigger-ordered planned queue (fleshed out with why + trigger each) / **Not Planned** table with reasons (Maven, app stores, publish-by-PR indexes, ML hubs, binary distribution).
- **Evaluation criteria** — how features and ecosystems are prioritized (moat-first, depth-over-breadth, trigger-gated expansion, registry-model fit).

**docs/adr/** (new) — the settled architecture decisions, extracted from the roadmap where they don't belong:
- [0001] Language remains TypeScript
- [0002] The agent surface is the CLI, not an MCP server
- [0003] Change files supported as an optional input, in changesets format (tracked by #545)

Positioning and competitor-watch material was dropped from the roadmap entirely.

Verification gate: `pnpm turbo run lint typecheck test` — 32/32 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BT6fVBZrmExXZj7vQ29881

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a `ROADMAP.md` at the repo root and establishes an ADR convention under `docs/adr/`, with no code changes. It also registers both locations in `AGENTS.md`'s reference table.

- **ROADMAP.md** organises planned work into five durable capability themes with checklists, an ecosystem support matrix (supported / deepening / planned / not-planned), and explicit evaluation criteria.
- **docs/adr/** (0001–0003 + README) captures three settled architecture decisions — TypeScript is kept, MCP server is not shipped, and change files are supported as an optional input — each with context, decision, and consequences following Nygard's ADR format.
</details>

<h3>Confidence Score: 5/5</h3>

Documentation-only change; no code, configuration, or schema is modified.

All six files are Markdown. Relative cross-links between ROADMAP.md, docs/adr/, and AGENTS.md resolve correctly. Issue references are well-formed GitHub URLs. No runtime behaviour is touched.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ROADMAP.md | New 137-line roadmap; cross-links to ADRs and issues are consistent; relative paths are correct from the repo root. |
| docs/adr/README.md | ADR index with a correctly resolved ../../ROADMAP.md back-link and a well-formed status table for all three ADRs. |
| docs/adr/0001-language-remains-typescript.md | ADR documenting the stay-TypeScript decision; context is thorough, reconsider-triggers are explicit and well-scoped. |
| docs/adr/0002-no-mcp-server-cli-is-the-agent-surface.md | ADR for CLI-over-MCP; rationale is grounded in cited ecosystem evidence and includes a clear reconsider-trigger. |
| docs/adr/0003-optional-change-file-input.md | ADR for optional changesets-format input; decision, aggregation modes, and VersionOutput contract implications are clearly stated. |
| AGENTS.md | Two rows added to the reference table pointing to ROADMAP.md and docs/adr/; links and descriptions are accurate. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    ROADMAP["ROADMAP.md\n(root)"]
    AGENTS["AGENTS.md\n(reference table)"]
    ADR_README["docs/adr/README.md\n(index)"]
    ADR1["0001-language-remains-typescript.md"]
    ADR2["0002-no-mcp-server-cli-is-the-agent-surface.md"]
    ADR3["0003-optional-change-file-input.md"]

    AGENTS -->|links to| ROADMAP
    AGENTS -->|links to| ADR_README
    ROADMAP -->|"theme: Machine-readable"| ADR2
    ROADMAP -->|"theme: Change intent"| ADR3
    ADR_README --> ADR1
    ADR_README --> ADR2
    ADR_README --> ADR3
    ADR_README -->|"../../ROADMAP.md"| ROADMAP
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    ROADMAP["ROADMAP.md\n(root)"]
    AGENTS["AGENTS.md\n(reference table)"]
    ADR_README["docs/adr/README.md\n(index)"]
    ADR1["0001-language-remains-typescript.md"]
    ADR2["0002-no-mcp-server-cli-is-the-agent-surface.md"]
    ADR3["0003-optional-change-file-input.md"]

    AGENTS -->|links to| ROADMAP
    AGENTS -->|links to| ADR_README
    ROADMAP -->|"theme: Machine-readable"| ADR2
    ROADMAP -->|"theme: Change intent"| ADR3
    ADR_README --> ADR1
    ADR_README --> ADR2
    ADR_README --> ADR3
    ADR_README -->|"../../ROADMAP.md"| ROADMAP
```

</a>
</details>

<sub>Reviews (6): Last reviewed commit: ["docs: trim &#39;changesets/sampo&#39; to &#39;change..."](https://github.com/goosewobbler/releasekit/commit/23ebec24cc6d260d7b17752edb0a3529f2bde78a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45381727)</sub>

<!-- /greptile_comment -->