### PR TITLE
fix(publish): discover before authenticating so an empty registry no-ops

### DIFF
--- a/packages/publish/src/registry/dispatcher.ts
+++ b/packages/publish/src/registry/dispatcher.ts
@@ -26,16 +26,22 @@ export async function runPublishStage<T extends RegistryTarget, S>(
 
   const dryRun = ctx.cliOptions.dryRun;
   const results = ctx.output[registry.id];
+
+  // Discover before authenticating: an enabled registry with nothing to publish must no-op, not
+  // demand credentials it will never use. `enabled` means "publish the detected packages of this
+  // kind", so a repo with none (e.g. no crates) must not fail on a missing registry token.
+  const targets = await registry.discover(ctx);
+  if (targets.length === 0) {
+    // Restores the per-registry "nothing to do" breadcrumb the old per-target stages logged, so
+    // verbose output still confirms the stage ran and found no targets (vs. not running at all).
+    debug(`[${registry.id}] No targets found, nothing to publish`);
+    return;
+  }
+
   const session = await registry.authCheck(ctx);
 
   try {
-    const targets = await registry.discover(ctx, session);
-    if (targets.length === 0) {
-      // Restores the per-registry "nothing to do" breadcrumb the old per-target stages logged, so
-      // verbose output still confirms the stage ran and found no targets (vs. not running at all).
-      debug(`[${registry.id}] No targets found, nothing to publish`);
-    }
-    if (targets.length > 0) await registry.prepare?.(ctx, session);
+    await registry.prepare?.(ctx, session);
 
     for (const target of targets) {
       const result: PublishResult = {

--- a/packages/publish/src/registry/types.ts
+++ b/packages/publish/src/registry/types.ts
@@ -52,8 +52,11 @@ export interface Registry<T extends RegistryTarget = RegistryTarget, S = unknown
    */
   authCheck(ctx: PipelineContext): Promise<S>;
 
-  /** This registry's manifests from `ctx.input.updates`, already in publish order. */
-  discover(ctx: PipelineContext, session: S): Promise<T[]>;
+  /**
+   * This registry's manifests from `ctx.input.updates`, already in publish order. Runs before
+   * `authCheck` so an enabled-but-empty stage can no-op without demanding credentials.
+   */
+  discover(ctx: PipelineContext): Promise<T[]>;
 
   /**
    * One-time setup that should run only when there is at least one target — so an enabled-but-empty

--- a/packages/publish/test/unit/registry/dispatcher.spec.ts
+++ b/packages/publish/test/unit/registry/dispatcher.spec.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { getDefaultConfig } from '../../../src/config.js';
 import { PublishErrorCode } from '../../../src/errors/index.js';
+import { cargoRegistry } from '../../../src/registry/cargo.js';
 import { runPublishStage } from '../../../src/registry/dispatcher.js';
 import type { Registry, RegistryTarget } from '../../../src/registry/types.js';
 import type { PipelineContext } from '../../../src/types.js';
@@ -79,6 +80,40 @@ describe('runPublishStage dispatcher', () => {
 
     expect(authCheck).not.toHaveBeenCalled();
     expect(ctx.output.npm).toHaveLength(0);
+  });
+
+  it('should not authenticate when enabled but no targets are discovered', async () => {
+    // Enabled + zero targets must no-op without authenticating: discovery runs before authCheck, so a
+    // stage with nothing to publish can't fail on credentials it never needs (e.g. no crates, no token).
+    const authCheck = vi.fn(async () => {
+      throw new Error('missing registry token');
+    });
+    const ctx = createContext();
+
+    await expect(
+      runPublishStage(makeRegistry({ isEnabled: () => true, discover: async () => [], authCheck }), ctx),
+    ).resolves.toBeUndefined();
+
+    expect(authCheck).not.toHaveBeenCalled();
+    expect(ctx.output.npm).toHaveLength(0);
+  });
+
+  it('should no-op the real cargo registry for a crateless repo without demanding a token', async () => {
+    // A dry run can't cover this: cargo's authCheck is dry-run-exempt, so the enabled-but-crateless
+    // no-op is only exercised by a real (non-dry-run) run with no token.
+    const savedToken = process.env.CARGO_REGISTRY_TOKEN;
+    delete process.env.CARGO_REGISTRY_TOKEN;
+    try {
+      const ctx = createContext();
+      ctx.config.cargo.enabled = true;
+      ctx.input.updates = [{ packageName: '@smoke/pkg', newVersion: '1.1.0', filePath: 'package.json' }];
+
+      await expect(runPublishStage(cargoRegistry, ctx)).resolves.toBeUndefined();
+      expect(ctx.output.cargo).toHaveLength(0);
+    } finally {
+      if (savedToken === undefined) delete process.env.CARGO_REGISTRY_TOKEN;
+      else process.env.CARGO_REGISTRY_TOKEN = savedToken;
+    }
   });
 
   it('should record a precheckSkip as a non-publishing skip', async () => {


### PR DESCRIPTION
Closes #578.

## Problem

The publish dispatcher ran `registry.authCheck()` **before** `registry.discover()` and the zero-targets check. Since #563 flipped `publish.cargo.enabled` to default `true`, every repo now runs the cargo stage — and `cargo.authCheck` throws on a missing `CARGO_REGISTRY_TOKEN`. So a repo with **no crates** fails the whole release on cargo auth, *after* npm has already published (roll-forward), leaving it published-but-untagged and posting a false publish-failure report. ReleaseKit hit this on its own 0.41.0 release.

## Fix

`dispatcher.ts` — discover first; if there are no targets, no-op the stage (skip auth **and** dispose); only `authCheck` when there's something to publish:

```ts
if (!registry.isEnabled(ctx.config)) return;

const targets = await registry.discover(ctx);   // was after authCheck; session dropped (unused)
if (targets.length === 0) { debug('…nothing to publish'); return; }

const session = await registry.authCheck(ctx);   // only when it matters
await registry.prepare?.(ctx, session);
// …publish loop…
```

This restores the interface's already-documented intent — *"an enabled-but-empty stage stays side-effect-free"* — which the auth ordering had violated.

## Scope / safety

- **cargo** — the reported failure; fixed.
- **npm** — same structural flaw (`npm.authCheck` also throws pre-discovery); a zero-npm-package repo would hit it. Pre-existing, rarer; fixed by the same reorder.
- **pub.dev** — was never affected (`pub.authCheck` is a no-op; token setup lives in `prepare`, gated on targets). No behavior change.
- A repo that **does** have crates but no token still fails `authCheck` (targets > 0) — the real misconfiguration is preserved.
- `Registry.discover` no longer receives `session` (no implementation used it).

## Tests

Added a dispatcher regression test: an enabled registry with zero targets never calls `authCheck` and resolves cleanly even when `authCheck` would throw. Full gate green (publish 282 tests; `pnpm turbo run lint typecheck test` 32/32).

## Sequencing

This needs to be **on main before the 0.41.0 standing-PR retry** — the retry re-runs the publish, and without this fix it will fail on cargo auth again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a regression introduced in #563 where `cargo.enabled` defaulted to `true`, causing every repo (even those with no crates) to fail on a missing `CARGO_REGISTRY_TOKEN` because `authCheck` ran before `discover`. The fix reorders the dispatcher so `discover` runs first and an enabled-but-empty stage no-ops cleanly without demanding credentials.

- **`dispatcher.ts`**: Moves `discover()` ahead of `authCheck()`; exits early with a debug log when `targets.length === 0`, skipping auth and dispose (no session is created for the empty case).
- **`types.ts`**: Drops the unused `session` parameter from the `discover` interface signature, reflecting that no implementation used it and it no longer makes sense pre-auth.
- **`dispatcher.spec.ts`**: Adds a generic regression test (enabled + zero targets → authCheck never called) and a real-`cargoRegistry` smoke test that exercises the exact failure path with no `CARGO_REGISTRY_TOKEN`.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a targeted reorder of two calls in a single function, backed by regression tests covering the exact broken scenario.

Discover runs first, auth is only demanded when there is something to publish, and the finally block that calls dispose is correctly scoped after authCheck so an empty stage never creates a session to clean up. Tests cover the generic dispatcher contract and the specific cargo regression.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/publish/src/registry/dispatcher.ts | Reorders discover() before authCheck(); early-returns on zero targets without touching auth or dispose — correct lifecycle change with no session created for the empty case. |
| packages/publish/src/registry/types.ts | Removes the unused `session` parameter from the `discover` interface signature and updates the JSDoc to document the new pre-auth ordering guarantee. |
| packages/publish/test/unit/registry/dispatcher.spec.ts | Adds two well-targeted regression tests: a synthetic test confirming authCheck is never called on zero targets, and a real cargoRegistry smoke test that exercises the exact pre-fix failure (no CARGO_REGISTRY_TOKEN, no crates). |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant D as dispatcher
    participant R as Registry

    D->>R: isEnabled(config)
    alt disabled
        R-->>D: false
        D-->>D: log disabled, return
    else enabled
        R-->>D: true
        D->>R: discover(ctx)
        R-->>D: targets[]
        alt "targets.length === 0"
            D-->>D: debug No targets, return (no auth, no dispose)
        else "targets.length > 0"
            D->>R: authCheck(ctx)
            R-->>D: session
            D->>R: prepare?(ctx, session)
            loop for each target
                D->>R: precheckSkip? / isPublished / publish
            end
            D->>R: dispose?(session)
        end
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant D as dispatcher
    participant R as Registry

    D->>R: isEnabled(config)
    alt disabled
        R-->>D: false
        D-->>D: log disabled, return
    else enabled
        R-->>D: true
        D->>R: discover(ctx)
        R-->>D: targets[]
        alt "targets.length === 0"
            D-->>D: debug No targets, return (no auth, no dispose)
        else "targets.length > 0"
            D->>R: authCheck(ctx)
            R-->>D: session
            D->>R: prepare?(ctx, session)
            loop for each target
                D->>R: precheckSkip? / isPublished / publish
            end
            D->>R: dispose?(session)
        end
    end
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(publish): discover before authentica..."](https://github.com/goosewobbler/releasekit/commit/5041be01e8c0eea004e17207d66068e15b09fca2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45480881)</sub>

<!-- /greptile_comment -->