### PR TITLE
chore: drop bare origin-issue citations from comments and test titles

### DIFF
--- a/packages/core/src/changelogRefs.ts
+++ b/packages/core/src/changelogRefs.ts
@@ -3,7 +3,7 @@
  * issue/PR ref (with a hovercard) and treats a bare `@scope/pkg` / `@user` as a mention (a stray
  * link that can ping/subscribe a real org or team on every release PR). Both render surfaces — the
  * notes Markdown (`CHANGELOG.md`, GitHub release body) and the standing-PR body — share these two
- * pure helpers so the treatment stays identical (#499).
+ * pure helpers so the treatment stays identical.
  */
 
 /** How bare `#NNN` issue/PR refs in a changelog are rendered. */
@@ -125,7 +125,7 @@ const CODE_SPAN_OR_DESC_REF = /`[^`]*`|( ?)(?:\(#(\d+)\)|(?<![\\[/\w])#(\d+)\b)/
 
 /**
  * Neutralise bare `#N` issue/PR refs left inside an entry *description* — they come from the squash
- * commit subject and GitHub otherwise auto-links them into verbose hovercards (#507). A ref that also
+ * commit subject and GitHub otherwise auto-links them into verbose hovercards. A ref that also
  * appears in the appended `(PR … · closes …)` label (`appendedRefs`) is REMOVED as a duplicate; any
  * other bare ref is rendered per `mode`: `escape` → `\#N`, `strip` → removed, `link` → a canonical
  * `[#N](…/issues/N)` link (falls back to `escape` for a non-GitHub repo). Complements
@@ -154,6 +154,6 @@ export function neutralizeDescriptionRefs(
     },
   );
   // `( ?)` eats the space *before* a ref, so a ref removed from the very start of the description
-  // (nothing before it to consume) leaves the following space behind — trim boundary residue (#507).
+  // (nothing before it to consume) leaves the following space behind — trim boundary residue.
   return out.trim();
 }

--- a/packages/core/src/selectionRegion.ts
+++ b/packages/core/src/selectionRegion.ts
@@ -24,7 +24,7 @@ export function rkSelMarker(packageName: string): string {
 }
 
 /**
- * Identity marker for a stable row's channel toggle — "ship this package as a prerelease" (#521). A
+ * Identity marker for a stable row's channel toggle — "ship this package as a prerelease". A
  * nested, interactive task item under an rk-sel row; its `[x]`/`[ ]` glyph carries the intent while
  * this marker carries the package name. The symmetric twin of {@link rkGradMarker}. Machine-read,
  * never the row's prose.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -29,7 +29,7 @@ export interface VersionChangelogEntry {
    * version-groups engine for a lockstep carry — a group member bumped only to stay in sync, with
    * no commits of its own. It is not derived from a real commit. The preview formatter treats a
    * changelog whose entries are *all* synthetic as "no real changes" and collapses the package into
-   * the "Also bumped" list instead of rendering a full block of placeholder noise (#468).
+   * the "Also bumped" list instead of rendering a full block of placeholder noise.
    *
    * Only the groups engine sets it, and only on a clean empty extraction: an independently-released
    * package (single/async strategy) or an extraction-error fallback keeps its visible block, since
@@ -61,7 +61,7 @@ export interface VersionPackageChangelog {
 export type VersionAction = 'first-release' | 'graduated' | 'bumped';
 
 /**
- * The release channel a version sits on (#485). Derived per-package and purely from the resolved
+ * The release channel a version sits on. Derived per-package and purely from the resolved
  * version: `'prerelease'` when the version carries a semver prerelease segment (`…-<preid>.N`), else
  * `'stable'`. A standing PR with permanently-mixed maturity carries both at once — some `'stable'`
  * packages, some `'prerelease'` — each advancing along its own line. #486 (per-package graduation)
@@ -129,7 +129,7 @@ export interface VersionPackageUpdate {
    * Absent for a first release and whenever the baseline was unreachable / fell back to all-history
    * (#339), so consumers derive the bump magnitude only when it is present. Optional for backwards
    * compatibility: standing-PR manifests written before this field existed omit it (old PRs still
-   * open), so every consumer must tolerate its absence (render a dash / skip the delta). #520.
+   * open), so every consumer must tolerate its absence (render a dash / skip the delta).
    */
   previousVersion?: string;
   filePath: string;

--- a/packages/core/test/unit/types.spec.ts
+++ b/packages/core/test/unit/types.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { deriveReleaseChannel } from '../../src/types.js';
 
