### PR TITLE
docs(adr): record ecosystem-enablement and required-LLM-model decisions

### DIFF
--- a/docs/adr/0004-ecosystem-enablement-detection-enables-config-opts-out.md
+++ b/docs/adr/0004-ecosystem-enablement-detection-enables-config-opts-out.md
@@ -1,0 +1,31 @@
+# 4. Ecosystem enablement: detection enables, config opts out
+
+Date: 2026-07-19
+
+## Status
+
+Accepted. Implementation tracked in [#554](https://github.com/goosewobbler/releasekit/issues/554).
+
+## Context
+
+ReleaseKit's pipeline is registry-agnostic and spans multiple ecosystems (npm, crates.io, pub.dev today; more planned). Enablement had grown asymmetric: npm published by default while crates.io and pub.dev were opt-in (`publish.*.enabled: false`), and npm alone had no version-handling toggle at all — the other two did.
+
+That asymmetry is a footgun that worsens with every ecosystem added. A contributor wiring a new adapter has to decide, per ecosystem, whether it versions and whether it publishes by default, and a user reading the config finds the same key means different things in different ecosystems. A detected-but-off ecosystem also fails silently — the packages are simply never published, with no error.
+
+The question this settles: when ReleaseKit detects an ecosystem, what does it do with it by default?
+
+## Decision
+
+**No ecosystem is special — detection enables, config opts out.** Every ecosystem ReleaseKit detects is versioned, and (where publishing is configured and authenticated) published, by default. Explicit config is only ever an *opt-out*.
+
+- `publish.<eco>.enabled` defaults `true` for every ecosystem (was `false` for crates.io/pub.dev).
+- `version.<eco>.enabled` exists for every ecosystem (npm gained `version.npm.enabled`) and defaults `true`.
+- The two opt-outs are kept deliberately separate because they express different real needs: `version.<eco>.enabled: false` means "don't touch this ecosystem's manifests at all" (e.g. a vendored crate, or Rust versioning handled by release-plz); `publish.<eco>.enabled: false` means "version and tag this ecosystem, but publish it elsewhere".
+
+Default-on is safe because the pipeline already fails safe *structurally*, independent of the toggle: an enabled registry that discovers zero targets no-ops, and publishing without credentials fails or skips at the auth check. The toggle is an opt-out, not a safety mechanism.
+
+## Consequences
+
+- One symmetric mental model that scales: a newly-added ecosystem adapter is on-by-default with no per-ecosystem special-casing, and "detected" and "released" no longer diverge silently.
+- Flipping the crates.io/pub.dev publish defaults from `false` to `true` is a behaviour change — a pre-existing config relying on the old opt-in would start publishing. Acceptable here (pre-1.0, single maintainer, configs updated alongside the change); a `!`/`BREAKING CHANGE` release note carries it.
+- Two independent per-ecosystem opt-outs are more config surface than one, but collapsing them would conflate "don't manage this ecosystem" with "manage but don't publish" — two outcomes users genuinely need to select between.

--- a/docs/adr/0005-require-an-explicit-llm-model-no-defaults.md
+++ b/docs/adr/0005-require-an-explicit-llm-model-no-defaults.md
@@ -1,0 +1,30 @@
+# 5. Require an explicit LLM model; ship no defaults
+
+Date: 2026-07-19
+
+## Status
+
+Accepted. Implementation tracked in [#541](https://github.com/goosewobbler/releasekit/issues/541).
+
+## Context
+
+LLM-enhanced release notes need a model id per provider. The obvious convenience is to ship a curated default per provider so a user can set `provider` and omit `model`.
+
+Model ids rot. Verifying the defaults while implementing this showed the openai default we were about to ship — `gpt-4o-mini` — was already deprecated and removed from OpenAI's API. A shipped default is therefore two liabilities at once: a per-release maintenance treadmill for ReleaseKit (every default must be re-checked and bumped as providers churn), and a silent failure mode for consumers (anyone relying on the default breaks the day the provider removes that model).
+
+Crucially, there is no zero-config path to protect: LLM enhancement is already an explicit opt-in that requires an API key (or a running Ollama with a model already pulled). Naming the model is a marginal addition to a setup the user has already committed to.
+
+## Decision
+
+**ReleaseKit ships no model defaults. `llm.model` is required and validated at config load.**
+
+- `llm.model` is a required, non-empty string (Zod `z.string().min(1)`) — a missing or empty model fails at config validation, not silently inside the notes soft-fail catch.
+- `provider` is a closed Zod enum (`openai | openai-compatible | anthropic | ollama`); `openai-compatible` additionally requires `baseURL`.
+- Configs assembled in-process (the CLI's `--llm-*` flags, which bypass `loadConfig`'s Zod pass) are run through the same schema before use, so a bad provider or missing model fails loud (non-zero exit) rather than degrading to non-LLM notes.
+
+## Consequences
+
+- Zero model-id maintenance for ReleaseKit: no default to track, re-verify, or get wrong. The consumer owns the fast-moving model choice for their account and budget — the party best placed to keep it current.
+- Fail-loud at config validation is consistent with the `provider`/`baseURL` validation this decision also introduces; misconfiguration surfaces at load, not three stages deep.
+- The "zero-config local-first Ollama" story loses its literal zero-config-ness — a user must name their local model. Acceptable: an Ollama user already has to run the server and pull a model, so they know its name.
+- Docs use a `<your-model>` placeholder in examples rather than a real id, so the examples themselves can't rot into recommending a dead model — the same rot this ADR refuses to ship in code.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -9,3 +9,5 @@ Roadmap sequencing lives in [ROADMAP.md](../../ROADMAP.md); implementation detai
 | [0001](./0001-language-remains-typescript.md) | ReleaseKit remains a TypeScript codebase | Accepted |
 | [0002](./0002-no-mcp-server-cli-is-the-agent-surface.md) | The agent-facing surface is the CLI, not an MCP server | Accepted |
 | [0003](./0003-optional-change-file-input.md) | Change files are supported as an optional input, in changesets format | Accepted |
+| [0004](./0004-ecosystem-enablement-detection-enables-config-opts-out.md) | Ecosystem enablement: detection enables, config opts out | Accepted |
+| [0005](./0005-require-an-explicit-llm-model-no-defaults.md) | Require an explicit LLM model; ship no defaults | Accepted |


### PR DESCRIPTION
Two ADRs capturing decisions made in the 0.41.0 work that someone will otherwise re-litigate. Kept as a standalone docs PR (rather than folding into #563/#564) to avoid more stacked-rebase churn and to keep the decisions reviewable on their own.

## ADR-0004 — Ecosystem enablement: detection enables, config opts out
The durable *why* behind #554. Every detected ecosystem is versioned and (where publishing is configured and authenticated) published by default; config is only ever an opt-out, with two independent per-ecosystem toggles (`version.<eco>.enabled`, `publish.<eco>.enabled`). Records why default-on is safe (the pipeline fails safe structurally) and why the crates.io/pub.dev default flip is an acceptable breaking change. Answers the inevitable "why does cargo publish by default?"

## ADR-0005 — Require an explicit LLM model; ship no defaults
The durable *why* behind #541's pivot. releasekit ships no model ids (they rot — the openai default we nearly shipped, `gpt-4o-mini`, was already deprecated); `llm.model` is required and validated at config load, `provider` is a closed enum, and CLI-assembled configs go through the same schema so misconfig fails loud. Answers the inevitable "let's add model defaults for convenience."

Both follow the existing Nygard format (Context / Decision / Consequences), are indexed in `docs/adr/README.md`, and link their implementing issues. No code changes.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds two Architecture Decision Records capturing design decisions made during the 0.41.0 release cycle, with no code changes.

- **ADR-0004** records the ecosystem-enablement policy: detection defaults every ecosystem to on (versioning + publishing), with config as opt-out only — replacing the prior asymmetric per-ecosystem defaults that could silently drop packages.
- **ADR-0005** records the decision to require an explicit `llm.model` and ship zero model-id defaults, because shipped defaults rot as providers deprecate model ids; the ADR also notes that CLI-assembled configs are validated through the same schema so misconfiguration fails loud.
</details>

<h3>Confidence Score: 5/5</h3>

Documentation-only change; no executable code is modified.

Both ADRs follow the existing Nygard format, are correctly numbered and indexed in the README, and accurately describe the design decisions and their trade-offs — including the breaking-change implications of flipping crates.io/pub.dev publish defaults and the UX cost of dropping zero-config Ollama. Nothing here affects runtime behaviour.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/adr/0004-ecosystem-enablement-detection-enables-config-opts-out.md | New ADR documenting the detection-enables / config-opts-out policy for ecosystem publishing; follows Nygard format correctly, clearly explains the safety model and breaking-change implications. |
| docs/adr/0005-require-an-explicit-llm-model-no-defaults.md | New ADR documenting the decision to require llm.model and ship no provider defaults; format and reasoning are sound, consequences section is thorough including the Ollama UX trade-off. |
| docs/adr/README.md | Index updated with correct sequential numbering, matching filenames, and accurate one-line summaries for both new ADRs. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Ecosystem detected] --> B{publish configured\n& authenticated?}
    B -- Yes --> C[version.eco.enabled\ndefault: true]
    B -- No --> D[no-op / skip at auth check]
    C -- false --> E[Skip versioning\nand publishing]
    C -- true --> F[Version manifests]
    F --> G{publish.eco.enabled\ndefault: true}
    G -- false --> H[Version & tag only\ne.g. publish elsewhere]
    G -- true --> I[Publish to registry]

    style E fill:#f9c,stroke:#c66
    style H fill:#ffc,stroke:#aa0
    style I fill:#cfc,stroke:#060
    style D fill:#eee,stroke:#999
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Ecosystem detected] --> B{publish configured\n& authenticated?}
    B -- Yes --> C[version.eco.enabled\ndefault: true]
    B -- No --> D[no-op / skip at auth check]
    C -- false --> E[Skip versioning\nand publishing]
    C -- true --> F[Version manifests]
    F --> G{publish.eco.enabled\ndefault: true}
    G -- false --> H[Version & tag only\ne.g. publish elsewhere]
    G -- true --> I[Publish to registry]

    style E fill:#f9c,stroke:#c66
    style H fill:#ffc,stroke:#aa0
    style I fill:#cfc,stroke:#060
    style D fill:#eee,stroke:#999
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(adr): record ecosystem-enablement a..."](https://github.com/goosewobbler/releasekit/commit/3a8ce634b656c550bf0c4df671461662e3818d5d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45462741)</sub>

<!-- /greptile_comment -->