### PR TITLE
feat(config)!: unify per-ecosystem enablement — detection enables, config opts out

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -75,6 +75,7 @@ Versioning configuration.
 | `allowFirstBump` | boolean | `false` | Acknowledge applying a bump on a first release with an already-stable manifest. On a first release (no prior tag), `--stable --bump <type>` applies the bump (e.g. 1.0.0 → 2.0.0) rather than graduating, which can silently overshoot the staged first version. By default this is flagged per `mismatchStrategy` (warn, or abort under "error"); set true (or pass --allow-first-bump) to apply the bump silently — legitimate when importing a package with prior external version history. |
 | `strictReachable` | boolean | `false` | Only use reachable tags |
 | `zeroMajor` | `"spec"` \| `"strict"` | `"spec"` | Pre-1.0 handling of commit-inferred breaking changes. 'spec' (default): bump the 0.x minor (0.24.0 → 0.25.0), per semver §4. 'strict': bump the next major (→ 1.0.0). Inferred path only — explicit overrides (--bump major, bump:major) always graduate to 1.0.0. |
+| `npm` | object | — | npm/JavaScript version handling |
 | `pub` | object | — | Dart/Flutter pub configuration |
 
 ### `version.zeroMajor`
@@ -127,13 +128,21 @@ ungrouped packages honor targets as-is.
 **Workspace pins.** Intra-group `workspace:*` dependencies resolve to the group version within a
 run, so a fixed group publishes internally consistent.
 
+### `version.npm`
+
+npm/JavaScript version handling.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | boolean | `true` | Version package.json manifests. Detected npm packages are versioned by default; set false to opt out (e.g. npm versioning handled elsewhere). |
+
 ### `version.cargo`
 
 Cargo/Rust configuration.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `enabled` | boolean | `true` | Enable Cargo.toml version handling |
+| `enabled` | boolean | `true` | Version Cargo.toml manifests. Detected Rust packages are versioned by default; set false to opt out (e.g. a vendored crate, or Rust versioning handled elsewhere). |
 | `paths` | `string[]` | — | Directories to search for Cargo.toml files |
 
 ---
@@ -162,7 +171,7 @@ NPM publishing configuration.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `enabled` | boolean | `true` | Enable NPM publishing |
+| `enabled` | boolean | `true` | Publish to npm. Detected npm packages are published by default; set false to opt out (version and tag only). |
 | `auth` | `"auto"` \| `"oidc"` \| `"token"` | `"auto"` | Authentication method |
 | `provenance` | boolean | `true` | Enable npm provenance attestation |
 | `access` | `"public"` \| `"restricted"` | `"public"` | Package access level |
@@ -177,7 +186,7 @@ Cargo publishing configuration.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `enabled` | boolean | `false` | Enable Cargo publishing |
+| `enabled` | boolean | `true` | Publish to crates.io. Detected Rust packages are published by default; set false to opt out (version and tag only). |
 | `noVerify` | boolean | `false` | Skip verification before publish |
 | `publishOrder` | `string[]` | `[]` | Order in which to publish packages |
 | `clean` | boolean | `false` | Clean before publishing |
@@ -188,7 +197,7 @@ Dart/Flutter publishing configuration via pub.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `enabled` | boolean | `false` | Enable pub.dev publishing |
+| `enabled` | boolean | `true` | Publish to pub.dev. Detected Dart/Flutter packages are published by default; set false to opt out (version and tag only). |
 | `publishOrder` | `string[]` | `[]` | Order in which to publish packages |
 
 ### `publish.githubRelease`

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -26,13 +26,32 @@ export const MonorepoConfigSchema = z.object({
   packagesPath: z.string().optional().describe('Path to packages directory'),
 });
 
+export const VersionNpmConfigSchema = z.object({
+  enabled: z
+    .boolean()
+    .default(true)
+    .describe(
+      'Version package.json manifests. Detected npm packages are versioned by default; set false to opt out (e.g. npm versioning handled elsewhere).',
+    ),
+});
+
 export const VersionCargoConfigSchema = z.object({
-  enabled: z.boolean().default(true).describe('Enable Cargo.toml version handling'),
+  enabled: z
+    .boolean()
+    .default(true)
+    .describe(
+      'Version Cargo.toml manifests. Detected Rust packages are versioned by default; set false to opt out (e.g. a vendored crate, or Rust versioning handled elsewhere).',
+    ),
   paths: z.array(z.string()).optional().describe('Directories to search for Cargo.toml files'),
 });
 
 export const VersionPubConfigSchema = z.object({
-  enabled: z.boolean().default(true).describe('Enable pubspec.yaml version handling'),
+  enabled: z
+    .boolean()
+    .default(true)
+    .describe(
+      'Version pubspec.yaml manifests. Detected Dart/Flutter packages are versioned by default; set false to opt out.',
+    ),
   paths: z.array(z.string()).optional().describe('Directories to search for pubspec.yaml files'),
 });
 