-describe('deriveReleaseChannel (#485)', () => {
+describe('deriveReleaseChannel', () => {
   it('should classify clean semver as the stable channel', () => {
     expect(deriveReleaseChannel('1.0.0')).toBe('stable');
     expect(deriveReleaseChannel('10.2.0')).toBe('stable');

--- a/packages/notes/src/core/pipeline.ts
+++ b/packages/notes/src/core/pipeline.ts
@@ -91,7 +91,7 @@ function generateCompareUrl(repoUrl: string, from: string, to: string, packageNa
       // Sanitized package-specific tag: "<de-scoped-name>@[v]<version>" (e.g. "scope-pkg@v1.2.3").
       // formatTag always strips the "@scope/", so the raw package name never appears literally and
       // the isPackageSpecific check above can't match it. Keep the "<name>@" prefix and re-attach the
-      // new version, preserving a "v" only if the original tag had one (#338).
+      // new version, preserving a "v" only if the original tag had one.
       fromVersion = from;
       toVersion = `${from.slice(0, atPos + 1)}${from[atPos + 1] === 'v' ? 'v' : ''}${toClean}`;
     } else if (dashVPos > 0 && from.charCodeAt(dashVPos + 2) >= 48 && from.charCodeAt(dashVPos + 2) <= 57) {

--- a/packages/notes/src/core/types.ts
+++ b/packages/notes/src/core/types.ts
@@ -192,7 +192,7 @@ export interface ChangelogConfig {
   mode?: LocationMode;
   file?: string;
   templates?: TemplateConfig;
-  /** How bare `#NNN` issue/PR refs render in the changelog (#499). Default `'link'` when unset. */
+  /** How bare `#NNN` issue/PR refs render in the changelog. Default `'link'` when unset. */
   refs?: ChangelogRefsMode;
 }
 

--- a/packages/notes/src/output/markdown.ts
+++ b/packages/notes/src/output/markdown.ts
@@ -69,7 +69,7 @@ function formatEntry(entry: ChangelogEntry, opts?: EntryRefOptions): string {
   // org/team on a release PR) — always neutralise it, regardless of the refs mode. The scope and
   // lead-in are interpolated as bold prose too (a scoped package name like `@wdio/native-cdp-bridge`
   // would mention `@wdio`), so escape all three, not just the description. Bare `#N` refs carried over
-  // from the commit subject are also neutralised / de-duped against the appended label (#507).
+  // from the commit subject are also neutralised / de-duped against the appended label.
   const refsMode = opts?.refs ?? 'link';
   const appendedRefs = [...(entry.issueIds ?? []), entry.prNumber];
   const description = escapeChangelogMentions(

--- a/packages/notes/test/integration/pipeline-config.spec.ts
+++ b/packages/notes/test/integration/pipeline-config.spec.ts
@@ -185,7 +185,7 @@ describe('Pipeline: mode both does not double-write root', () => {
     );
   });
 
-  it('should forward the configured refs mode to per-package monorepo changelogs (#503)', async () => {
+  it('should forward the configured refs mode to per-package monorepo changelogs', async () => {
     const { writeMonorepoChangelogs } = await import('../../src/monorepo/aggregator.js');
     const { runPipeline } = await import('../../src/core/pipeline.js');
 

--- a/packages/notes/test/integration/pipeline.spec.ts
+++ b/packages/notes/test/integration/pipeline.spec.ts
@@ -64,7 +64,7 @@ describe('Pipeline: version output → markdown', () => {
     expect(markdown).toContain('### Added');
     expect(markdown).toContain('- **api**: Add streaming support');
     expect(markdown).toContain('### Fixed');
-    // Bare `#88` is rendered as a canonical Markdown link by default (link mode, #499).
+    // Bare `#88` is rendered as a canonical Markdown link by default (link mode).
     expect(markdown).toContain('- Null pointer in parser ([#88](https://github.com/acme/my-lib/issues/88))');
     expect(markdown).toContain('### Changed');
     expect(markdown).toContain('- Simplify config loading');
@@ -165,7 +165,7 @@ describe('compareUrl: platform detection', () => {
     );
   });
 
-  it('should generate compare URL for sanitized "@v" package-specific tags (#338)', () => {
+  it('should generate compare URL for sanitized "@v" package-specific tags', () => {
     // formatTag strips "@scope/" -> "scope-name", so a `${packageName}@v${version}` template
     // yields "zubridge-electron@v3.0.0". The raw "@zubridge/electron" never appears in the tag,
     // so the `to` ref must be derived from the tag's own prefix, not the package name.
@@ -183,7 +183,7 @@ describe('compareUrl: platform detection', () => {
     );
   });
 
-  it('should generate compare URL for sanitized "@v" tags across a prerelease escalation (#338)', () => {
+  it('should generate compare URL for sanitized "@v" tags across a prerelease escalation', () => {
     const ctx = createTemplateContext({
       packageName: '@zubridge/tauri',
       version: '2.0.0-next.0',

--- a/packages/notes/test/unit/output/markdown.spec.ts
+++ b/packages/notes/test/unit/output/markdown.spec.ts
@@ -588,7 +588,7 @@ describe('formatVersion: non-LLM path', () => {
 });
 
 // ---------------------------------------------------------------------------
-// formatVersion — issue refs + mention escaping (#499)
+// formatVersion — issue refs + mention escaping
 // ---------------------------------------------------------------------------
 
 describe('formatVersion: issue refs', () => {

--- a/packages/publish/src/stages/git-push.ts
+++ b/packages/publish/src/stages/git-push.ts
@@ -100,7 +100,7 @@ export async function pushPackageTag(tag: string, ctx: PipelineContext, setup?: 
 
   // Wrap raw exec failures as GIT_PUSH_ERROR so the failure report labels the stage `git-push`
   // rather than `unknown` — mirrors runGitPushStage. Without this, a branch push rejected by a
-  // branch ruleset surfaced as "Stage unknown" (#429).
+  // branch ruleset surfaced as "Stage unknown".
   try {
     // Push the specific tag ref (carries the underlying commit with it)
     await runGit(dryRun, `git push ${remote} refs/tags/${tag}`, () =>

--- a/packages/publish/test/unit/stages/git-push.spec.ts
+++ b/packages/publish/test/unit/stages/git-push.spec.ts
@@ -289,7 +289,7 @@ describe('pushPackageTag', () => {
     expect(ctx.output.git.pushed).toBe(true);
   });
 
-  it('should wrap a branch-push failure as GIT_PUSH_ERROR, not unknown (#429)', async () => {
+  it('should wrap a branch-push failure as GIT_PUSH_ERROR, not unknown', async () => {
     // The branch push is rejected by a branch ruleset — a raw seam failure.
     vi.spyOn(fakeGit, 'push').mockImplementation(async (opts) => {
       if (opts.ref === 'main') {

--- a/packages/publish/test/unit/utils/semver.spec.ts
+++ b/packages/publish/test/unit/utils/semver.spec.ts
@@ -38,7 +38,7 @@ describe('semver utils', () => {
       expect(getDistTag('1.0.0', 'stable')).toBe('stable');
     });
 
-    it('should resolve the dist-tag per package in a mixed (stable + prerelease) release (#485)', () => {
+    it('should resolve the dist-tag per package in a mixed (stable + prerelease) release', () => {
       // A standing PR with permanently-mixed maturity publishes each package on its own channel.
       // getDistTag is per-version, so the same run yields `latest` for the stable packages and the
       // prerelease identifier for the `-next` ones with no extra wiring.

--- a/packages/release/src/release.ts
+++ b/packages/release/src/release.ts
@@ -313,7 +313,7 @@ export async function runRelease(inputOptions: ReleaseOptions): Promise<ReleaseO
     success('Release notes generated');
   }
 
-  // Human-edited notes win per package (manual-mode draft dispatch, #319). Merged here so the
+  // Human-edited notes win per package (manual-mode draft dispatch). Merged here so the
   // edits flow into both the publish step's release-body map and the returned releaseNotes.
   if (options.editedNotes && Object.keys(options.editedNotes).length > 0) {
     releaseNotes = mergeNotesRegions(releaseNotes ?? {}, options.editedNotes);

--- a/packages/release/test/unit/changelog-region.spec.ts
+++ b/packages/release/test/unit/changelog-region.spec.ts
@@ -99,7 +99,7 @@ describe('changelog-region', () => {
       expect(footer).toContain('Show all changes (2 changes, de-duplicated)');
     });
 
-    it('should de-dupe a bare #N in the description that also appears in the appended label (#507)', () => {
+    it('should de-dupe a bare #N in the description that also appears in the appended label', () => {
       const footer = renderCombinedFooter(
         output({
           changelogs: [
@@ -165,7 +165,7 @@ describe('changelog-region', () => {
     });
   });
 
-  describe('issue refs + mention escaping (#499)', () => {
+  describe('issue refs + mention escaping', () => {
     const repo = 'https://github.com/octocat/hello';
 
     function output(over: Partial<VersionOutput>): VersionOutput {
@@ -335,7 +335,7 @@ describe('changelog-region', () => {
     });
   });
 
-  describe('scope demotion (#522)', () => {
+  describe('scope demotion', () => {
     function output(over: Partial<VersionOutput>): VersionOutput {
       return { dryRun: false, updates: [], changelogs: [], tags: [], ...over };
     }

--- a/packages/release/test/unit/label-definitions.spec.ts
+++ b/packages/release/test/unit/label-definitions.spec.ts
@@ -91,7 +91,7 @@ describe('deriveLabelDefinitions', () => {
     expect(releaseCount).toBe(1);
   });
 
-  it('should seed a graduate:<package> label for each graduatable package (#486)', () => {
+  it('should seed a graduate:<package> label for each graduatable package', () => {
     const defs = deriveLabelDefinitions(ciConfig(), ['@scope/a', '@scope/b']);
     expect(names(defs)).toContain('graduate:@scope/a');
     expect(names(defs)).toContain('graduate:@scope/b');
@@ -99,12 +99,12 @@ describe('deriveLabelDefinitions', () => {
     expect(names(defs)).toContain('release:graduate');
   });
 
-  it('should emit no per-package graduate labels when no graduatable packages are passed (#486)', () => {
+  it('should emit no per-package graduate labels when no graduatable packages are passed', () => {
     const defs = deriveLabelDefinitions(ciConfig());
     expect(names(defs).some((n) => n.startsWith('graduate:'))).toBe(false);
   });
 
-  it('should honour a renamed graduatePackagePrefix when seeding per-package graduate labels (#486)', () => {
+  it('should honour a renamed graduatePackagePrefix when seeding per-package graduate labels', () => {
     const config = ciConfig({
       labels: { ...DEFAULT_LABELS_CONFIG, graduatePackagePrefix: 'promote/' },
     } as Partial<CIConfig>);

--- a/packages/release/test/unit/label-utils.spec.ts
+++ b/packages/release/test/unit/label-utils.spec.ts
@@ -50,7 +50,7 @@ describe('composeBumpFromLabels', () => {
   });
 });
 
-describe('per-package graduate labels (#486)', () => {
+describe('per-package graduate labels', () => {
   it('should build a graduate:<package> label from a package name', () => {
     expect(graduatePackageLabel('@scope/pkg')).toBe('graduate:@scope/pkg');
   });

--- a/packages/release/test/unit/preview-format.spec.ts
+++ b/packages/release/test/unit/preview-format.spec.ts
@@ -215,7 +215,7 @@ describe('formatPreviewComment', () => {
     expect(result).toContain('- Migrate to Vitest');
   });
 
-  it('should render bare #NNN refs per the refs mode (#504)', () => {
+  it('should render bare #NNN refs per the refs mode', () => {
     expect(formatPreviewComment(releaseOutput, { refs: 'escape' })).toContain(
       '- Fix prerelease sorting (`semver`) (\\#42)',
     );
@@ -258,7 +258,7 @@ describe('formatPreviewComment', () => {
     expect(result).toContain('> - New dry-run flag (`cli`)');
   });
 
-  it('should always neutralise @-mentions in preview descriptions (#504)', () => {
+  it('should always neutralise @-mentions in preview descriptions', () => {
     const withMention = structuredClone(releaseOutput);
     const firstChangelog = withMention.versionOutput.changelogs[0];
     if (firstChangelog) {
@@ -974,7 +974,7 @@ describe('formatPreviewComment', () => {
 
   // --- Synthetic version-bump entries (#468) ---
 
-  describe('synthetic version-bump entries (#468)', () => {
+  describe('synthetic version-bump entries', () => {
     // A sync/lockstep carry: a bumped package with no commits of its own gets a fabricated
     // `Update version to X` placeholder from the version engine. The preview must collapse these
     // into the "Also bumped" list, not render full changelog blocks of placeholder noise.

--- a/packages/release/test/unit/preview.spec.ts
+++ b/packages/release/test/unit/preview.spec.ts
@@ -194,7 +194,7 @@ describe('runPreview', () => {
     });
   });
 
-  describe('standing release PR skip (#424)', () => {
+  describe('standing release PR skip', () => {
     afterEach(() => {
       delete process.env.GITHUB_EVENT_PATH;
       // clearAllMocks() (in beforeEach) clears calls but not return-value impls, so reset the fs

--- a/packages/release/test/unit/release.spec.ts
+++ b/packages/release/test/unit/release.spec.ts
@@ -982,7 +982,7 @@ describe('runRelease', () => {
     });
   });
 
-  describe('feeder-preview refresh (#459)', () => {
+  describe('feeder-preview refresh', () => {
     it('should refresh feeder previews in-process after a successful release', async () => {
       await runRelease(defaultOptions);
       expect(mockRefreshFeederPreviews).toHaveBeenCalledWith(expect.objectContaining({ projectDir: '/test/project' }));
@@ -999,7 +999,7 @@ describe('runRelease', () => {
     });
   });
 
-  describe('editedNotes (manual-mode draft dispatch, #319)', () => {
+  describe('editedNotes (manual-mode draft dispatch)', () => {
     it('should merge editedNotes over generated notes before publish (edited wins per package)', async () => {
       await runRelease({ ...defaultOptions, editedNotes: { 'test-pkg': '- edited by human' } });
 

--- a/packages/release/test/unit/selection-region.spec.ts
+++ b/packages/release/test/unit/selection-region.spec.ts
@@ -180,7 +180,7 @@ describe('selection-region', () => {
 
   // --- Hierarchical / release-unit selection (#464) ---
 
-  describe('hierarchical selection (#464)', () => {
+  describe('hierarchical selection', () => {
     const tauriGroups = { tauri: { sync: 'linked' as const, packages: ['@wdio/tauri-*', 'tauri-plugin-*'] } };
     const tauriAll = ['@wdio/tauri-service', '@wdio/tauri-plugin', 'tauri-plugin-wdio-webdriver'];
     const tauriUpdates: Update[] = [
@@ -330,7 +330,7 @@ describe('selection-region', () => {
         expect(region).not.toContain('rk-sel:@wdio/tauri-plugin');
       });
 
-      it('should label independent-group members "bundled" rather than "coupled" (#509)', () => {
+      it('should label independent-group members "bundled" rather than "coupled"', () => {
         // independent members version on their own commit-driven lines but ship atomically with the
         // unit — "coupled" implies a shared version they don't have; "bundled" conveys atomic shipping.
         const independent = { tauri: { sync: 'independent' as const, packages: ['@wdio/tauri-*', 'tauri-plugin-*'] } };
@@ -341,7 +341,7 @@ describe('selection-region', () => {
         expect(region).not.toContain('· coupled');
       });
 
-      it('should keep an independent primary’s prerequisite as "coupled", not "bundled" (#509)', () => {
+      it('should keep an independent primary’s prerequisite as "coupled", not "bundled"', () => {
         // A prerequisite ships with the unit but isn't a group member — it has no version-bundle with
         // the independent group, so it keeps `coupled` even while the true group member shows `bundled`.
         const independent = { tauri: { sync: 'independent' as const, packages: ['@wdio/tauri-*', 'tauri-plugin-*'] } };
@@ -432,7 +432,7 @@ describe('selection-region', () => {
 
   // --- Channel-grouped sections (#487) ---
 
-  describe('channel-grouped sections (#487)', () => {
+  describe('channel-grouped sections', () => {
     const STABLE = '#### Stable — advancing on `latest`';
     const PRERELEASE = '#### Prereleases — advancing on their pre-release dist-tag';
 
@@ -569,7 +569,7 @@ describe('selection-region', () => {
     });
   });
 
-  describe('channel toggles (#521)', () => {
+  describe('channel toggles', () => {
     const channel = (over: Partial<ChannelToggleConfig> = {}): ChannelToggleConfig => ({
       prereleased: new Set(),
       graduated: new Set(),

--- a/packages/release/test/unit/standing-pr.spec.ts
+++ b/packages/release/test/unit/standing-pr.spec.ts
@@ -261,7 +261,7 @@ describe('serializeManifest / parseManifest', () => {
     expect(parsed.firstUpdatedAt).toBe('2024-06-01T12:00:00.000Z');
   });
 
-  it('should round-trip overrideLabels (#337)', () => {
+  it('should round-trip overrideLabels', () => {
     const m = { ...baseManifest, schemaVersion: 2 as const, overrideLabels: ['bump:major', 'channel:prerelease'] };
     const parsed = parseManifest(serializeManifest(m));
     expect(parsed.overrideLabels).toEqual(['bump:major', 'channel:prerelease']);
@@ -272,7 +272,7 @@ describe('serializeManifest / parseManifest', () => {
     expect(parsed.overrideLabels).toBeUndefined();
   });
 
-  it('should round-trip graduated packages (#486)', () => {
+  it('should round-trip graduated packages', () => {
     const m = { ...baseManifest, schemaVersion: 2 as const, graduated: ['@scope/a', '@scope/b'] };
     const parsed = parseManifest(serializeManifest(m));
     expect(parsed.graduated).toEqual(['@scope/a', '@scope/b']);
@@ -345,7 +345,7 @@ describe('runStandingPRUpdate', () => {
     expect(result.action).toBe('noop');
   });
 
-  it('should return noop when a release commit lands on the base branch during the run (#323)', async () => {
+  it('should return noop when a release commit lands on the base branch during the run', async () => {
     // Top-of-function guard sees a non-release HEAD (passes), but after resetting to origin/main a
     // release commit is now HEAD — a release merged mid-run. The post-reset recheck must bow out so
     // the standing PR doesn't double-bump off the just-merged-but-untagged version bump.
@@ -491,7 +491,7 @@ describe('runStandingPRUpdate', () => {
     expect(body).toContain('→ 1.1.0');
   });
 
-  it('should exclude a package the maintainer unticked in the selection region (#367)', async () => {
+  it('should exclude a package the maintainer unticked in the selection region', async () => {
     const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
     const versionOutput = {
       ...createMockVersionOutput([
@@ -569,7 +569,7 @@ describe('runStandingPRUpdate', () => {
     sharedEntries: [],
   };
 
-  it('should render a streamlined release unit with read-only coupled children (#464)', async () => {
+  it('should render a streamlined release unit with read-only coupled children', async () => {
     const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
     await withPrimaries();
     vi.mocked(runVersionStep).mockResolvedValue(
@@ -589,7 +589,7 @@ describe('runStandingPRUpdate', () => {
     expect(body).not.toContain('rk-sel:@wdio/tauri-plugin');
   });
 
-  it('should cascade a held-back primary to exclude its whole unit from the write (#464)', async () => {
+  it('should cascade a held-back primary to exclude its whole unit from the write', async () => {
     const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
     await withPrimaries();
     vi.mocked(runVersionStep).mockResolvedValue(
@@ -681,7 +681,7 @@ describe('runStandingPRUpdate', () => {
   };
   const asEditedBy = (login: string) => asActionBy('edited', login);
 
-  it('should honour an authorized actor’s checkbox untick (#401)', async () => {
+  it('should honour an authorized actor’s checkbox untick', async () => {
     await withAuthz();
     await asEditedBy('admin-user');
     const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
@@ -707,7 +707,7 @@ describe('runStandingPRUpdate', () => {
     expect(writeCall.exclude).toEqual(['@scope/b']); // admin's untick is applied
   });
 
-  it('should ignore an unauthorized actor’s untick (manifest stays authoritative) and post a notice (#401)', async () => {
+  it('should ignore an unauthorized actor’s untick (manifest stays authoritative) and post a notice', async () => {
     await withAuthz();
     await asEditedBy('rando');
     const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
@@ -737,7 +737,7 @@ describe('runStandingPRUpdate', () => {
     expect(forge.upsertedComments.some((c) => c.marker === '<!-- releasekit-selection-denied -->')).toBe(true);
   });
 
-  it('should not crash the run when the permission check throws — fails closed to the manifest (#401)', async () => {
+  it('should not crash the run when the permission check throws — fails closed to the manifest', async () => {
     await withAuthz();
     await asEditedBy('rando');
     const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
@@ -767,7 +767,7 @@ describe('runStandingPRUpdate', () => {
     expect(writeCall.exclude).toEqual([]);
   });
 
-  it('should ignore + remove an unauthorized actor’s release label, preserving non-release labels (#402)', async () => {
+  it('should ignore + remove an unauthorized actor’s release label, preserving non-release labels', async () => {
     await withAuthz();
     await asActionBy('labeled', 'rando');
     const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
@@ -800,7 +800,7 @@ describe('runStandingPRUpdate', () => {
     expect(forge.upsertedComments.some((c) => c.marker === '<!-- releasekit-label-denied -->')).toBe(true);
   });
 
-  it('should restore an authorized label that an unauthorized actor removed (unlabeled) (#402)', async () => {
+  it('should restore an authorized label that an unauthorized actor removed (unlabeled)', async () => {
     await withAuthz();
     await asActionBy('unlabeled', 'rando');
     const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
@@ -830,7 +830,7 @@ describe('runStandingPRUpdate', () => {
     expect(forge.upsertedComments.some((c) => c.marker === '<!-- releasekit-label-denied -->')).toBe(true);
   });
 
-  it('should honour an authorized actor’s release label (#402)', async () => {
+  it('should honour an authorized actor’s release label', async () => {
     await withAuthz();
     await asActionBy('labeled', 'admin-user');
     const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
@@ -867,7 +867,7 @@ describe('runStandingPRUpdate', () => {
     vi.mocked(runNotesStep).mockResolvedValue({ packageNotes: {}, releaseNotes: {}, files: [] });
   };
 
-  it('should honour an authorized actor’s channel toggle (#526)', async () => {
+  it('should honour an authorized actor’s channel toggle', async () => {
     await withAuthzChannel();
     await asEditedBy('admin-user');
     await channelWriteOutput();
@@ -886,7 +886,7 @@ describe('runStandingPRUpdate', () => {
     expect(forge.upsertedComments.some((c) => c.marker === '<!-- releasekit-channel-denied -->')).toBe(false);
   });
 
-  it('should ignore an unauthorized actor’s channel toggle (manifest stays authoritative) and post a notice (#526)', async () => {
+  it('should ignore an unauthorized actor’s channel toggle (manifest stays authoritative) and post a notice', async () => {
     await withAuthzChannel();
     await asEditedBy('rando');
     await channelWriteOutput();
@@ -908,7 +908,7 @@ describe('runStandingPRUpdate', () => {
     expect(forge.upsertedComments.some((c) => c.marker === '<!-- releasekit-channel-denied -->')).toBe(true);
   });
 
-  it('should re-apply the manifest’s approved channel for an unauthorized actor (#526)', async () => {
+  it('should re-apply the manifest’s approved channel for an unauthorized actor', async () => {
     await withAuthzChannel();
     await asEditedBy('rando');
     await channelWriteOutput();
@@ -936,7 +936,7 @@ describe('runStandingPRUpdate', () => {
     expect(forge.upsertedComments.some((c) => c.marker === '<!-- releasekit-channel-denied -->')).toBe(true);
   });
 
-  it('should not post a channel-denied notice when an unauthorized edit leaves the toggles unchanged (#526)', async () => {
+  it('should not post a channel-denied notice when an unauthorized edit leaves the toggles unchanged', async () => {
     await withAuthzChannel();
     await asEditedBy('rando');
     await channelWriteOutput();
@@ -964,7 +964,7 @@ describe('runStandingPRUpdate', () => {
     expect(forge.upsertedComments.some((c) => c.marker === '<!-- releasekit-channel-denied -->')).toBe(false);
   });
 
-  it('should leave channel toggles unreconciled when the feature is disabled (#526)', async () => {
+  it('should leave channel toggles unreconciled when the feature is disabled', async () => {
     // authorization set, but channelToggle OFF — extractChannelSelection is never called, so a body
     // toggle can't drive the write regardless of actor. The gate is a no-op here.
     await withAuthz();
@@ -986,7 +986,7 @@ describe('runStandingPRUpdate', () => {
     expect(forge.upsertedComments.some((c) => c.marker === '<!-- releasekit-channel-denied -->')).toBe(false);
   });
 
-  it('should re-apply the manifest’s channel on a push run and post no notice (#526)', async () => {
+  it('should re-apply the manifest’s channel on a push run and post no notice', async () => {
     await withAuthzChannel();
     await asActionBy('synchronize', 'rando'); // a push/synchronize run — not a body edit
     await channelWriteOutput();
@@ -1016,7 +1016,7 @@ describe('runStandingPRUpdate', () => {
     expect(forge.upsertedComments.some((c) => c.marker === '<!-- releasekit-channel-denied -->')).toBe(false); // silent
   });
 
-  it('should never honour a residual selection region in a sync release (#367)', async () => {
+  it('should never honour a residual selection region in a sync release', async () => {
     // A repo that switched to sync may carry a leftover selection region. Sync ships atomically, so a
     // stale deselection must NOT narrow it into a partial release — exclude stays empty.
     const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
@@ -1045,7 +1045,7 @@ describe('runStandingPRUpdate', () => {
     expect(writeCall.exclude).toEqual([]);
   });
 
-  it('should bypass the initial skip-pattern guard on a pull_request label event (#336)', async () => {
+  it('should bypass the initial skip-pattern guard on a pull_request label event', async () => {
     // A label event checks out the standing PR's `chore: release preparation` commit (matches the
     // skip pattern) — the first guard would noop. A label-triggered run must proceed. The post-reset
     // HEAD is a normal commit, so the post-reset guard (not bypassed for label runs) passes.
@@ -1128,7 +1128,7 @@ describe('runStandingPRUpdate', () => {
     );
   });
 
-  it('should close (not render ****) when the write step recomputes to an empty release set (#396)', async () => {
+  it('should close (not render ****) when the write step recomputes to an empty release set', async () => {
     // Reconcile-race: the dry run sees updates (guard passes), but a release landing on base mid-run
     // makes the write step recompute to 0 publishable updates. The second guard must close the PR
     // instead of rendering a degenerate `****` body.
@@ -1610,7 +1610,7 @@ describe('runStandingPRUpdate', () => {
     expect(footer).not.toContain('Fix B bug');
   });
 
-  it("should truncate the PR body when the changelog would exceed GitHub's limit (#333)", async () => {
+  it("should truncate the PR body when the changelog would exceed GitHub's limit", async () => {
     const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
     // A no-baseline-tag package's full-history changelog: thousands of entries blow past 65,536 chars.
     const hugeEntries = Array.from({ length: 4000 }, (_, i) => ({
@@ -2069,7 +2069,7 @@ describe('runStandingPRUpdate', () => {
       expect(runVersionStepMock.mock.calls[1]?.[0]).toMatchObject({ bump: 'premajor', prerelease: true });
     });
 
-    it('should record the override labels in the manifest, excluding the marker label (#337)', async () => {
+    it('should record the override labels in the manifest, excluding the marker label', async () => {
       const { forge } = await setupWithStandingPRLabels(['release', 'bump:major', 'channel:prerelease']);
 
       await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
@@ -2157,7 +2157,7 @@ describe('runStandingPRUpdate', () => {
     });
   });
 
-  describe('per-package graduation (#486)', () => {
+  describe('per-package graduation', () => {
     // A mixed async standing PR: @scope/a stays on its stable line, @scope/b is a prerelease.
     const mixedOutput = (graduatedName?: string) => ({
       dryRun: false,
@@ -2260,7 +2260,7 @@ describe('runStandingPRUpdate', () => {
     });
   });
 
-  describe('preview-notes editable region (#200)', () => {
+  describe('preview-notes editable region', () => {
     async function setupPreviewPR(opts: { labels: string[]; liveBody?: string; freshNotes?: Record<string, string> }) {
       const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
       const versionOutput = createMockVersionOutput([{ packageName: '@scope/core', newVersion: '1.2.3' }]);
@@ -2538,7 +2538,7 @@ describe('runStandingPRPublish', () => {
     expect(vi.mocked(refreshFeederPreviews)).toHaveBeenCalledWith(expect.objectContaining({ projectDir: '/test' }));
   });
 
-  it('should refuse to publish when override labels diverge from the manifest (#337)', async () => {
+  it('should refuse to publish when override labels diverge from the manifest', async () => {
     const { readFileSync } = await import('node:fs');
     vi.mocked(readFileSync).mockReturnValue(
       JSON.stringify({ pull_request: { head: { ref: 'release/next' }, number: 42, merged: true } }),
@@ -2576,7 +2576,7 @@ describe('runStandingPRPublish', () => {
     );
   };
 
-  it('should refuse to publish when the merger is not authorized (#403)', async () => {
+  it('should refuse to publish when the merger is not authorized', async () => {
     await publishConfigWithAuthz({ requiredPermission: 'admin', enforceMergeAuthor: true });
     await mergedByEvent('rando');
     await mockForge({
@@ -2592,7 +2592,7 @@ describe('runStandingPRPublish', () => {
     expect(vi.mocked(runPublishStep)).not.toHaveBeenCalled();
   });
 
-  it('should publish when the merger is authorized (#403)', async () => {
+  it('should publish when the merger is authorized', async () => {
     await publishConfigWithAuthz({ requiredPermission: 'admin', enforceMergeAuthor: true });
     await mergedByEvent('admin-user');
     await mockForge({
@@ -2611,7 +2611,7 @@ describe('runStandingPRPublish', () => {
     expect(vi.mocked(runPublishStep)).toHaveBeenCalled();
   });
 
-  it('should not check the merger when enforceMergeAuthor is false (#403)', async () => {
+  it('should not check the merger when enforceMergeAuthor is false', async () => {
     await publishConfigWithAuthz({ requiredPermission: 'admin', enforceMergeAuthor: false });
     await mergedByEvent('rando'); // unauthorized, but the check is disabled
     await mockForge({
@@ -2630,7 +2630,7 @@ describe('runStandingPRPublish', () => {
     expect(vi.mocked(runPublishStep)).toHaveBeenCalled();
   });
 
-  it('should publish (fail open) when the merger permission check is unverifiable (#403)', async () => {
+  it('should publish (fail open) when the merger permission check is unverifiable', async () => {
     await publishConfigWithAuthz({ requiredPermission: 'admin', enforceMergeAuthor: true });
     await mergedByEvent('someone');
     const forge = await mockForge({ comments: [{ id: 1, body: serializeManifest(baseManifest) }] });
@@ -2648,7 +2648,7 @@ describe('runStandingPRPublish', () => {
     expect(vi.mocked(runPublishStep)).toHaveBeenCalled(); // failed open
   });
 
-  it('should treat a Bot merger as authorized via merged_by.type, without a permission call (#403)', async () => {
+  it('should treat a Bot merger as authorized via merged_by.type, without a permission call', async () => {
     await publishConfigWithAuthz({ requiredPermission: 'admin', enforceMergeAuthor: true });
     const { readFileSync } = await import('node:fs');
     // A GitHub App whose login does NOT end in [bot] — recognised by type, not the login suffix.
@@ -2677,7 +2677,7 @@ describe('runStandingPRPublish', () => {
     expect(permSpy).not.toHaveBeenCalled(); // recognised as a bot by type — no permission lookup
   });
 
-  it('should publish when override labels match the manifest, ignoring non-override labels (#337)', async () => {
+  it('should publish when override labels match the manifest, ignoring non-override labels', async () => {
     const { readFileSync } = await import('node:fs');
     vi.mocked(readFileSync).mockReturnValue(
       JSON.stringify({ pull_request: { head: { ref: 'release/next' }, number: 42, merged: true } }),
@@ -2722,7 +2722,7 @@ describe('runStandingPRPublish', () => {
     expect(vi.mocked(runPublishStep)).toHaveBeenCalled();
   });
 
-  it('should refuse to publish when the PR is unreadable but the manifest carried override labels (#337)', async () => {
+  it('should refuse to publish when the PR is unreadable but the manifest carried override labels', async () => {
     const { readFileSync } = await import('node:fs');
     vi.mocked(readFileSync).mockReturnValue(
       JSON.stringify({ pull_request: { head: { ref: 'release/next' }, number: 42, merged: true } }),
@@ -2902,7 +2902,7 @@ describe('publishFromManifest', () => {
     ).rejects.toThrow(/manifest not found/);
   });
 
-  it('should use human-edited notes from the PR body at merge, overriding regenerated notes (#200)', async () => {
+  it('should use human-edited notes from the PR body at merge, overriding regenerated notes', async () => {
     const { runNotesStep, runPublishStep } = await import('../../src/steps.js');
     vi.mocked(runNotesStep).mockResolvedValue({
       packageNotes: {},

--- a/packages/version/src/changelog/commitParser.ts
+++ b/packages/version/src/changelog/commitParser.ts
@@ -16,7 +16,7 @@ const CONVENTIONAL_COMMIT_REGEX = /^(\w+)(?:\(([^)]+)\))?(!)?: (.+)(?:\n\n([\s\S
 const BREAKING_CHANGE_REGEX = /BREAKING CHANGE: ([\s\S]+?)(?:\n\n|$)/;
 // Free-form (non-conventional) subjects that are pure version-sync / release bookkeeping and carry no
 // changelog signal — e.g. `Update version to 1.2.3`, `update package versions across multiple
-// packages` — leaked in as `Changed` entries (#522). Only applied to the non-conventional fallback
+// packages` — leaked in as `Changed` entries. Only applied to the non-conventional fallback
 // branch, and narrow by construction (`version to <digit>` / `package versions`) so a real code
 // change like "update version handling in the parser" is never swallowed.
 const VERSION_BUMP_SUBJECT_REGEX = /^update (?:version to v?\d|package versions)\b/i;
@@ -317,7 +317,7 @@ function parseCommitMessage(message: string): ChangelogEntry | null {
 
   // Non-conventional commit - try to extract basic information
   // Only include if it seems meaningful (not a merge, a bare version tag, or a version-sync /
-  // release-bump bookkeeping subject — #522).
+  // release-bump bookkeeping subject).
   if (
     !trimmedMessage.startsWith('Merge') &&
     !trimmedMessage.match(/^v?\d+\.\d+\.\d+/) &&
@@ -356,7 +356,7 @@ function mapCommitTypeToChangelogType(type: string): ChangelogEntry['type'] {
       return 'changed';
     case 'test':
       // Surfaced as "Changed", not dropped: ReleaseKit lists every merged change (low-signal ones are
-      // demoted, not hidden). Excluding test alone undercounted the standing-PR preview. #569
+      // demoted, not hidden). Excluding test alone undercounted the standing-PR preview.
       return 'changed';
     default:
       // For unknown types, put in 'changed'

--- a/packages/version/test/unit/changelog/commitParser.spec.ts
+++ b/packages/version/test/unit/changelog/commitParser.spec.ts
@@ -41,7 +41,7 @@ describe('Commit Parser', () => {
 
     const entries = await extractChangelogEntriesFromCommits('/test', RANGE, gitWithLog(mockGitOutput));
 
-    expect(entries).toHaveLength(11); // every conventional type is surfaced, including 'test' (#569)
+    expect(entries).toHaveLength(11); // every conventional type is surfaced, including 'test'
 
     expect(entries.find((e) => e.description === 'add new feature')).toEqual(
       expect.objectContaining({ type: 'added', scope: 'core' }),
@@ -52,7 +52,7 @@ describe('Commit Parser', () => {
     expect(entries.find((e) => e.description === 'update README')).toEqual(
       expect.objectContaining({ type: 'changed', scope: undefined }),
     );
-    // `test:` is categorized as Changed, not dropped (#569).
+    // `test:` is categorized as Changed, not dropped.
     expect(entries.find((e) => e.description === 'add new tests')).toEqual(
       expect.objectContaining({ type: 'changed', scope: undefined }),
     );
@@ -140,7 +140,7 @@ describe('Commit Parser', () => {
     expect(entries.map((e) => e.description)).toContain('Fix bug in login');
   });
 
-  it('should drop version-sync / release-bump bookkeeping subjects (#522)', async () => {
+  it('should drop version-sync / release-bump bookkeeping subjects', async () => {
     const mockGitOutput = [
       'Update version to 0.2.0',
       'Update version to 1.2.3 (wdio_flutter)',

--- a/scripts/examples-smoke/generate-smoke-workflow.ts
+++ b/scripts/examples-smoke/generate-smoke-workflow.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env tsx
 /**
  * Generates .github/workflows/examples-smoke.yml from the SHIPPED example
- * workflows (issue #276).
+ * workflows.
  *
  * Why generated instead of hand-written: the smoke test must run the same setup
  * steps the example ships, or it proves nothing — and a hand-written mirror rots

--- a/scripts/examples-smoke/scenarios.ts
+++ b/scripts/examples-smoke/scenarios.ts
@@ -1,5 +1,5 @@
 /**
- * Scenario manifest for the examples execution smoke-test (issue #276).
+ * Scenario manifest for the examples execution smoke-test.
  *
  * Deliberately METADATA, not a mirror of the example steps: it names which
  * example workflow/job to EXTRACT setup steps from, which shipped config the


### PR DESCRIPTION
Follow-up to the #571/#569 discussion: a repo-wide, **narrow** cleanup of bare origin-issue citations. Related: #573 (the hyperlink/AGENTS.md follow-up).

## What

Removes **80** trailing `#NNN` tags that merely cited the issue/PR a piece of code closed or a test covers, where the comment or test title already stands on its own:

- `// …undercounted the standing-PR preview. #569` → `// …undercounted the standing-PR preview.`
- `it('should honour an authorized actor's channel toggle (#526)')` → `it('should honour an authorized actor's channel toggle')`

80 insertions / 80 deletions across 26 files — every change is a single-line, citation-only removal. Comments and test/`describe` titles only; **no behavior change**.

## Why

A bare number isn't actionable — not clickable in a comment or in test-reporter/CI output, and in-source it's largely redundant with `git blame` → PR → issue (the canonical trace). Low value for human readers, marginal-and-redundant for LLMs.

## Deliberately kept (not touched)

Classified per-package with a conservative "when in doubt, keep" rubric:

- **Load-bearing** tracking refs ("until #X", "remove when #X").
- **`(#NNN review)`** provenance.
- **Illustrative** `#123` / `#NNN` / `#88` refs that are *example data* in ref-parsing regexes.
- **Cross-file decision-shorthand** (e.g. `#372` = strictReachable-abort) and mid-sentence refs where the number is part of the meaning.

## Breakdown

| Package | Drops |
|---|---|
| release | 53 |
| core | 8 |
| notes | 8 |
| version | 6 (incl. the 3 `#569` tags that landed on main via #570) |
| publish | 3 |
| scripts | 2 |

## Verification

`pnpm turbo run lint typecheck test` — 32/32 tasks green. Artifact scan confirms no double-periods, empty parens, or dangling punctuation; kept refs verified still present.

## Follow-up (#573)

Convert the kept refs to explicit hyperlink comments (`// … See <url>`) and codify the convention in AGENTS.md's `### Comments` rules (kept refs = hyperlinks not bare numbers; drop bare origin citations; titles stay ref-free).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR performs a narrow, mechanical cleanup across 26 files, removing 80 bare trailing `#NNN` origin-issue citations from source comments and test/describe titles where the surrounding text already stands on its own. No logic, behavior, or configuration is modified.

- **Comments**: Trailing `#NNN` tags stripped from JSDoc and inline comments in `changelogRefs.ts`, `types.ts`, `commitParser.ts`, `git-push.ts`, and others — the prose remains complete and self-explanatory without the citation.
- **Test titles**: `describe`/`it` strings have their parenthesized issue refs removed across the release, notes, publish, version, and core test suites; section-header comments and mid-sentence/illustrative refs were deliberately left untouched per the stated "when in doubt, keep" rubric.
</details>

<h3>Confidence Score: 5/5</h3>

Pure cosmetic cleanup with no behavior change — every edit is a single-line removal of a trailing issue citation from a comment or test title, and the PR verification confirms lint, typecheck, and all 32 test tasks pass green.

Every changed line is a deletion of a bare #NNN tag from prose; no logic, types, exports, or test assertions are altered. The conservative keep-if-in-doubt rubric the author applied is visible in the diff — mid-sentence refs, section-header comments with ---, and regex example data are all preserved. There is nothing here that could introduce a regression.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/release/test/unit/standing-pr.spec.ts | Largest single file change (26 it/describe title cleanups); all assertion bodies are unchanged. |
| packages/release/test/unit/selection-region.spec.ts | Removed citations from describe/it titles; section-header comments were correctly left untouched. |
| packages/core/src/types.ts | Removed trailing #468 and #485 citations from JSDoc; mid-sentence #486 ref left intact per the stated rubric. |
| packages/core/src/changelogRefs.ts | Removed three trailing #507/#499 citations from JSDoc and inline comments; prose remains self-contained. |
| packages/version/src/changelog/commitParser.ts | Removed trailing #522 and #569 citations from two inline comments; no logic changed. |
| packages/publish/src/stages/git-push.ts | Removed single trailing #429 citation from an inline comment; no behavior change. |
| scripts/examples-smoke/generate-smoke-workflow.ts | Removed 'issue #276' citation from the file-level JSDoc; description remains clear. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PR #574: Drop bare origin-issue citations] --> B{Citation type?}
    B -->|Trailing bare ref in comment| C[Remove citation]
    B -->|Parenthesized ref in test title| D[Remove citation]
    B -->|Load-bearing tracking ref| E[Keep — not touched]
    B -->|Mid-sentence / part of meaning| E
    B -->|Illustrative example data in regex/fixtures| E
    B -->|Section-header comment with dashes| E
    C --> F[80 single-line deletions across 26 files]
    D --> F
    F --> G[No behavior change — lint + typecheck + 32 tests green]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[PR #574: Drop bare origin-issue citations] --> B{Citation type?}
    B -->|Trailing bare ref in comment| C[Remove citation]
    B -->|Parenthesized ref in test title| D[Remove citation]
    B -->|Load-bearing tracking ref| E[Keep — not touched]
    B -->|Mid-sentence / part of meaning| E
    B -->|Illustrative example data in regex/fixtures| E
    B -->|Section-header comment with dashes| E
    C --> F[80 single-line deletions across 26 files]
    D --> F
    F --> G[No behavior change — lint + typecheck + 32 tests green]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["chore: drop bare origin-issue citations ..."](https://github.com/goosewobbler/releasekit/commit/8107bc4546da93e3458c9f97423f63137dc71355) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45477534)</sub>

<!-- /greptile_comment -->