### PR TITLE
test(harness): cover the npm-disabled cargo-only version path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,12 @@ jobs:
       - name: Run backfill test harness
         run: pnpm test:harness:backfill
 
+      - name: Run multi-registry test harness (npm + cargo)
+        run: pnpm test:harness:multi
+
+      - name: Run multi-registry test harness (npm disabled, cargo only)
+        run: pnpm test:harness:multi-npm-disabled
+
   lint:
     name: Lint
     needs: [detect-changes, build]

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "test:action:preview": "node scripts/test-harness/index.mjs preview",
     "test:action:release": "node scripts/test-harness/index.mjs release --bump patch",
     "test:harness:multi": "node scripts/test-harness/index.mjs release-multi",
+    "test:harness:multi-npm-disabled": "node scripts/test-harness/index.mjs release-multi-npm-disabled",
     "test:harness:backfill": "node scripts/test-harness/index.mjs backfill",
     "lint": "biome check . && eslint --cache \"packages/**/*.ts\"",
     "lint:fix": "biome check --write .",

--- a/scripts/test-harness/index.mjs
+++ b/scripts/test-harness/index.mjs
@@ -13,6 +13,7 @@
  *   pnpm test:harness:preview   # Run preview mode explicitly
  *   pnpm test:harness:release   # Run release mode with patch bump
  *   pnpm test:harness:multi     # Run release mode with npm + cargo, verify both manifests bumped
+ *   pnpm test:harness:multi-npm-disabled  # As above but version.npm.enabled:false — package.json untouched, Cargo.toml bumped
  *   pnpm test:harness:backfill  # Reconstruct notes from git history (--all + --package), verify files/dates/scoping
  *
  * The harness defaults to running in "CI simulation" mode where:
