### PR TITLE
ci: harden workflows — SHA-pin actions, drop inlined SSH key, least-privilege

### DIFF
--- a/.github/workflows/_ci-detect-changes.reusable.yml
+++ b/.github/workflows/_ci-detect-changes.reusable.yml
@@ -58,7 +58,7 @@ jobs:
           fetch-depth: 0
 
       - name: Detect changed files
-        uses: dorny/paths-filter@v4
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4
         id: changes
         with:
           filters: |

--- a/.github/workflows/_ci-integration.reusable.yml
+++ b/.github/workflows/_ci-integration.reusable.yml
@@ -36,7 +36,7 @@ jobs:
 
       # Provides cargo for the Cargo.lock self-version sync integration test (#496). The test is
       # skipped when cargo is absent, so this toolchain is what makes it actually run in CI.
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
 
       - name: Run integration tests
         run: pnpm --filter @releasekit/integration-tests test

--- a/.github/workflows/_release.reusable.yml
+++ b/.github/workflows/_release.reusable.yml
@@ -79,11 +79,6 @@ jobs:
       - name: Build packages
         run: pnpm build
 
-      - name: Configure git SSH for tag pushes
-        if: ${{ !inputs.dry_run }}
-        run: |
-          git config --global core.sshCommand "ssh -i ${{ secrets.ssh_key }} -o StrictHostKeyChecking=no"
-
       - name: Run releasekit
         id: release
         if: inputs.standing_pr_number == ''

--- a/.github/workflows/actions/setup-workspace/action.yml
+++ b/.github/workflows/actions/setup-workspace/action.yml
@@ -10,7 +10,7 @@ runs:
   using: composite
   steps:
     - name: Setup pnpm
-      uses: pnpm/action-setup@v5
+      uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
 
     - name: Setup Node.js
       uses: actions/setup-node@v6

--- a/.github/workflows/examples-validate.yml
+++ b/.github/workflows/examples-validate.yml
@@ -95,7 +95,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -14,7 +14,7 @@ jobs:
     name: Validate PR Title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v6
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,9 @@ jobs:
   check-labels:
     name: Check Release Labels
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read # reads the merged PR + its labels via `gh api repos/.../commits/.../pulls`
     if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push'
     outputs:
       should_release: ${{ steps.check.outputs.should_release }}


### PR DESCRIPTION
## Summary