@@ -129,12 +148,18 @@ export const VersionConfigSchema = z.object({
     .describe(
       "Pre-1.0 handling of commit-inferred breaking changes. 'spec' (default): bump the 0.x minor (0.24.0 → 0.25.0), per semver §4. 'strict': bump the next major (→ 1.0.0). Inferred path only — explicit overrides (--bump major, bump:major) always graduate to 1.0.0.",
     ),
+  npm: VersionNpmConfigSchema.optional().describe('npm/JavaScript version handling'),
   cargo: VersionCargoConfigSchema.optional().describe('Cargo/Rust configuration'),
   pub: VersionPubConfigSchema.optional().describe('Dart/Flutter pub configuration'),
 });
 
 export const NpmConfigSchema = z.object({
-  enabled: z.boolean().default(true).describe('Enable NPM publishing'),
+  enabled: z
+    .boolean()
+    .default(true)
+    .describe(
+      'Publish to npm. Detected npm packages are published by default; set false to opt out (version and tag only).',
+    ),
   auth: z.enum(['auto', 'oidc', 'token']).default('auto').describe('Authentication method'),
   provenance: z.boolean().default(true).describe('Enable npm provenance attestation'),
   access: z.enum(['public', 'restricted']).default('public').describe('Package access level'),
@@ -148,14 +173,24 @@ export const NpmConfigSchema = z.object({
 });
 
 export const CargoPublishConfigSchema = z.object({
-  enabled: z.boolean().default(false).describe('Enable Cargo publishing'),
+  enabled: z
+    .boolean()
+    .default(true)
+    .describe(
+      'Publish to crates.io. Detected Rust packages are published by default; set false to opt out (version and tag only).',
+    ),
   noVerify: z.boolean().default(false).describe('Skip verification before publish'),
   publishOrder: z.array(z.string()).default([]).describe('Order in which to publish packages'),
   clean: z.boolean().default(false).describe('Clean before publishing'),
 });
 
 export const PubPublishConfigSchema = z.object({
-  enabled: z.boolean().default(false).describe('Enable pub.dev publishing'),
+  enabled: z
+    .boolean()
+    .default(true)
+    .describe(
+      'Publish to pub.dev. Detected Dart/Flutter packages are published by default; set false to opt out (version and tag only).',
+    ),
   publishOrder: z.array(z.string()).default([]).describe('Order in which to publish packages'),
 });
 
@@ -248,13 +283,13 @@ export const PublishConfigSchema = z.object({
     publishOrder: [],
   }).describe('NPM publishing configuration'),
   cargo: CargoPublishConfigSchema.default({
-    enabled: false,
+    enabled: true,
     noVerify: false,
     publishOrder: [],
     clean: false,
   }).describe('Cargo publishing configuration'),
   pub: PubPublishConfigSchema.default({
-    enabled: false,
+    enabled: true,
     publishOrder: [],
   }).describe('Dart/Flutter publishing configuration via pub'),
   githubRelease: GitHubReleaseConfigSchema.default({

--- a/packages/config/test/unit/schema.spec.ts
+++ b/packages/config/test/unit/schema.spec.ts
@@ -18,6 +18,7 @@ import {
   TemplateConfigSchema,
   VerifyConfigSchema,
   VersionConfigSchema,
+  VersionNpmConfigSchema,
 } from '../../src/schema.js';
 
 describe('GitConfigSchema', () => {
@@ -64,7 +65,6 @@ describe('MonorepoConfigSchema', () => {
 describe('VersionConfigSchema', () => {
   it('should apply defaults', () => {
     const result = VersionConfigSchema.parse({});
-    // biome-ignore lint/suspicious/noTemplateCurlyInString: checking the literal default string
     expect(result.tagTemplate).toBe('${prefix}${version}');
     expect(result.packageSpecificTags).toBe(false);
     expect(result.preset).toBe('conventional');
@@ -102,6 +102,11 @@ describe('VersionConfigSchema', () => {
     });
     expect(result.cargo?.enabled).toBe(true);
     expect(result.cargo?.paths).toEqual(['crates/core', 'crates/cli']);
+  });
+
+  it('should default version.npm.enabled to true and accept an opt-out', () => {
+    expect(VersionNpmConfigSchema.parse({}).enabled).toBe(true);
+    expect(VersionConfigSchema.parse({ npm: { enabled: false } }).npm?.enabled).toBe(false);
   });
 
   it('should accept version groups with fixed and linked sync modes', () => {
@@ -172,7 +177,8 @@ describe('NpmConfigSchema', () => {
 describe('CargoPublishConfigSchema', () => {
   it('should apply defaults', () => {
     const result = CargoPublishConfigSchema.parse({});
-    expect(result.enabled).toBe(false);
+    // Detection enables, config opts out: crates.io publishing defaults on.
+    expect(result.enabled).toBe(true);
     expect(result.noVerify).toBe(false);
     expect(result.publishOrder).toEqual([]);
     expect(result.clean).toBe(false);
@@ -221,10 +227,11 @@ describe('VerifyConfigSchema', () => {
 });
 
 describe('PublishConfigSchema', () => {
-  it('should apply defaults for npm and cargo', () => {
+  it('should default publishing on for npm, cargo, and pub (detection enables, config opts out)', () => {
     const result = PublishConfigSchema.parse({});
     expect(result.npm.enabled).toBe(true);
-    expect(result.cargo.enabled).toBe(false);
+    expect(result.cargo.enabled).toBe(true);
+    expect(result.pub.enabled).toBe(true);
     expect(result.githubRelease.enabled).toBe(true);
   });
 });

--- a/packages/version/src/core/groupStrategy.ts
+++ b/packages/version/src/core/groupStrategy.ts
@@ -407,7 +407,10 @@ async function releaseGroup(
     }
 
     const packageJsonPath = path.join(pkg.dir, 'package.json');
-    if (fs.existsSync(packageJsonPath)) {
+    // npm version handling gates package.json manifests (default true).
+    if (config.npm?.enabled === false) {
+      log(`Skipping package.json update for ${name} - npm version handling disabled`, 'debug');
+    } else if (fs.existsSync(packageJsonPath)) {
       updatePackageVersion(packageJsonPath, version, config.dryRun);
     } else {
       log(`Skipping package.json update for ${name} - no package.json found (Rust-only package)`, 'debug');
@@ -567,7 +570,8 @@ export function createGroupStrategy(config: Config): (packages: PackagesWithRoot
 
         const name = pkg.packageJson.name;
         const packageJsonPath = path.join(pkg.dir, 'package.json');
-        if (fs.existsSync(packageJsonPath)) {
+        // npm version handling gates package.json manifests (default true).
+        if (config.npm?.enabled !== false && fs.existsSync(packageJsonPath)) {
           updatePackageVersion(packageJsonPath, plan.ownNext, config.dryRun);
         }
         const cargoTomlPath = path.join(pkg.dir, 'Cargo.toml');

--- a/packages/version/src/core/versionStrategies.ts
+++ b/packages/version/src/core/versionStrategies.ts
@@ -225,17 +225,29 @@ export function createSyncStrategy(config: Config): StrategyFunction {
         // Check if packages.root is defined before joining paths
         if (packages.root) {
           const rootPkgPath = path.join(packages.root, 'package.json');
-          if (fs.existsSync(rootPkgPath)) {
+          // npm version handling gates package.json manifests (default true).
+          if (config.npm?.enabled !== false && fs.existsSync(rootPkgPath)) {
             // Mark as root so consumers (preview, standing PR) can exclude this lockstep
             // bump from package counts — it isn't a publishable package.
             updatePackageVersion(rootPkgPath, nextVersion, dryRun, true);
             files.push(rootPkgPath);
             updatedPackages.push('root');
-            processedPaths.add(rootPkgPath);
+          }
+          // Record the root path unconditionally (even when npm is disabled) so the per-package loop
+          // skips it in a single-package repo where packages.root === packages[0].dir — otherwise its
+          // Cargo.toml would be versioned twice (once here, once in the loop).
+          processedPaths.add(rootPkgPath);
 
-            // Handle Cargo.toml files in root
-            const rootCargoFiles = updateCargoFiles(packages.root, nextVersion, config.cargo, dryRun);
-            files.push(...rootCargoFiles);
+          // Root Cargo.toml handling is independent of npm (updateCargoFiles honors cargo.enabled),
+          // so it runs whether or not npm versioning is disabled — matching the per-package loop below.
+          const rootCargoFiles = updateCargoFiles(packages.root, nextVersion, config.cargo, dryRun);
+          files.push(...rootCargoFiles);
+          // Record 'root' when only the root Cargo.toml was versioned (npm disabled, or no root
+          // package.json). In a single-package repo where packages.root === packages[0].dir the loop
+          // skips this path via processedPaths, so without this nothing tracks the write and the empty
+          // updatedPackages triggers the early return below — abandoning the already-written file.
+          if (rootCargoFiles.length > 0 && !updatedPackages.includes('root')) {
+            updatedPackages.push('root');
           }
         } else {
           log('Root package path is undefined, skipping root package.json update', 'warning');
@@ -258,8 +270,10 @@ export function createSyncStrategy(config: Config): StrategyFunction {
           continue;
         }
 
-        // Skip pure Rust packages that don't have a package.json
-        if (!fs.existsSync(packageJsonPath)) {
+        // Skip when npm version handling is opted out, or for pure Rust packages with no package.json.
+        if (config.npm?.enabled === false) {
+          log(`Skipping package.json update for ${pkg.packageJson.name} - npm version handling disabled`, 'debug');
+        } else if (!fs.existsSync(packageJsonPath)) {
           log(
             `Skipping package.json update for ${pkg.packageJson.name} - no package.json found (Rust-only package)`,
             'debug',
@@ -275,8 +289,10 @@ export function createSyncStrategy(config: Config): StrategyFunction {
         const pkgCargoFiles = updateCargoFiles(pkg.dir, nextVersion, config.cargo, dryRun);
         files.push(...pkgCargoFiles);
 
-        // Track pure-Rust packages by name when their Cargo.toml was updated
-        if (!fs.existsSync(packageJsonPath) && pkgCargoFiles.length > 0) {
+        // Track by name when only the Cargo.toml was updated: a pure-Rust package (no package.json),
+        // or a hybrid package whose package.json write was skipped because npm handling is disabled.
+        // Without this the early return below abandons the already-written Cargo.toml changes.
+        if ((!fs.existsSync(packageJsonPath) || config.npm?.enabled === false) && pkgCargoFiles.length > 0) {
           updatedPackages.push(pkg.packageJson.name);
         }
       }
@@ -641,12 +657,15 @@ export function createSingleStrategy(config: Config): StrategyFunction {
       // Track all files that need to be committed
       const filesToCommit: string[] = [];
 
-      // Only update package.json if it exists (skip for pure Rust packages)
-      if (fs.existsSync(packageJsonPath)) {
+      // Update package.json when npm version handling is enabled (default true) and it exists;
+      // otherwise skip (opted out, or a pure Rust package with no package.json).
+      const npmEnabled = config.npm?.enabled !== false;
+      if (npmEnabled && fs.existsSync(packageJsonPath)) {
         updatePackageVersion(packageJsonPath, nextVersion, dryRun);
         filesToCommit.push(packageJsonPath);
       } else {
-        log(`Skipping package.json update for ${packageName} - no package.json found (Rust-only package)`, 'debug');
+        const reason = !npmEnabled ? 'npm version handling disabled' : 'no package.json found (Rust-only package)';
+        log(`Skipping package.json update for ${packageName} - ${reason}`, 'debug');
       }
 
       // Handle Cargo.toml files for this package

--- a/packages/version/src/package/packageProcessor.ts
+++ b/packages/version/src/package/packageProcessor.ts
@@ -346,8 +346,9 @@ export class PackageProcessor {
       //       This ensures consistent versioning across language ecosystems.
       const packageJsonPath = path.join(pkgPath, 'package.json');
 
-      // Always update package.json if it exists
-      if (fs.existsSync(packageJsonPath)) {
+      // Update package.json when npm version handling is enabled (default true) and it exists.
+      const npmEnabled = this.fullConfig.npm?.enabled !== false;
+      if (npmEnabled && fs.existsSync(packageJsonPath)) {
         updatePackageVersion(packageJsonPath, nextVersion, this.dryRun);
       }
 

--- a/packages/version/src/types.ts
+++ b/packages/version/src/types.ts
@@ -159,6 +159,9 @@ export interface Config extends VersionConfigBase {
   strictReachable?: boolean;
   /** Pre-1.0 inferred-breaking bump policy ('spec' | 'strict'). See docs/configuration.md#versionzeromajor. */
   zeroMajor?: 'spec' | 'strict';
+  npm?: {
+    enabled?: boolean;
+  };
   cargo?: {
     enabled?: boolean;
     paths?: string[];
@@ -240,6 +243,7 @@ export function toVersionConfig(config: VersionConfig | undefined): Config {
     zeroMajor: config.zeroMajor,
     versionPrefix: config.versionPrefix ?? '',
     prereleaseIdentifier: config.prereleaseIdentifier,
+    npm: config.npm,
     cargo: config.cargo,
     pub: config.pub,
   };

--- a/packages/version/test/unit/core/versionStrategies.spec.ts
+++ b/packages/version/test/unit/core/versionStrategies.spec.ts
@@ -230,6 +230,58 @@ describe('Version Strategies', () => {
       expect(jsonOutput.setPackageUpdateTag).not.toHaveBeenCalled();
     });
 
+    it('should still version Cargo.toml and not abandon it when npm handling is disabled on a hybrid repo', async () => {
+      // Hybrid sync monorepo (existsSync mock returns true for every package.json AND Cargo.toml) with
+      // npm versioning opted out: package.json writes are skipped, but Cargo.toml must still be versioned
+      // and the run must not early-return as "no packages updated" (which would abandon the written files).
+      const config: Partial<Config> = { ...defaultConfig, sync: true, npm: { enabled: false } };
+      const syncStrategy = strategies.createSyncStrategy(config as Config);
+
+      await syncStrategy(mockPackages);
+
+      // package.json manifests (root 4-arg, members 3-arg) are skipped...
+      expect(packageManagement.updatePackageVersion).not.toHaveBeenCalledWith(
+        packageAPath,
+        expect.anything(),
+        expect.anything(),
+      );
+      expect(packageManagement.updatePackageVersion).not.toHaveBeenCalledWith(
+        rootPackagePath,
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+      );
+      // ...but Cargo.toml is still versioned (root + members); updateCargoFiles passes dryRun=false.
+      expect(packageManagement.updatePackageVersion).toHaveBeenCalledWith(
+        '/test/workspace/packages/a/Cargo.toml',
+        '1.1.0',
+        false,
+      );
+      expect(packageManagement.updatePackageVersion).toHaveBeenCalledWith('/test/workspace/Cargo.toml', '1.1.0', false);
+      // ...and the run proceeds to tag rather than early-returning.
+      expect(jsonOutput.addTag).toHaveBeenCalledWith('v1.1.0');
+    });
+
+    it('should not version a single-package repo Cargo.toml twice when npm is disabled', async () => {
+      // Single-package repo where the package IS the root (packages.root === packages[0].dir). With
+      // npm disabled, processedPaths must still record the root path so the per-package loop skips it,
+      // or updateCargoFiles runs for the same dir twice — writing Cargo.toml twice.
+      const singlePkg = {
+        root: '/test/workspace',
+        packages: [{ dir: '/test/workspace', packageJson: { name: 'root-pkg', version: '1.0.0' } }],
+      };
+      const config: Partial<Config> = { ...defaultConfig, sync: true, npm: { enabled: false } };
+      await strategies.createSyncStrategy(config as Config)(singlePkg as typeof mockPackages);
+
+      const cargoCalls = vi
+        .mocked(packageManagement.updatePackageVersion)
+        .mock.calls.filter((c) => c[0] === '/test/workspace/Cargo.toml');
+      expect(cargoCalls).toHaveLength(1);
+      // The run must not early-return as "nothing updated" — 'root' is tracked for the cargo-only
+      // update, so the shared tag is still created and the written Cargo.toml is committed.
+      expect(jsonOutput.addTag).toHaveBeenCalledWith('v1.1.0');
+    });
+
     it('should use mainPackage for version calculation when specified', async () => {
       // Setup with mainPackage
       const config: Partial<Config> = {

--- a/packages/version/test/unit/package/packageProcessor.spec.ts
+++ b/packages/version/test/unit/package/packageProcessor.spec.ts
@@ -929,6 +929,36 @@ describe('Package Processor', () => {
         false,
       );
     });
+
+    it('should skip package.json but still update Cargo.toml when version.npm.enabled is false', async () => {
+      vi.spyOn(fs, 'existsSync').mockImplementation(() => true);
+
+      const hybridPackage = {
+        ...mockPackages[0],
+        dir: '/path/to/hybrid-package',
+        packageJson: { name: 'hybrid-package', version: '0.1.0' },
+      };
+
+      const processor = new PackageProcessor({
+        getLatestTag: gitTags.getLatestTag,
+        config: {},
+        fullConfig: { ...mockConfig, npm: { enabled: false } },
+      });
+
+      await processor.processPackages([hybridPackage]);
+
+      // npm opted out → package.json is left untouched; Cargo.toml is still versioned.
+      expect(packageManagement.updatePackageVersion).not.toHaveBeenCalledWith(
+        '/path/to/hybrid-package/package.json',
+        expect.anything(),
+        expect.anything(),
+      );
+      expect(packageManagement.updatePackageVersion).toHaveBeenCalledWith(
+        '/path/to/hybrid-package/Cargo.toml',
+        '1.1.0',
+        false,
+      );
+    });
   });
 
   describe('Cargo.toml handling', () => {

--- a/releasekit.schema.json
+++ b/releasekit.schema.json
@@ -210,6 +210,18 @@
           "default": "spec",
           "description": "Pre-1.0 handling of commit-inferred breaking changes. 'spec' (default): bump the 0.x minor (0.24.0 → 0.25.0), per semver §4. 'strict': bump the next major (→ 1.0.0). Inferred path only — explicit overrides (--bump major, bump:major) always graduate to 1.0.0."
         },
+        "npm": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": true,
+              "description": "Version package.json manifests. Detected npm packages are versioned by default; set false to opt out (e.g. npm versioning handled elsewhere)."
+            }
+          },
+          "description": "npm/JavaScript version handling"
+        },
         "cargo": {
           "type": "object",
           "additionalProperties": false,
@@ -217,7 +229,7 @@
             "enabled": {
               "type": "boolean",
               "default": true,
-              "description": "Enable Cargo.toml version handling"
+              "description": "Version Cargo.toml manifests. Detected Rust packages are versioned by default; set false to opt out (e.g. a vendored crate, or Rust versioning handled elsewhere)."
             },
             "paths": {
               "type": "array",
@@ -236,7 +248,7 @@
             "enabled": {
               "type": "boolean",
               "default": true,
-              "description": "Enable pubspec.yaml version handling"
+              "description": "Version pubspec.yaml manifests. Detected Dart/Flutter packages are versioned by default; set false to opt out."
             },
             "paths": {
               "type": "array",
@@ -298,7 +310,7 @@
             "enabled": {
               "type": "boolean",
               "default": true,
-              "description": "Enable NPM publishing"
+              "description": "Publish to npm. Detected npm packages are published by default; set false to opt out (version and tag only)."
             },
             "auth": {
               "type": "string",
@@ -361,8 +373,8 @@
           "properties": {
             "enabled": {
               "type": "boolean",
-              "default": false,
-              "description": "Enable Cargo publishing"
+              "default": true,
+              "description": "Publish to crates.io. Detected Rust packages are published by default; set false to opt out (version and tag only)."
             },
             "noVerify": {
               "type": "boolean",
@@ -391,8 +403,8 @@
           "properties": {
             "enabled": {
               "type": "boolean",
-              "default": false,
-              "description": "Enable pub.dev publishing"
+              "default": true,
+              "description": "Publish to pub.dev. Detected Dart/Flutter packages are published by default; set false to opt out (version and tag only)."
             },
             "publishOrder": {
               "type": "array",

--- a/scripts/generate-config-docs.ts
+++ b/scripts/generate-config-docs.ts
@@ -213,6 +213,14 @@ function renderVersion(prop: SchemaProperty): void {
     );
   }
 
+  const npm = prop.properties?.npm;
+  if (npm) {
+    emit('### `version.npm`', '');
+    emit(ensurePeriod(npm.description), '');
+    emit(propsTable(npm.properties ?? {}));
+    emitBlank();
+  }
+
   const cargo = prop.properties?.cargo;
   if (cargo) {
     emit('### `version.cargo`', '');


### PR DESCRIPTION
## What

Make ecosystem enablement symmetric: **detection enables, config opts out**. Every ecosystem ReleaseKit detects is versioned and — where publishing is configured and authenticated — published by default. Explicit config is only ever an opt-out.

| | npm | crates.io | pub.dev |
|---|---|---|---|
| `version.*.enabled` | **`true` (new toggle)** | `true` | `true` |
| `publish.*.enabled` | `true` | **`true` (was `false`)** | **`true` (was `false`)** |

## Changes

- `publish.cargo.enabled` / `publish.pub.enabled` default `false` → `true`.
- Add `version.npm.enabled` (default `true`) so package.json handling is opt-out-able like Cargo.toml/pubspec.yaml, wired into **every** version-stage package.json write (packageProcessor, sync/single strategies, group + ungrouped-member strategies, and the root lockstep bump).
- Reframe the `enabled` `.describe()` text as opt-outs; regenerate `releasekit.schema.json` + `docs/configuration.md` (`schema:check` passes).
- Migration note in `docs/migration.md`.

Two independent opt-outs per ecosystem are kept deliberately:
- `version.<eco>.enabled: false` → don't touch this ecosystem's manifests at all.
- `publish.<eco>.enabled: false` → version and tag, but don't publish.

## Why it's safe

Default-on relies on the pipeline's existing structural fail-safes (`publish/src/registry/dispatcher.ts`): an enabled registry that discovers zero targets no-ops, and publishing without credentials fails/skips at the auth check. This repo (npm-only) is unaffected — the cargo/pub flip no-ops with no Rust/Dart packages.

## Tests

- Schema: publish defaults on for npm/cargo/pub; `version.npm.enabled` defaults true and accepts an opt-out.
- Behavior: `version.npm.enabled: false` leaves package.json untouched while Cargo.toml is still versioned.

## Breaking change

crates.io and pub.dev publishing now default on for detected packages. Set `publish.cargo.enabled` / `publish.pub.enabled` to `false` to opt out (version and tag only).

Closes #554

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes ecosystem enablement symmetric across npm, Cargo, and pub.dev: every detected ecosystem is versioned and published by default, with explicit config only ever serving as an opt-out. It adds `version.npm.enabled` (default `true`) to make package.json handling opt-out-able like Cargo.toml/pubspec.yaml, flips `publish.cargo.enabled` and `publish.pub.enabled` from `false` to `true`, and wires the new npm gate into every version-stage code path.

- **`version.npm.enabled` gate** added to sync strategy (root + per-package loop), single strategy, async/packageProcessor, group strategy (grouped members + ungrouped packages) — all paths consistently check `config.npm?.enabled !== false` before writing package.json.
- **Three previously-reported bugs fixed**: `processedPaths.add(rootPkgPath)` is now unconditional (single-package dedup), root Cargo.toml update runs outside the npm guard (no silent skip), and hybrid-package Cargo.toml changes are tracked in `updatedPackages` when npm is disabled (no abandoned writes).
- **Schema, JSON schema, and docs** regenerated and consistent; two targeted test cases cover the dedup and abandoned-write scenarios directly.
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge — the three logic bugs called out in prior review rounds are all correctly addressed, and the new npm-gate is applied consistently across every version-stage code path.

The sync-strategy restructuring (unconditional processedPaths.add, root Cargo outside the npm gate, hybrid-package Cargo tracking) is well-reasoned and covered by two targeted new tests. Schema, docs, and type changes are internally consistent. The only gap is a documentation omission rather than a logic defect.

No files require special attention; the documentation gap (missing migration note) is the only remaining item.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/version/src/core/versionStrategies.ts | Sync strategy correctly restructured: processedPaths.add(rootPkgPath) is now unconditional, root Cargo.toml runs outside the npm gate, and hybrid-package Cargo.toml tracking fires when either package.json is absent or npm is disabled — all three previously-reported bugs are fixed. |
| packages/config/src/schema.ts | Adds VersionNpmConfigSchema (enabled: true default), wires it into VersionConfigSchema.npm, and flips CargoPublishConfigSchema/PubPublishConfigSchema enabled defaults from false to true — consistent with the detection-enables model. |
| packages/version/src/core/groupStrategy.ts | Both releaseGroup members and ungrouped packages now correctly gate package.json writes on config.npm?.enabled !== false; Cargo.toml handling is unchanged and independent of the npm gate. |
| packages/version/src/package/packageProcessor.ts | Adds npmEnabled check before writing package.json; Cargo.toml and pubspec.yaml handling remain independent. updatedPackagesInfo is still pushed unconditionally after version calculation, so the async strategy commit path is unaffected when npm is disabled. |
| packages/version/src/types.ts | Adds npm?: { enabled?: boolean } to the Config interface and threads it through toVersionConfig, correctly matching the cargo/pub pattern already established. |
| packages/version/test/unit/core/versionStrategies.spec.ts | Two new tests directly cover the previously-reported bugs: one for hybrid monorepo Cargo.toml not being abandoned, and one for single-package repo dedup (Cargo.toml versioned exactly once). Both assert tagging proceeds correctly. |
| packages/config/test/unit/schema.spec.ts | Tests verify version.npm.enabled defaults to true, accepts opt-out false, and that publish defaults for cargo and pub are now true. Clean. |
| docs/configuration.md | Adds ### version.npm subsection (parallel to ### version.cargo) and updates publish enabled defaults and descriptions to reflect the opt-out framing. |
| releasekit.schema.json | Generated schema correctly reflects the new version.npm object, updated cargo/pub publish defaults (false to true), and refreshed descriptions throughout. Consistent with schema.ts. |
| scripts/generate-config-docs.ts | Adds a renderVersion branch for version.npm parallel to the existing version.cargo branch, ensuring the docs generator produces the new subsection. |
| packages/version/test/unit/package/packageProcessor.spec.ts | New test covers hybrid package processor behavior when npm is disabled: package.json is skipped and Cargo.toml is still updated, verifying the two ecosystems are independent. |

</details>


<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Version stage triggered] --> B{packages.root defined?}
    B -->|yes| C{npm enabled?\nconfig.npm?.enabled !== false}
    B -->|no| G
    C -->|yes + package.json exists| D[updatePackageVersion root package.json\nupdatedPackages.push root]
    C -->|no| E[skip package.json\nlog debug]
    D --> F[processedPaths.add rootPkgPath\nunconditional]
    E --> F
    F --> G[updateCargoFiles root dir\nindependent of npm gate]
    G --> H{rootCargoFiles.length > 0\nand root not yet tracked?}
    H -->|yes| I[updatedPackages.push root]
    H -->|no| J
    I --> J[for each pkg in packages]
    J --> K{processedPaths.has\npkg package.json path?}
    K -->|yes - single-pkg dedup| L[continue - skip]
    K -->|no| M{npm enabled?}
    M -->|yes + file exists| N[updatePackageVersion pkg package.json\nupdatedPackages.push pkg.name\nprocessedPaths.add]
    M -->|no| O[skip package.json\nlog debug]
    N --> P[updateCargoFiles pkg dir]
    O --> P
    P --> Q{no package.json OR npm disabled\nAND pkgCargoFiles.length > 0?}
    Q -->|yes| R[updatedPackages.push pkg.name]
    Q -->|no| S
    R --> S{more packages?}
    S -->|yes| J
    S -->|no| T{updatedPackages empty?}
    T -->|yes| U[early return - no packages updated]
    T -->|no| V[proceed to tag + commit]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Version stage triggered] --> B{packages.root defined?}
    B -->|yes| C{npm enabled?\nconfig.npm?.enabled !== false}
    B -->|no| G
    C -->|yes + package.json exists| D[updatePackageVersion root package.json\nupdatedPackages.push root]
    C -->|no| E[skip package.json\nlog debug]
    D --> F[processedPaths.add rootPkgPath\nunconditional]
    E --> F
    F --> G[updateCargoFiles root dir\nindependent of npm gate]
    G --> H{rootCargoFiles.length > 0\nand root not yet tracked?}
    H -->|yes| I[updatedPackages.push root]
    H -->|no| J
    I --> J[for each pkg in packages]
    J --> K{processedPaths.has\npkg package.json path?}
    K -->|yes - single-pkg dedup| L[continue - skip]
    K -->|no| M{npm enabled?}
    M -->|yes + file exists| N[updatePackageVersion pkg package.json\nupdatedPackages.push pkg.name\nprocessedPaths.add]
    M -->|no| O[skip package.json\nlog debug]
    N --> P[updateCargoFiles pkg dir]
    O --> P
    P --> Q{no package.json OR npm disabled\nAND pkgCargoFiles.length > 0?}
    Q -->|yes| R[updatedPackages.push pkg.name]
    Q -->|no| S
    R --> S{more packages?}
    S -->|yes| J
    S -->|no| T{updatedPackages empty?}
    T -->|yes| U[early return - no packages updated]
    T -->|no| V[proceed to tag + commit]
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `packages/version/src/core/versionStrategies.ts`, line 226-240 ([link](https://github.com/goosewobbler/releasekit/blob/9ec230f4c0f86914b3e036ecd5e2ba33235cfc75/packages/version/src/core/versionStrategies.ts#L226-L240)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Root Cargo.toml skipped when npm versioning is disabled**

   The `updateCargoFiles` call for the workspace root is nested inside the npm-enabled guard, so setting `version.npm.enabled: false` on a hybrid monorepo (npm + Rust, sync mode) silently skips the root `Cargo.toml` update entirely. Compare the per-package loop directly below: there, `updateCargoFiles` runs *after* the npm block unconditionally. The fix is to move the root `updateCargoFiles` call (and its `files.push`) outside the npm gate, matching the pattern used for every workspace package in the same function.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fversion%2Fsrc%2Fcore%2FversionStrategies.ts%0ALine%3A%20226-240%0A%0AComment%3A%0A**Root%20Cargo.toml%20skipped%20when%20npm%20versioning%20is%20disabled**%0A%0AThe%20%60updateCargoFiles%60%20call%20for%20the%20workspace%20root%20is%20nested%20inside%20the%20npm-enabled%20guard%2C%20so%20setting%20%60version.npm.enabled%3A%20false%60%20on%20a%20hybrid%20monorepo%20%28npm%20%2B%20Rust%2C%20sync%20mode%29%20silently%20skips%20the%20root%20%60Cargo.toml%60%20update%20entirely.%20Compare%20the%20per-package%20loop%20directly%20below%3A%20there%2C%20%60updateCargoFiles%60%20runs%20*after*%20the%20npm%20block%20unconditionally.%20The%20fix%20is%20to%20move%20the%20root%20%60updateCargoFiles%60%20call%20%28and%20its%20%60files.push%60%29%20outside%20the%20npm%20gate%2C%20matching%20the%20pattern%20used%20for%20every%20workspace%20package%20in%20the%20same%20function.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=goosewobbler%2Freleasekit&pr=563&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fversion%2Fsrc%2Fcore%2FversionStrategies.ts%0ALine%3A%20226-240%0A%0AComment%3A%0A**Root%20Cargo.toml%20skipped%20when%20npm%20versioning%20is%20disabled**%0A%0AThe%20%60updateCargoFiles%60%20call%20for%20the%20workspace%20root%20is%20nested%20inside%20the%20npm-enabled%20guard%2C%20so%20setting%20%60version.npm.enabled%3A%20false%60%20on%20a%20hybrid%20monorepo%20%28npm%20%2B%20Rust%2C%20sync%20mode%29%20silently%20skips%20the%20root%20%60Cargo.toml%60%20update%20entirely.%20Compare%20the%20per-package%20loop%20directly%20below%3A%20there%2C%20%60updateCargoFiles%60%20runs%20*after*%20the%20npm%20block%20unconditionally.%20The%20fix%20is%20to%20move%20the%20root%20%60updateCargoFiles%60%20call%20%28and%20its%20%60files.push%60%29%20outside%20the%20npm%20gate%2C%20matching%20the%20pattern%20used%20for%20every%20workspace%20package%20in%20the%20same%20function.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=563&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a>

2. `packages/version/src/core/versionStrategies.ts`, line 277-293 ([link](https://github.com/goosewobbler/releasekit/blob/930a4ab10c2c1ea2372abf4f60b7155f8dc6c8ef/packages/version/src/core/versionStrategies.ts#L277-L293)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Cargo changes abandoned on early exit when npm is disabled**

   When `version.npm.enabled: false` on a sync-mode hybrid monorepo (packages have both `package.json` and `Cargo.toml`), `pkgCargoFiles` are written to disk and pushed into `files`, but `updatedPackages` never receives the package name — the npm path skips it, and the cargo fallback at line 282 only fires when `!fs.existsSync(packageJsonPath)` (i.e. pure-Rust packages without a `package.json`). With `updatedPackages` empty, the `return` at line 292 fires and the already-written Cargo.toml changes are never committed, leaving the working tree dirty.

   Fix: extend the cargo tracking to also cover hybrid packages when npm is disabled:
   ```
   if ((!fs.existsSync(packageJsonPath) || config.npm?.enabled === false) && pkgCargoFiles.length > 0) {
     updatedPackages.push(pkg.packageJson.name);
   }
   ```

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fversion%2Fsrc%2Fcore%2FversionStrategies.ts%0ALine%3A%20277-293%0A%0AComment%3A%0A**Cargo%20changes%20abandoned%20on%20early%20exit%20when%20npm%20is%20disabled**%0A%0AWhen%20%60version.npm.enabled%3A%20false%60%20on%20a%20sync-mode%20hybrid%20monorepo%20%28packages%20have%20both%20%60package.json%60%20and%20%60Cargo.toml%60%29%2C%20%60pkgCargoFiles%60%20are%20written%20to%20disk%20and%20pushed%20into%20%60files%60%2C%20but%20%60updatedPackages%60%20never%20receives%20the%20package%20name%20%E2%80%94%20the%20npm%20path%20skips%20it%2C%20and%20the%20cargo%20fallback%20at%20line%20282%20only%20fires%20when%20%60!fs.existsSync%28packageJsonPath%29%60%20%28i.e.%20pure-Rust%20packages%20without%20a%20%60package.json%60%29.%20With%20%60updatedPackages%60%20empty%2C%20the%20%60return%60%20at%20line%20292%20fires%20and%20the%20already-written%20Cargo.toml%20changes%20are%20never%20committed%2C%20leaving%20the%20working%20tree%20dirty.%0A%0AFix%3A%20extend%20the%20cargo%20tracking%20to%20also%20cover%20hybrid%20packages%20when%20npm%20is%20disabled%3A%0A%60%60%60%0Aif%20%28%28!fs.existsSync%28packageJsonPath%29%20%7C%7C%20config.npm%3F.enabled%20%3D%3D%3D%20false%29%20%26%26%20pkgCargoFiles.length%20%3E%200%29%20%7B%0A%20%20updatedPackages.push%28pkg.packageJson.name%29%3B%0A%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=goosewobbler%2Freleasekit&pr=563&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fversion%2Fsrc%2Fcore%2FversionStrategies.ts%0ALine%3A%20277-293%0A%0AComment%3A%0A**Cargo%20changes%20abandoned%20on%20early%20exit%20when%20npm%20is%20disabled**%0A%0AWhen%20%60version.npm.enabled%3A%20false%60%20on%20a%20sync-mode%20hybrid%20monorepo%20%28packages%20have%20both%20%60package.json%60%20and%20%60Cargo.toml%60%29%2C%20%60pkgCargoFiles%60%20are%20written%20to%20disk%20and%20pushed%20into%20%60files%60%2C%20but%20%60updatedPackages%60%20never%20receives%20the%20package%20name%20%E2%80%94%20the%20npm%20path%20skips%20it%2C%20and%20the%20cargo%20fallback%20at%20line%20282%20only%20fires%20when%20%60!fs.existsSync%28packageJsonPath%29%60%20%28i.e.%20pure-Rust%20packages%20without%20a%20%60package.json%60%29.%20With%20%60updatedPackages%60%20empty%2C%20the%20%60return%60%20at%20line%20292%20fires%20and%20the%20already-written%20Cargo.toml%20changes%20are%20never%20committed%2C%20leaving%20the%20working%20tree%20dirty.%0A%0AFix%3A%20extend%20the%20cargo%20tracking%20to%20also%20cover%20hybrid%20packages%20when%20npm%20is%20disabled%3A%0A%60%60%60%0Aif%20%28%28!fs.existsSync%28packageJsonPath%29%20%7C%7C%20config.npm%3F.enabled%20%3D%3D%3D%20false%29%20%26%26%20pkgCargoFiles.length%20%3E%200%29%20%7B%0A%20%20updatedPackages.push%28pkg.packageJson.name%29%3B%0A%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=563&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a>

3. `packages/version/src/core/versionStrategies.ts`, line 258-261 ([link](https://github.com/goosewobbler/releasekit/blob/037e4db6e3c029c0149523dd0020c96e1b951b48/packages/version/src/core/versionStrategies.ts#L258-L261)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`processedPaths` dedup broken for single-package repos when npm is disabled**

   `processedPaths` is populated only when npm is enabled and a `package.json` is written (line 275). When `version.npm.enabled: false`, the set stays empty, so `processedPaths.has(packageJsonPath)` is always `false` and the `continue` guard never fires.

   For a single-package repo configured with `sync: true` — where `packages.root === packages.packages[0].dir` — `updateCargoFiles` is called twice: once unconditionally for the root (line 240) and again in the loop without being short-circuited. The result is the root `Cargo.toml` path appearing twice in `files` and `updatedPackages` being inflated by one. The comment on line 221 (`// Track processed paths to avoid duplicates in single-package repos`) acknowledges this invariant, but it no longer holds when npm versioning is opted out.

   The simplest fix is to populate `processedPaths` with `packageJsonPath` in the npm-disabled branch (line 265) so the loop still skips the root-as-package path, even though no `package.json` was written.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fversion%2Fsrc%2Fcore%2FversionStrategies.ts%0ALine%3A%20258-261%0A%0AComment%3A%0A**%60processedPaths%60%20dedup%20broken%20for%20single-package%20repos%20when%20npm%20is%20disabled**%0A%0A%60processedPaths%60%20is%20populated%20only%20when%20npm%20is%20enabled%20and%20a%20%60package.json%60%20is%20written%20%28line%20275%29.%20When%20%60version.npm.enabled%3A%20false%60%2C%20the%20set%20stays%20empty%2C%20so%20%60processedPaths.has%28packageJsonPath%29%60%20is%20always%20%60false%60%20and%20the%20%60continue%60%20guard%20never%20fires.%0A%0AFor%20a%20single-package%20repo%20configured%20with%20%60sync%3A%20true%60%20%E2%80%94%20where%20%60packages.root%20%3D%3D%3D%20packages.packages%5B0%5D.dir%60%20%E2%80%94%20%60updateCargoFiles%60%20is%20called%20twice%3A%20once%20unconditionally%20for%20the%20root%20%28line%20240%29%20and%20again%20in%20the%20loop%20without%20being%20short-circuited.%20The%20result%20is%20the%20root%20%60Cargo.toml%60%20path%20appearing%20twice%20in%20%60files%60%20and%20%60updatedPackages%60%20being%20inflated%20by%20one.%20The%20comment%20on%20line%20221%20%28%60%2F%2F%20Track%20processed%20paths%20to%20avoid%20duplicates%20in%20single-package%20repos%60%29%20acknowledges%20this%20invariant%2C%20but%20it%20no%20longer%20holds%20when%20npm%20versioning%20is%20opted%20out.%0A%0AThe%20simplest%20fix%20is%20to%20populate%20%60processedPaths%60%20with%20%60packageJsonPath%60%20in%20the%20npm-disabled%20branch%20%28line%20265%29%20so%20the%20loop%20still%20skips%20the%20root-as-package%20path%2C%20even%20though%20no%20%60package.json%60%20was%20written.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=goosewobbler%2Freleasekit&pr=563&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fversion%2Fsrc%2Fcore%2FversionStrategies.ts%0ALine%3A%20258-261%0A%0AComment%3A%0A**%60processedPaths%60%20dedup%20broken%20for%20single-package%20repos%20when%20npm%20is%20disabled**%0A%0A%60processedPaths%60%20is%20populated%20only%20when%20npm%20is%20enabled%20and%20a%20%60package.json%60%20is%20written%20%28line%20275%29.%20When%20%60version.npm.enabled%3A%20false%60%2C%20the%20set%20stays%20empty%2C%20so%20%60processedPaths.has%28packageJsonPath%29%60%20is%20always%20%60false%60%20and%20the%20%60continue%60%20guard%20never%20fires.%0A%0AFor%20a%20single-package%20repo%20configured%20with%20%60sync%3A%20true%60%20%E2%80%94%20where%20%60packages.root%20%3D%3D%3D%20packages.packages%5B0%5D.dir%60%20%E2%80%94%20%60updateCargoFiles%60%20is%20called%20twice%3A%20once%20unconditionally%20for%20the%20root%20%28line%20240%29%20and%20again%20in%20the%20loop%20without%20being%20short-circuited.%20The%20result%20is%20the%20root%20%60Cargo.toml%60%20path%20appearing%20twice%20in%20%60files%60%20and%20%60updatedPackages%60%20being%20inflated%20by%20one.%20The%20comment%20on%20line%20221%20%28%60%2F%2F%20Track%20processed%20paths%20to%20avoid%20duplicates%20in%20single-package%20repos%60%29%20acknowledges%20this%20invariant%2C%20but%20it%20no%20longer%20holds%20when%20npm%20versioning%20is%20opted%20out.%0A%0AThe%20simplest%20fix%20is%20to%20populate%20%60processedPaths%60%20with%20%60packageJsonPath%60%20in%20the%20npm-disabled%20branch%20%28line%20265%29%20so%20the%20loop%20still%20skips%20the%20root-as-package%20path%2C%20even%20though%20no%20%60package.json%60%20was%20written.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=563&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (8): Last reviewed commit: ["feat(config)!: unify per-ecosystem enabl..."](https://github.com/goosewobbler/releasekit/commit/56166dd805c98bcb60fde9d464d406de97e0b1ed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45450546)</sub>

<!-- /greptile_comment -->