### PR TITLE
docs(adr): scope ADR-0005 to LLM-enhanced release notes

### DIFF
--- a/docs/adr/0005-llm-enhanced-notes-require-an-explicit-model-no-defaults.md
+++ b/docs/adr/0005-llm-enhanced-notes-require-an-explicit-model-no-defaults.md
@@ -16,7 +16,7 @@ Crucially, there is no zero-config path to protect: LLM enhancement is already a
 
 ## Decision
 
-This decision is scoped to LLM-enhanced release notes — the only place ReleaseKit calls a model. Versioning, changelog generation, and publishing are deterministic and LLM-free, and it does not touch them.
+This decision is scoped to LLM-enhanced release notes — the only place ReleaseKit calls a model. Versioning, changelog generation, and publishing are deterministic and LLM-free; this decision does not touch them.
 
 **For LLM-enhanced release notes, ReleaseKit ships no model defaults. When enhancement is enabled, `llm.model` is required and validated at config load.**
 

--- a/docs/adr/0005-llm-enhanced-notes-require-an-explicit-model-no-defaults.md
+++ b/docs/adr/0005-llm-enhanced-notes-require-an-explicit-model-no-defaults.md
@@ -1,4 +1,4 @@
-# 5. Require an explicit LLM model; ship no defaults
+# 5. LLM-enhanced release notes require an explicit model; ship no defaults
 
 Date: 2026-07-19
 
@@ -16,7 +16,9 @@ Crucially, there is no zero-config path to protect: LLM enhancement is already a
 
 ## Decision
 
-**ReleaseKit ships no model defaults. `llm.model` is required and validated at config load.**
+This decision is scoped to LLM-enhanced release notes — the only place ReleaseKit calls a model. Versioning, changelog generation, and publishing are deterministic and LLM-free, and it does not touch them.
+
+**For LLM-enhanced release notes, ReleaseKit ships no model defaults. When enhancement is enabled, `llm.model` is required and validated at config load.**
 
 - `llm.model` is a required, non-empty string (Zod `z.string().min(1)`) — a missing or empty model fails at config validation, not silently inside the notes soft-fail catch.
 - `provider` is a closed Zod enum (`openai | openai-compatible | anthropic | ollama`); `openai-compatible` additionally requires `baseURL`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -10,4 +10,4 @@ Roadmap sequencing lives in [ROADMAP.md](../../ROADMAP.md); implementation detai
 | [0002](./0002-no-mcp-server-cli-is-the-agent-surface.md) | The agent-facing surface is the CLI, not an MCP server | Accepted |
 | [0003](./0003-optional-change-file-input.md) | Change files are supported as an optional input, in changesets format | Accepted |
 | [0004](./0004-ecosystem-enablement-detection-enables-config-opts-out.md) | Ecosystem enablement: detection enables, config opts out | Accepted |
-| [0005](./0005-require-an-explicit-llm-model-no-defaults.md) | Require an explicit LLM model; ship no defaults | Accepted |
+| [0005](./0005-llm-enhanced-notes-require-an-explicit-model-no-defaults.md) | LLM-enhanced release notes require an explicit model; ship no defaults | Accepted |


### PR DESCRIPTION
## What

Renames and re-scopes ADR-0005 so its title and filename make clear the "explicit model, no defaults" decision applies **only to LLM-enhanced release notes** — not to ReleaseKit as a whole.

- `0005-require-an-explicit-llm-model-no-defaults.md` → `0005-llm-enhanced-notes-require-an-explicit-model-no-defaults.md`
- Title → *"LLM-enhanced release notes require an explicit model; ship no defaults"*
- Adds a scoping lead sentence to the Decision section (versioning, changelog, and publishing are deterministic and LLM-free — untouched by this decision)
- Updates the ADR index in `docs/adr/README.md`

## Why

The bare title "require an explicit LLM model" reads as a repo-wide stance. In fact a model is called in exactly one place — release-notes enhancement, an explicit opt-in. The narrower title/filename prevents that misreading.

## Note on ADR immutability

The [ADR index](../blob/main/docs/adr/README.md) states ADRs are immutable once accepted, with changes made by superseding. This is **not** a decision change — the decision (no defaults; `llm.model` required and validated at load) is identical. It's a same-scope title/framing clarification of an ADR merged hours ago in #566, so it's edited in place rather than superseded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR narrows the scope of ADR-0005 by renaming the file and title to make explicit that the "no defaults, explicit model required" decision applies solely to LLM-enhanced release notes, not to ReleaseKit as a whole.

- The ADR file is renamed from `0005-require-an-explicit-llm-model-no-defaults.md` to `0005-llm-enhanced-notes-require-an-explicit-model-no-defaults.md` and its title updated to match.
- A scoping lead sentence is added to the Decision section clarifying that versioning, changelog generation, and publishing are deterministic and LLM-free, untouched by this ADR.
- The ADR index in `docs/adr/README.md` is updated to reflect the new filename and title.
</details>

<h3>Confidence Score: 5/5</h3>

Documentation-only change with no impact on runtime behaviour; safe to merge.

The change is a file rename plus a prose addition that brings the ADR title, filename, and Decision section into alignment. No code is touched, no config is modified, and the README index is updated consistently.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/adr/0005-llm-enhanced-notes-require-an-explicit-model-no-defaults.md | Renamed and re-scoped ADR: title, filename, and Decision section updated consistently to restrict the "explicit model, no defaults" stance to LLM-enhanced release notes only. |
| docs/adr/README.md | ADR index updated with the new filename and title for ADR-0005; all other entries are unchanged. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ReleaseKit] --> B[Versioning]
    A --> C[Changelog generation]
    A --> D[Publishing]
    A --> E[LLM-enhanced release notes]

    B --> F[Deterministic / LLM-free]
    C --> F
    D --> F

    E --> G{llm.model set?}
    G -- No --> H[Config validation fails loud]
    G -- Yes --> I[Enhancement proceeds]

    style E fill:#f0e6ff,stroke:#9b59b6
    style G fill:#f0e6ff,stroke:#9b59b6
    style H fill:#fdecea,stroke:#e74c3c
    style I fill:#e8f8f0,stroke:#2ecc71
    style F fill:#eaf4fb,stroke:#3498db
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[ReleaseKit] --> B[Versioning]
    A --> C[Changelog generation]
    A --> D[Publishing]
    A --> E[LLM-enhanced release notes]

    B --> F[Deterministic / LLM-free]
    C --> F
    D --> F

    E --> G{llm.model set?}
    G -- No --> H[Config validation fails loud]
    G -- Yes --> I[Enhancement proceeds]

    style E fill:#f0e6ff,stroke:#9b59b6
    style G fill:#f0e6ff,stroke:#9b59b6
    style H fill:#fdecea,stroke:#e74c3c
    style I fill:#e8f8f0,stroke:#2ecc71
    style F fill:#eaf4fb,stroke:#3498db
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["docs(adr): disambiguate the ADR-0005 sco..."](https://github.com/goosewobbler/releasekit/commit/f190ec0067a3b764a66918f47e794b384e6db4bc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45467171)</sub>

<!-- /greptile_comment -->