### PR TITLE
fix(version): include test commits in changelogs instead of dropping them

### DIFF
--- a/packages/version/src/changelog/commitParser.ts
+++ b/packages/version/src/changelog/commitParser.ts
@@ -285,11 +285,6 @@ function parseCommitMessage(message: string): ChangelogEntry | null {
     // Map conventional commit type to changelog type
     const changelogType = mapCommitTypeToChangelogType(type);
 
-    // Skip certain commit types that usually aren't relevant to the changelog
-    if (!changelogType) {
-      return null;
-    }
-
     // GitHub appends `(#N)` to the squash-merge subject — that's the PR. Pull it off the subject so it
     // renders as a labelled PR ref instead of a bare inline autolink GitHub expands into a rich card,
     // and record the number so the changelog can tell PR from closed issue.
@@ -341,7 +336,7 @@ function parseCommitMessage(message: string): ChangelogEntry | null {
 /**
  * Map conventional commit type to changelog entry type
  */
-function mapCommitTypeToChangelogType(type: string): ChangelogEntry['type'] | null {
+function mapCommitTypeToChangelogType(type: string): ChangelogEntry['type'] {
   switch (type) {
     case 'feat':
       return 'added';

--- a/packages/version/src/changelog/commitParser.ts
+++ b/packages/version/src/changelog/commitParser.ts
@@ -360,8 +360,9 @@ function mapCommitTypeToChangelogType(type: string): ChangelogEntry['type'] | nu
       // Special case - depend on commit message
       return 'changed';
     case 'test':
-      // Usually test changes are not in changelog
-      return null;
+      // Surfaced as "Changed", not dropped: ReleaseKit lists every merged change (low-signal ones are
+      // demoted, not hidden). Excluding test alone undercounted the standing-PR preview. #569
+      return 'changed';
     default:
       // For unknown types, put in 'changed'
       return 'changed';

--- a/packages/version/test/unit/changelog/commitParser.spec.ts
+++ b/packages/version/test/unit/changelog/commitParser.spec.ts
@@ -41,7 +41,7 @@ describe('Commit Parser', () => {
 
     const entries = await extractChangelogEntriesFromCommits('/test', RANGE, gitWithLog(mockGitOutput));
 
-    expect(entries).toHaveLength(10); // Should exclude 'test' commit
+    expect(entries).toHaveLength(11); // every conventional type is surfaced, including 'test' (#569)
 
     expect(entries.find((e) => e.description === 'add new feature')).toEqual(
       expect.objectContaining({ type: 'added', scope: 'core' }),
@@ -50,6 +50,10 @@ describe('Commit Parser', () => {
       expect.objectContaining({ type: 'fixed', scope: 'ui' }),
     );
     expect(entries.find((e) => e.description === 'update README')).toEqual(
+      expect.objectContaining({ type: 'changed', scope: undefined }),
+    );
+    // `test:` is categorized as Changed, not dropped (#569).
+    expect(entries.find((e) => e.description === 'add new tests')).toEqual(
       expect.objectContaining({ type: 'changed', scope: undefined }),
     );
     expect(entries.find((e) => e.description === 'revert previous commit')).toEqual(


### PR DESCRIPTION
Closes #569.

## Problem

`test:` was the **only** conventional-commit type silently deleted from generated changelogs — `mapCommitTypeToChangelogType` (`packages/version/src/changelog/commitParser.ts`) returned `null` for it, while `docs`, `style`, `refactor`, `perf`, `build`, `ci`, and `chore` all already surface as "Changed". That single exclusion:

- **Violated ReleaseKit's own invariant** — `demoteScopes` is documented as *"Nothing is hidden or dropped"* (noise is demoted, not removed).
- **Undercounted the standing-PR preview** — the "N changes, de-duplicated" count dropped test commits before counting, so it didn't match the merged history. (Surfaced when #567, a `test:` PR, never appeared in the v0.41.0 preview.)
- **Substituted a placeholder in sync/group releases** — a package whose changes were only `test:` commits came back with `entries: []` and got a synthetic `"Update version to ${version}"` line (`groupStrategy.ts:358`) instead of its real changes.

## Fix

Map `test` to `"Changed"`, alongside the other code-adjacent types. One-line behavioral change plus the spec that pinned the old behavior.

**Why "Changed" and not a dedicated "Tests" section:** Keep a Changelog categories describe the _nature_ of a change (Added/Changed/Fixed/…), not the commit type; `docs`/`ci`/`chore`/etc. already fold into "Changed"; and `test` is low-signal, so it shouldn't be elevated to its own section (the future refinement, if wanted, is _demotion_ like `deps`, not promotion).

## Safety

Display-only. Releasability is decided by the semver bump-rank calc (feat→minor, fix→patch, breaking→major; test/docs/chore→no bump), which is **independent of changelog-entry presence** — so no test-only change becomes releasable. Verified `pnpm turbo run lint typecheck test` (32/32 tasks green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a single omission in `mapCommitTypeToChangelogType`: `test` commits previously returned `null` and were silently dropped from changelogs, while every other conventional-commit type was already surfaced. The fix maps `test` to `'changed'`, removes the now-dead null-check guard, narrows the return type from `… | null` to `ChangelogEntry['type']`, and updates the spec to assert 11 entries instead of 10.

- `packages/version/src/changelog/commitParser.ts`: removes the `null` short-circuit path and its guard, maps `case 'test'` to `'changed'`, and tightens the return type signature.
- `packages/version/test/unit/changelog/commitParser.spec.ts`: updates the fixture assertion count and adds an explicit expectation that a `test:` commit surfaces as `type: 'changed'`.
</details>


<h3>Confidence Score: 5/5</h3>

Display-only change with no effect on semver bump logic; safe to merge.

The change touches only the changelog rendering path — mapCommitTypeToChangelogType — and explicitly leaves the bump-rank calculation (which governs releasability) untouched. The old null return and its guard are removed consistently: no call site relied on the null path for correctness, and the return-type narrowing matches the new reality. The spec update directly pins the new behaviour. No edge cases are left unaddressed.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/version/src/changelog/commitParser.ts | Maps `test` to 'changed' instead of null, removes the dead null-guard, and narrows the return type — all consistent and correct. |
| packages/version/test/unit/changelog/commitParser.spec.ts | Count updated from 10 to 11 and a new assertion verifies `test:` is categorised as 'changed'; covers the behavioural change adequately. |

</details>


<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["commit message"] --> B["parseCommitMessage()"]
    B --> C{"conventional\ncommit?"}
    C -- No --> D{"meaningful\nnon-conventional?"}
    D -- Yes --> E["type: 'changed'"]
    D -- No --> F["return null\n(filtered out)"]
    C -- Yes --> G["mapCommitTypeToChangelogType(type)"]
    G --> H{"type?"}
    H -- "feat" --> I["'added'"]
    H -- "fix" --> J["'fixed'"]
    H -- "revert" --> K["'removed'"]
    H -- "docs, style, refactor,\nperf, build, ci, chore,\ntest, (default)" --> L["'changed'"]
    I & J & K & L --> M["ChangelogEntry"]

    style L fill:#d4edda,stroke:#28a745
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["commit message"] --> B["parseCommitMessage()"]
    B --> C{"conventional\ncommit?"}
    C -- No --> D{"meaningful\nnon-conventional?"}
    D -- Yes --> E["type: 'changed'"]
    D -- No --> F["return null\n(filtered out)"]
    C -- Yes --> G["mapCommitTypeToChangelogType(type)"]
    G --> H{"type?"}
    H -- "feat" --> I["'added'"]
    H -- "fix" --> J["'fixed'"]
    H -- "revert" --> K["'removed'"]
    H -- "docs, style, refactor,\nperf, build, ci, chore,\ntest, (default)" --> L["'changed'"]
    I & J & K & L --> M["ChangelogEntry"]

    style L fill:#d4edda,stroke:#28a745
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/version/src/changelog/commitParser.ts`, line 344 ([link](https://github.com/goosewobbler/releasekit/blob/7762e88c1bc8cf8f3933b19ef88cc99a2b47b42e/packages/version/src/changelog/commitParser.ts#L344)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> Now that `test` returns `'changed'`, every branch in the switch returns a non-null value — the `| null` in the return type is unreachable. Removing it makes the type accurately reflect the function's actual behaviour and avoids null-checks at call sites.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fversion%2Fsrc%2Fchangelog%2FcommitParser.ts%0ALine%3A%20344%0A%0AComment%3A%0ANow%20that%20%60test%60%20returns%20%60'changed'%60%2C%20every%20branch%20in%20the%20switch%20returns%20a%20non-null%20value%20%E2%80%94%20the%20%60%7C%20null%60%20in%20the%20return%20type%20is%20unreachable.%20Removing%20it%20makes%20the%20type%20accurately%20reflect%20the%20function's%20actual%20behaviour%20and%20avoids%20null-checks%20at%20call%20sites.%0A%0A%60%60%60suggestion%0Afunction%20mapCommitTypeToChangelogType%28type%3A%20string%29%3A%20ChangelogEntry%5B'type'%5D%20%7B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=goosewobbler%2Freleasekit&pr=570&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fversion%2Fsrc%2Fchangelog%2FcommitParser.ts%0ALine%3A%20344%0A%0AComment%3A%0ANow%20that%20%60test%60%20returns%20%60'changed'%60%2C%20every%20branch%20in%20the%20switch%20returns%20a%20non-null%20value%20%E2%80%94%20the%20%60%7C%20null%60%20in%20the%20return%20type%20is%20unreachable.%20Removing%20it%20makes%20the%20type%20accurately%20reflect%20the%20function's%20actual%20behaviour%20and%20avoids%20null-checks%20at%20call%20sites.%0A%0A%60%60%60suggestion%0Afunction%20mapCommitTypeToChangelogType%28type%3A%20string%29%3A%20ChangelogEntry%5B'type'%5D%20%7B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=570&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["refactor(version): drop now-unreachable ..."](https://github.com/goosewobbler/releasekit/commit/6d635013ad592095905f5d71ec87d94a295ed34c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45471684)</sub>

<!-- /greptile_comment -->