### PR TITLE
feat(notes): require an explicit llm.model; enum-validate provider

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -75,6 +75,7 @@ Versioning configuration.
 | `allowFirstBump` | boolean | `false` | Acknowledge applying a bump on a first release with an already-stable manifest. On a first release (no prior tag), `--stable --bump <type>` applies the bump (e.g. 1.0.0 → 2.0.0) rather than graduating, which can silently overshoot the staged first version. By default this is flagged per `mismatchStrategy` (warn, or abort under "error"); set true (or pass --allow-first-bump) to apply the bump silently — legitimate when importing a package with prior external version history. |
 | `strictReachable` | boolean | `false` | Only use reachable tags |
 | `zeroMajor` | `"spec"` \| `"strict"` | `"spec"` | Pre-1.0 handling of commit-inferred breaking changes. 'spec' (default): bump the 0.x minor (0.24.0 → 0.25.0), per semver §4. 'strict': bump the next major (→ 1.0.0). Inferred path only — explicit overrides (--bump major, bump:major) always graduate to 1.0.0. |
+| `npm` | object | — | npm/JavaScript version handling |
 | `pub` | object | — | Dart/Flutter pub configuration |
 
 ### `version.zeroMajor`
@@ -127,13 +128,21 @@ ungrouped packages honor targets as-is.
 **Workspace pins.** Intra-group `workspace:*` dependencies resolve to the group version within a
 run, so a fixed group publishes internally consistent.
 
+### `version.npm`
+
+npm/JavaScript version handling.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | boolean | `true` | Version package.json manifests. Detected npm packages are versioned by default; set false to opt out (e.g. npm versioning handled elsewhere). |
+
 ### `version.cargo`
 
 Cargo/Rust configuration.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `enabled` | boolean | `true` | Enable Cargo.toml version handling |
+| `enabled` | boolean | `true` | Version Cargo.toml manifests. Detected Rust packages are versioned by default; set false to opt out (e.g. a vendored crate, or Rust versioning handled elsewhere). |
 | `paths` | `string[]` | — | Directories to search for Cargo.toml files |
 
 ---
@@ -162,7 +171,7 @@ NPM publishing configuration.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `enabled` | boolean | `true` | Enable NPM publishing |
+| `enabled` | boolean | `true` | Publish to npm. Detected npm packages are published by default; set false to opt out (version and tag only). |
 | `auth` | `"auto"` \| `"oidc"` \| `"token"` | `"auto"` | Authentication method |
 | `provenance` | boolean | `true` | Enable npm provenance attestation |
 | `access` | `"public"` \| `"restricted"` | `"public"` | Package access level |
@@ -177,7 +186,7 @@ Cargo publishing configuration.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `enabled` | boolean | `false` | Enable Cargo publishing |
+| `enabled` | boolean | `true` | Publish to crates.io. Detected Rust packages are published by default; set false to opt out (version and tag only). |
 | `noVerify` | boolean | `false` | Skip verification before publish |
 | `publishOrder` | `string[]` | `[]` | Order in which to publish packages |
 | `clean` | boolean | `false` | Clean before publishing |
@@ -188,7 +197,7 @@ Dart/Flutter publishing configuration via pub.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `enabled` | boolean | `false` | Enable pub.dev publishing |
+| `enabled` | boolean | `true` | Publish to pub.dev. Detected Dart/Flutter packages are published by default; set false to opt out (version and tag only). |
 | `publishOrder` | `string[]` | `[]` | Order in which to publish packages |
 
 ### `publish.githubRelease`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -299,9 +299,9 @@ LLM configuration for release notes.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `provider` | string | — | LLM provider |
-| `model` | string | — | Model identifier |
-| `baseURL` | string | — | Custom API base URL |
+| `provider` | `"openai"` \| `"openai-compatible"` \| `"anthropic"` \| `"ollama"` | — | LLM provider |
+| `model` | string | — | Model identifier for the selected provider. Required — releasekit ships no default, so enabling LLM enhancement needs an explicit, current model (a missing model fails config validation). |
+| `baseURL` | string | — | Custom API base URL. Required for the openai-compatible provider. |
 | `apiKey` | string | — | API key |
 | `concurrency` | integer | — | Concurrent LLM requests |
 | `style` | string | — | Writing style for LLM |

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -24,6 +24,7 @@ export {
   type GitHubReleaseConfig,
   type LLMCategory,
   type LLMConfig,
+  LLMConfigSchema,
   type LLMPromptOverrides,
   type LLMPromptsConfig,
   type LocationMode,

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -432,10 +432,17 @@ export const LLMPromptsConfigSchema = z.object({
   ),
 });
 
