### PR TITLE
fix(git): redact URL credentials in GitError message, argv, and stderr

### DIFF
--- a/packages/git/src/errors.ts
+++ b/packages/git/src/errors.ts
@@ -1,23 +1,40 @@
 /**
+ * Mask the `user:password@` userinfo of any URL embedded in a string, e.g.
+ * `https://x-access-token:<token>@github.com/o/r` → `https://***@github.com/o/r`. A push/fetch remote
+ * can be an authenticated HTTPS URL, and git also echoes that URL in its own stderr on an auth/ref
+ * failure — so the token would otherwise ride the failed argv and stderr into logs and the
+ * failure-report PR comment. Anchors on the literal `://` and matches the userinfo with a negated
+ * class terminated by the excluded `@`, so there is no ambiguous prefix to backtrack on (linear —
+ * avoids the polynomial-regex ReDoS a `scheme` prefix like `[a-z]+://` would introduce).
+ */
+export function redactUrlCredentials(text: string): string {
+  return text.replace(/:\/\/[^/@\s]+@/g, '://***@');
+}
+
+/**
  * Raised when a `git` invocation fails unexpectedly. Carries the full argv that was run, the exit
  * code, and stderr, so a caller (or a failure report) can show exactly what was attempted without the
  * adapter having to log. The argv is the array passed to `execFile` — never a shell string — so there
- * is nothing to un-escape and no shell interpolation to reconstruct.
+ * is nothing to un-escape and no shell interpolation to reconstruct. Credentials are the one thing an
+ * argv *can* carry (an authenticated remote URL), so `message`, `args`, and `stderr` are run through
+ * {@link redactUrlCredentials} here — every construction site is covered without each caller having to
+ * remember. The array handed to the runner is untouched (this stores a redacted copy), so the real
+ * push still uses the real URL.
  */
 export class GitError extends Error {
-  /** The argv that failed, e.g. `['tag', '-a', 'v1.0.0', '-m', 'release']`. */
+  /** The argv that failed, e.g. `['tag', '-a', 'v1.0.0', '-m', 'release']`; URL userinfo redacted. */
   readonly args: string[];
   /** The process exit code, or undefined when git could not be spawned at all. */
   readonly exitCode: number | undefined;
-  /** Captured stderr, trimmed; empty when none. */
+  /** Captured stderr, trimmed; empty when none; URL userinfo redacted. */
   readonly stderr: string;
 
   constructor(message: string, args: string[], exitCode: number | undefined, stderr: string) {
-    super(message);
+    super(redactUrlCredentials(message));
     this.name = 'GitError';
-    this.args = args;
+    this.args = args.map(redactUrlCredentials);
     this.exitCode = exitCode;
-    this.stderr = stderr;
+    this.stderr = redactUrlCredentials(stderr);
   }
 }
 

--- a/packages/git/test/unit/git.spec.ts
+++ b/packages/git/test/unit/git.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { GitError, gitExitCode, isCommandNotFound, isExecTimeout } from '../../src/errors.js';
+import { GitError, gitExitCode, isCommandNotFound, isExecTimeout, redactUrlCredentials } from '../../src/errors.js';
 import { createGitCli, GitCli, type GitRunner } from '../../src/git.js';
 
 interface RunOptions {
@@ -368,6 +368,38 @@ describe('GitError mapping', () => {
     expect(error.exitCode).toBe(128);
     expect(error.stderr).toBe('fatal: bad object');
     expect(error.message).toContain('fatal: bad object');
+  });
+
+  it('should redact URL userinfo in a push failure message, argv, and stderr', async () => {
+    const remote = 'https://x-access-token:SECRETTOKEN@github.com/o/r.git';
+    const { run } = makeRunner({
+      reject: exitError(128, `fatal: unable to access '${remote}/': The requested URL returned error: 403`),
+    });
+    const error = await new GitCli(run).push({ remote, ref: 'main' }).catch((e) => e as GitError);
+    expect(error).toBeInstanceOf(GitError);
+    expect(error.message).not.toContain('SECRETTOKEN');
+    expect(error.stderr).not.toContain('SECRETTOKEN');
+    expect(error.args.join(' ')).not.toContain('SECRETTOKEN');
+    expect(error.message).toContain('https://***@github.com/o/r.git');
+  });
+});
+
+describe('redactUrlCredentials', () => {
+  it('should mask user:password userinfo while leaving credential-free URLs intact', () => {
+    expect(redactUrlCredentials('https://x-access-token:tok@github.com/o/r')).toBe('https://***@github.com/o/r');
+    expect(redactUrlCredentials('git push https://user:pw@host/a failed: https://user:pw@host/a')).toBe(
+      'git push https://***@host/a failed: https://***@host/a',
+    );
+    // No userinfo → unchanged; scp-style remotes have no scheme:// and carry no inline secret.
+    expect(redactUrlCredentials('https://github.com/o/r.git')).toBe('https://github.com/o/r.git');
+    expect(redactUrlCredentials('git@github.com:o/r.git')).toBe('git@github.com:o/r.git');
+  });
+
+  it('should scan a long adversarial input linearly (no polynomial-regex ReDoS)', () => {
+    // A long scheme-like run with no `://…@` span must return promptly and unchanged; the fixed
+    // `://` anchor + negated class give a linear scan (guards the CodeQL polynomial-regex alert).
+    const long = 'a'.repeat(200_000);
+    expect(redactUrlCredentials(long)).toBe(long);
   });
 });
 