Defense-in-depth hardening of the CI workflows (from the 2026-07-19 security review, #560). No confirmed-exploitable RCE — these are supply-chain and least-privilege tightenings, scoped to `.github/workflows/*.yml`.

- Pin the action in the privileged `pull_request_target` (`pr-title.yml`, `amannn/action-semantic-pull-request`) to a full SHA.
- Remove the inlined SSH key in `_release.reusable.yml` (`git config --global core.sshCommand "ssh -i <key>…"`) — it inlined key material into a shell command, was buggy (`ssh -i` expects a file path), and is redundant with `actions/checkout`'s `ssh-key:`. The deploy key still flows through checkout.
- Add `permissions: { contents: read }` to the `release.yml` `check-labels` job (read-only `gh api` calls).
- Pin the remaining mutable third-party tags (`dtolnay/rust-toolchain@stable`, `dorny/paths-filter@v4`, `pnpm/action-setup@v5`/`@v6`) to full SHAs so Dependabot can manage them.

First-party `actions/*` and `github/codeql-action` are left as-is per the issue's scope; consumer-facing docs/templates keep readable tags.

## Test plan

- SHAs were resolved from each action's currently-pinned tag via `gh api repos/<owner>/<repo>/commits/<tag> --jq .sha`, verified by the orchestrator (all four spot-checks match), and each pin carries a `# <tag>` comment.
- All 20 workflow files parse as valid YAML.
- `pnpm turbo run lint typecheck test` — all 32 tasks pass; `pnpm lint` — exit 0.

Closes #560

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BT6fVBZrmExXZj7vQ29881

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR hardens the CI/CD supply chain by SHA-pinning all mutable third-party action tags, removing a broken inlined SSH key step, and adding minimal required permissions to the `check-labels` job.

- Four third-party actions (`amannn/action-semantic-pull-request`, `dorny/paths-filter`, `dtolnay/rust-toolchain`, `pnpm/action-setup`) are pinned to verified full commit SHAs with tag comments, making Dependabot-managed updates possible.
- The `git config core.sshCommand "ssh -i <key>"` step in `_release.reusable.yml` is removed; it was never functional (`ssh -i` requires a file path, not raw key material) and redundant with the `ssh-key:` input already passed to `actions/checkout`.
- The `check-labels` job in `release.yml` gains explicit `contents: read` and `pull-requests: read` permissions, the latter required for the `gh api repos/.../commits/.../pulls` call to succeed.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are pure hardening with no logic modifications to release or CI orchestration.

Every change is a targeted security improvement: SHA pins replace mutable tags, a broken and redundant SSH inlining step is removed, and a missing permission is added to a read-only job. No business logic is touched, and the pull-requests: read addition directly addresses the previously flagged gap in check-labels.

No files require special attention. release.yml is the most sensitive file changed but its edit is minimal and correct.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/pr-title.yml | Pinned amannn/action-semantic-pull-request@v6 to a full commit SHA — the most security-critical pin in this PR because the workflow runs under pull_request_target. |
| .github/workflows/release.yml | Added contents: read and pull-requests: read to the check-labels job; both permissions are required for the gh api repos/.../commits/.../pulls call and the job is correctly scoped. |
| .github/workflows/_release.reusable.yml | Removed the broken/redundant Configure git SSH step that incorrectly passed raw key material (not a file path) to ssh -i; the deploy key continues to flow through actions/checkout's ssh-key: input correctly. |
| .github/workflows/_ci-detect-changes.reusable.yml | SHA-pinned dorny/paths-filter@v4 with a tag comment; no logic changes. |
| .github/workflows/_ci-integration.reusable.yml | SHA-pinned dtolnay/rust-toolchain@stable; Dependabot will now manage Rust toolchain version bumps. |
| .github/workflows/actions/setup-workspace/action.yml | SHA-pinned pnpm/action-setup@v5 in the shared composite action. |
| .github/workflows/examples-validate.yml | SHA-pinned pnpm/action-setup@v6; uses v6 directly (separate from the v5 pin in setup-workspace) with no logic changes. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[workflow_run: CI on main] --> B[check-labels\ncontents:read + pull-requests:read]
    B -->|gh api commits/SHA/pulls| C{Release label?}
    C -->|yes| D[release-auto\nid-token:write / contents:write]
    C -->|no| E[Skip]
    D --> F[_release.reusable.yml]
    F --> G[Checkout via ssh-key input]
    F --> H[Build + releasekit]
    J[pull_request_target] --> K[pr-title.yml\nSHA-pinned: amannn @48f2562]
    subgraph Pinned Actions
        L[dorny/paths-filter @7b450ff]
        M[dtolnay/rust-toolchain @4cda84d]
        N[pnpm/action-setup v5 @fc06bc1]
        O[pnpm/action-setup v6 @0ebf471]
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[workflow_run: CI on main] --> B[check-labels\ncontents:read + pull-requests:read]
    B -->|gh api commits/SHA/pulls| C{Release label?}
    C -->|yes| D[release-auto\nid-token:write / contents:write]
    C -->|no| E[Skip]
    D --> F[_release.reusable.yml]
    F --> G[Checkout via ssh-key input]
    F --> H[Build + releasekit]
    J[pull_request_target] --> K[pr-title.yml\nSHA-pinned: amannn @48f2562]
    subgraph Pinned Actions
        L[dorny/paths-filter @7b450ff]
        M[dtolnay/rust-toolchain @4cda84d]
        N[pnpm/action-setup v5 @fc06bc1]
        O[pnpm/action-setup v6 @0ebf471]
    end
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["ci: harden workflows — pin actions to SH..."](https://github.com/goosewobbler/releasekit/commit/d4a5bf5fe6c7169bd622d782110474b452bde7c3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45485186)</sub>

<!-- /greptile_comment -->