-export const LLMConfigSchema = z.object({
-  provider: z.string().describe('LLM provider'),
-  model: z.string().describe('Model identifier'),
-  baseURL: z.string().optional().describe('Custom API base URL'),
+const LLMConfigBaseSchema = z.object({
+  provider: z.enum(['openai', 'openai-compatible', 'anthropic', 'ollama']).describe('LLM provider'),
+  model: z
+    .string()
+    // .min(1): an empty string passes z.string(), so "model": "" would slip through Zod at load and
+    // only fail deep in the pipeline (soft-caught). Reject it at config validation instead.
+    .min(1, 'model must be a non-empty string — set it to a model the provider serves.')
+    .describe(
+      'Model identifier for the selected provider. Required — releasekit ships no default, so enabling LLM enhancement needs an explicit, current model (a missing model fails config validation).',
+    ),
+  baseURL: z.string().optional().describe('Custom API base URL. Required for the openai-compatible provider.'),
   apiKey: z.string().optional().describe('API key'),
   options: LLMOptionsSchema.optional(),
   concurrency: z.number().int().positive().optional().describe('Concurrent LLM requests'),
@@ -481,6 +488,19 @@ export const LLMConfigSchema = z.object({
     .describe(
       'Cache LLM responses on disk (under the OS temp dir), keyed by a hash of the provider, model, prompt, and request options. A re-run or backfill with the same inputs reuses the cached generation instead of re-calling the provider. Off by default.',
     ),
+});
+
+// The openai-compatible provider points at a custom endpoint, so releasekit can't assume a base URL:
+// it must be set explicitly. Enforced at config-validation time (a Zod refinement) so a misconfig
+// fails loudly here rather than silently degrading to non-LLM notes inside the notes soft-fail catch.
+export const LLMConfigSchema = LLMConfigBaseSchema.superRefine((cfg, ctx) => {
+  if (cfg.provider === 'openai-compatible' && !cfg.baseURL) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['baseURL'],
+      message: 'baseURL is required when provider is "openai-compatible".',
+    });
+  }
 });
 
 export const ReleaseNotesConfigSchema = z

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -26,13 +26,32 @@ export const MonorepoConfigSchema = z.object({
   packagesPath: z.string().optional().describe('Path to packages directory'),
 });
 
+export const VersionNpmConfigSchema = z.object({
+  enabled: z
+    .boolean()
+    .default(true)
+    .describe(
+      'Version package.json manifests. Detected npm packages are versioned by default; set false to opt out (e.g. npm versioning handled elsewhere).',
+    ),
+});
+
 export const VersionCargoConfigSchema = z.object({
-  enabled: z.boolean().default(true).describe('Enable Cargo.toml version handling'),
+  enabled: z
+    .boolean()
+    .default(true)
+    .describe(
+      'Version Cargo.toml manifests. Detected Rust packages are versioned by default; set false to opt out (e.g. a vendored crate, or Rust versioning handled elsewhere).',
+    ),
   paths: z.array(z.string()).optional().describe('Directories to search for Cargo.toml files'),
 });
 
 export const VersionPubConfigSchema = z.object({
-  enabled: z.boolean().default(true).describe('Enable pubspec.yaml version handling'),
+  enabled: z
+    .boolean()
+    .default(true)
+    .describe(
+      'Version pubspec.yaml manifests. Detected Dart/Flutter packages are versioned by default; set false to opt out.',
+    ),
   paths: z.array(z.string()).optional().describe('Directories to search for pubspec.yaml files'),
 });
 
@@ -129,12 +148,18 @@ export const VersionConfigSchema = z.object({
     .describe(
       "Pre-1.0 handling of commit-inferred breaking changes. 'spec' (default): bump the 0.x minor (0.24.0 → 0.25.0), per semver §4. 'strict': bump the next major (→ 1.0.0). Inferred path only — explicit overrides (--bump major, bump:major) always graduate to 1.0.0.",
     ),
+  npm: VersionNpmConfigSchema.optional().describe('npm/JavaScript version handling'),
   cargo: VersionCargoConfigSchema.optional().describe('Cargo/Rust configuration'),
   pub: VersionPubConfigSchema.optional().describe('Dart/Flutter pub configuration'),
 });
 
 export const NpmConfigSchema = z.object({
-  enabled: z.boolean().default(true).describe('Enable NPM publishing'),
+  enabled: z
+    .boolean()
+    .default(true)
+    .describe(
+      'Publish to npm. Detected npm packages are published by default; set false to opt out (version and tag only).',
+    ),
   auth: z.enum(['auto', 'oidc', 'token']).default('auto').describe('Authentication method'),
   provenance: z.boolean().default(true).describe('Enable npm provenance attestation'),
   access: z.enum(['public', 'restricted']).default('public').describe('Package access level'),
@@ -148,14 +173,24 @@ export const NpmConfigSchema = z.object({
 });
 
 export const CargoPublishConfigSchema = z.object({
-  enabled: z.boolean().default(false).describe('Enable Cargo publishing'),
+  enabled: z
+    .boolean()
+    .default(true)
+    .describe(
+      'Publish to crates.io. Detected Rust packages are published by default; set false to opt out (version and tag only).',
+    ),
   noVerify: z.boolean().default(false).describe('Skip verification before publish'),
   publishOrder: z.array(z.string()).default([]).describe('Order in which to publish packages'),
   clean: z.boolean().default(false).describe('Clean before publishing'),
 });
 
 export const PubPublishConfigSchema = z.object({
-  enabled: z.boolean().default(false).describe('Enable pub.dev publishing'),
+  enabled: z
+    .boolean()
+    .default(true)
+    .describe(
+      'Publish to pub.dev. Detected Dart/Flutter packages are published by default; set false to opt out (version and tag only).',
+    ),
   publishOrder: z.array(z.string()).default([]).describe('Order in which to publish packages'),
 });
 
@@ -248,13 +283,13 @@ export const PublishConfigSchema = z.object({
     publishOrder: [],
   }).describe('NPM publishing configuration'),
   cargo: CargoPublishConfigSchema.default({
-    enabled: false,
+    enabled: true,
     noVerify: false,
     publishOrder: [],
     clean: false,
   }).describe('Cargo publishing configuration'),
   pub: PubPublishConfigSchema.default({
-    enabled: false,
+    enabled: true,
     publishOrder: [],
   }).describe('Dart/Flutter publishing configuration via pub'),
   githubRelease: GitHubReleaseConfigSchema.default({

--- a/packages/config/test/unit/schema.spec.ts
+++ b/packages/config/test/unit/schema.spec.ts
@@ -18,6 +18,7 @@ import {
   TemplateConfigSchema,
   VerifyConfigSchema,
   VersionConfigSchema,
+  VersionNpmConfigSchema,
 } from '../../src/schema.js';
 
 describe('GitConfigSchema', () => {
@@ -64,7 +65,6 @@ describe('MonorepoConfigSchema', () => {
 describe('VersionConfigSchema', () => {
   it('should apply defaults', () => {
     const result = VersionConfigSchema.parse({});
-    // biome-ignore lint/suspicious/noTemplateCurlyInString: checking the literal default string
     expect(result.tagTemplate).toBe('${prefix}${version}');
     expect(result.packageSpecificTags).toBe(false);
     expect(result.preset).toBe('conventional');
@@ -102,6 +102,11 @@ describe('VersionConfigSchema', () => {
     });
     expect(result.cargo?.enabled).toBe(true);
     expect(result.cargo?.paths).toEqual(['crates/core', 'crates/cli']);
+  });
+
+  it('should default version.npm.enabled to true and accept an opt-out', () => {
+    expect(VersionNpmConfigSchema.parse({}).enabled).toBe(true);
+    expect(VersionConfigSchema.parse({ npm: { enabled: false } }).npm?.enabled).toBe(false);
   });
 
   it('should accept version groups with fixed and linked sync modes', () => {
@@ -172,7 +177,8 @@ describe('NpmConfigSchema', () => {
 describe('CargoPublishConfigSchema', () => {
   it('should apply defaults', () => {
     const result = CargoPublishConfigSchema.parse({});
-    expect(result.enabled).toBe(false);
+    // Detection enables, config opts out: crates.io publishing defaults on.
+    expect(result.enabled).toBe(true);
     expect(result.noVerify).toBe(false);
     expect(result.publishOrder).toEqual([]);
     expect(result.clean).toBe(false);
@@ -221,10 +227,11 @@ describe('VerifyConfigSchema', () => {
 });
 
 describe('PublishConfigSchema', () => {
-  it('should apply defaults for npm and cargo', () => {
+  it('should default publishing on for npm, cargo, and pub (detection enables, config opts out)', () => {
     const result = PublishConfigSchema.parse({});
     expect(result.npm.enabled).toBe(true);
-    expect(result.cargo.enabled).toBe(false);
+    expect(result.cargo.enabled).toBe(true);
+    expect(result.pub.enabled).toBe(true);
     expect(result.githubRelease.enabled).toBe(true);
   });
 });

--- a/packages/config/test/unit/schema.spec.ts
+++ b/packages/config/test/unit/schema.spec.ts
@@ -332,10 +332,32 @@ describe('LLMPromptsConfigSchema', () => {
 });
 
 describe('LLMConfigSchema', () => {
-  it('should require provider and model', () => {
+  it('should accept provider and model', () => {
     const result = LLMConfigSchema.parse({ provider: 'openai', model: 'gpt-4' });
     expect(result.provider).toBe('openai');
     expect(result.model).toBe('gpt-4');
+  });
+
+  it('should require a non-empty model for every provider (releasekit ships no default)', () => {
+    expect(() => LLMConfigSchema.parse({ provider: 'anthropic' })).toThrow();
+    expect(() => LLMConfigSchema.parse({ provider: 'openai' })).toThrow();
+    expect(() => LLMConfigSchema.parse({ provider: 'ollama' })).toThrow();
+    // An empty string must not slip through z.string().
+    expect(() => LLMConfigSchema.parse({ provider: 'openai', model: '' })).toThrow(/non-empty/);
+  });
+
+  it('should reject an unknown provider (enum, not free-form string)', () => {
+    expect(() => LLMConfigSchema.parse({ provider: 'gpt', model: 'x' })).toThrow();
+    expect(() => LLMConfigSchema.parse({ provider: 'anthropicc', model: 'x' })).toThrow();
+  });
+
+  it('should require baseURL for openai-compatible', () => {
+    expect(() => LLMConfigSchema.parse({ provider: 'openai-compatible', model: 'local-model' })).toThrow(
+      /baseURL is required/,
+    );
+    const ok = LLMConfigSchema.parse({ provider: 'openai-compatible', baseURL: 'https://x/v1', model: 'local-model' });
+    expect(ok.provider).toBe('openai-compatible');
+    expect(ok.model).toBe('local-model');
   });
 
   it('should accept optional fields', () => {

--- a/packages/notes/docs/configuration.md
+++ b/packages/notes/docs/configuration.md
@@ -138,7 +138,7 @@ LLM configuration for release notes enhancement. Requires `provider` and `model`
     "releaseNotes": {
       "llm": {
         "provider": "openai",
-        "model": "gpt-4o-mini",
+        "model": "<your-model>",
         "tasks": { "enhance": true, "summarize": true }
       }
     }
@@ -207,7 +207,7 @@ How existing changelog files are updated when new entries are generated.
 | Option | Type | Description |
 |--------|------|-------------|
 | `provider` | `string` | LLM provider key. See [LLM providers](./llm-providers.md). |
-| `model` | `string` | Model identifier (e.g. `"gpt-4o-mini"`, `"claude-sonnet-4-5"`) |
+| `model` | `string` | Model identifier for the selected provider (see [LLM providers](./llm-providers.md)). Required — releasekit ships no default, so pick a current model your provider serves. |
 
 ### Connection
 
@@ -243,7 +243,7 @@ How existing changelog files are updated when new entries are generated.
     "releaseNotes": {
       "llm": {
         "provider": "openai",
-        "model": "gpt-4o",
+        "model": "<your-model>",
         "options": { "temperature": 0.3, "maxTokens": 1000 }
       }
     }

--- a/packages/notes/docs/llm-providers.md
+++ b/packages/notes/docs/llm-providers.md
@@ -42,7 +42,7 @@ Model names change frequently — check your provider's documentation for the cu
     "releaseNotes": {
       "llm": {
         "provider": "openai",
-        "model": "gpt-4o-mini",
+        "model": "<your-model>",
         "tasks": { "enhance": true }
       }
     }
@@ -62,7 +62,7 @@ See the [OpenAI models documentation](https://platform.openai.com/docs/models) f
     "releaseNotes": {
       "llm": {
         "provider": "anthropic",
-        "model": "claude-haiku-4-5",
+        "model": "<your-model>",
         "tasks": { "releaseNotes": true }
       }
     }
@@ -89,7 +89,7 @@ ollama pull llama3.2
     "releaseNotes": {
       "llm": {
         "provider": "ollama",
-        "model": "llama3.2",
+        "model": "<your-model>",
         "tasks": { "enhance": true }
       }
     }
@@ -109,7 +109,7 @@ For self-hosted or third-party OpenAI-compatible APIs (LM Studio, vLLM, Azure Op
     "releaseNotes": {
       "llm": {
         "provider": "openai-compatible",
-        "model": "your-model-name",
+        "model": "<your-model>",
         "baseURL": "http://localhost:1234/v1",
         "tasks": { "enhance": true }
       }

--- a/packages/notes/docs/llm-release-notes.md
+++ b/packages/notes/docs/llm-release-notes.md
@@ -14,7 +14,7 @@ Add an `llm` block under `notes.releaseNotes` in `releasekit.config.json`:
     "releaseNotes": {
       "llm": {
         "provider": "openai",
-        "model": "gpt-4o-mini",
+        "model": "<your-model>",
         "tasks": { "enhance": true, "categorize": true }
       }
     }
@@ -418,7 +418,7 @@ chore: migrate bundler from webpack to esbuild 0.20
     "releaseNotes": {
       "llm": {
         "provider": "anthropic",
-        "model": "claude-haiku-4-5",
+        "model": "<your-model>",
         "tasks": { "enhance": true, "categorize": true },
         "categoryOrder": ["Breaking", "New", "Fixed", "Changed", "Developer"]
       },

--- a/packages/notes/docs/monorepo.md
+++ b/packages/notes/docs/monorepo.md
@@ -125,7 +125,7 @@ LLM tasks run per-package. Each package's entries are processed independently. W
     "releaseNotes": {
       "llm": {
         "provider": "openai",
-        "model": "gpt-4o-mini",
+        "model": "<your-model>",
         "concurrency": 5,
         "tasks": { "enhance": true }
       }

--- a/packages/notes/src/command.ts
+++ b/packages/notes/src/command.ts
@@ -1,6 +1,6 @@
 import * as fs from 'node:fs';
 import * as readline from 'node:readline';
-import { loadConfig, saveAuth } from '@releasekit/config';
+import { LLMConfigSchema, loadConfig, saveAuth } from '@releasekit/config';
 import { EXIT_CODES, error, info, setLogLevel, setQuietMode, success, warn } from '@releasekit/core';
 import { Command } from 'commander';
 import { runPipeline } from './core/pipeline.js';
@@ -110,7 +110,7 @@ export function createNotesCommand(): Command {
             const existingLlm = existingRn.llm;
             const llm = {
               provider: existingLlm?.provider ?? 'openai-compatible',
-              model: existingLlm?.model ?? '',
+              model: existingLlm?.model,
               ...(existingLlm ?? {}),
             };
             if (options.llmProvider) llm.provider = options.llmProvider;
@@ -126,12 +126,28 @@ export function createNotesCommand(): Command {
               };
             }
 
+            // Validate the CLI-assembled LLM config the same way loadConfig validates a config file,
+            // so a bad --llm-provider or a missing --llm-model fails loud here (non-zero exit via
+            // handleError) instead of reaching createProvider and being swallowed by the pipeline's
+            // soft-fail as a silent degradation to non-LLM notes.
+            let validatedLlm: import('./core/types.js').LLMConfig;
+            try {
+              validatedLlm = LLMConfigSchema.parse(llm) as import('./core/types.js').LLMConfig;
+            } catch (err) {
+              // Surface the Zod issue messages, which name the actual failing field (provider enum,
+              // empty/missing model, or missing baseURL for openai-compatible) — a static message
+              // would misattribute e.g. a missing --llm-base-url to the model.
+              const issues = (err as { issues?: Array<{ message: string }> }).issues;
+              const detail =
+                issues?.map((i) => i.message).join('; ') ?? (err instanceof Error ? err.message : String(err));
+              throw new Error(`Invalid LLM configuration from --llm-* flags: ${detail}`);
+            }
             config.releaseNotes = {
               ...existingRn,
-              llm: llm as import('./core/types.js').LLMConfig,
+              llm: validatedLlm,
             };
 
-            info(`LLM configured: ${llm.provider}${llm.model ? ` (${llm.model})` : ''}`);
+            info(`LLM configured: ${validatedLlm.provider}${validatedLlm.model ? ` (${validatedLlm.model})` : ''}`);
             if (llm.baseURL) {
               info(`LLM base URL: ${llm.baseURL}`);
             }

--- a/packages/notes/src/core/types.ts
+++ b/packages/notes/src/core/types.ts
@@ -155,7 +155,7 @@ export interface TemplateConfig {
 }
 
 export interface LLMConfig {
-  provider: string;
+  provider: 'openai' | 'openai-compatible' | 'anthropic' | 'ollama';
   model: string;
   baseURL?: string;
   apiKey?: string;

--- a/packages/notes/src/llm/anthropic.ts
+++ b/packages/notes/src/llm/anthropic.ts
@@ -2,14 +2,13 @@ import Anthropic from '@anthropic-ai/sdk';
 import type { CompleteOptions } from '../core/types.js';
 import { LLMError } from '../errors/index.js';
 import { BaseLLMProvider } from './base.js';
-import { LLM_DEFAULTS } from './defaults.js';
 import type { CompleteResult, LLMMessage } from './messages.js';
 import { debugLogMessages } from './messages.js';
 import type { ProviderCapabilities } from './provider.js';
 
 export interface AnthropicConfig {
   apiKey?: string;
-  model?: string;
+  model: string;
 }
 
 export class AnthropicProvider extends BaseLLMProvider {
@@ -23,7 +22,7 @@ export class AnthropicProvider extends BaseLLMProvider {
   private client: Anthropic;
   private model: string;
 
-  constructor(config: AnthropicConfig = {}) {
+  constructor(config: AnthropicConfig) {
     super();
 
     const apiKey = config.apiKey ?? process.env.ANTHROPIC_API_KEY;
@@ -33,7 +32,7 @@ export class AnthropicProvider extends BaseLLMProvider {
     }
 
     this.client = new Anthropic({ apiKey });
-    this.model = config.model ?? LLM_DEFAULTS.models.anthropic;
+    this.model = config.model;
   }
 
   async complete(messages: LLMMessage[], options?: CompleteOptions): Promise<CompleteResult> {

--- a/packages/notes/src/llm/defaults.ts
+++ b/packages/notes/src/llm/defaults.ts
@@ -11,10 +11,7 @@ export const LLM_DEFAULTS = {
     maxDelay: 30_000,
     backoffFactor: 2,
   },
-  models: {
-    openai: 'gpt-4o-mini',
-    'openai-compatible': 'gpt-4o-mini',
-    anthropic: 'claude-haiku-4-5-20251001',
-    ollama: 'llama3.2',
-  },
+  // No default model: releasekit ships no model ids (they rot — e.g. a provider deprecates one), so
+  // `llm.model` is required and validated at config load. The model choice, and keeping it current,
+  // is the consumer's.
 } as const;

--- a/packages/notes/src/llm/index.ts
+++ b/packages/notes/src/llm/index.ts
@@ -59,6 +59,14 @@ export interface CategorizedEntries {
 }
 
 export function createProvider(config: LLMConfig): LLMProvider {
+  // releasekit ships no default model (they rot), so a model is required. The Zod schema enforces
+  // this at config load; this guard also covers configs assembled in-process (e.g. the CLI's
+  // --llm-* flags, which bypass schema parsing) so a missing model fails loud, not silently.
+  if (!config.model) {
+    throw new LLMError(
+      `llm.model is required for the '${config.provider}' provider — set it to a model the provider serves.`,
+    );
+  }
   // Resolve API key: explicit config → auth.json → environment (handled per-provider)
   const authKeys = loadAuth();
   const apiKey = config.apiKey ?? authKeys[config.provider];

--- a/packages/notes/src/llm/ollama.ts
+++ b/packages/notes/src/llm/ollama.ts
@@ -3,7 +3,6 @@ import type { CompleteOptions } from '../core/types.js';
 import { LLMError } from '../errors/index.js';
 import { extractJsonFromResponse } from '../utils/json.js';
 import { BaseLLMProvider } from './base.js';
-import { LLM_DEFAULTS } from './defaults.js';
 import type { CompleteResult, LLMMessage } from './messages.js';
 import { debugLogMessages } from './messages.js';
 import type { ProviderCapabilities } from './provider.js';
@@ -11,7 +10,7 @@ import type { ProviderCapabilities } from './provider.js';
 export interface OllamaConfig {
   apiKey?: string;
   baseURL?: string;
-  model?: string;
+  model: string;
 }
 
 interface OllamaChatRequest {
@@ -48,11 +47,11 @@ export class OllamaProvider extends BaseLLMProvider {
   private model: string;
   private apiKey?: string;
 
-  constructor(config: OllamaConfig = {}) {
+  constructor(config: OllamaConfig) {
     super();
 
     this.baseURL = config.baseURL ?? process.env.OLLAMA_BASE_URL ?? 'http://localhost:11434';
-    this.model = config.model ?? process.env.OLLAMA_MODEL ?? LLM_DEFAULTS.models.ollama;
+    this.model = config.model;
     this.apiKey = config.apiKey ?? process.env.OLLAMA_API_KEY;
   }
 

--- a/packages/notes/src/llm/openai-compatible.ts
+++ b/packages/notes/src/llm/openai-compatible.ts
@@ -2,7 +2,6 @@ import OpenAI from 'openai';
 import type { CompleteOptions } from '../core/types.js';
 import { LLMError } from '../errors/index.js';
 import { BaseLLMProvider } from './base.js';
-import { LLM_DEFAULTS } from './defaults.js';
 import type { CompleteResult, LLMMessage } from './messages.js';
 import { debugLogMessages } from './messages.js';
 import type { ProviderCapabilities } from './provider.js';
@@ -10,7 +9,7 @@ import type { ProviderCapabilities } from './provider.js';
 export interface OpenAICompatibleConfig {
   apiKey?: string;
   baseURL: string;
-  model?: string;
+  model: string;
 }
 
 export class OpenAICompatibleProvider extends BaseLLMProvider {
@@ -34,7 +33,7 @@ export class OpenAICompatibleProvider extends BaseLLMProvider {
       baseURL: config.baseURL,
     });
 
-    this.model = config.model ?? LLM_DEFAULTS.models['openai-compatible'];
+    this.model = config.model;
   }
 
   async complete(messages: LLMMessage[], options?: CompleteOptions): Promise<CompleteResult> {

--- a/packages/notes/src/llm/openai.ts
+++ b/packages/notes/src/llm/openai.ts
@@ -4,7 +4,6 @@ import type { CompleteOptions } from '../core/types.js';
 import { LLMError } from '../errors/index.js';
 import { extractJsonFromResponse } from '../utils/json.js';
 import { BaseLLMProvider } from './base.js';
-import { LLM_DEFAULTS } from './defaults.js';
 import type { CompleteResult, LLMMessage } from './messages.js';
 import { debugLogMessages } from './messages.js';
 import type { ProviderCapabilities } from './provider.js';
@@ -12,7 +11,7 @@ import type { ProviderCapabilities } from './provider.js';
 export interface OpenAIConfig {
   apiKey?: string;
   baseURL?: string;
-  model?: string;
+  model: string;
 }
 
 export class OpenAIProvider extends BaseLLMProvider {
@@ -26,7 +25,7 @@ export class OpenAIProvider extends BaseLLMProvider {
   private client: OpenAI;
   private model: string;
 
-  constructor(config: OpenAIConfig = {}) {
+  constructor(config: OpenAIConfig) {
     super();
 
     const apiKey = config.apiKey ?? process.env.OPENAI_API_KEY;
@@ -40,7 +39,7 @@ export class OpenAIProvider extends BaseLLMProvider {
       baseURL: config.baseURL,
     });
 
-    this.model = config.model ?? LLM_DEFAULTS.models.openai;
+    this.model = config.model;
   }
 
   async complete(messages: LLMMessage[], options?: CompleteOptions): Promise<CompleteResult> {

--- a/packages/notes/test/unit/llm/createProvider.spec.ts
+++ b/packages/notes/test/unit/llm/createProvider.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { LLMConfig } from '../../../src/core/types.js';
+import { LLMError } from '../../../src/errors/index.js';
+import { createProvider } from '../../../src/llm/index.js';
+
+// The OpenAI-backed providers construct a client in their constructor; stub it so we can assert the
+// factory's own guards without a network client.
+vi.mock('openai', () => ({
+  default: class MockOpenAI {
+    chat = { completions: { create: vi.fn() } };
+  },
+}));
+
+describe('createProvider', () => {
+  it('should throw a clear error when llm.model is missing (no curated default)', () => {
+    // A config assembled in-process (e.g. from CLI --llm-* flags) can bypass schema validation.
+    const cfg = { provider: 'openai' } as unknown as LLMConfig;
+    expect(() => createProvider(cfg)).toThrow(LLMError);
+    expect(() => createProvider(cfg)).toThrow(/llm\.model is required/);
+  });
+
+  it('should require baseURL for the openai-compatible provider', () => {
+    const cfg = { provider: 'openai-compatible', model: 'local-model' } as unknown as LLMConfig;
+    expect(() => createProvider(cfg)).toThrow(/requires baseURL/);
+  });
+
+  it('should construct a provider when model (and baseURL for openai-compatible) are set', () => {
+    expect(createProvider({ provider: 'openai', model: 'gpt-x', apiKey: 'k' } as LLMConfig).name).toBe('openai');
+    expect(
+      createProvider({ provider: 'openai-compatible', model: 'local-model', baseURL: 'https://x/v1' } as LLMConfig)
+        .name,
+    ).toBe('openai-compatible');
+  });
+});

--- a/packages/publish/docs/github-releases.md
+++ b/packages/publish/docs/github-releases.md
@@ -64,7 +64,7 @@ To populate the GitHub Release body with LLM-written prose:
     "releaseNotes": {
       "llm": {
         "provider": "openai",
-        "model": "gpt-4o-mini",
+        "model": "<your-model>",
         "tasks": { "releaseNotes": true }
       }
     }
@@ -90,7 +90,7 @@ If `body` is `"auto"` (default), LLM release notes are used automatically when a
       "file": { "dir": "release-notes" },
       "llm": {
         "provider": "anthropic",
-        "model": "claude-haiku-4-5",
+        "model": "<your-model>",
         "tasks": { "releaseNotes": true }
       }
     }

--- a/packages/version/src/core/groupStrategy.ts
+++ b/packages/version/src/core/groupStrategy.ts
@@ -407,7 +407,10 @@ async function releaseGroup(
     }
 
     const packageJsonPath = path.join(pkg.dir, 'package.json');
-    if (fs.existsSync(packageJsonPath)) {
+    // npm version handling gates package.json manifests (default true).
+    if (config.npm?.enabled === false) {
+      log(`Skipping package.json update for ${name} - npm version handling disabled`, 'debug');
+    } else if (fs.existsSync(packageJsonPath)) {
       updatePackageVersion(packageJsonPath, version, config.dryRun);
     } else {
       log(`Skipping package.json update for ${name} - no package.json found (Rust-only package)`, 'debug');
@@ -567,7 +570,8 @@ export function createGroupStrategy(config: Config): (packages: PackagesWithRoot
 
         const name = pkg.packageJson.name;
         const packageJsonPath = path.join(pkg.dir, 'package.json');
-        if (fs.existsSync(packageJsonPath)) {
+        // npm version handling gates package.json manifests (default true).
+        if (config.npm?.enabled !== false && fs.existsSync(packageJsonPath)) {
           updatePackageVersion(packageJsonPath, plan.ownNext, config.dryRun);
         }
         const cargoTomlPath = path.join(pkg.dir, 'Cargo.toml');

--- a/packages/version/src/core/versionStrategies.ts
+++ b/packages/version/src/core/versionStrategies.ts
@@ -225,17 +225,29 @@ export function createSyncStrategy(config: Config): StrategyFunction {
         // Check if packages.root is defined before joining paths
         if (packages.root) {
           const rootPkgPath = path.join(packages.root, 'package.json');
-          if (fs.existsSync(rootPkgPath)) {
+          // npm version handling gates package.json manifests (default true).
+          if (config.npm?.enabled !== false && fs.existsSync(rootPkgPath)) {
             // Mark as root so consumers (preview, standing PR) can exclude this lockstep
             // bump from package counts — it isn't a publishable package.
             updatePackageVersion(rootPkgPath, nextVersion, dryRun, true);
             files.push(rootPkgPath);
             updatedPackages.push('root');
-            processedPaths.add(rootPkgPath);
+          }
+          // Record the root path unconditionally (even when npm is disabled) so the per-package loop
+          // skips it in a single-package repo where packages.root === packages[0].dir — otherwise its
+          // Cargo.toml would be versioned twice (once here, once in the loop).
+          processedPaths.add(rootPkgPath);
 
-            // Handle Cargo.toml files in root
-            const rootCargoFiles = updateCargoFiles(packages.root, nextVersion, config.cargo, dryRun);
-            files.push(...rootCargoFiles);
+          // Root Cargo.toml handling is independent of npm (updateCargoFiles honors cargo.enabled),
+          // so it runs whether or not npm versioning is disabled — matching the per-package loop below.
+          const rootCargoFiles = updateCargoFiles(packages.root, nextVersion, config.cargo, dryRun);
+          files.push(...rootCargoFiles);
+          // Record 'root' when only the root Cargo.toml was versioned (npm disabled, or no root
+          // package.json). In a single-package repo where packages.root === packages[0].dir the loop
+          // skips this path via processedPaths, so without this nothing tracks the write and the empty
+          // updatedPackages triggers the early return below — abandoning the already-written file.
+          if (rootCargoFiles.length > 0 && !updatedPackages.includes('root')) {
+            updatedPackages.push('root');
           }
         } else {
           log('Root package path is undefined, skipping root package.json update', 'warning');
@@ -258,8 +270,10 @@ export function createSyncStrategy(config: Config): StrategyFunction {
           continue;
         }
 
-        // Skip pure Rust packages that don't have a package.json
-        if (!fs.existsSync(packageJsonPath)) {
+        // Skip when npm version handling is opted out, or for pure Rust packages with no package.json.
+        if (config.npm?.enabled === false) {
+          log(`Skipping package.json update for ${pkg.packageJson.name} - npm version handling disabled`, 'debug');
+        } else if (!fs.existsSync(packageJsonPath)) {
           log(
             `Skipping package.json update for ${pkg.packageJson.name} - no package.json found (Rust-only package)`,
             'debug',
@@ -275,8 +289,10 @@ export function createSyncStrategy(config: Config): StrategyFunction {
         const pkgCargoFiles = updateCargoFiles(pkg.dir, nextVersion, config.cargo, dryRun);
         files.push(...pkgCargoFiles);
 
-        // Track pure-Rust packages by name when their Cargo.toml was updated
-        if (!fs.existsSync(packageJsonPath) && pkgCargoFiles.length > 0) {
+        // Track by name when only the Cargo.toml was updated: a pure-Rust package (no package.json),
+        // or a hybrid package whose package.json write was skipped because npm handling is disabled.
+        // Without this the early return below abandons the already-written Cargo.toml changes.
+        if ((!fs.existsSync(packageJsonPath) || config.npm?.enabled === false) && pkgCargoFiles.length > 0) {
           updatedPackages.push(pkg.packageJson.name);
         }
       }
@@ -641,12 +657,15 @@ export function createSingleStrategy(config: Config): StrategyFunction {
       // Track all files that need to be committed
       const filesToCommit: string[] = [];
 
-      // Only update package.json if it exists (skip for pure Rust packages)
-      if (fs.existsSync(packageJsonPath)) {
+      // Update package.json when npm version handling is enabled (default true) and it exists;
+      // otherwise skip (opted out, or a pure Rust package with no package.json).
+      const npmEnabled = config.npm?.enabled !== false;
+      if (npmEnabled && fs.existsSync(packageJsonPath)) {
         updatePackageVersion(packageJsonPath, nextVersion, dryRun);
         filesToCommit.push(packageJsonPath);
       } else {
-        log(`Skipping package.json update for ${packageName} - no package.json found (Rust-only package)`, 'debug');
+        const reason = !npmEnabled ? 'npm version handling disabled' : 'no package.json found (Rust-only package)';
+        log(`Skipping package.json update for ${packageName} - ${reason}`, 'debug');
       }
 
       // Handle Cargo.toml files for this package

--- a/packages/version/src/package/packageProcessor.ts
+++ b/packages/version/src/package/packageProcessor.ts
@@ -346,8 +346,9 @@ export class PackageProcessor {
       //       This ensures consistent versioning across language ecosystems.
       const packageJsonPath = path.join(pkgPath, 'package.json');
 
-      // Always update package.json if it exists
-      if (fs.existsSync(packageJsonPath)) {
+      // Update package.json when npm version handling is enabled (default true) and it exists.
+      const npmEnabled = this.fullConfig.npm?.enabled !== false;
+      if (npmEnabled && fs.existsSync(packageJsonPath)) {
         updatePackageVersion(packageJsonPath, nextVersion, this.dryRun);
       }
 

--- a/packages/version/src/types.ts
+++ b/packages/version/src/types.ts
@@ -159,6 +159,9 @@ export interface Config extends VersionConfigBase {
   strictReachable?: boolean;
   /** Pre-1.0 inferred-breaking bump policy ('spec' | 'strict'). See docs/configuration.md#versionzeromajor. */
   zeroMajor?: 'spec' | 'strict';
+  npm?: {
+    enabled?: boolean;
+  };
   cargo?: {
     enabled?: boolean;
     paths?: string[];
@@ -240,6 +243,7 @@ export function toVersionConfig(config: VersionConfig | undefined): Config {
     zeroMajor: config.zeroMajor,
     versionPrefix: config.versionPrefix ?? '',
     prereleaseIdentifier: config.prereleaseIdentifier,
+    npm: config.npm,
     cargo: config.cargo,
     pub: config.pub,
   };

--- a/packages/version/test/unit/core/versionStrategies.spec.ts
+++ b/packages/version/test/unit/core/versionStrategies.spec.ts
@@ -230,6 +230,58 @@ describe('Version Strategies', () => {
       expect(jsonOutput.setPackageUpdateTag).not.toHaveBeenCalled();
     });
 
+    it('should still version Cargo.toml and not abandon it when npm handling is disabled on a hybrid repo', async () => {
+      // Hybrid sync monorepo (existsSync mock returns true for every package.json AND Cargo.toml) with
+      // npm versioning opted out: package.json writes are skipped, but Cargo.toml must still be versioned
+      // and the run must not early-return as "no packages updated" (which would abandon the written files).
+      const config: Partial<Config> = { ...defaultConfig, sync: true, npm: { enabled: false } };
+      const syncStrategy = strategies.createSyncStrategy(config as Config);
+
+      await syncStrategy(mockPackages);
+
+      // package.json manifests (root 4-arg, members 3-arg) are skipped...
+      expect(packageManagement.updatePackageVersion).not.toHaveBeenCalledWith(
+        packageAPath,
+        expect.anything(),
+        expect.anything(),
+      );
+      expect(packageManagement.updatePackageVersion).not.toHaveBeenCalledWith(
+        rootPackagePath,
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+      );
+      // ...but Cargo.toml is still versioned (root + members); updateCargoFiles passes dryRun=false.
+      expect(packageManagement.updatePackageVersion).toHaveBeenCalledWith(
+        '/test/workspace/packages/a/Cargo.toml',
+        '1.1.0',
+        false,
+      );
+      expect(packageManagement.updatePackageVersion).toHaveBeenCalledWith('/test/workspace/Cargo.toml', '1.1.0', false);
+      // ...and the run proceeds to tag rather than early-returning.
+      expect(jsonOutput.addTag).toHaveBeenCalledWith('v1.1.0');
+    });
+
+    it('should not version a single-package repo Cargo.toml twice when npm is disabled', async () => {
+      // Single-package repo where the package IS the root (packages.root === packages[0].dir). With
+      // npm disabled, processedPaths must still record the root path so the per-package loop skips it,
+      // or updateCargoFiles runs for the same dir twice — writing Cargo.toml twice.
+      const singlePkg = {
+        root: '/test/workspace',
+        packages: [{ dir: '/test/workspace', packageJson: { name: 'root-pkg', version: '1.0.0' } }],
+      };
+      const config: Partial<Config> = { ...defaultConfig, sync: true, npm: { enabled: false } };
+      await strategies.createSyncStrategy(config as Config)(singlePkg as typeof mockPackages);
+
+      const cargoCalls = vi
+        .mocked(packageManagement.updatePackageVersion)
+        .mock.calls.filter((c) => c[0] === '/test/workspace/Cargo.toml');
+      expect(cargoCalls).toHaveLength(1);
+      // The run must not early-return as "nothing updated" — 'root' is tracked for the cargo-only
+      // update, so the shared tag is still created and the written Cargo.toml is committed.
+      expect(jsonOutput.addTag).toHaveBeenCalledWith('v1.1.0');
+    });
+
     it('should use mainPackage for version calculation when specified', async () => {
       // Setup with mainPackage
       const config: Partial<Config> = {

--- a/packages/version/test/unit/package/packageProcessor.spec.ts
+++ b/packages/version/test/unit/package/packageProcessor.spec.ts
@@ -929,6 +929,36 @@ describe('Package Processor', () => {
         false,
       );
     });
+
+    it('should skip package.json but still update Cargo.toml when version.npm.enabled is false', async () => {
+      vi.spyOn(fs, 'existsSync').mockImplementation(() => true);
+
+      const hybridPackage = {
+        ...mockPackages[0],
+        dir: '/path/to/hybrid-package',
+        packageJson: { name: 'hybrid-package', version: '0.1.0' },
+      };
+
+      const processor = new PackageProcessor({
+        getLatestTag: gitTags.getLatestTag,
+        config: {},
+        fullConfig: { ...mockConfig, npm: { enabled: false } },
+      });
+
+      await processor.processPackages([hybridPackage]);
+
+      // npm opted out → package.json is left untouched; Cargo.toml is still versioned.
+      expect(packageManagement.updatePackageVersion).not.toHaveBeenCalledWith(
+        '/path/to/hybrid-package/package.json',
+        expect.anything(),
+        expect.anything(),
+      );
+      expect(packageManagement.updatePackageVersion).toHaveBeenCalledWith(
+        '/path/to/hybrid-package/Cargo.toml',
+        '1.1.0',
+        false,
+      );
+    });
   });
 
   describe('Cargo.toml handling', () => {

--- a/releasekit.schema.json
+++ b/releasekit.schema.json
@@ -210,6 +210,18 @@
           "default": "spec",
           "description": "Pre-1.0 handling of commit-inferred breaking changes. 'spec' (default): bump the 0.x minor (0.24.0 → 0.25.0), per semver §4. 'strict': bump the next major (→ 1.0.0). Inferred path only — explicit overrides (--bump major, bump:major) always graduate to 1.0.0."
         },
+        "npm": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": true,
+              "description": "Version package.json manifests. Detected npm packages are versioned by default; set false to opt out (e.g. npm versioning handled elsewhere)."
+            }
+          },
+          "description": "npm/JavaScript version handling"
+        },
         "cargo": {
           "type": "object",
           "additionalProperties": false,
@@ -217,7 +229,7 @@
             "enabled": {
               "type": "boolean",
               "default": true,
-              "description": "Enable Cargo.toml version handling"
+              "description": "Version Cargo.toml manifests. Detected Rust packages are versioned by default; set false to opt out (e.g. a vendored crate, or Rust versioning handled elsewhere)."
             },
             "paths": {
               "type": "array",
@@ -236,7 +248,7 @@
             "enabled": {
               "type": "boolean",
               "default": true,
-              "description": "Enable pubspec.yaml version handling"
+              "description": "Version pubspec.yaml manifests. Detected Dart/Flutter packages are versioned by default; set false to opt out."
             },
             "paths": {
               "type": "array",
@@ -298,7 +310,7 @@
             "enabled": {
               "type": "boolean",
               "default": true,
-              "description": "Enable NPM publishing"
+              "description": "Publish to npm. Detected npm packages are published by default; set false to opt out (version and tag only)."
             },
             "auth": {
               "type": "string",
@@ -361,8 +373,8 @@
           "properties": {
             "enabled": {
               "type": "boolean",
-              "default": false,
-              "description": "Enable Cargo publishing"
+              "default": true,
+              "description": "Publish to crates.io. Detected Rust packages are published by default; set false to opt out (version and tag only)."
             },
             "noVerify": {
               "type": "boolean",
@@ -391,8 +403,8 @@
           "properties": {
             "enabled": {
               "type": "boolean",
-              "default": false,
-              "description": "Enable pub.dev publishing"
+              "default": true,
+              "description": "Publish to pub.dev. Detected Dart/Flutter packages are published by default; set false to opt out (version and tag only)."
             },
             "publishOrder": {
               "type": "array",

--- a/releasekit.schema.json
+++ b/releasekit.schema.json
@@ -702,15 +702,22 @@
                   "properties": {
                     "provider": {
                       "type": "string",
+                      "enum": [
+                        "openai",
+                        "openai-compatible",
+                        "anthropic",
+                        "ollama"
+                      ],
                       "description": "LLM provider"
                     },
                     "model": {
                       "type": "string",
-                      "description": "Model identifier"
+                      "minLength": 1,
+                      "description": "Model identifier for the selected provider. Required — releasekit ships no default, so enabling LLM enhancement needs an explicit, current model (a missing model fails config validation)."
                     },
                     "baseURL": {
                       "type": "string",
-                      "description": "Custom API base URL"
+                      "description": "Custom API base URL. Required for the openai-compatible provider."
                     },
                     "apiKey": {
                       "type": "string",

--- a/scripts/generate-config-docs.ts
+++ b/scripts/generate-config-docs.ts
@@ -213,6 +213,14 @@ function renderVersion(prop: SchemaProperty): void {
     );
   }
 
+  const npm = prop.properties?.npm;
+  if (npm) {
+    emit('### `version.npm`', '');
+    emit(ensurePeriod(npm.description), '');
+    emit(propsTable(npm.properties ?? {}));
+    emitBlank();
+  }
+
   const cargo = prop.properties?.cargo;
   if (cargo) {
     emit('### `version.cargo`', '');


### PR DESCRIPTION
Stacked on #563 (base branch `feat/unify-ecosystem-enablement`) — review/merge #563 first.

## What (revised approach)

Instead of shipping curated per-provider default models (the original plan), **require the consumer to name a model** and fail loud if they don't. The evidence for the pivot: the openai default we would have shipped, `gpt-4o-mini`, is **already deprecated/removed** from OpenAI's API — proving any default releasekit ships will rot and become a per-release maintenance treadmill (and a silent failure mode for consumers relying on it).

- **`llm.model` is required** — a missing model fails at **config validation** (Zod), not silently inside the notes soft-fail catch. releasekit ships no model IDs, so there is nothing to rot or maintain.
- **`provider` is a Zod enum** (`openai | openai-compatible | anthropic | ollama`), not a free-form string — a typo errors at config load.
- **`openai-compatible` requires `baseURL`** at the schema level.
- **`createProvider` enforces the required model** for in-process configs too (the CLI `--llm-*` flags bypass schema parsing), with a clear message.
- Dropped the curated-default machinery: `LLM_DEFAULTS.models`, `resolveModelId`, and the per-provider `?? default` fallbacks.
- Regenerated `releasekit.schema.json` + `docs/configuration.md`.

## Why require, not default

LLM enhancement is already an explicit opt-in (needs an API key, or a running Ollama with a pulled model), so also naming the model is a marginal, honest addition — there is no true zero-config LLM path to protect. The consumer is best placed to pick a current model for their account/budget, and forcing an explicit, fail-loud choice is more robust than releasekit guessing with an ID that rots.

## Tests

- Schema: `model` required for every provider; unknown `provider` rejected (enum); `openai-compatible` requires `baseURL`.
- `createProvider`: a missing model throws a clear `llm.model is required` error; `openai-compatible` requires `baseURL`; valid configs construct the right provider.

Closes #541

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes `llm.model` an explicit requirement and validates `provider` as a Zod enum, replacing the earlier approach of shipping curated per-provider default model IDs that were already rotting (e.g., `gpt-4o-mini` deprecated). Both the config-file path (Zod at load time) and the CLI `--llm-*` flag path (new `LLMConfigSchema.parse` block in `command.ts`) now fail loudly with non-zero exit codes rather than silently degrading to non-LLM notes.

- **Schema hardening**: `LLMConfigSchema` becomes `LLMConfigBaseSchema.superRefine(...)` — `model` gets `.min(1)` (empty string rejected), `provider` becomes an enum, and `openai-compatible` requires `baseURL` at config-validation time.
- **CLI path closed**: `command.ts` now runs `LLMConfigSchema.parse(llm)` on the CLI-assembled object before entering the pipeline; Zod errors are surfaced as a plain `Error` caught by `handleError` (non-zero exit), not swallowed by the soft-fail catch.
- **Defaults removed**: `LLM_DEFAULTS.models`, `resolveModelId`, and all per-provider `?? default` fallbacks are dropped; provider constructors now require `model: string` (non-optional).
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — all three validation gaps flagged in the previous review round are now closed.

The CLI path now runs through LLMConfigSchema.parse before entering the pipeline, so a bad provider or missing model exits non-zero instead of silently degrading. The Zod schema adds .min(1) so an empty-string model is caught at config load. The provider field is an enum so typos are rejected at validation time. The JSON schema required array is correct. New tests cover all the new constraints. No residual gaps identified.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/config/src/schema.ts | LLMConfigSchema split into base + superRefine; model gets .min(1), provider becomes z.enum, openai-compatible baseURL enforced at validation time. Logic is correct. |
| packages/notes/src/command.ts | CLI-assembled LLM config now parsed through LLMConfigSchema before runPipeline; bad provider or missing model throws a plain Error caught by handleError (non-zero exit). Closes the silent-degradation gap from the previous review. |
| packages/notes/src/llm/index.ts | createProvider retains a runtime model guard as a safety net for programmatic callers that bypass schema parsing; the guard is now redundant for the two primary paths (config file + CLI) but is a reasonable defense layer. |
| packages/notes/src/llm/defaults.ts | Dropped the models sub-object; LLM_DEFAULTS now only contains retry defaults. Clean removal. |
| packages/config/test/unit/schema.spec.ts | New tests cover: missing model for all four providers, empty-string model rejection, unknown provider (enum), and openai-compatible requiring baseURL. Coverage matches the new schema constraints. |
| packages/notes/test/unit/llm/createProvider.spec.ts | New test file covering missing model, missing baseURL for openai-compatible, and successful construction for openai and openai-compatible. OpenAI client is correctly mocked to avoid network setup. |
| releasekit.schema.json | Regenerated correctly: provider gains enum, model gains minLength:1, both are in the required array. Conditional baseURL requirement for openai-compatible is not expressible in the generated JSON Schema but is enforced at Zod runtime. |
| packages/notes/src/core/types.ts | LLMConfig.provider narrowed from string to the explicit union type, matching the Zod enum. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User provides LLM config] --> B{Source?}
    B -->|Config file| C[loadConfig - Zod parses full config]
    B -->|CLI --llm flags| D[Assemble llm object in command.ts]
    C --> E{LLMConfigSchema valid?}
    D --> F[LLMConfigSchema.parse llm]
    F --> G{Valid?}
    E -->|No| H[ZodError - hard exit non-zero]
    E -->|Yes| I[config.releaseNotes.llm set]
    G -->|No| J[Error caught by handleError - hard exit non-zero]
    G -->|Yes| I
    I --> K[runPipeline - createProvider]
    K --> L{model truthy?}
    L -->|No| M[throw LLMError - soft-catch warn]
    L -->|Yes| N[Construct provider]
    N --> O[LLM enhancement runs]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User provides LLM config] --> B{Source?}
    B -->|Config file| C[loadConfig - Zod parses full config]
    B -->|CLI --llm flags| D[Assemble llm object in command.ts]
    C --> E{LLMConfigSchema valid?}
    D --> F[LLMConfigSchema.parse llm]
    F --> G{Valid?}
    E -->|No| H[ZodError - hard exit non-zero]
    E -->|Yes| I[config.releaseNotes.llm set]
    G -->|No| J[Error caught by handleError - hard exit non-zero]
    G -->|Yes| I
    I --> K[runPipeline - createProvider]
    K --> L{model truthy?}
    L -->|No| M[throw LLMError - soft-catch warn]
    L -->|Yes| N[Construct provider]
    N --> O[LLM enhancement runs]
```

</a>
</details>

<sub>Reviews (6): Last reviewed commit: ["feat(notes): require an explicit llm.mod..."](https://github.com/goosewobbler/releasekit/commit/25bc9e96665ade4da981ce6c8554f1df20105291) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45451625)</sub>

<!-- /greptile_comment -->