### PR TITLE
fix(ci): restore Examples Smoke as a working regression detector

### DIFF
--- a/.github/workflows/examples-smoke.yml
+++ b/.github/workflows/examples-smoke.yml
@@ -22,6 +22,9 @@ on:
       - examples/**
       - scripts/examples-smoke/**
       - .github/workflows/examples-smoke.yml
+      - packages/**
+      - package.json
+      - pnpm-lock.yaml
   pull_request:
     branches:
       - main
@@ -29,6 +32,11 @@ on:
       - examples/**
       - scripts/examples-smoke/**
       - .github/workflows/examples-smoke.yml
+      - packages/**
+      - package.json
+      - pnpm-lock.yaml
+  schedule:
+    - cron: 0 3 * * *
   workflow_dispatch: {}
 permissions:
   contents: read

--- a/scripts/examples-smoke/build-fixture.ts
+++ b/scripts/examples-smoke/build-fixture.ts
@@ -110,7 +110,10 @@ function writeRootPackageJson(
 }
 
 function buildNpmSingle(out: string, tarballNames: Record<string, string>): void {
-  writeRootPackageJson(out, 'smoke-consumer', {}, tarballNames);
+  // A single-package consumer's one package IS the publishable one, so it must not be `private`.
+  // writeRootPackageJson defaults `private: true` for the monorepo roots (where only members ship),
+  // but a private single package is skipped at discovery — leaving nothing to release.
+  writeRootPackageJson(out, 'smoke-consumer', { private: false }, tarballNames);
 }
 
 function buildNpmMonorepo(out: string, tarballNames: Record<string, string>): void {

--- a/scripts/examples-smoke/generate-smoke-workflow.ts
+++ b/scripts/examples-smoke/generate-smoke-workflow.ts
@@ -215,17 +215,32 @@ export function buildWorkflow(): Record<string, unknown> {
     jobs[`smoke-${scenario.id}`] = smokeJob(scenario);
   }
 
+  // The smoke exercises `releasekit release`, so it must also run when that release code — or the
+  // dependencies it resolves — changes, not just the examples/harness; otherwise a regression in
+  // release logic can break the smoke without ever re-triggering it.
+  const triggerPaths = [
+    'examples/**',
+    'scripts/examples-smoke/**',
+    '.github/workflows/examples-smoke.yml',
+    'packages/**',
+    'package.json',
+    'pnpm-lock.yaml',
+  ];
+
   return {
     name: 'Examples Smoke',
     on: {
       push: {
         branches: ['main'],
-        paths: ['examples/**', 'scripts/examples-smoke/**', '.github/workflows/examples-smoke.yml'],
+        paths: [...triggerPaths],
       },
       pull_request: {
         branches: ['main'],
-        paths: ['examples/**', 'scripts/examples-smoke/**', '.github/workflows/examples-smoke.yml'],
+        paths: [...triggerPaths],
       },
+      // Nightly backstop on main: catches regressions the path filters miss (transitive dep bumps,
+      // runner-image drift) within a day.
+      schedule: [{ cron: '0 3 * * *' }],
       workflow_dispatch: {},
     },
     permissions: { contents: 'read' },


### PR DESCRIPTION
Closes #575, closes #576.

## Background

The Examples Smoke workflow (runs `releasekit release --dry-run` against shipped example configs) had been silently broken on main since ~2026-06-23. #482 (`skip private npm packages by default`) meets the smoke's private `npm-single` fixture — but the workflow is path-gated to the examples/harness, so it never re-ran when the release code changed. A comments-only PR (#574) incidentally touched a smoke path weeks later and surfaced it.

## Fixes

**1. Fixture (#575)** — `scripts/examples-smoke/build-fixture.ts`
The `npm-single` fixture's root `package.json` was `private: true`; as the sole package it got skipped at discovery → "No packages found in workspace". A single consumer's one package *is* the publishable one, so build it non-private. Monorepo fixtures keep their private root (members are public and discovered). Verified locally: the dry-run then reaches `[SUCCESS] Publish complete`.

**2. Triggers (#576)** — `scripts/examples-smoke/generate-smoke-workflow.ts` (+ regenerated `examples-smoke.yml`)
The workflow only triggered on `examples/**` / `scripts/examples-smoke/**` — the smoke's *inputs*, not the code it tests. Now also triggers on:
- `packages/**`, `package.json`, `pnpm-lock.yaml` — so any release-affecting change re-runs it before merge.
- a nightly `schedule:` (`0 3 * * *`) as a backstop for anything the path filter misses.

The workflow is generated; edited the generator and ran `pnpm examples:smoke:generate` (drift-checked by `examples:smoke:check`). Each trigger gets its own `paths` array so the YAML has no anchors — GitHub Actions doesn't reliably support them.

## Validation

This PR touches `scripts/examples-smoke/**` and the workflow file, so **Examples Smoke runs on the PR itself** — validating the fixture fix end-to-end in CI (previously-failing `npm-single` scenarios should now pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR restores the Examples Smoke workflow as a working regression detector by fixing two independent root causes: a `private: true` flag on the `npm-single` fixture root (causing all five `npm-single` scenarios to silently produce "No packages found in workspace"), and overly narrow path triggers that let release-logic regressions slip past the smoke entirely.

- **Fixture fix** (`build-fixture.ts`): `buildNpmSingle` now explicitly passes `{ private: false }` to `writeRootPackageJson`; since `extra` is spread after the hardcoded `private: true`, the override is correctly applied and the single-package root becomes discoverable at release time.
- **Trigger expansion** (`generate-smoke-workflow.ts` + regenerated `examples-smoke.yml`): `packages/**`, `package.json`, and `pnpm-lock.yaml` are added to the path filter for both `push` and `pull_request`, and a nightly `schedule` backstop (`0 3 * * *`) is introduced to catch any regressions the path filter still misses.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — both fixes are minimal, targeted, and validated by the smoke workflow running against this very PR.

The `private: false` override is correctly applied via the existing `extra` spread in `writeRootPackageJson`, the regenerated YAML exactly matches the generator output, and the new path filters and nightly schedule only expand coverage without removing anything. No production code is touched.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/examples-smoke/build-fixture.ts | Sets `private: false` for the `npm-single` fixture root so releasekit can discover the single package at release time; the spread ordering in `writeRootPackageJson` guarantees the override takes effect. |
| scripts/examples-smoke/generate-smoke-workflow.ts | Adds `packages/**`, `package.json`, and `pnpm-lock.yaml` to `triggerPaths` (shared across `push` and `pull_request`), and adds a nightly `schedule` backstop; no logic issues. |
| .github/workflows/examples-smoke.yml | Generated output faithfully reflects the generator: expanded path filters under both `push` and `pull_request`, nightly `schedule` at 03:00 UTC, and `workflow_dispatch` preserved. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Code push / PR / nightly schedule] --> B{Path filter matches?\nexamples/**, scripts/examples-smoke/**\npackages/**, package.json\npnpm-lock.yaml}
    B -- Yes --> C[prepare job\nCheckout + build releasekit\nPack tarballs]
    B -- No --> Z[Workflow skipped]
    C --> D[build-fixture.ts\nfor each scenario]
    D --> E{fixture type?}
    E -- npm-single --> F[writeRootPackageJson\nprivate: false ✅]
    E -- npm-monorepo --> G[writeRootPackageJson\nprivate: true root\n+ workspace members]
    E -- npm-cargo-monorepo --> H[writeRootPackageJson\nprivate: true root\n+ npm + cargo members]
    F --> I[Upload fixture bundle]
    G --> I
    H --> I
    I --> J[smoke-minimal\nsmoke-label-driven\nsmoke-oidc\nsmoke-prerelease\nsmoke-standing-pr]
    I --> K[smoke-monorepo-rust]
    J --> L[pnpm exec releasekit release --dry-run\n✅ reaches publish]
    K --> M[cargo probe + pnpm exec releasekit release --dry-run]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Code push / PR / nightly schedule] --> B{Path filter matches?\nexamples/**, scripts/examples-smoke/**\npackages/**, package.json\npnpm-lock.yaml}
    B -- Yes --> C[prepare job\nCheckout + build releasekit\nPack tarballs]
    B -- No --> Z[Workflow skipped]
    C --> D[build-fixture.ts\nfor each scenario]
    D --> E{fixture type?}
    E -- npm-single --> F[writeRootPackageJson\nprivate: false ✅]
    E -- npm-monorepo --> G[writeRootPackageJson\nprivate: true root\n+ workspace members]
    E -- npm-cargo-monorepo --> H[writeRootPackageJson\nprivate: true root\n+ npm + cargo members]
    F --> I[Upload fixture bundle]
    G --> I
    H --> I
    I --> J[smoke-minimal\nsmoke-label-driven\nsmoke-oidc\nsmoke-prerelease\nsmoke-standing-pr]
    I --> K[smoke-monorepo-rust]
    J --> L[pnpm exec releasekit release --dry-run\n✅ reaches publish]
    K --> M[cargo probe + pnpm exec releasekit release --dry-run]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(ci): restore Examples Smoke as a wor..."](https://github.com/goosewobbler/releasekit/commit/da07f47d96fd13e3513e3455e928f57f1538ee41) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45479413)</sub>

<!-- /greptile_comment -->