@@ -49,11 +50,15 @@ console.log('');
 
 let projectDir;
 try {
-  if (mode === 'release-multi') {
-    const testProject = createMultiRegistryTestProject();
+  if (mode === 'release-multi' || mode === 'release-multi-npm-disabled') {
+    // release-multi-npm-disabled sets version.npm.enabled: false — package.json manifests are left
+    // untouched while Cargo.toml is still versioned (the "detection enables, config opts out" path,
+    // where sync-strategy bugs previously skipped or abandoned the cargo write).
+    const npmEnabled = mode !== 'release-multi-npm-disabled';
+    const testProject = createMultiRegistryTestProject({ npmEnabled });
     projectDir = testProject.projectDir;
 
-    console.log(`\n--- Running release-multi mode ---`);
+    console.log(`\n--- Running ${mode} mode (npm ${npmEnabled ? 'enabled' : 'disabled'}) ---`);
 
     const envVars = {
       INPUT_MODE: 'release',
@@ -81,32 +86,43 @@ try {
     }
 
     if (result.status !== 0) {
-      throw new Error(`release-multi failed with exit code ${result.status}`);
+      throw new Error(`${mode} failed with exit code ${result.status}`);
+    }
+
+    // The Cargo.toml write happens before the sync strategy's "nothing updated" early return, so a
+    // manifest check alone can't catch the abandonment regression — assert the run actually released.
+    const output = `${result.stdout ?? ''}${result.stderr ?? ''}`;
+    if (!npmEnabled && /No packages were updated/i.test(output)) {
+      throw new Error(`${mode}: run reported "No packages were updated" — the cargo-only update was abandoned`);
     }
 
     console.log('\n--- Verifying Multi-Registry Version Bumps ---');
-    const expectedVersion = '1.0.1';
+    const bumpedVersion = '1.0.1';
+    // npm disabled leaves package.json at its original version; cargo is versioned either way.
+    const expectedPkgVersion = npmEnabled ? bumpedVersion : '1.0.0';
     for (const pkgSlug of testProject.packages) {
       const pkgDir = path.join(testProject.projectDir, 'packages', pkgSlug);
 
       const pkgJsonPath = path.join(pkgDir, 'package.json');
       const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf-8'));
-      if (pkgJson.version !== expectedVersion) {
-        throw new Error(`${pkgSlug} package.json: expected ${expectedVersion}, got ${pkgJson.version}`);
+      if (pkgJson.version !== expectedPkgVersion) {
+        throw new Error(
+          `${pkgSlug} package.json: expected ${expectedPkgVersion} (npm ${npmEnabled ? 'enabled' : 'disabled'}), got ${pkgJson.version}`,
+        );
       }
 
       const cargoTomlPath = path.join(pkgDir, 'Cargo.toml');
       const cargoContent = fs.readFileSync(cargoTomlPath, 'utf-8');
       const cargoVersionMatch = cargoContent.match(/^version = "([^"]+)"/m);
       const cargoVersion = cargoVersionMatch?.[1];
-      if (cargoVersion !== expectedVersion) {
-        throw new Error(`${pkgSlug} Cargo.toml: expected ${expectedVersion}, got ${cargoVersion}`);
+      if (cargoVersion !== bumpedVersion) {
+        throw new Error(`${pkgSlug} Cargo.toml: expected ${bumpedVersion}, got ${cargoVersion}`);
       }
 
       console.log(`✓ ${pkgSlug}: package.json=${pkgJson.version}, Cargo.toml=${cargoVersion}`);
     }
 
-    console.log(`\n✅ release-multi completed successfully`);
+    console.log(`\n✅ ${mode} completed successfully`);
   } else if (mode === 'backfill') {
     const testProject = createBackfillTestProject();
     projectDir = testProject.projectDir;

--- a/scripts/test-harness/test-project.mjs
+++ b/scripts/test-harness/test-project.mjs
@@ -213,7 +213,7 @@ export function cleanupTestProject(projectDir) {
   }
 }
 
-export function createMultiRegistryTestProject(_options = {}) {
+export function createMultiRegistryTestProject({ npmEnabled = true } = {}) {
   const timestamp = Date.now();
   const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), `${TEST_PREFIX}-multi-${timestamp}`));
 
@@ -222,7 +222,7 @@ export function createMultiRegistryTestProject(_options = {}) {
   const remotePath = path.join(projectDir, 'test-remote.git');
   createBareRemote(remotePath);
 
-  createMultiRegistryMonorepoStructure(projectDir);
+  createMultiRegistryMonorepoStructure(projectDir, { npmEnabled });
   initGitRepo(projectDir, remotePath);
 
   const commits = [
@@ -251,7 +251,7 @@ export function createMultiRegistryTestProject(_options = {}) {
   };
 }
 
-function createMultiRegistryMonorepoStructure(projectDir) {
+function createMultiRegistryMonorepoStructure(projectDir, { npmEnabled = true } = {}) {
   const rootPackageJson = {
     name: 'test-monorepo',
     version: '1.0.0',
@@ -309,6 +309,9 @@ function createMultiRegistryMonorepoStructure(projectDir) {
     version: {
       preset: 'angular',
       packages: ['packages/*'],
+      // Opt out of npm version handling to exercise the "detection enables, config opts out" path:
+      // package.json manifests are left untouched while Cargo.toml is still versioned.
+      ...(npmEnabled ? {} : { npm: { enabled: false } }),
     },
   };
 


### PR DESCRIPTION
## What

Adds e2e coverage for the `version.npm.enabled: false` path in the multi-registry (npm + cargo) harness — the "detection enables, config opts out" model from #554.

## Why

The multi-registry harness only exercised npm version handling **enabled**. The npm-disabled cargo-only path is exactly where the three sync-strategy P1s surfaced during #554 review (root Cargo.toml skipped, hybrid package abandoned, single-package `'root'` not tracked). Those were only unit-covered; nothing ran them end-to-end through the built action.

## What it asserts

`release-multi-npm-disabled` runs the multi fixture with `version.npm.enabled: false` and checks:

- each package's `package.json` **stays at `1.0.0`** (npm handling opted out)
- each package's `Cargo.toml` **bumps to `1.0.1`** (cargo still versioned)
- the run does **not** early-return as `"No packages were updated"` — the abandonment guard. The Cargo.toml write lands *before* the sync strategy's nothing-updated return, so a manifest check alone can't catch a regression; the stdout assertion closes that gap.

## Changes

- `test-project.mjs`: parameterize the multi fixture with `npmEnabled` (adds `version.npm.enabled: false` to the generated config when disabled).
- `index.mjs`: `release-multi` now handles both modes via `npmEnabled`; adds the abandonment-guard stdout check and npm-aware expected `package.json` version.
- `package.json`: `test:harness:multi-npm-disabled` script.
- `ci.yml`: run both the baseline `multi` and new `multi-npm-disabled` variants in the `action-test-harness` job (the baseline `multi` wasn't in CI before).

Both modes pass locally (`pnpm test:harness:multi` and `pnpm test:harness:multi-npm-disabled`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds an end-to-end harness test for the `version.npm.enabled: false` path in the multi-registry (npm + cargo) fixture, targeting the sync-strategy bugs from #554 where cargo-only versioning could be abandoned after Cargo.toml was already written. The key insight is that a Cargo.toml manifest check alone cannot catch the abandonment regression because the write precedes the sync-strategy's early return — only an explicit stdout assertion on "No packages were updated" closes that gap.

- `test-project.mjs` parameterises `createMultiRegistryTestProject` and `createMultiRegistryMonorepoStructure` with `npmEnabled`, conditionally injecting `npm: { enabled: false }` into the generated config.
- `index.mjs` handles the new `release-multi-npm-disabled` mode, with a targeted abandonment guard (stdout check) that fires only when npm is disabled, since for npm-enabled mode the `package.json` manifest assertion already serves as an implicit abandonment guard.
- `ci.yml` promotes both `multi` and `multi-npm-disabled` to the `action-test-harness` CI job; the `multi` baseline had not been run in CI before this PR.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the changes are purely additive test harness code with no modifications to production logic.

All four changed files are test infrastructure. The abandonment guard is correctly conditional on !npmEnabled because the npm-enabled mode has an implicit guard via the package.json manifest check, while the npm-disabled mode genuinely needs the stdout assertion to distinguish a successful cargo-only run from one abandoned mid-flight.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/test-harness/index.mjs | Adds release-multi-npm-disabled mode and a stdout-based abandonment guard correctly gated on !npmEnabled; manifest assertions and abandonment guard together provide complete coverage of the cargo-only regression scenario. |
| scripts/test-harness/test-project.mjs | Parameterises createMultiRegistryTestProject / createMultiRegistryMonorepoStructure with npmEnabled; spreads npm: { enabled: false } into the fixture config when disabled. Change is backward-compatible (default true). |
| .github/workflows/ci.yml | Adds both multi and multi-npm-disabled harness steps to action-test-harness job; the baseline multi was previously only runnable locally. |
| package.json | Adds test:harness:multi-npm-disabled script; no issues. |

</details>

<sub>Reviews (1): Last reviewed commit: ["test(harness): cover the npm-disabled ca..."](https://github.com/goosewobbler/releasekit/commit/6687dbc30bd5dc7e43ab284765874c6f1b692d04) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45466986)</sub>

<!-- /greptile_comment -->