### PR TITLE
fix(publish): harden gh calls against arg injection; lock down temp .npmrc

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -61,4 +61,4 @@ export {
   type VersionPackageChangelog,
   type VersionPackageUpdate,
 } from './types.js';
-export { sanitizePackageName } from './utils.js';
+export { assertNotOption, sanitizePackageName } from './utils.js';

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -5,3 +5,17 @@
 export function sanitizePackageName(name: string): string {
   return name.startsWith('@') ? name.slice(1).replace(/\//g, '-') : name;
 }
+
+/**
+ * Reject a value a getopt/cobra-style CLI (git, gh) would parse as an option flag instead of a
+ * positional. `execFile`/`execFileSync` spawn with no shell, so there's no shell injection, but a
+ * leading-`-` positional still becomes argument injection: `gh release` exposes `-R/--repo` and
+ * `-F/--notes-file`, so a tag of `--repo=evil` or `-F/etc/passwd` would be read as a flag. Tag, ref,
+ * and package names can never legitimately start with `-`, so we refuse them before the value reaches
+ * the argv. Mirrors git's own assertNotOption barrier for the gh call sites (publish + notes-backfill).
+ */
+export function assertNotOption(value: string, kind: string): void {
+  if (value.startsWith('-')) {
+    throw new Error(`Refusing to run: ${kind} '${value}' looks like an option (starts with '-')`);
+  }
+}

--- a/packages/core/test/unit/utils.spec.ts
+++ b/packages/core/test/unit/utils.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { sanitizePackageName } from '../../src/utils.js';
+import { assertNotOption, sanitizePackageName } from '../../src/utils.js';
 
 describe('utils', () => {
   describe('sanitizePackageName', () => {
@@ -20,6 +20,25 @@ describe('utils', () => {
     it('should handle special characters', () => {
       expect(sanitizePackageName('@scope/pkg-name')).toBe('scope-pkg-name');
       expect(sanitizePackageName('@scope/pkg_name')).toBe('scope-pkg_name');
+    });
+  });
+
+  describe('assertNotOption', () => {
+    it('should throw for a value starting with a dash', () => {
+      expect(() => assertNotOption('-rf', 'tag')).toThrow(/looks like an option/);
+      expect(() => assertNotOption('--repo=evil', 'tag')).toThrow(/tag '--repo=evil'/);
+    });
+
+    it('should include the kind in the error message', () => {
+      expect(() => assertNotOption('-x', 'ref')).toThrow(/ref '-x'/);
+    });
+
+    it('should not throw for values that do not start with a dash', () => {
+      expect(() => assertNotOption('v1.0.0', 'tag')).not.toThrow();
+      expect(() => assertNotOption('@scope/pkg@v1.0.0', 'tag')).not.toThrow();
+      expect(() => assertNotOption('', 'tag')).not.toThrow();
+      // An interior dash is fine — only a leading dash is parsed as a flag.
+      expect(() => assertNotOption('release-v1.0.0', 'tag')).not.toThrow();
     });
   });
 });

--- a/packages/publish/src/stages/github-release.ts
+++ b/packages/publish/src/stages/github-release.ts
@@ -1,5 +1,5 @@
 import type { VersionPackageChangelog } from '@releasekit/core';
-import { debug, info, sanitizePackageName, success, warn } from '@releasekit/core';
+import { assertNotOption, debug, info, sanitizePackageName, success, warn } from '@releasekit/core';
 import type { GitHubReleaseResult, PipelineContext } from '../types.js';
 import { execCommand, execCommandSafe } from '../utils/exec.js';
 import { isPrerelease } from '../utils/semver.js';
@@ -208,6 +208,25 @@ export async function runGithubReleaseStage(ctx: PipelineContext): Promise<void>
   const skipPackages = config.githubRelease.skipPackages ?? [];
 
   for (const tag of tagsToRelease) {
+    // Argument-injection guard (defense-in-depth): the git stage creates the tag first and already
+    // rejects a leading `-`, but reject here too so a `-`-prefixed tag can never reach the `gh` argv
+    // (cobra would parse it as a flag, e.g. -R/--repo). Non-critical per the per-tag error strategy —
+    // record the failure and move on rather than aborting the whole stage.
+    try {
+      assertNotOption(tag, 'tag');
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
+      warn(`Failed to create GitHub release for ${tag}: ${reason}`);
+      ctx.output.githubReleases.push({
+        tag,
+        draft: config.githubRelease.draft,
+        prerelease: false,
+        success: false,
+        reason,
+      });
+      continue;
+    }
+
     // Skip GitHub release creation when the package is listed in githubRelease.skipPackages.
     // Tags are still created (needed for changelog range detection on the next release) and
     // npm publish still runs — only the `gh release create` call is skipped.

--- a/packages/publish/src/utils/npm-env.ts
+++ b/packages/publish/src/utils/npm-env.ts
@@ -13,7 +13,9 @@ export interface NpmEnvIsolation {
 function writeTempNpmrc(contents: string): { npmrcPath: string; cleanup: () => void } {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'releasekit-npmrc-'));
   const npmrcPath = path.join(dir, '.npmrc');
-  fs.writeFileSync(npmrcPath, contents, 'utf-8');
+  // The temp `.npmrc` carries an auth token; write it owner-only (parity with config's saveAuth) so
+  // it isn't left readable even if the enclosing 0700 mkdtemp dir's protection is ever weakened.
+  fs.writeFileSync(npmrcPath, contents, { encoding: 'utf-8', mode: 0o600 });
   return {
     npmrcPath,
     cleanup: () => {

--- a/packages/publish/test/unit/stages/github-release.spec.ts
+++ b/packages/publish/test/unit/stages/github-release.spec.ts
@@ -567,6 +567,30 @@ describe('github-release stage', () => {
     expect(args[titleIndex + 1]).toBe('my-package: v1.0.0');
   });
 
+  it('should reject a tag beginning with a dash instead of passing it to gh', async () => {
+    const { execCommand, execCommandSafe } = await import('../../../src/utils/exec.js');
+    const ctx = createContext({
+      input: { dryRun: false, updates: [], changelogs: [], tags: ['--repo=evil'] },
+      output: {
+        dryRun: false,
+        git: { committed: true, tags: ['--repo=evil'], pushed: true },
+        npm: [],
+        cargo: [],
+        verification: [],
+        githubReleases: [],
+      },
+    });
+
+    await runGithubReleaseStage(ctx);
+
+    // The `-`-prefixed tag never reaches either gh invocation.
+    expect(execCommand).not.toHaveBeenCalled();
+    expect(execCommandSafe).not.toHaveBeenCalled();
+    expect(ctx.output.githubReleases).toHaveLength(1);
+    expect(ctx.output.githubReleases[0]?.success).toBe(false);
+    expect(ctx.output.githubReleases[0]?.reason).toMatch(/looks like an option/);
+  });
+
   describe('githubRelease.skipPackages config', () => {
     it('should skip GitHub release creation for packages listed in skipPackages', async () => {
       const { execCommand } = await import('../../../src/utils/exec.js');

--- a/packages/publish/test/unit/utils/npm-env.spec.ts
+++ b/packages/publish/test/unit/utils/npm-env.spec.ts
@@ -62,4 +62,16 @@ describe('npm env isolation', () => {
 
     iso.cleanup();
   });
+
+  it('should write the token-bearing temp .npmrc with 0600 mode', () => {
+    process.env.NPM_TOKEN = 'npm_test_token';
+
+    const iso = createNpmSubprocessIsolation({ authMethod: 'token', registryUrl: 'https://registry.npmjs.org' });
+
+    const npmrcPath = iso.env.NPM_CONFIG_USERCONFIG as string;
+    createdPaths.push(npmrcPath);
+    expect(fs.statSync(npmrcPath).mode & 0o777).toBe(0o600);
+
+    iso.cleanup();
+  });
 });

--- a/packages/release/src/backfill/github-release.ts
+++ b/packages/release/src/backfill/github-release.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process';
-import { NOTES_MARKER } from '@releasekit/core';
+import { assertNotOption, NOTES_MARKER } from '@releasekit/core';
 
 /**
  * Marker that identifies a GitHub release body releasekit authored. Embedded at the top of every
@@ -48,6 +48,7 @@ export function withMarker(body: string): string {
  * or any other failure) throws so the caller surfaces it instead of silently skipping the work.
  */
 export function getReleaseBody(tag: string): string | null {
+  assertNotOption(tag, 'tag');
   try {
     return execFileSync('gh', ['release', 'view', tag, '--json', 'body', '--jq', '.body'], { encoding: 'utf8' });
   } catch (err) {
@@ -63,6 +64,7 @@ export function getReleaseBody(tag: string): string | null {
 
 /** Overwrite a GitHub release body via `gh release edit`. */
 export function editReleaseBody(tag: string, body: string): void {
+  assertNotOption(tag, 'tag');
   execFileSync('gh', ['release', 'edit', tag, '--notes', body], { encoding: 'utf8' });
 }
 
@@ -71,6 +73,7 @@ export function editReleaseBody(tag: string, body: string): void {
  * Throws on auth/CLI/network failures.
  */
 export function getReleaseInfo(tag: string): { isDraft: boolean; body: string | null } | null {
+  assertNotOption(tag, 'tag');
   try {
     const json = execFileSync('gh', ['release', 'view', tag, '--json', 'isDraft,body'], { encoding: 'utf8' });
     const parsed = JSON.parse(json) as { isDraft: boolean; body: string | null };

--- a/packages/release/test/unit/backfill/github-release.spec.ts
+++ b/packages/release/test/unit/backfill/github-release.spec.ts
@@ -2,6 +2,7 @@ import { execFileSync } from 'node:child_process';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   decideReleaseUpdate,
+  editReleaseBody,
   getReleaseBody,
   getReleaseInfo,
   NOTES_MARKER,
@@ -96,6 +97,27 @@ describe('getReleaseBody', () => {
       throw execError('gh: Bad credentials (HTTP 401)\n');
     });
     expect(() => getReleaseBody('v1.0.0')).toThrow(/Bad credentials/);
+  });
+});
+
+describe('gh argument-injection guard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should reject a tag beginning with a dash before reaching gh', () => {
+    // Backfill enumerates tags from existing repo refs, so an out-of-band `refs/tags/-…` can reach
+    // gh unguarded — cobra would parse the leading-`-` positional as a flag. Reject before spawn.
+    expect(() => getReleaseBody('--repo=evil')).toThrow(/looks like an option/);
+    expect(() => getReleaseInfo('-F/etc/passwd')).toThrow(/looks like an option/);
+    expect(() => editReleaseBody('-x', 'body')).toThrow(/looks like an option/);
+    expect(execFileSync).not.toHaveBeenCalled();
+  });
+
+  it('should still call gh for a normal tag', () => {
+    vi.mocked(execFileSync).mockReturnValue('## Notes\n');
+    getReleaseBody('v1.0.0');
+    expect(execFileSync).toHaveBeenCalledTimes(1);
   });
 });
 


### PR DESCRIPTION
## Summary

Two small, self-contained publish-path hardening fixes from the security review (defense-in-depth):

- **Leading-`-` guard on `gh` calls.** Adds `assertNotOption` to `@releasekit/core` (mirrors git's existing barrier) and applies it to the `tag` positional before it reaches the `gh` argv in `packages/publish/src/stages/github-release.ts` (both `release view` and `release create`) and `packages/release/src/backfill/github-release.ts` (`getReleaseBody`/`editReleaseBody`/`getReleaseInfo`). `gh` (cobra) would otherwise parse a `-`-prefixed tag as a flag (`-R/--repo`, `-F/--notes-file`). Reachability is low in the publish pipeline (git creates the tag first and rejects leading-`-`), but the backfill path feeds `gh` tags enumerated from existing repo refs, so an out-of-band `refs/tags/-…` reached `gh` unguarded. Not RCE — `gh` has no shell/exec flag. In the publish stage the guard records a failed per-tag result and continues (preserving the stage's per-tag non-critical error strategy); in backfill it throws (consistent with existing handling).
- **`0600` mode on the temp `.npmrc`.** The token-bearing temp `.npmrc` is now written `mode: 0o600` (`packages/publish/src/utils/npm-env.ts`), for parity with config's `saveAuth`.

The guard lives in `@releasekit/core` (both `packages/publish` and `packages/release` already depend on it) since the reachable backfill call site is in `packages/release`.

## Test plan

- New unit tests (all `should …`): dash-guard rejection before `gh` is invoked (core helper, the three backfill functions, and the publish stage), and the temp `.npmrc` `0600` mode.
- Re-verified by the orchestrator the CI way: `biome check .` exit 0; forced `turbo run typecheck test --force` → 24/24, 0 cached.

Closes #561

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BT6fVBZrmExXZj7vQ29881

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR hardens the publish and backfill paths against argument injection into `gh` CLI calls and tightens the file-permission posture of the token-bearing temp `.npmrc`. Both fixes are narrowly scoped and backed by new unit tests.

- **`assertNotOption` guard in `@releasekit/core`**: rejects any tag value starting with `-` before it reaches a `gh` argv; applied to `runGithubReleaseStage` (publish, non-critical per-tag strategy) and all three backfill functions `getReleaseBody`/`editReleaseBody`/`getReleaseInfo` (throws, consistent with existing error handling there).
- **`0o600` mode on temp `.npmrc`**: the token-bearing file is now written owner-only, matching the permission that `config`'s `saveAuth` already enforces and adding a second layer of protection beyond the `0700` mkdtemp directory.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — both changes are narrowly scoped, well-tested, and do not alter any existing behaviour for valid inputs.

The guard correctly uses `startsWith('-')` which catches both short (`-x`) and long (`--flag`) forms. The per-tag try/catch in the publish stage preserves the existing non-critical error strategy. The backfill functions place `assertNotOption` before the try/catch so a bad tag throws rather than being absorbed. The `0o600` file-mode test masks `mode & 0o777` correctly. Env-var cleanup in the npm-env test suite uses `afterEach` to delete `NPM_TOKEN`/`NODE_AUTH_TOKEN`, so no cross-test leakage. No issues found across all nine changed files.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/core/src/utils.ts | Adds `assertNotOption` guard that rejects any value starting with `-` before it can reach a CLI argv; well-documented and correctly scoped. |
| packages/core/src/index.ts | Exports the new `assertNotOption` helper from the core public API. |
| packages/publish/src/stages/github-release.ts | Wraps `assertNotOption` in a per-tag try/catch consistent with the existing non-critical error strategy; records failure and continues rather than aborting the stage. |
| packages/publish/src/utils/npm-env.ts | Adds `mode: 0o600` to the token-bearing temp `.npmrc` write, matching the owner-only permission that `config`'s `saveAuth` already enforces. |
| packages/release/src/backfill/github-release.ts | Guards all three `gh` call sites (`getReleaseBody`, `editReleaseBody`, `getReleaseInfo`) with `assertNotOption`; the guard throws synchronously before `execFileSync` is reached. |
| packages/core/test/unit/utils.spec.ts | New `assertNotOption` tests cover dash-prefix rejection (single and double dash), kind inclusion in error message, and clean acceptance of normal values. |
| packages/publish/test/unit/stages/github-release.spec.ts | New test verifies that a dash-prefixed tag is caught before either `execCommand` or `execCommandSafe` is invoked, and that a failure result is recorded in the output. |
| packages/publish/test/unit/utils/npm-env.spec.ts | New test uses `fs.statSync(...).mode & 0o777` to confirm the written `.npmrc` has exactly `0600` permissions; `afterEach` properly cleans up env vars and paths. |
| packages/release/test/unit/backfill/github-release.spec.ts | New `gh argument-injection guard` suite tests all three guarded functions reject dash-prefixed tags without spawning `execFileSync`, plus a happy-path check for normal tags. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller
    participant assertNotOption
    participant gh

    Note over Caller,gh: publish stage (non-critical, per-tag)
    Caller->>assertNotOption: assertNotOption(tag, 'tag')
    alt tag starts with '-'
        assertNotOption-->>Caller: throws Error
        Caller->>Caller: "push {success:false, reason} → continue"
    else tag is safe
        assertNotOption-->>Caller: returns void
        Caller->>gh: execCommandSafe / execCommand
        gh-->>Caller: result
    end

    Note over Caller,gh: backfill path (throws to surface errors)
    Caller->>assertNotOption: assertNotOption(tag, 'tag')
    alt tag starts with '-'
        assertNotOption-->>Caller: throws Error (propagates up)
    else tag is safe
        assertNotOption-->>Caller: returns void
        Caller->>gh: execFileSync(gh, [...])
        gh-->>Caller: stdout
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller
    participant assertNotOption
    participant gh

    Note over Caller,gh: publish stage (non-critical, per-tag)
    Caller->>assertNotOption: assertNotOption(tag, 'tag')
    alt tag starts with '-'
        assertNotOption-->>Caller: throws Error
        Caller->>Caller: "push {success:false, reason} → continue"
    else tag is safe
        assertNotOption-->>Caller: returns void
        Caller->>gh: execCommandSafe / execCommand
        gh-->>Caller: result
    end

    Note over Caller,gh: backfill path (throws to surface errors)
    Caller->>assertNotOption: assertNotOption(tag, 'tag')
    alt tag starts with '-'
        assertNotOption-->>Caller: throws Error (propagates up)
    else tag is safe
        assertNotOption-->>Caller: returns void
        Caller->>gh: execFileSync(gh, [...])
        gh-->>Caller: stdout
    end
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(publish): harden gh calls against ar..."](https://github.com/goosewobbler/releasekit/commit/fb2811cdfdae2c7c224cbf1b3f88475a6e7f4394) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45485352)</sub>

<!-- /greptile_comment -->