### PR DESCRIPTION
## What

Mask `user:password@` userinfo in any URL embedded in a `GitError`'s `message`, `args`, and `stderr`, at the constructor choke point in `@releasekit/git`.

## Why

When `git.httpsTokenEnv` is configured, the push remote is an authenticated URL (`https://x-access-token:<token>@github.com/…`). On **any** push failure (e.g. a branch-protection ruleset rejection), that URL rode the failed argv — and git's own stderr — into `GitError.message`, which propagates into `PipelineError` → the **failure-report PR comment** (world-readable on public repos) and CI logs. GitHub's log masking doesn't apply to comment bodies, so the token was disclosed.

## How

- `redactUrlCredentials()` does a linear (no-backtracking) scan over `scheme://userinfo@` spans and replaces the userinfo with `***`.
- Applied in the `GitError` constructor so every construction site is covered without each caller remembering. The array handed to the runner is untouched (a redacted copy is stored), so the real push still uses the real URL.
- Catches the token whether it rides the argv or git echoes the URL in stderr.

## Tests

- End-to-end: a push failure with an authenticated remote yields a `GitError` whose `message`/`args`/`stderr` contain no token and show `https://***@github.com/o/r.git`.
- Unit: `redactUrlCredentials` masks `user:pass@` spans and leaves credential-free / scp-style remotes intact.

Closes #557

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a credential-disclosure vulnerability where authenticated HTTPS remote URLs were leaking into `GitError.message`, `.args`, and `.stderr`, which propagate to the failure-report PR comment and CI logs.

- Introduces `redactUrlCredentials(text)` using a linear regex anchored on the literal `://` that replaces the userinfo segment with `***`, avoiding ReDoS via a negated character class instead of a quantified scheme prefix.
- Applies redaction centrally in the `GitError` constructor so all construction sites are covered without per-caller changes; the real args array passed to the runner is left untouched so the live push still uses the real URL.
- Adds an end-to-end test asserting redaction across all three fields on a push failure, plus unit tests covering multi-occurrence strings, credential-free URLs, scp-style remotes, and a 200 k-character adversarial input for linearity.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a well-scoped security fix applied at a single constructor choke point with no changes to the live call path.

The regex is intentionally linear (negated character class anchored on `://`, no alternation or nested quantifiers), is applied in the `GitError` constructor so every call site is covered automatically, and the real args array handed to the runner is untouched. Tests cover end-to-end push failure redaction, multi-URL strings, credential-free URLs, scp-style remotes, and the adversarial-length input. No defects found.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/git/src/errors.ts | Adds `redactUrlCredentials` and wires it into the `GitError` constructor; regex is linear, handles all tested credential formats, and correctly excludes `/` to respect the authority boundary. |
| packages/git/test/unit/git.spec.ts | Adds targeted tests for credential redaction on push failure and unit tests for the regex; coverage includes multi-URL strings, no-credential URLs, scp-style remotes, and the ReDoS guard. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Runner as GitRunner
    participant GitCli as GitCli.push()
    participant GitError as GitError constructor
    participant Caller as Caller / PipelineError

    GitCli->>Runner: run(['push','--', authenticatedRemoteUrl, ...])
    Runner-->>GitCli: throws exec error (exit 128, stderr with URL)
    GitCli->>GitError: new GitError(message, args, exitCode, stderr)
    Note over GitError: redactUrlCredentials applied to message, each arg, and stderr
    GitError-->>Caller: "GitError with credentials replaced by ***"
    Note over Caller: Token never reaches PR comment or CI logs
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Runner as GitRunner
    participant GitCli as GitCli.push()
    participant GitError as GitError constructor
    participant Caller as Caller / PipelineError

    GitCli->>Runner: run(['push','--', authenticatedRemoteUrl, ...])
    Runner-->>GitCli: throws exec error (exit 128, stderr with URL)
    GitCli->>GitError: new GitError(message, args, exitCode, stderr)
    Note over GitError: redactUrlCredentials applied to message, each arg, and stderr
    GitError-->>Caller: "GitError with credentials replaced by ***"
    Note over Caller: Token never reaches PR comment or CI logs
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(git): redact URL credentials in GitE..."](https://github.com/goosewobbler/releasekit/commit/95ba88f3fe1b64dddfa4e60410040816c2db34fc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45448891)</sub>

<!-- /greptile_comment -->