### PR TITLE
fix(notes): harden LLM notes reliability

### DIFF
--- a/packages/notes/src/core/pipeline.ts
+++ b/packages/notes/src/core/pipeline.ts
@@ -15,9 +15,11 @@ import {
   generateReleaseNotes,
   summarizeEntries,
 } from '../llm/index.js';
+import { isRetryableLLMError } from '../llm/retryable.js';
 import { type FormatVersionOptions, formatVersion, writeMarkdown } from '../output/markdown.js';
 import { writeVersionedNotes } from '../output/versioned.js';
 import { renderTemplate } from '../templates/index.js';
+import { mapWithConcurrency } from '../utils/concurrency.js';
 import { withRetry } from '../utils/retry.js';
 import type {
   ChangelogInput,
@@ -198,6 +200,7 @@ async function processWithLLM(
     entries: context.entries,
   };
 
+  let provider: LLMProvider;
   try {
     info(`Using LLM provider: ${llmConfig.provider}${llmConfig.model ? ` (${llmConfig.model})` : ''}`);
     if (llmConfig.baseURL) {
@@ -211,40 +214,69 @@ async function processWithLLM(
       : rawProvider;
     const retryOpts = llmConfig.retry ?? LLM_DEFAULTS.retry;
     const configOptions = llmConfig.options;
-    const provider: LLMProvider = {
+    provider = {
       name: baseProvider.name,
       capabilities: baseProvider.capabilities,
+      // Fail fast on non-transient errors (4xx auth/validation); only retry timeout/429/5xx/network.
       complete: (messages, opts) =>
-        withRetry(() => baseProvider.complete(messages, { ...configOptions, ...opts }), retryOpts),
+        withRetry(() => baseProvider.complete(messages, { ...configOptions, ...opts }), {
+          ...retryOpts,
+          shouldRetry: isRetryableLLMError,
+        }),
     };
 
     const activeTasks = Object.entries(tasks)
       .filter(([, enabled]) => enabled)
       .map(([name]) => name);
     info(`Running LLM tasks: ${activeTasks.join(', ')}`);
+  } catch (error) {
+    // Provider setup failed — nothing computed yet, so fall back to the raw context.
+    warn(`LLM setup failed: ${error instanceof Error ? error.message : String(error)}`);
+    warn('Falling back to non-LLM changelog rendering. Check your LLM config or set RELEASEKIT_DEBUG=1 for details.');
+    return context;
+  }
 
-    if (tasks.enhance && tasks.categorize) {
+  // Each task soft-fails independently: a late summarize/releaseNotes failure must not discard the
+  // (already paid-for) enhancement and categorization computed earlier in the same run.
+  const taskFailed = (task: string, error: unknown): void => {
+    warn(`LLM ${task} failed: ${error instanceof Error ? error.message : String(error)}. Keeping results so far.`);
+  };
+
+  if (tasks.enhance && tasks.categorize) {
+    try {
       info('Enhancing and categorizing entries with LLM...');
       const result = await enhanceAndCategorize(provider, context.entries, llmContext);
       enhanced.entries = result.enhancedEntries;
       enhanced.categories = buildOrderedCategories(result.categories, llmContext.categories);
       info(`Enhanced ${enhanced.entries.length} entries into ${result.categories.length} categories`);
-    } else {
-      if (tasks.enhance) {
+    } catch (error) {
+      taskFailed('enhance+categorize', error);
+    }
+  } else {
+    if (tasks.enhance) {
+      try {
         info('Enhancing entries with LLM...');
         enhanced.entries = await enhanceEntries(provider, context.entries, llmContext, llmConfig.concurrency);
         info(`Enhanced ${enhanced.entries.length} entries`);
+      } catch (error) {
+        taskFailed('enhance', error);
       }
+    }
 
-      if (tasks.categorize) {
+    if (tasks.categorize) {
+      try {
         info('Categorizing entries with LLM...');
         const categorized = await categorizeEntries(provider, enhanced.entries, llmContext);
         enhanced.categories = buildOrderedCategories(categorized, llmContext.categories);
         info(`Created ${categorized.length} categories`);
+      } catch (error) {
+        taskFailed('categorize', error);
       }
     }
+  }
 
-    if (tasks.summarize) {
+  if (tasks.summarize) {
+    try {
       info('Summarizing entries with LLM...');
       enhanced.summary = await summarizeEntries(provider, enhanced.entries, llmContext);
       if (enhanced.summary) {
@@ -253,9 +285,13 @@ async function processWithLLM(
       } else {
         warn('Summary generation returned empty result');
       }
+    } catch (error) {
+      taskFailed('summarize', error);
     }
+  }
 
-    if (tasks.releaseNotes) {
+  if (tasks.releaseNotes) {
+    try {
       info('Generating release notes with LLM...');
       enhanced.releaseNotes = await generateReleaseNotes(provider, enhanced.entries, llmContext);
       if (enhanced.releaseNotes) {
@@ -263,17 +299,15 @@ async function processWithLLM(
       } else {
         warn('Release notes generation returned empty result');
       }
+    } catch (error) {
+      taskFailed('releaseNotes', error);
     }
-
-    return {
-      ...context,
-      enhanced,
-    };
-  } catch (error) {
-    warn(`LLM processing failed: ${error instanceof Error ? error.message : String(error)}`);
-    warn('Falling back to non-LLM changelog rendering. Check your LLM config or set RELEASEKIT_DEBUG=1 for details.');
-    return context;
   }
+
+  return {
+    ...context,
+    enhanced,
+  };
 }
 
 function getBuiltinTemplatePath(style: string): string {
@@ -437,10 +471,11 @@ export async function runPipeline(
     }
 
     const allPackageNames = contexts.map((c) => c.packageName);
-    contexts = await Promise.all(
-      contexts.map((ctx) =>
-        processWithLLM(ctx, llmConfig, examplesByPackage.get(ctx.packageName) ?? [], allPackageNames),
-      ),
+    // Bound cross-package fan-out with the same `concurrency` knob used within a package, so a large
+    // monorepo doesn't open one in-flight LLM request per package all at once and trip rate limits.
+    const concurrency = llmConfig.concurrency ?? LLM_DEFAULTS.concurrency;
+    contexts = await mapWithConcurrency(contexts, concurrency, (ctx) =>
+      processWithLLM(ctx, llmConfig, examplesByPackage.get(ctx.packageName) ?? [], allPackageNames),
     );
   }
 

--- a/packages/notes/src/errors/index.ts
+++ b/packages/notes/src/errors/index.ts
@@ -28,6 +28,20 @@ export class LLMError extends NotesError {
     'Check network connectivity',
     'Try with --no-llm to skip LLM processing',
   ];
+
+  /**
+   * Whether the underlying failure is transient and worth retrying (timeout / 429 / 5xx / network).
+   * `false` marks a non-retryable failure (4xx auth/validation) so `withRetry` fails fast instead of
+   * burning the whole backoff budget. `undefined` means "unclassified" — callers retry by default.
+   */
+  readonly retryable?: boolean;
+
+  constructor(message: string, options?: { retryable?: boolean; cause?: unknown }) {
+    super(message);
+    // Chain the original provider/SDK error so its stack survives (the message only carries its text).
+    if (options?.cause !== undefined) this.cause = options.cause;
+    this.retryable = options?.retryable;
+  }
 }
 
 export class GitHubError extends NotesError {

--- a/packages/notes/src/llm/anthropic.ts
+++ b/packages/notes/src/llm/anthropic.ts
@@ -5,6 +5,7 @@ import { BaseLLMProvider } from './base.js';
 import type { CompleteResult, LLMMessage } from './messages.js';
 import { debugLogMessages } from './messages.js';
 import type { ProviderCapabilities } from './provider.js';
+import { isRetryableProviderError } from './retryable.js';
 
 export interface AnthropicConfig {
   apiKey?: string;
@@ -17,6 +18,8 @@ export class AnthropicProvider extends BaseLLMProvider {
     systemRole: true,
     structuredOutputs: true,
     toolUse: true,
+    // temperature is deliberately not forwarded (see complete()), so it must not key the cache.
+    honorsTemperature: false,
   };
 
   private client: Anthropic;
@@ -38,6 +41,10 @@ export class AnthropicProvider extends BaseLLMProvider {
   async complete(messages: LLMMessage[], options?: CompleteOptions): Promise<CompleteResult> {
     debugLogMessages(this.name, messages);
 
+    // `options.temperature` is intentionally not passed to the Messages API: thinking-enabled models
+    // (Sonnet 5, Fable 5, Opus 4.8) reject `temperature` with a 400, and releasekit uses one provider
+    // for any configured model. Reflected as capabilities.honorsTemperature: false so the cache key
+    // ignores it too. To honor temperature, gate it on the model and drop that capability flag.
     const systemMsg = messages.find((m) => m.role === 'system');
     const nonSystemMessages = messages
       .filter((m) => m.role !== 'system')
@@ -84,17 +91,24 @@ export class AnthropicProvider extends BaseLLMProvider {
         { signal },
       );
 
-      const firstBlock = response.content[0];
+      // Find the text block rather than assuming content[0]: thinking-enabled models (Sonnet 5,
+      // Fable 5) return one or more `thinking` blocks ahead of the `text` block for non-schema tasks.
+      const textBlock = response.content.find((b) => b.type === 'text');
 
-      if (!firstBlock || firstBlock.type !== 'text') {
-        throw new LLMError('Unexpected response format from Anthropic');
+      if (textBlock?.type !== 'text') {
+        throw new LLMError('Expected a text block in Anthropic response');
       }
 
-      return { content: firstBlock.text };
+      return { content: textBlock.text };
     } catch (error) {
       if (error instanceof LLMError) throw error;
-      if (signal.aborted) throw new LLMError(`Anthropic request timed out after ${this.getTimeout(options)}ms`);
-      throw new LLMError(`Anthropic API error: ${error instanceof Error ? error.message : String(error)}`);
+      if (signal.aborted) {
+        throw new LLMError(`Anthropic request timed out after ${this.getTimeout(options)}ms`, { retryable: true });
+      }
+      throw new LLMError(`Anthropic API error: ${error instanceof Error ? error.message : String(error)}`, {
+        cause: error,
+        retryable: isRetryableProviderError(error),
+      });
     }
   }
 }

--- a/packages/notes/src/llm/cache.ts
+++ b/packages/notes/src/llm/cache.ts
@@ -43,6 +43,10 @@ export function withContentHashCache(
     name: provider.name,
     capabilities: provider.capabilities,
     async complete(messages: LLMMessage[], options?: CompleteOptions): Promise<CompleteResult> {
+      // Only key on temperature for providers that actually apply it. Anthropic reports
+      // honorsTemperature: false — it never forwards temperature — so including it here would bust an
+      // otherwise-identical cached response whenever the (ignored) value changes.
+      const temperature = provider.capabilities.honorsTemperature === false ? undefined : options?.temperature;
       const key = createHash('sha256')
         .update(
           stableStringify({
@@ -50,7 +54,7 @@ export function withContentHashCache(
             model: identity.model,
             baseURL: identity.baseURL,
             messages,
-            temperature: options?.temperature,
+            temperature,
             maxTokens: options?.maxTokens,
             schema: options?.schema,
             toolName: options?.toolName,

--- a/packages/notes/src/llm/defaults.ts
+++ b/packages/notes/src/llm/defaults.ts
@@ -5,6 +5,10 @@ export const LLM_DEFAULTS = {
   // 0.7 balances coherence (low temp) with natural-sounding variation (high temp).
   temperature: 0.7,
   concurrency: 5,
+  // Max entries per enhance+categorize prompt. Large releases in a single prompt overflow the output
+  // ceiling → entry-count validation fails → corrective retries resend a growing transcript. Bounded
+  // chunks keep each call within budget and isolate a bad chunk's fallback to that chunk alone.
+  enhanceCategorizeChunkSize: 30,
   retry: {
     maxAttempts: 3,
     initialDelay: 1_000,

--- a/packages/notes/src/llm/ollama.ts
+++ b/packages/notes/src/llm/ollama.ts
@@ -6,6 +6,7 @@ import { BaseLLMProvider } from './base.js';
 import type { CompleteResult, LLMMessage } from './messages.js';
 import { debugLogMessages } from './messages.js';
 import type { ProviderCapabilities } from './provider.js';
+import { isRetryableProviderError, isRetryableStatus } from './retryable.js';
 
 export interface OllamaConfig {
   apiKey?: string;
@@ -41,6 +42,7 @@ export class OllamaProvider extends BaseLLMProvider {
     systemRole: true,
     structuredOutputs: true,
     toolUse: false,
+    honorsTemperature: true,
   };
 
   private baseURL: string;
@@ -96,10 +98,13 @@ export class OllamaProvider extends BaseLLMProvider {
             : 'OLLAMA_API_KEY is not set. Set the environment variable or use --no-llm to skip LLM processing.';
           throw new LLMError(
             `Ollama request failed: ${response.status} ${response.statusText}${text ? ` - ${text}` : ''}. ${keyHint}`,
+            { retryable: false },
           );
         }
         const text = await response.text();
-        throw new LLMError(`Ollama request failed: ${response.status} ${text}`);
+        throw new LLMError(`Ollama request failed: ${response.status} ${text}`, {
+          retryable: isRetryableStatus(response.status),
+        });
       }
 
       const data = (await response.json()) as OllamaChatResponse;
@@ -125,8 +130,13 @@ export class OllamaProvider extends BaseLLMProvider {
       return { content };
     } catch (error) {
       if (error instanceof LLMError) throw error;
-      if (signal.aborted) throw new LLMError(`Ollama request timed out after ${this.getTimeout(options)}ms`);
-      throw new LLMError(`Ollama error: ${error instanceof Error ? error.message : String(error)}`);
+      if (signal.aborted) {
+        throw new LLMError(`Ollama request timed out after ${this.getTimeout(options)}ms`, { retryable: true });
+      }
+      throw new LLMError(`Ollama error: ${error instanceof Error ? error.message : String(error)}`, {
+        cause: error,
+        retryable: isRetryableProviderError(error),
+      });
     }
   }
 }

--- a/packages/notes/src/llm/openai-compatible.ts
+++ b/packages/notes/src/llm/openai-compatible.ts
@@ -5,6 +5,7 @@ import { BaseLLMProvider } from './base.js';
 import type { CompleteResult, LLMMessage } from './messages.js';
 import { debugLogMessages } from './messages.js';
 import type { ProviderCapabilities } from './provider.js';
+import { isRetryableProviderError } from './retryable.js';
 
 export interface OpenAICompatibleConfig {
   apiKey?: string;
@@ -18,6 +19,7 @@ export class OpenAICompatibleProvider extends BaseLLMProvider {
     systemRole: true,
     structuredOutputs: false,
     toolUse: false,
+    honorsTemperature: true,
   };
 
   private client: OpenAI;
@@ -62,8 +64,13 @@ export class OpenAICompatibleProvider extends BaseLLMProvider {
       return { content };
     } catch (error) {
       if (error instanceof LLMError) throw error;
-      if (signal.aborted) throw new LLMError(`${this.name} request timed out after ${this.getTimeout(options)}ms`);
-      throw new LLMError(`LLM API error: ${error instanceof Error ? error.message : String(error)}`);
+      if (signal.aborted) {
+        throw new LLMError(`${this.name} request timed out after ${this.getTimeout(options)}ms`, { retryable: true });
+      }
+      throw new LLMError(`LLM API error: ${error instanceof Error ? error.message : String(error)}`, {
+        cause: error,
+        retryable: isRetryableProviderError(error),
+      });
     }
   }
 }

--- a/packages/notes/src/llm/openai.ts
+++ b/packages/notes/src/llm/openai.ts
@@ -7,6 +7,7 @@ import { BaseLLMProvider } from './base.js';
 import type { CompleteResult, LLMMessage } from './messages.js';
 import { debugLogMessages } from './messages.js';
 import type { ProviderCapabilities } from './provider.js';
+import { isRetryableProviderError } from './retryable.js';
 
 export interface OpenAIConfig {
   apiKey?: string;
@@ -20,6 +21,7 @@ export class OpenAIProvider extends BaseLLMProvider {
     systemRole: true,
     structuredOutputs: true,
     toolUse: false,
+    honorsTemperature: true,
   };
 
   private client: OpenAI;
@@ -91,8 +93,13 @@ export class OpenAIProvider extends BaseLLMProvider {
       return { content };
     } catch (error) {
       if (error instanceof LLMError) throw error;
-      if (signal.aborted) throw new LLMError(`OpenAI request timed out after ${this.getTimeout(options)}ms`);
-      throw new LLMError(`OpenAI API error: ${error instanceof Error ? error.message : String(error)}`);
+      if (signal.aborted) {
+        throw new LLMError(`OpenAI request timed out after ${this.getTimeout(options)}ms`, { retryable: true });
+      }
+      throw new LLMError(`OpenAI API error: ${error instanceof Error ? error.message : String(error)}`, {
+        cause: error,
+        retryable: isRetryableProviderError(error),
+      });
     }
   }
 }

--- a/packages/notes/src/llm/provider.ts
+++ b/packages/notes/src/llm/provider.ts
@@ -7,6 +7,14 @@ export interface ProviderCapabilities {
   systemRole: boolean;
   structuredOutputs: boolean;
   toolUse: boolean;
+  /**
+   * Whether the provider actually applies the `temperature` option to its output. Absent = honored
+   * (the common case). When `false`, the on-disk cache leaves `temperature` out of the cache key —
+   * toggling a parameter the provider ignores must not bust an otherwise-identical cached response.
+   * Anthropic sets this `false`: it never forwards `temperature`, and thinking-enabled models reject
+   * it with a 400.
+   */
+  honorsTemperature?: boolean;
 }
 
 export interface LLMProvider {

--- a/packages/notes/src/llm/retryable.ts
+++ b/packages/notes/src/llm/retryable.ts
@@ -1,0 +1,53 @@
+import { LLMError } from '../errors/index.js';
+
+/** Node/undici socket-level failures — transient, so worth retrying. */
+const NETWORK_ERROR_CODES = new Set([
+  'ECONNRESET',
+  'ECONNREFUSED',
+  'ECONNABORTED',
+  'ETIMEDOUT',
+  'ENOTFOUND',
+  'EAI_AGAIN',
+  'EPIPE',
+  'ENETUNREACH',
+  'ENETDOWN',
+]);
+
+/**
+ * Classify an HTTP status as retryable. Only transient failures are retried: 429 (rate limit),
+ * 5xx (server), and the timeout/conflict/too-early family (408/409/425). Every other 4xx is an
+ * auth, permission, validation, or not-found error that retrying can't fix — fail fast.
+ */
+export function isRetryableStatus(status: number): boolean {
+  if (status === 408 || status === 409 || status === 425 || status === 429) return true;
+  if (status >= 500) return true;
+  if (status >= 400) return false;
+  // Non-error status (shouldn't reach here for a thrown error) — retry rather than silently drop.
+  return true;
+}
+
+/**
+ * Classify a raw provider/SDK error (before it's wrapped in an {@link LLMError}). The Anthropic and
+ * OpenAI SDKs expose `.status`; fetch/undici surface a socket `.code` or an abort/timeout `.name`.
+ * Unknown shapes default to retryable so a genuinely transient error is never dropped — the only
+ * fail-fast path is an explicit non-retryable 4xx status.
+ */
+export function isRetryableProviderError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return true;
+  const e = error as { status?: unknown; code?: unknown; name?: unknown };
+  if (typeof e.status === 'number') return isRetryableStatus(e.status);
+  if (typeof e.code === 'string' && NETWORK_ERROR_CODES.has(e.code)) return true;
+  // Everything else — abort/timeout error names (AbortError, TimeoutError, APIConnectionError,
+  // APIConnectionTimeoutError) and unknown shapes alike — defaults to retryable; the only fail-fast
+  // path is the explicit non-retryable 4xx status handled above.
+  return true;
+}
+
+/**
+ * Predicate for {@link withRetry}: an {@link LLMError} carries the provider's retry classification;
+ * any other error (unclassified) is retried by default.
+ */
+export function isRetryableLLMError(error: unknown): boolean {
+  if (error instanceof LLMError) return error.retryable ?? true;
+  return true;
+}

--- a/packages/notes/src/llm/tasks/enhance-and-categorize.ts
+++ b/packages/notes/src/llm/tasks/enhance-and-categorize.ts
@@ -1,6 +1,7 @@
 import { warn } from '@releasekit/core';
 import type { ChangelogEntry, LLMCategory } from '../../core/types.js';
 import { LLMError } from '../../errors/index.js';
+import { LLM_DEFAULTS } from '../defaults.js';
 import { renderExamplesBlock } from '../examples/parser.js';
 import type { CategorizeContext, CategorizedEntries, EnhanceContext, LLMProvider } from '../index.js';
 import type { LLMMessage } from '../messages.js';
@@ -134,6 +135,54 @@ export function createEnhanceAndCategorizeValidator(
   };
 }
 
+/**
+ * Merge `incoming` categories into `target` by category name, preserving first-seen order and
+ * concatenating entries. Chunked runs can each emit e.g. a "Fixed" category — without merging, the
+ * changelog would render duplicate sections for the same name.
+ */
+function mergeCategories(target: CategorizedEntries[], incoming: CategorizedEntries[]): void {
+  for (const cat of incoming) {
+    const existing = target.find((c) => c.category === cat.category);
+    if (existing) existing.entries.push(...cat.entries);
+    else target.push({ category: cat.category, entries: [...cat.entries] });
+  }
+}
+
+async function enhanceAndCategorizeChunk(
+  provider: LLMProvider,
+  chunk: ChangelogEntry[],
+  context: EnhanceContext & CategorizeContext,
+  systemPrompt: string,
+): Promise<CombinedResult> {
+  const initialMessages: LLMMessage[] = [
+    { role: 'system', content: systemPrompt },
+    { role: 'user', content: buildUserPrompt(chunk) },
+  ];
+
+  try {
+    return await runCorrectiveTask({
+      provider,
+      initialMessages,
+      schema: buildEnhanceAndCategorizeSchema(context.categories ?? []),
+      toolName: 'emit_release_notes',
+      validate: createEnhanceAndCategorizeValidator(chunk, context),
+    });
+  } catch (error) {
+    if (error instanceof LLMError) {
+      warn(`enhanceAndCategorize failed for a ${chunk.length}-entry chunk: ${error.message}. Returning it ungrouped.`);
+      // Triggered by structural validation failures the LLM couldn't recover from across the
+      // retry budget: malformed JSON, schema-incompatible output, wrong entry count, or
+      // categories outside the configured list. (Disallowed scopes don't reach here — the
+      // configured invalidScopeAction resolves them in-place.) Strip the original entries'
+      // scope/leadIn since the LLM run never produced validated values for either. Isolated to this
+      // chunk so one bad batch can't drag the whole release into the General fallback.
+      const stripped = chunk.map((e) => ({ ...e, scope: undefined, leadIn: undefined }));
+      return { enhancedEntries: stripped, categories: [{ category: 'General', entries: stripped }] };
+    }
+    throw error;
+  }
+}
+
 export async function enhanceAndCategorize(
   provider: LLMProvider,
   entries: ChangelogEntry[],
@@ -151,30 +200,20 @@ export async function enhanceAndCategorize(
     context.prompts,
   );
 
-  const initialMessages: LLMMessage[] = [
-    { role: 'system', content: systemPrompt },
-    { role: 'user', content: buildUserPrompt(entries) },
-  ];
+  // Chunk so a large release doesn't go into one prompt: the whole set overflows the output ceiling,
+  // fails entry-count validation, and drives corrective retries that resend a growing transcript
+  // (~3× tokens by attempt 3). Bounded chunks keep each call within budget with per-chunk corrective
+  // retry and per-chunk fallback. A release at or under the chunk size is a single call, unchanged.
+  const chunkSize = LLM_DEFAULTS.enhanceCategorizeChunkSize;
+  const enhancedEntries: ChangelogEntry[] = [];
+  const categories: CategorizedEntries[] = [];
 
-  try {
-    return await runCorrectiveTask({
-      provider,
-      initialMessages,
-      schema: buildEnhanceAndCategorizeSchema(context.categories ?? []),
-      toolName: 'emit_release_notes',
-      validate: createEnhanceAndCategorizeValidator(entries, context),
-    });
-  } catch (error) {
-    if (error instanceof LLMError) {
-      warn(`enhanceAndCategorize failed after all attempts: ${error.message}. Returning entries ungrouped.`);
-      // Triggered by structural validation failures the LLM couldn't recover from across the
-      // retry budget: malformed JSON, schema-incompatible output, wrong entry count, or
-      // categories outside the configured list. (Disallowed scopes don't reach here — the
-      // configured invalidScopeAction resolves them in-place.) Strip the original entries'
-      // scope/leadIn since the LLM run never produced validated values for either.
-      const stripped = entries.map((e) => ({ ...e, scope: undefined, leadIn: undefined }));
-      return { enhancedEntries: stripped, categories: [{ category: 'General', entries: stripped }] };
-    }
-    throw error;
+  for (let i = 0; i < entries.length; i += chunkSize) {
+    const chunk = entries.slice(i, i + chunkSize);
+    const result = await enhanceAndCategorizeChunk(provider, chunk, context, systemPrompt);
+    enhancedEntries.push(...result.enhancedEntries);
+    mergeCategories(categories, result.categories);
   }
+
+  return { enhancedEntries, categories };
 }

--- a/packages/notes/src/llm/tasks/enhance.ts
+++ b/packages/notes/src/llm/tasks/enhance.ts
@@ -1,3 +1,4 @@
+import { warn } from '@releasekit/core';
 import type { ChangelogEntry } from '../../core/types.js';
 import { LLM_DEFAULTS } from '../defaults.js';
 import type { EnhanceContext, LLMProvider } from '../index.js';
@@ -49,6 +50,7 @@ export async function enhanceEntries(
   concurrency: number = LLM_DEFAULTS.concurrency,
 ): Promise<ChangelogEntry[]> {
   const results: ChangelogEntry[] = [];
+  let failures = 0;
 
   for (let i = 0; i < entries.length; i += concurrency) {
     const batch = entries.slice(i, i + concurrency);
@@ -58,11 +60,18 @@ export async function enhanceEntries(
           const newDescription = await enhanceEntry(provider, entry, context);
           return { ...entry, description: newDescription };
         } catch {
+          // Per-entry soft-fail: keep the raw entry so one failure doesn't sink the batch.
+          failures++;
           return entry;
         }
       }),
     );
     results.push(...batchResults);
+  }
+
+  if (failures > 0) {
+    // Surface the count so a run that silently mixes enhanced and raw voice is visible.
+    warn(`LLM enhancement failed for ${failures} of ${entries.length} entries; keeping their original text.`);
   }
 
   return results;

--- a/packages/notes/src/utils/concurrency.ts
+++ b/packages/notes/src/utils/concurrency.ts
@@ -1,0 +1,34 @@
+/**
+ * Map over `items` running at most `limit` calls of `fn` concurrently, preserving input order in the
+ * result. Used to bound fan-out that would otherwise fire one in-flight LLM request per item (e.g.
+ * one `processWithLLM` per package), which can blow past provider rate limits on large monorepos.
+ */
+export async function mapWithConcurrency<T, R>(
+  items: readonly T[],
+  limit: number,
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const bound = Math.max(1, Math.floor(limit) || 1);
+  const results: R[] = new Array(items.length);
+  let next = 0;
+  let failed = false;
+
+  async function worker(): Promise<void> {
+    // Stop pulling new items once any worker's fn has thrown, so a throwing fn doesn't keep starting
+    // fresh work after the first failure (in-flight calls still settle; Promise.all surfaces the error).
+    while (!failed) {
+      const i = next++;
+      if (i >= items.length) return;
+      try {
+        results[i] = await fn(items[i] as T, i);
+      } catch (err) {
+        failed = true;
+        throw err;
+      }
+    }
+  }
+
+  const workers = Array.from({ length: Math.min(bound, items.length) }, () => worker());
+  await Promise.all(workers);
+  return results;
+}

--- a/packages/notes/src/utils/retry.ts
+++ b/packages/notes/src/utils/retry.ts
@@ -3,6 +3,12 @@ export interface RetryOptions {
   initialDelay?: number;
   maxDelay?: number;
   backoffFactor?: number;
+  /**
+   * Decide whether a thrown error is worth retrying. `true` (or omitting the predicate) retries;
+   * `false` stops immediately and rethrows. Lets callers fail fast on non-transient errors
+   * (e.g. 4xx auth/validation) while still retrying timeout/429/5xx/network failures.
+   */
+  shouldRetry?: (error: unknown) => boolean;
 }
 
 function sleep(ms: number): Promise<void> {
@@ -22,6 +28,7 @@ export async function withRetry<T>(fn: () => Promise<T>, options: RetryOptions =
       return await fn();
     } catch (error) {
       lastError = error;
+      if (options.shouldRetry && !options.shouldRetry(error)) break;
       if (attempt < maxAttempts - 1) {
         const base = Math.min(initialDelay * backoffFactor ** attempt, maxDelay);
         const jitter = base * 0.2 * (Math.random() * 2 - 1);

--- a/packages/notes/test/integration/notes-llm-e2e.spec.ts
+++ b/packages/notes/test/integration/notes-llm-e2e.spec.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import type { ChangelogEntry } from '../../src/core/types.js';
+import { OllamaProvider } from '../../src/llm/ollama.js';
+import { enhanceAndCategorize } from '../../src/llm/tasks/enhance-and-categorize.js';
+import { generateReleaseNotes } from '../../src/llm/tasks/release-notes.js';
+import { summarizeEntries } from '../../src/llm/tasks/summarize.js';
+
+/**
+ * Opt-in real-provider e2e for the LLM notes pipeline. The unit specs drive a mock provider and verify
+ * the plumbing; this exercises the reliability changes against a *real* Ollama server, where mocks can
+ * only approximate the API shape — chunking across the >30-entry boundary (two real structured calls +
+ * a merge), the structured task path, and the free-text task path (summarize / release notes).
+ *
+ * Skipped by default so the gate stays fast and offline. To run (needs a reachable Ollama with the
+ * model pulled):
+ *   RELEASEKIT_NOTES_E2E=1 [RELEASEKIT_NOTES_E2E_MODEL=llama3.2] [OLLAMA_BASE_URL=http://localhost:11434] \
+ *     pnpm --filter @releasekit/notes test
+ *
+ * Assertions check structure, not content — LLM output is non-deterministic. Even when the model
+ * mangles a structured response, the pipeline's per-chunk fallback preserves every entry, so the
+ * counts below hold regardless of model quality; the point is that the real provider path runs end to
+ * end without hanging or dropping entries.
+ */
+const E2E_ENABLED = process.env.RELEASEKIT_NOTES_E2E === '1' || process.env.RELEASEKIT_NOTES_E2E === 'true';
+const MODEL = process.env.RELEASEKIT_NOTES_E2E_MODEL ?? 'llama3.2';
+const context = { packageName: 'my-lib', version: '2.0.0', previousVersion: '1.0.0' };
+
+describe.skipIf(!E2E_ENABLED)('notes LLM e2e (real Ollama)', () => {
+  const provider = new OllamaProvider({ model: MODEL });
+
+  it('should enhance and categorize a large release across chunk boundaries', async () => {
+    // 35 entries crosses the 30-entry chunk boundary → two real structured calls, then a category merge.
+    const entries: ChangelogEntry[] = Array.from({ length: 35 }, (_, i) => ({
+      type: i % 2 === 0 ? 'fixed' : 'added',
+      description: `${i % 2 === 0 ? 'Fix' : 'Add'} behaviour ${i} in the widget subsystem`,
+    }));
+
+    const result = await enhanceAndCategorize(provider, entries, context);
+
+    // Every input entry is accounted for exactly once (enhanced or fallback-preserved), with non-empty
+    // descriptions, and lands in some non-empty category.
+    expect(result.enhancedEntries).toHaveLength(35);
+    expect(result.enhancedEntries.every((e) => typeof e.description === 'string' && e.description.length > 0)).toBe(
+      true,
+    );
+    expect(result.categories.length).toBeGreaterThan(0);
+    const categorized = result.categories.reduce((total, c) => total + c.entries.length, 0);
+    expect(categorized).toBe(35);
+  }, 180_000);
+
+  it('should produce a prose summary and release notes via the text path', async () => {
+    const entries: ChangelogEntry[] = [
+      { type: 'added', description: 'Add deeplink support for the mobile client' },
+      { type: 'fixed', description: 'Fix a crash when the config file is missing' },
+    ];
+
+    const summary = await summarizeEntries(provider, entries, context);
+    expect(summary.trim().length).toBeGreaterThan(0);
+
+    const notes = await generateReleaseNotes(provider, entries, context);
+    expect(notes.trim().length).toBeGreaterThan(0);
+  }, 180_000);
+});

--- a/packages/notes/test/integration/pipeline-softfail.spec.ts
+++ b/packages/notes/test/integration/pipeline-softfail.spec.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { runPipeline } from '../../src/core/pipeline.js';
+import type { ChangelogInput, Config } from '../../src/core/types.js';
+
+const { createMock } = vi.hoisted(() => ({ createMock: vi.fn() }));
+
+vi.mock('openai', () => ({
+  default: class MockOpenAI {
+    chat = { completions: { create: createMock } };
+  },
+}));
+
+// No repoUrl → the pipeline skips example and PR-context fetches (no network).
+const input: ChangelogInput = {
+  source: 'version',
+  packages: [
+    {
+      packageName: 'my-lib',
+      version: '2.0.0',
+      previousVersion: 'v1.0.0',
+      revisionRange: 'v1.0.0..HEAD',
+      date: '2026-01-15',
+      entries: [
+        { type: 'added', description: 'raw one' },
+        { type: 'fixed', description: 'raw two' },
+        { type: 'changed', description: 'raw three' },
+      ],
+    },
+  ],
+};
+
+const config: Config = {
+  changelog: false,
+  releaseNotes: {
+    llm: {
+      provider: 'openai',
+      model: 'gpt-test',
+      apiKey: 'k',
+      retry: { maxAttempts: 1, initialDelay: 0 },
+      tasks: { enhance: true, categorize: true, summarize: true },
+    },
+  },
+};
+
+const enhancedPayload = JSON.stringify({
+  entries: [
+    { description: 'ENHANCED one', category: 'New', scope: null, breaking: null, leadIn: null },
+    { description: 'ENHANCED two', category: 'Fixed', scope: null, breaking: null, leadIn: null },
+    { description: 'ENHANCED three', category: 'Changed', scope: null, breaking: null, leadIn: null },
+  ],
+});
+
+describe('Pipeline: per-task soft-fail', () => {
+  beforeEach(() => {
+    createMock.mockReset();
+  });
+
+  it('should keep enhance+categorize output when a later summarize task fails', async () => {
+    createMock.mockImplementation((params: { response_format?: unknown }) => {
+      // enhance+categorize uses the structured-output (response_format) path; summarize is plain text.
+      if (params.response_format) {
+        return Promise.resolve({ choices: [{ message: { content: enhancedPayload } }] });
+      }
+      return Promise.reject(Object.assign(new Error('summarize boom'), { status: 400 }));
+    });
+
+    const result = await runPipeline(input, config, false);
+
+    // Old behavior discarded the whole enhancement on a late failure and re-rendered the raw entries.
+    const notes = result.packageNotes['my-lib'] ?? '';
+    expect(notes).toContain('ENHANCED');
+    expect(notes).not.toContain('raw one');
+  });
+});

--- a/packages/notes/test/unit/llm.spec.ts
+++ b/packages/notes/test/unit/llm.spec.ts
@@ -532,6 +532,111 @@ describe('enhanceAndCategorize()', () => {
     await expect(enhanceAndCategorize(provider, sampleEntries, llmContext)).rejects.toThrow();
   });
 
+  it('should chunk a large release into bounded ~30-entry batches and merge same-named categories', async () => {
+    const many: ChangelogEntry[] = Array.from({ length: 35 }, (_, i) => ({ type: 'added', description: `Entry ${i}` }));
+    // Echo back one 'General' entry per input entry in the chunk (counted from the rendered prompt).
+    const chunkSizes: number[] = [];
+    let callCount = 0;
+    const provider: LLMProvider & { callCount: number } = {
+      name: 'mock',
+      capabilities: { systemRole: true, structuredOutputs: false, toolUse: false },
+      get callCount() {
+        return callCount;
+      },
+      async complete(messages: LLMMessage[]): Promise<CompleteResult> {
+        callCount++;
+        const userMsg = messages.find((m) => m.role === 'user')?.content ?? '';
+        const count = (userMsg.match(/<entry /g) ?? []).length;
+        chunkSizes.push(count);
+        const entries = Array.from({ length: count }, () => ({
+          description: 'ok',
+          category: 'General',
+          scope: null,
+          breaking: null,
+          leadIn: null,
+        }));
+        const content = JSON.stringify({ entries });
+        return { content, structured: JSON.parse(content) };
+      },
+    };
+
+    const result = await enhanceAndCategorize(provider, many, llmContext);
+
+    expect(provider.callCount).toBe(2);
+    expect(chunkSizes).toEqual([30, 5]);
+    expect(result.enhancedEntries).toHaveLength(35);
+    expect(result.categories).toHaveLength(1);
+    expect(result.categories[0]?.category).toBe('General');
+    expect(result.categories[0]?.entries).toHaveLength(35);
+  });
+
+  it('should isolate a failing chunk to a General fallback without discarding good chunks', async () => {
+    const many: ChangelogEntry[] = Array.from({ length: 35 }, (_, i) => ({ type: 'added', description: `Entry ${i}` }));
+    let callCount = 0;
+    const provider: LLMProvider & { callCount: number } = {
+      name: 'mock',
+      capabilities: { systemRole: true, structuredOutputs: false, toolUse: false },
+      get callCount() {
+        return callCount;
+      },
+      async complete(messages: LLMMessage[]): Promise<CompleteResult> {
+        callCount++;
+        const userMsg = messages.find((m) => m.role === 'user')?.content ?? '';
+        const count = (userMsg.match(/<entry /g) ?? []).length;
+        // First chunk (30 entries) succeeds; the small tail chunk (5) never validates → its fallback.
+        if (count === 30) {
+          const entries = Array.from({ length: 30 }, () => ({
+            description: 'ok',
+            category: 'New',
+            scope: null,
+            breaking: null,
+            leadIn: null,
+          }));
+          const content = JSON.stringify({ entries });
+          return { content, structured: JSON.parse(content) };
+        }
+        return { content: 'invalid json' };
+      },
+    };
+
+    const result = await enhanceAndCategorize(provider, many, llmContext);
+
+    // chunk 1: one valid call. chunk 2: 1 initial + 2 corrective, all invalid → General fallback.
+    expect(provider.callCount).toBe(4);
+    expect(result.enhancedEntries).toHaveLength(35);
+    expect(result.categories.find((c) => c.category === 'New')?.entries).toHaveLength(30);
+    expect(result.categories.find((c) => c.category === 'General')?.entries).toHaveLength(5);
+  });
+
+  it('should preserve entry order across chunk boundaries', async () => {
+    const many: ChangelogEntry[] = Array.from({ length: 35 }, (_, i) => ({ type: 'added', description: `Entry ${i}` }));
+    // Emit a monotonically increasing marker per entry across chunks; a cross-chunk reorder breaks the sequence.
+    let emitted = 0;
+    const provider: LLMProvider = {
+      name: 'mock',
+      capabilities: { systemRole: true, structuredOutputs: false, toolUse: false },
+      async complete(messages: LLMMessage[]): Promise<CompleteResult> {
+        const userMsg = messages.find((m) => m.role === 'user')?.content ?? '';
+        const count = (userMsg.match(/<entry /g) ?? []).length;
+        const entries = Array.from({ length: count }, () => ({
+          description: `enhanced-${emitted++}`,
+          category: 'General',
+          scope: null,
+          breaking: null,
+          leadIn: null,
+        }));
+        const content = JSON.stringify({ entries });
+        return { content, structured: JSON.parse(content) };
+      },
+    };
+
+    const result = await enhanceAndCategorize(provider, many, llmContext);
+
+    expect(result.enhancedEntries.map((e) => e.description)).toEqual(
+      Array.from({ length: 35 }, (_, i) => `enhanced-${i}`),
+    );
+  });
+
   it('should apply invalidScopeAction to disallowed scopes without retrying the LLM', async () => {
     const response = JSON.stringify({
       entries: [

--- a/packages/notes/test/unit/llm/anthropic.spec.ts
+++ b/packages/notes/test/unit/llm/anthropic.spec.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { LLMError } from '../../../src/errors/index.js';
+import { AnthropicProvider } from '../../../src/llm/anthropic.js';
+
+const { createMock } = vi.hoisted(() => ({ createMock: vi.fn() }));
+
+vi.mock('@anthropic-ai/sdk', () => ({
+  default: class MockAnthropic {
+    messages = { create: createMock };
+  },
+}));
+
+function makeProvider(model = 'claude-sonnet-5') {
+  return new AnthropicProvider({ model, apiKey: 'k' });
+}
+
+describe('AnthropicProvider', () => {
+  beforeEach(() => {
+    createMock.mockReset();
+  });
+
+  it('should extract structured output from a tool_use block on the schema path', async () => {
+    createMock.mockResolvedValue({
+      content: [{ type: 'tool_use', name: 'emit_release_notes', input: { entries: [{ category: 'Fixed' }] } }],
+    });
+
+    const result = await makeProvider().complete([{ role: 'user', content: 'hi' }], { schema: { type: 'object' } });
+
+    expect(result.structured).toEqual({ entries: [{ category: 'Fixed' }] });
+    expect(JSON.parse(result.content)).toEqual({ entries: [{ category: 'Fixed' }] });
+  });
+
+  it('should throw when the schema path returns no tool_use block', async () => {
+    createMock.mockResolvedValue({ content: [{ type: 'text', text: 'I could not do that' }] });
+
+    await expect(
+      makeProvider().complete([{ role: 'user', content: 'hi' }], { schema: { type: 'object' } }),
+    ).rejects.toThrow(/Expected tool_use block/);
+  });
+
+  it('should find the text block even when a thinking block precedes it (thinking-model forward-compat)', async () => {
+    // Sonnet 5 / Fable 5 return thinking blocks ahead of the text block; content[0] would be `thinking`.
+    createMock.mockResolvedValue({
+      content: [
+        { type: 'thinking', thinking: 'let me reason about this' },
+        { type: 'text', text: 'A concise summary.' },
+      ],
+    });
+
+    const result = await makeProvider().complete([{ role: 'user', content: 'summarize' }]);
+
+    expect(result.content).toBe('A concise summary.');
+  });
+
+  it('should return the text of a plain single-block response', async () => {
+    createMock.mockResolvedValue({ content: [{ type: 'text', text: 'hello' }] });
+
+    const result = await makeProvider().complete([{ role: 'user', content: 'hi' }]);
+
+    expect(result.content).toBe('hello');
+  });
+
+  it('should throw when the response contains no text block', async () => {
+    createMock.mockResolvedValue({ content: [{ type: 'thinking', thinking: 'only thinking' }] });
+
+    await expect(makeProvider().complete([{ role: 'user', content: 'hi' }])).rejects.toThrow(/Expected a text block/);
+  });
+
+  it('should split the system message out and map only non-system messages', async () => {
+    createMock.mockResolvedValue({ content: [{ type: 'text', text: 'ok' }] });
+
+    await makeProvider().complete([
+      { role: 'system', content: 'You are helpful.' },
+      { role: 'user', content: 'question' },
+      { role: 'assistant', content: 'partial' },
+    ]);
+
+    const params = createMock.mock.calls[0]?.[0];
+    expect(params.system).toBe('You are helpful.');
+    expect(params.messages).toEqual([
+      { role: 'user', content: 'question' },
+      { role: 'assistant', content: 'partial' },
+    ]);
+  });
+
+  it('should not forward temperature (thinking models reject it) and report honorsTemperature: false', async () => {
+    createMock.mockResolvedValue({ content: [{ type: 'text', text: 'ok' }] });
+
+    const provider = makeProvider();
+    await provider.complete([{ role: 'user', content: 'hi' }], { temperature: 0.9 });
+
+    const params = createMock.mock.calls[0]?.[0];
+    expect(params).not.toHaveProperty('temperature');
+    expect(provider.capabilities.honorsTemperature).toBe(false);
+  });
+
+  it('should map an aborted request to a clear timeout error', async () => {
+    // A create call that only settles when the request's abort signal fires.
+    createMock.mockImplementation(
+      (_params, opts: { signal?: AbortSignal }) =>
+        new Promise((_resolve, reject) => {
+          opts.signal?.addEventListener('abort', () => reject(new DOMException('aborted', 'AbortError')));
+        }),
+    );
+
+    await expect(makeProvider().complete([{ role: 'user', content: 'hi' }], { timeout: 5 })).rejects.toThrow(
+      /timed out/,
+    );
+  });
+
+  it('should mark a 4xx auth/validation error as non-retryable', async () => {
+    createMock.mockRejectedValue(Object.assign(new Error('unauthorized'), { status: 401 }));
+
+    await expect(makeProvider().complete([{ role: 'user', content: 'hi' }])).rejects.toMatchObject({
+      retryable: false,
+    });
+  });
+
+  it('should mark a 429 / 5xx error as retryable', async () => {
+    createMock.mockRejectedValueOnce(Object.assign(new Error('rate limited'), { status: 429 }));
+    await expect(makeProvider().complete([{ role: 'user', content: 'hi' }])).rejects.toMatchObject({ retryable: true });
+
+    createMock.mockRejectedValueOnce(Object.assign(new Error('server error'), { status: 503 }));
+    await expect(makeProvider().complete([{ role: 'user', content: 'hi' }])).rejects.toMatchObject({ retryable: true });
+  });
+
+  it('should surface a timeout error as an LLMError instance', async () => {
+    createMock.mockImplementation(
+      (_params, opts: { signal?: AbortSignal }) =>
+        new Promise((_resolve, reject) => {
+          opts.signal?.addEventListener('abort', () => reject(new DOMException('aborted', 'AbortError')));
+        }),
+    );
+
+    await expect(makeProvider().complete([{ role: 'user', content: 'hi' }], { timeout: 5 })).rejects.toBeInstanceOf(
+      LLMError,
+    );
+  });
+});

--- a/packages/notes/test/unit/llm/cache.spec.ts
+++ b/packages/notes/test/unit/llm/cache.spec.ts
@@ -74,6 +74,26 @@ describe('withContentHashCache', () => {
     expect(provider.calls).toBe(6);
   });
 
+  it('should ignore temperature in the cache key for providers that do not honor it', async () => {
+    const dir = freshDir();
+    // Mirrors the Anthropic provider: temperature is never forwarded, so toggling it must not miss.
+    const provider: LLMProvider & { calls: number } = {
+      name: 'anthropic',
+      capabilities: { systemRole: true, structuredOutputs: true, toolUse: true, honorsTemperature: false },
+      calls: 0,
+      async complete(): Promise<CompleteResult> {
+        this.calls += 1;
+        return { content: 'r' };
+      },
+    };
+    const cached = withContentHashCache(provider, { model: 'claude-sonnet-5' }, dir);
+
+    await cached.complete(msgs, { temperature: 0.1 });
+    await cached.complete(msgs, { temperature: 0.9 });
+
+    expect(provider.calls).toBe(1);
+  });
+
   it('should hash message order, not just contents', async () => {
     const dir = freshDir();
     const provider = mockProvider(() => 'r');

--- a/packages/notes/test/unit/llm/retryable.spec.ts
+++ b/packages/notes/test/unit/llm/retryable.spec.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { LLMError } from '../../../src/errors/index.js';
+import { isRetryableLLMError, isRetryableProviderError, isRetryableStatus } from '../../../src/llm/retryable.js';
+
+describe('isRetryableStatus()', () => {
+  it('should retry timeout, conflict, too-early, and rate-limit statuses', () => {
+    for (const status of [408, 409, 425, 429]) {
+      expect(isRetryableStatus(status)).toBe(true);
+    }
+  });
+
+  it('should retry 5xx server errors', () => {
+    for (const status of [500, 502, 503, 529]) {
+      expect(isRetryableStatus(status)).toBe(true);
+    }
+  });
+
+  it('should fail fast on 4xx auth/validation statuses', () => {
+    for (const status of [400, 401, 403, 404, 413, 422]) {
+      expect(isRetryableStatus(status)).toBe(false);
+    }
+  });
+});
+
+describe('isRetryableProviderError()', () => {
+  it('should classify SDK errors by their HTTP status', () => {
+    expect(isRetryableProviderError(Object.assign(new Error('x'), { status: 401 }))).toBe(false);
+    expect(isRetryableProviderError(Object.assign(new Error('x'), { status: 429 }))).toBe(true);
+    expect(isRetryableProviderError(Object.assign(new Error('x'), { status: 500 }))).toBe(true);
+  });
+
+  it('should retry socket-level network errors', () => {
+    expect(isRetryableProviderError(Object.assign(new Error('reset'), { code: 'ECONNRESET' }))).toBe(true);
+    expect(isRetryableProviderError(Object.assign(new Error('dns'), { code: 'ENOTFOUND' }))).toBe(true);
+  });
+
+  it('should retry abort/timeout and connection errors by name', () => {
+    expect(isRetryableProviderError(Object.assign(new Error('a'), { name: 'AbortError' }))).toBe(true);
+    expect(isRetryableProviderError(Object.assign(new Error('a'), { name: 'APIConnectionError' }))).toBe(true);
+  });
+
+  it('should default an unknown error shape to retryable', () => {
+    expect(isRetryableProviderError(new Error('mystery'))).toBe(true);
+    expect(isRetryableProviderError('nope')).toBe(true);
+  });
+});
+
+describe('isRetryableLLMError()', () => {
+  it('should honor the retryable flag carried by an LLMError', () => {
+    expect(isRetryableLLMError(new LLMError('auth', { retryable: false }))).toBe(false);
+    expect(isRetryableLLMError(new LLMError('rate', { retryable: true }))).toBe(true);
+  });
+
+  it('should retry an unclassified LLMError or any non-LLMError', () => {
+    expect(isRetryableLLMError(new LLMError('unclassified'))).toBe(true);
+    expect(isRetryableLLMError(new Error('plain'))).toBe(true);
+  });
+});

--- a/packages/notes/test/unit/retry.spec.ts
+++ b/packages/notes/test/unit/retry.spec.ts
@@ -73,6 +73,34 @@ describe('withRetry()', () => {
     ).rejects.toBeInstanceOf(CustomError);
   });
 
+  it('should stop immediately when shouldRetry returns false', async () => {
+    let calls = 0;
+    await expect(
+      withRetry(
+        async () => {
+          calls++;
+          throw new Error('non-retryable');
+        },
+        { maxAttempts: 3, initialDelay: 0, shouldRetry: () => false },
+      ),
+    ).rejects.toThrow('non-retryable');
+    expect(calls).toBe(1);
+  });
+
+  it('should keep retrying when shouldRetry returns true', async () => {
+    let calls = 0;
+    await expect(
+      withRetry(
+        async () => {
+          calls++;
+          throw new Error('retryable');
+        },
+        { maxAttempts: 3, initialDelay: 0, shouldRetry: () => true },
+      ),
+    ).rejects.toThrow('retryable');
+    expect(calls).toBe(3);
+  });
+
   it('should succeed on the last allowed attempt', async () => {
     let calls = 0;
     const result = await withRetry(

--- a/packages/notes/test/unit/utils/concurrency.spec.ts
+++ b/packages/notes/test/unit/utils/concurrency.spec.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { mapWithConcurrency } from '../../../src/utils/concurrency.js';
+
+describe('mapWithConcurrency()', () => {
+  it('should preserve input order in the results', async () => {
+    const result = await mapWithConcurrency([1, 2, 3, 4, 5], 2, async (n) => n * 10);
+    expect(result).toEqual([10, 20, 30, 40, 50]);
+  });
+
+  it('should never exceed the concurrency limit of in-flight calls', async () => {
+    let active = 0;
+    let peak = 0;
+    const items = Array.from({ length: 12 }, (_, i) => i);
+
+    await mapWithConcurrency(items, 3, async (n) => {
+      active++;
+      peak = Math.max(peak, active);
+      await new Promise((r) => setTimeout(r, 1));
+      active--;
+      return n;
+    });
+
+    expect(peak).toBeLessThanOrEqual(3);
+  });
+
+  it('should return an empty array for empty input without invoking the mapper', async () => {
+    let called = false;
+    const result = await mapWithConcurrency([], 5, async () => {
+      called = true;
+      return 0;
+    });
+    expect(result).toEqual([]);
+    expect(called).toBe(false);
+  });
+
+  it('should treat a non-positive limit as a single worker', async () => {
+    let active = 0;
+    let peak = 0;
+    await mapWithConcurrency([1, 2, 3], 0, async (n) => {
+      active++;
+      peak = Math.max(peak, active);
+      await new Promise((r) => setTimeout(r, 1));
+      active--;
+      return n;
+    });
+    expect(peak).toBe(1);
+  });
+
+  it('should stop scheduling new work after the mapper throws', async () => {
+    const seen: number[] = [];
+    await expect(
+      mapWithConcurrency([0, 1, 2], 1, async (n) => {
+        seen.push(n);
+        if (n === 1) throw new Error('boom');
+        return n;
+      }),
+    ).rejects.toThrow('boom');
+    expect(seen).toEqual([0, 1]); // index 2 is never started once the failure is observed
+  });
+});


### PR DESCRIPTION
## Summary

A batch of P2 LLM-notes reliability fixes (July 2026 direction review), all in `packages/notes`:

- **Independent per-task soft-fail** (`core/pipeline.ts`): provider setup falls back to the raw context on failure; `enhance+categorize`, `summarize`, and `releaseNotes` each soft-fail in isolation, so a late failure keeps earlier (paid-for) results.
- **Anthropic thinking-model text path** (`llm/anthropic.ts`): use `content.find(b => b.type === 'text')` instead of `content[0]`, so a leading `thinking` block (Sonnet 5 / Fable 5) doesn't hard-fail non-schema tasks.
- **Temperature handling**: Anthropic never forwards `temperature` (thinking models 400 on it — documented) and now reports `honorsTemperature: false`; the on-disk cache drops `temperature` from the key for such providers so toggling it no longer busts an identical response.
- **Retry classification** (`llm/retryable.ts`, `utils/retry.ts`, all providers): fail fast on 4xx auth/validation; retry only timeout/429/5xx/network. `LLMError` carries a `retryable` flag and `withRetry` gained a `shouldRetry` predicate.
- **Chunk `enhanceAndCategorize`** into ~30-entry batches with per-chunk corrective retry and per-chunk General fallback; merges same-named categories. ≤30 entries stays a single call.
- **Bound cross-package parallelism** (`utils/concurrency.ts`): replace the unbounded `Promise.all(contexts.map(...))` with a `concurrency`-bounded map.
- **Warn on partial enhancement** (`tasks/enhance.ts`): surface a failure count when entries silently fall back to raw voice.
- **New `AnthropicProvider` unit spec**: tool_use extraction, missing-tool-block error, thinking-before-text, timeout mapping, system-message splitting, temperature, and retry classification.

No Zod config schema changes, so no generated docs/schema updates.

## Test plan

- New/extended specs: `test/unit/llm/anthropic.spec.ts`, `test/unit/llm/retryable.spec.ts`, `test/unit/utils/concurrency.spec.ts`, `test/integration/pipeline-softfail.spec.ts`, plus additions to `retry.spec.ts`, `cache.spec.ts`, `llm.spec.ts` (chunking + isolated fallback).
- Re-verified by the orchestrator the CI way: `biome check .` exit 0; forced `turbo run typecheck test --force` → 24/24.

Closes #543

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BT6fVBZrmExXZj7vQ29881

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR hardens LLM notes reliability across `packages/notes` with a batch of complementary fixes: per-task soft-fail isolation in the pipeline, retry classification that fast-fails on 4xx auth/validation while retrying transient errors, chunked `enhanceAndCategorize` for large releases, bounded cross-package concurrency, and a thinking-model text-block fix for Anthropic. New unit and integration specs cover the key new paths.

- **Soft-fail refactor** (`pipeline.ts`): provider setup and each LLM task now fail independently; a late `summarize`/`releaseNotes` failure keeps earlier enhancement and categorization results rather than discarding them.
- **Chunking** (`enhance-and-categorize.ts`): `enhanceAndCategorize` splits large entry lists into ≤30-entry batches, each with its own corrective-retry budget and `General`-fallback isolation; `mergeCategories` reassembles same-named categories across chunks.
- **Retry classification** (`retryable.ts`, `retry.ts`, all providers): `withRetry` gains a `shouldRetry` predicate; `LLMError` now carries a `retryable` flag; 4xx auth/validation errors fast-fail while 429/5xx/network/timeout errors retry.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge. All changes are additive reliability improvements with no regressions to existing LLM task behaviour; the soft-fail paths are exercised by a dedicated integration test.

The three most complex changes — per-task soft-fail isolation in processWithLLM, chunked enhanceAndCategorize, and the mapWithConcurrency worker pool — are each internally consistent and covered by targeted unit/integration specs. The retry classification follows a clear, conservative 'default retryable, explicit fast-fail on 4xx' policy applied uniformly across all four providers. Error cause chaining and the temperature-cache fix address known gaps without touching unrelated code paths. No schema changes and no breaking public-interface alterations.

pipeline.ts carries the largest surface area (provider setup soft-fail + four independent task try/catch blocks + concurrency switch); worth a careful read-through, but the logic is straightforward and the integration test covers the key failure scenario.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/notes/src/core/pipeline.ts | Provider setup now soft-fails to raw context; all four LLM tasks are independently wrapped in try/catch; cross-package fan-out replaced with mapWithConcurrency. The let provider pattern (assigned in try, catch returns early) is correctly handled by TypeScript's CFA. Largest surface area of the change and the most complex; logic is correct. |
| packages/notes/src/llm/tasks/enhance-and-categorize.ts | Chunking logic extracted into enhanceAndCategorizeChunk; mergeCategories merges same-named categories across chunks; system prompt is built once and shared across all chunks. Sequential processing is intentional for rate-limit safety. Category merge is case-sensitive (consistent with LLM prompt constraints). |
| packages/notes/src/llm/retryable.ts | New file with three well-scoped predicates: isRetryableStatus (4xx fast-fail / 5xx+429/408/409/425 retry), isRetryableProviderError (delegates to status then code, defaults retryable for unknowns), and isRetryableLLMError (reads LLMError.retryable, defaults true for unclassified). Logic is sound and consistently applied across providers. |
| packages/notes/src/utils/concurrency.ts | New bounded-concurrency map utility using a shared next counter and failed flag behind a worker-pool pattern. Order is preserved via index-based slot assignment. JS single-thread guarantees no race on next/failed. Edge cases (empty input, limit <= 0, NaN limit) all handled. Worker-pool stops scheduling new items after first failure; in-flight calls still settle. |
| packages/notes/src/utils/retry.ts | shouldRetry predicate added cleanly; checked before the sleep decision so non-retryable errors break out of the loop immediately without burning any delay budget. Correct across all attempt counts including the last. |
| packages/notes/src/llm/anthropic.ts | content.find(b => b.type === 'text') correctly handles thinking-model responses where content[0] would be a thinking block. honorsTemperature: false set to prevent cache busts and 400s from thinking models. Error classification delegates to isRetryableProviderError with cause chaining. |
| packages/notes/src/errors/index.ts | LLMError gains a retryable?: boolean flag and a constructor that accepts {retryable, cause}. Cause is chained via direct property assignment (valid in ES2022+ environments). Addresses the previous review thread's request for cause chaining. |
| packages/notes/src/llm/cache.ts | Cache key omits temperature when honorsTemperature === false (Anthropic), preventing cache misses when the ignored temperature option changes between runs. Clean conditional keying. |
| packages/notes/src/llm/ollama.ts | 401/403 hardcoded to retryable: false with helpful key-hint message; other non-OK statuses use isRetryableStatus. honorsTemperature: true added. Error wrapping gains cause and retryable classification consistently with other providers. |
| packages/notes/src/llm/openai.ts | honorsTemperature: true and isRetryableProviderError classification added in line with other providers. Cause chained on non-timeout errors. |
| packages/notes/src/llm/openai-compatible.ts | Same honorsTemperature and isRetryableProviderError treatment as openai.ts. Consistent with the pattern across all providers. |
| packages/notes/src/llm/provider.ts | honorsTemperature?: boolean added to ProviderCapabilities with clear JSDoc. Optional (absent = honored) so existing providers without the field default to the common case without a migration. |
| packages/notes/src/llm/tasks/enhance.ts | failures counter added; warn emitted when any per-entry soft-fail occurs. Surfaces mixed-voice output that would previously be silent. Minimal and correct change. |
| packages/notes/src/llm/defaults.ts | enhanceCategorizeChunkSize: 30 added to LLM_DEFAULTS with explanatory comment. Not exposed in the Zod config schema yet (intentional per PR description). |
| packages/notes/test/integration/pipeline-softfail.spec.ts | Integration test validates the key soft-fail guarantee: enhance+categorize output survives a later summarize failure. Mocks the OpenAI completions path with response_format discrimination. Correctly sets maxAttempts: 1 to skip retry noise. |
| packages/notes/test/unit/llm/anthropic.spec.ts | New spec covers tool_use extraction, missing-tool-block error, thinking-before-text ordering, plain text response, no-text-block error, system message splitting, temperature non-forwarding, timeout mapping, and retry classification. Good coverage of the changed behaviour. |
| packages/notes/test/unit/llm/retryable.spec.ts | Unit tests for isRetryableStatus, isRetryableProviderError, and isRetryableLLMError covering the key decision boundaries (401 vs 429, network codes, unknown shapes, LLMError.retryable flag). |
| packages/notes/test/unit/utils/concurrency.spec.ts | Tests cover order preservation, peak concurrency enforcement, empty input, non-positive limit normalisation, and early-stop on failure. Complete for the implemented contract. |
| packages/notes/test/unit/llm.spec.ts | Two new chunking specs added: one for happy-path 35-entry split (2 calls, merged General category) and one for isolated chunk failure (first 30 succeed as New, tail 5 fall back to General). Both correctly count calls and validate the merged result shape. |
| packages/notes/test/unit/llm/cache.spec.ts | New test confirms that toggling temperature does not bust the cache for a provider with honorsTemperature: false (mirrors Anthropic behaviour). Correctly asserts provider.calls === 1 after two requests with different temperatures. |
| packages/notes/test/unit/retry.spec.ts | Two new tests for shouldRetry: one asserting immediate stop (calls === 1) when predicate returns false, one asserting full retry budget is consumed (calls === 3) when predicate returns true. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[runPipeline] --> B[mapWithConcurrency\nbounded by concurrency knob]
    B --> C[processWithLLM per package]
    C --> D{Provider setup}
    D -- throws --> E[warn + return raw context\nsoft-fail]
    D -- success --> F{tasks.enhance\n&& tasks.categorize?}
    F -- yes --> G[enhanceAndCategorize\nchunked into <= 30 entries]
    G --> H[enhanceAndCategorizeChunk\nper chunk]
    H --> I{runCorrectiveTask\nsucceeds?}
    I -- yes --> J[merge categories\npreserve order]
    I -- no LLMError --> K[General fallback\nisolated to chunk]
    J --> L[tasks.summarize?]
    K --> L
    F -- no --> L
    L -- yes --> M[summarizeEntries\ntry/catch soft-fail]
    L -- no --> N[tasks.releaseNotes?]
    M -- fails --> O[warn + keep prior results]
    M -- success --> N
    O --> N
    N -- yes --> P[generateReleaseNotes\ntry/catch soft-fail]
    N -- no --> Q[return enhanced context]
    P --> Q
    P -- fails --> Q

    subgraph withRetry
        R[attempt fn] -- throws --> S{shouldRetry isRetryableLLMError?}
        S -- false 4xx --> T[fast-fail immediately]
        S -- true 429/5xx/network --> U[sleep + retry]
        U --> R
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[runPipeline] --> B[mapWithConcurrency\nbounded by concurrency knob]
    B --> C[processWithLLM per package]
    C --> D{Provider setup}
    D -- throws --> E[warn + return raw context\nsoft-fail]
    D -- success --> F{tasks.enhance\n&& tasks.categorize?}
    F -- yes --> G[enhanceAndCategorize\nchunked into <= 30 entries]
    G --> H[enhanceAndCategorizeChunk\nper chunk]
    H --> I{runCorrectiveTask\nsucceeds?}
    I -- yes --> J[merge categories\npreserve order]
    I -- no LLMError --> K[General fallback\nisolated to chunk]
    J --> L[tasks.summarize?]
    K --> L
    F -- no --> L
    L -- yes --> M[summarizeEntries\ntry/catch soft-fail]
    L -- no --> N[tasks.releaseNotes?]
    M -- fails --> O[warn + keep prior results]
    M -- success --> N
    O --> N
    N -- yes --> P[generateReleaseNotes\ntry/catch soft-fail]
    N -- no --> Q[return enhanced context]
    P --> Q
    P -- fails --> Q

    subgraph withRetry
        R[attempt fn] -- throws --> S{shouldRetry isRetryableLLMError?}
        S -- false 4xx --> T[fast-fail immediately]
        S -- true 429/5xx/network --> U[sleep + retry]
        U --> R
    end
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(notes): harden LLM notes reliability..."](https://github.com/goosewobbler/releasekit/commit/1f385a9f84d82d4294b0711755387d12d06c7dd9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45485903)</sub>

<!-- /greptile_comment -->