### PR TITLE
fix(config): confine config-driven filesystem and env access

### DIFF
--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -48,7 +48,7 @@ This is an internal package that handles configuration loading, schema validatio
 | Export | Description |
 |--------|-------------|
 | `parseJsonc(content)` | Parse JSON with comments |
-| `substituteInObject(obj)` | Substitute `{env:VAR}` and `{file:path}` |
+| `substituteInObject(obj, rootDir)` | Substitute `{env:VAR}` and `{file:path}` (file reads confined to `rootDir`) |
 | `deepMerge(target, source)` | Deep merge objects |
 | `mergeGitConfig(top, pkg)` | Merge git config layers |
 

--- a/packages/config/src/load.ts
+++ b/packages/config/src/load.ts
@@ -119,7 +119,9 @@ function loadConfigFile(configPath: string): ReleaseKitConfig {
   try {
     const content = fs.readFileSync(configPath, 'utf-8');
     const parsed = parseJsonc(content);
-    const substituted = substituteInObject(parsed);
+    // Confine {file:} substitution to the config file's directory (the repo root) so a config can't
+    // read files outside the tree.
+    const substituted = substituteInObject(parsed, path.dirname(configPath));
     assertNoRemovedReleaseNotesFields(substituted);
     assertNoRemovedVersionFields(substituted);
     assertNoRemovedTopLevelFields(substituted);

--- a/packages/config/src/substitute.ts
+++ b/packages/config/src/substitute.ts
@@ -1,10 +1,25 @@
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import { isPathWithinRoot } from '@releasekit/core';
+import { ConfigError } from './errors.js';
 
 const MAX_INPUT_LENGTH = 10000;
 
-export function substituteVariables(value: string): string {
+/**
+ * Inline `{env:NAME}` and `{file:REL_PATH}` references in a config string.
+ *
+ * Trust boundary: substituted values flow into config fields that can surface in bot-authored
+ * output — tag templates, `standingPr.title`, changelog/notes text echoed into PR comments and
+ * releases — so the two read primitives are scoped differently:
+ * - `{env:NAME}` reads process env, the trusted-operator injection point for secrets (npm/LLM
+ *   tokens). Returned verbatim; an unset variable resolves to an empty string.
+ * - `{file:REL_PATH}` is confined to `rootDir` (the config file's directory). A reference that
+ *   escapes it — via `..` or an absolute path outside the tree — is rejected rather than read, so a
+ *   config cannot exfiltrate files such as `~/.ssh/id_rsa` or `/etc/passwd`. An in-bounds but
+ *   unreadable path resolves to an empty string.
+ */
+export function substituteVariables(value: string, rootDir: string = process.cwd()): string {
   // Limit input length to prevent ReDoS attacks
   if (value.length > MAX_INPUT_LENGTH) {
     throw new Error(`Input too long: ${value.length} characters (max ${MAX_INPUT_LENGTH})`);
@@ -21,10 +36,16 @@ export function substituteVariables(value: string): string {
   });
 
   result = result.replace(filePattern, (_, filePath: string) => {
-    const expandedPath = filePath.startsWith('~') ? path.join(os.homedir(), filePath.slice(1)) : filePath;
+    const resolved = path.resolve(rootDir, filePath);
+    if (!isPathWithinRoot(rootDir, resolved)) {
+      throw new ConfigError(
+        `{file:${filePath}} resolves outside the config directory (${path.resolve(rootDir)}); ` +
+          'config file references are confined to the repository. Use {env:NAME} for secrets kept outside the repo.',
+      );
+    }
 
     try {
-      return fs.readFileSync(expandedPath, 'utf-8').trim();
+      return fs.readFileSync(resolved, 'utf-8').trim();
     } catch {
       return '';
     }
@@ -35,9 +56,9 @@ export function substituteVariables(value: string): string {
 
 const SOLE_REFERENCE_PATTERN = /^\{(?:env|file):[^}]+\}$/;
 
-export function substituteInObject<T>(obj: T): T {
+export function substituteInObject<T>(obj: T, rootDir: string = process.cwd()): T {
   if (typeof obj === 'string') {
-    const result = substituteVariables(obj);
+    const result = substituteVariables(obj, rootDir);
     // When the entire string was a single {env:…} or {file:…} reference that
     // resolved to nothing, return undefined so downstream ?? fallbacks work.
     if (result === '' && SOLE_REFERENCE_PATTERN.test(obj)) {
@@ -47,13 +68,13 @@ export function substituteInObject<T>(obj: T): T {
   }
 
   if (Array.isArray(obj)) {
-    return obj.map((item) => substituteInObject(item)) as T;
+    return obj.map((item) => substituteInObject(item, rootDir)) as T;
   }
 
   if (obj && typeof obj === 'object') {
     const result: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(obj)) {
-      result[key] = substituteInObject(value);
+      result[key] = substituteInObject(value, rootDir);
     }
     return result as T;
   }

--- a/packages/config/test/unit/substitute.spec.ts
+++ b/packages/config/test/unit/substitute.spec.ts
@@ -1,7 +1,7 @@
 import * as fs from 'node:fs';
-import * as os from 'node:os';
 import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ConfigError } from '../../src/errors.js';
 import { loadAuth, saveAuth, substituteInObject, substituteVariables } from '../../src/substitute.js';
 
 vi.mock('node:fs', () => ({
@@ -12,6 +12,7 @@ vi.mock('node:fs', () => ({
 }));
 
 const mockedFs = vi.mocked(fs);
+const fileRoot = path.resolve('/repo');
 
 describe('substituteVariables', () => {
   const originalEnv = process.env;
@@ -45,30 +46,38 @@ describe('substituteVariables', () => {
     expect(result).toBe('No variables here');
   });
 
-  it('should substitute {file:PATH} with file contents', () => {
+  it('should substitute {file:PATH} with file contents from within the confinement root', () => {
     mockedFs.readFileSync.mockReturnValue('  file contents  \n');
-    const result = substituteVariables('File: {file:/path/to/file.txt}');
+    const result = substituteVariables('File: {file:secret.txt}', fileRoot);
     expect(result).toBe('File: file contents');
-    expect(mockedFs.readFileSync).toHaveBeenCalledWith('/path/to/file.txt', 'utf-8');
+    expect(mockedFs.readFileSync).toHaveBeenCalledWith(path.join(fileRoot, 'secret.txt'), 'utf-8');
   });
 
-  it('should expand ~ to home directory in file path', () => {
-    mockedFs.readFileSync.mockReturnValue('contents');
-    substituteVariables('{file:~/secrets/api-key}');
-    expect(mockedFs.readFileSync).toHaveBeenCalledWith(path.join(os.homedir(), 'secrets/api-key'), 'utf-8');
+  it('should resolve a {file:} reference relative to the confinement root', () => {
+    mockedFs.readFileSync.mockReturnValue('nested');
+    substituteVariables('{file:config/token}', fileRoot);
+    expect(mockedFs.readFileSync).toHaveBeenCalledWith(path.join(fileRoot, 'config', 'token'), 'utf-8');
   });
 
-  it('should return empty string for unreadable file', () => {
+  it('should reject a {file:} reference that escapes the root via ..', () => {
+    expect(() => substituteVariables('{file:../../etc/passwd}', fileRoot)).toThrow(ConfigError);
+  });
+
+  it('should reject an absolute {file:} reference outside the root', () => {
+    expect(() => substituteVariables('{file:/etc/passwd}', fileRoot)).toThrow(/outside the config directory/);
+  });
+
+  it('should return empty string for an in-bounds unreadable file', () => {
     mockedFs.readFileSync.mockImplementation(() => {
       throw new Error('ENOENT');
     });
-    const result = substituteVariables('{file:/nonexistent}');
+    const result = substituteVariables('{file:missing.txt}', fileRoot);
     expect(result).toBe('');
   });
 
   it('should substitute mixed env and file variables', () => {
     mockedFs.readFileSync.mockReturnValue('file-content');
-    const result = substituteVariables('{env:TEST_VAR} and {file:/path/to/file}');
+    const result = substituteVariables('{env:TEST_VAR} and {file:data.txt}', fileRoot);
     expect(result).toBe('test-value and file-content');
   });
 });
@@ -167,9 +176,14 @@ describe('substituteInObject', () => {
     mockedFs.readFileSync.mockImplementation(() => {
       throw new Error('ENOENT');
     });
-    const obj = { secret: '{file:/nonexistent/path}' };
-    const result = substituteInObject(obj);
+    const obj = { secret: '{file:nonexistent/path}' };
+    const result = substituteInObject(obj, fileRoot);
     expect(result.secret).toBeUndefined();
+  });
+
+  it('should reject a {file:} reference that escapes the confinement root', () => {
+    const obj = { secret: '{file:../../../etc/passwd}' };
+    expect(() => substituteInObject(obj, fileRoot)).toThrow(ConfigError);
   });
 
   it('should substitute in deeply nested structures', () => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -42,6 +42,7 @@ export {
   shouldMatchPackageTargets,
   shouldProcessPackage,
 } from './packageUtils.js';
+export { isPathWithinRoot } from './paths.js';
 export { type PrerequisiteResolution, resolvePrerequisites } from './prerequisites.js';
 export {
   extractSelectionRegion,

--- a/packages/core/src/paths.ts
+++ b/packages/core/src/paths.ts
@@ -1,0 +1,23 @@
+import * as path from 'node:path';
+
+/**
+ * True when `target` resolves to `root` itself or a path nested within it.
+ *
+ * Used to confine config-driven filesystem access — manifest write targets (`version.cargo.paths` /
+ * `version.pub.paths`), `npm.copyFiles` destinations, and `{file:}` reads — to the repository root so
+ * a malicious or mistaken config cannot drive reads/writes outside the tree via `..` or an absolute
+ * path. Both paths are resolved to absolute form first, so a relative `target` is interpreted
+ * against `process.cwd()` unless the caller has already resolved it against the intended base.
+ */
+export function isPathWithinRoot(root: string, target: string): boolean {
+  const resolvedRoot = path.resolve(root);
+  const resolvedTarget = path.resolve(target);
+  if (resolvedTarget === resolvedRoot) {
+    return true;
+  }
+  const relative = path.relative(resolvedRoot, resolvedTarget);
+  // The equal case already returned, so `relative` is non-empty here. `..` / `../…` catch parent
+  // escapes; isAbsolute catches a Windows cross-drive target (path.relative returns an absolute path
+  // when root and target are on different drives).
+  return relative !== '..' && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative);
+}

--- a/packages/core/test/unit/paths.spec.ts
+++ b/packages/core/test/unit/paths.spec.ts
@@ -1,0 +1,45 @@
+import * as path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { isPathWithinRoot } from '../../src/paths.js';
+
+const root = path.resolve('/repo');
+
+describe('isPathWithinRoot', () => {
+  it('should treat the root itself as within the root', () => {
+    expect(isPathWithinRoot(root, root)).toBe(true);
+  });
+
+  it('should accept a direct child of the root', () => {
+    expect(isPathWithinRoot(root, path.join(root, 'packages', 'foo', 'Cargo.toml'))).toBe(true);
+  });
+
+  it('should accept a relative path that resolves inside the root', () => {
+    expect(isPathWithinRoot(root, path.join(root, 'packages', '..', 'crates', 'foo'))).toBe(true);
+  });
+
+  it('should reject a parent-directory escape', () => {
+    expect(isPathWithinRoot(root, path.join(root, '..', 'other-repo', 'crate'))).toBe(false);
+  });
+
+  it('should reject a deeply nested escape that climbs above the root', () => {
+    expect(isPathWithinRoot(root, path.join(root, 'packages', 'foo', '..', '..', '..', 'secrets'))).toBe(false);
+  });
+
+  it('should reject the root parent directory', () => {
+    expect(isPathWithinRoot(root, path.dirname(root))).toBe(false);
+  });
+
+  it('should reject an absolute path outside the root', () => {
+    expect(isPathWithinRoot(root, path.resolve('/etc/passwd'))).toBe(false);
+  });
+
+  it('should accept a sibling whose name merely starts with the escape sequence', () => {
+    // A child literally named "..foo" is inside the root — it must not be mistaken for a `..` escape.
+    expect(isPathWithinRoot(root, path.join(root, '..foo'))).toBe(true);
+  });
+
+  it('should reject a sibling directory sharing the root name prefix', () => {
+    // "/repo-evil" shares the "/repo" prefix as a string but is not nested within "/repo".
+    expect(isPathWithinRoot(root, path.resolve('/repo-evil', 'crate'))).toBe(false);
+  });
+});

--- a/packages/publish/src/stages/prepare.ts
+++ b/packages/publish/src/stages/prepare.ts
@@ -1,6 +1,6 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { debug, info } from '@releasekit/core';
+import { debug, info, isPathWithinRoot } from '@releasekit/core';
 import { createPublishError, PublishErrorCode } from '../errors/index.js';
 import type { PipelineContext } from '../types.js';
 import { syncCargoLockfile, updateCargoVersion } from '../utils/cargo.js';
@@ -16,6 +16,15 @@ export async function runPrepareStage(ctx: PipelineContext): Promise<void> {
       for (const file of config.npm.copyFiles) {
         const src = path.resolve(cwd, file);
         const dest = path.join(pkgDir, file);
+
+        // Confine both the read source and the write destination to the repo root — a `../` or
+        // absolute copyFiles entry would otherwise read or write outside the tree.
+        if (!isPathWithinRoot(cwd, src) || !isPathWithinRoot(cwd, dest)) {
+          throw createPublishError(
+            PublishErrorCode.FILE_COPY_ERROR,
+            `Refusing to copy '${file}': it resolves outside the repository root (${cwd})`,
+          );
+        }
 
         if (!fs.existsSync(src)) {
           debug(`Source file not found, skipping copy: ${src}`);

--- a/packages/publish/test/unit/stages/prepare.spec.ts
+++ b/packages/publish/test/unit/stages/prepare.spec.ts
@@ -225,4 +225,28 @@ describe('prepare stage', () => {
     await runPrepareStage(ctx);
     expect(fs.readFileSync(path.join(dir, 'LICENSE'), 'utf-8')).toBe('MIT License');
   });
+
+  it('should reject a copyFiles entry that escapes the repository root', async () => {
+    const dir = createTmpDir();
+    const pkgDir = path.join(dir, 'packages', 'foo');
+    fs.mkdirSync(pkgDir, { recursive: true });
+    fs.writeFileSync(path.join(pkgDir, 'package.json'), '{"name":"foo","version":"1.0.0"}');
+
+    const config = getDefaultConfig();
+    config.npm.enabled = true;
+    config.npm.copyFiles = ['../../escape.txt'];
+
+    const ctx = createContext({
+      cwd: dir,
+      config,
+      input: {
+        dryRun: false,
+        updates: [{ packageName: 'foo', newVersion: '1.1.0', filePath: 'packages/foo/package.json' }],
+        changelogs: [],
+        tags: [],
+      },
+    });
+
+    await expect(runPrepareStage(ctx)).rejects.toThrow(/outside the repository root/);
+  });
 });

--- a/packages/version/src/core/versionStrategies.ts
+++ b/packages/version/src/core/versionStrategies.ts
@@ -16,6 +16,7 @@ import { getLatestTag, getLatestTagForPackage } from '../git/tagsAndBranches.js'
 import { updatePackageVersion } from '../package/packageManagement.js';
 import { PackageProcessor } from '../package/packageProcessor.js';
 import type { Config } from '../types.js';
+import { resolveConfinedManifestPath } from '../utils/confinedPath.js';
 import { deriveBaselineTagPrefix, formatCommitMessage, formatTag, formatVersionPrefix } from '../utils/formatting.js';
 import {
   addBaselineTag,
@@ -65,9 +66,17 @@ function shouldProcessPackage(pkg: Package, config: Config): boolean {
  * @param packageDir - The directory containing the package
  * @param version - The version to update to
  * @param cargoConfig - The cargo configuration from config
+ * @param dryRun - When true, log the intended writes without touching disk
+ * @param repoRoot - Confinement boundary for config-driven `cargo.paths` writes
  * @returns Array of Cargo.toml file paths that were updated
  */
-function updateCargoFiles(packageDir: string, version: string, cargoConfig: Config['cargo'], dryRun = false): string[] {
+function updateCargoFiles(
+  packageDir: string,
+  version: string,
+  cargoConfig: Config['cargo'],
+  dryRun = false,
+  repoRoot: string = process.cwd(),
+): string[] {
   const updatedFiles: string[] = [];
 
   // Check if Cargo.toml handling is enabled (default to true if not specified)
@@ -92,7 +101,7 @@ function updateCargoFiles(packageDir: string, version: string, cargoConfig: Conf
   if (cargoPaths && cargoPaths.length > 0) {
     // If paths are specified, only include those Cargo.toml files
     for (const cargoPath of cargoPaths) {
-      const resolvedCargoPath = path.resolve(packageDir, cargoPath, 'Cargo.toml');
+      const resolvedCargoPath = resolveConfinedManifestPath(repoRoot, packageDir, cargoPath, 'Cargo.toml');
       if (fs.existsSync(resolvedCargoPath)) {
         stageCargo(resolvedCargoPath);
       }
@@ -240,7 +249,7 @@ export function createSyncStrategy(config: Config): StrategyFunction {
 
           // Root Cargo.toml handling is independent of npm (updateCargoFiles honors cargo.enabled),
           // so it runs whether or not npm versioning is disabled — matching the per-package loop below.
-          const rootCargoFiles = updateCargoFiles(packages.root, nextVersion, config.cargo, dryRun);
+          const rootCargoFiles = updateCargoFiles(packages.root, nextVersion, config.cargo, dryRun, repoRoot);
           files.push(...rootCargoFiles);
           // Record 'root' when only the root Cargo.toml was versioned (npm disabled, or no root
           // package.json). In a single-package repo where packages.root === packages[0].dir the loop
@@ -286,7 +295,7 @@ export function createSyncStrategy(config: Config): StrategyFunction {
         }
 
         // Handle Cargo.toml files for this package
-        const pkgCargoFiles = updateCargoFiles(pkg.dir, nextVersion, config.cargo, dryRun);
+        const pkgCargoFiles = updateCargoFiles(pkg.dir, nextVersion, config.cargo, dryRun, repoRoot);
         files.push(...pkgCargoFiles);
 
         // Track by name when only the Cargo.toml was updated: a pure-Rust package (no package.json),
@@ -534,6 +543,7 @@ export function createSingleStrategy(config: Config): StrategyFunction {
       }
 
       const pkgPath = pkg.dir;
+      const repoRoot = packages.root ?? process.cwd();
       const formattedPrefix = formatVersionPrefix(versionPrefix || 'v');
 
       // Try to get the latest tag specific to this package first
@@ -669,7 +679,7 @@ export function createSingleStrategy(config: Config): StrategyFunction {
       }
 
       // Handle Cargo.toml files for this package
-      const cargoFiles = updateCargoFiles(pkgPath, nextVersion, config.cargo, dryRun);
+      const cargoFiles = updateCargoFiles(pkgPath, nextVersion, config.cargo, dryRun, repoRoot);
       filesToCommit.push(...cargoFiles);
 
       log(`Updated package ${packageName} to version ${nextVersion}`, 'success');
@@ -754,8 +764,9 @@ export function createAsyncStrategy(config: Config): StrategyFunction {
 
       log(`Processing ${packagesToProcess.length} packages`, 'info');
 
-      // 2. Process packages with PackageProcessor
-      const result = await packageProcessor.processPackages(packagesToProcess);
+      // 2. Process packages with PackageProcessor. Pass the discovered workspace root so
+      // config-driven cargo.paths / pub.paths writes are confined to the repository.
+      const result = await packageProcessor.processPackages(packagesToProcess, packages.root ?? process.cwd());
 
       // 3. Report results
       if (result.updatedPackages.length === 0) {

--- a/packages/version/src/errors/versionError.ts
+++ b/packages/version/src/errors/versionError.ts
@@ -15,6 +15,7 @@ export enum VersionErrorCode {
   INVALID_CONFIG = 'INVALID_CONFIG',
   PACKAGE_NOT_FOUND = 'PACKAGE_NOT_FOUND',
   VERSION_CALCULATION_ERROR = 'VERSION_CALCULATION_ERROR',
+  UNSAFE_CONFIG_PATH = 'UNSAFE_CONFIG_PATH',
 }
 
 /**
@@ -31,6 +32,7 @@ export function createVersionError(code: VersionErrorCode, details?: string): Ve
     [VersionErrorCode.INVALID_CONFIG]: 'Invalid configuration',
     [VersionErrorCode.PACKAGE_NOT_FOUND]: 'Package not found',
     [VersionErrorCode.VERSION_CALCULATION_ERROR]: 'Failed to calculate version',
+    [VersionErrorCode.UNSAFE_CONFIG_PATH]: 'Refusing to write a manifest outside the repository root',
   };
 
   // Provide helpful suggestions for specific error types
@@ -63,6 +65,10 @@ export function createVersionError(code: VersionErrorCode, details?: string): Ve
       'Ensure git repository has commits',
       'Check conventional commit message format',
       'Verify git tags are properly formatted',
+    ],
+    [VersionErrorCode.UNSAFE_CONFIG_PATH]: [
+      'Use a version.cargo.paths / version.pub.paths entry that stays inside the repository',
+      'Remove any leading ../ segments or absolute paths that point outside the project',
     ],
   };
 

--- a/packages/version/src/package/packageProcessor.ts
+++ b/packages/version/src/package/packageProcessor.ts
@@ -9,6 +9,7 @@ import { calculateVersion } from '../core/versionCalculator.js';
 import { StrictReachableError } from '../errors/strictReachableError.js';
 import { getLatestTagForPackage } from '../git/tagsAndBranches.js';
 import type { Config, VersionConfigBase } from '../types.js';
+import { resolveConfinedManifestPath } from '../utils/confinedPath.js';
 import { deriveBaselineTagPrefix, formatCommitMessage, formatTag, formatVersionPrefix } from '../utils/formatting.js';
 import {
   addChangelogData,
@@ -71,9 +72,14 @@ export class PackageProcessor {
   }
 
   /**
-   * Process packages based on skip list only (targeting handled at discovery time)
+   * Process packages based on skip list only (targeting handled at discovery time).
+   *
+   * `repoRoot` is the confinement boundary for config-driven manifest writes
+   * (`version.cargo.paths` / `version.pub.paths`): a path escaping it is rejected. It defaults
+   * to `process.cwd()` but callers pass the discovered workspace root when they have it, since the
+   * tool can run from a subdirectory whose cwd is narrower than the repo.
    */
-  async processPackages(packages: Package[]): Promise<ProcessResult> {
+  async processPackages(packages: Package[], repoRoot: string = process.cwd()): Promise<ProcessResult> {
     const tags: string[] = [];
     const updatedPackagesInfo: Array<{ name: string; version: string; path: string }> = [];
 
@@ -364,7 +370,7 @@ export class PackageProcessor {
         if (cargoPaths && cargoPaths.length > 0) {
           // If paths are specified, only include those Cargo.toml files
           for (const cargoPath of cargoPaths) {
-            const resolvedCargoPath = path.resolve(pkgPath, cargoPath, 'Cargo.toml');
+            const resolvedCargoPath = resolveConfinedManifestPath(repoRoot, pkgPath, cargoPath, 'Cargo.toml');
             log(`Checking cargo path for ${name}: ${resolvedCargoPath}`, 'debug');
             if (fs.existsSync(resolvedCargoPath)) {
               log(`Found Cargo.toml for ${name} at ${resolvedCargoPath}, updating...`, 'debug');
@@ -398,7 +404,7 @@ export class PackageProcessor {
 
         if (dartPaths && dartPaths.length > 0) {
           for (const dartPath of dartPaths) {
-            const resolvedPubspecPath = path.resolve(pkgPath, dartPath, 'pubspec.yaml');
+            const resolvedPubspecPath = resolveConfinedManifestPath(repoRoot, pkgPath, dartPath, 'pubspec.yaml');
             log(`Checking pub path for ${name}: ${resolvedPubspecPath}`, 'debug');
             if (fs.existsSync(resolvedPubspecPath)) {
               log(`Found pubspec.yaml for ${name} at ${resolvedPubspecPath}, updating...`, 'debug');

--- a/packages/version/src/utils/confinedPath.ts
+++ b/packages/version/src/utils/confinedPath.ts
@@ -1,0 +1,25 @@
+import path from 'node:path';
+import { isPathWithinRoot } from '@releasekit/core';
+import { createVersionError, VersionErrorCode } from '../errors/versionError.js';
+
+/**
+ * Resolve a config-driven manifest location (`version.cargo.paths` / `version.pub.paths`) and confine
+ * it to the repository root. A `..` or absolute-path entry that escapes the root would let a config
+ * drive a version rewrite of a manifest outside the tree — reject it loudly rather than resolving out
+ * of bounds.
+ */
+export function resolveConfinedManifestPath(
+  repoRoot: string,
+  packageDir: string,
+  configuredPath: string,
+  manifestFile: string,
+): string {
+  const resolved = path.resolve(packageDir, configuredPath, manifestFile);
+  if (!isPathWithinRoot(repoRoot, resolved)) {
+    throw createVersionError(
+      VersionErrorCode.UNSAFE_CONFIG_PATH,
+      `${resolved} is outside the repository root ${path.resolve(repoRoot)}`,
+    );
+  }
+  return resolved;
+}

--- a/packages/version/test/unit/core/versionStrategies.spec.ts
+++ b/packages/version/test/unit/core/versionStrategies.spec.ts
@@ -1167,7 +1167,7 @@ describe('Version Strategies', () => {
       await asyncStrategy(mockPackages);
 
       // Verify that packages are processed (no setTargets call since targeting is at discovery time)
-      expect(PackageProcessor.prototype.processPackages).toHaveBeenCalledWith(mockPackages.packages);
+      expect(PackageProcessor.prototype.processPackages).toHaveBeenCalledWith(mockPackages.packages, '/test/workspace');
 
       // Check logging
       expect(logging.log).toHaveBeenCalledWith('Processing 2 packages', 'info');
@@ -1195,7 +1195,10 @@ describe('Version Strategies', () => {
         },
       ];
 
-      expect(PackageProcessor.prototype.processPackages).toHaveBeenCalledWith(expectedFilteredPackages);
+      expect(PackageProcessor.prototype.processPackages).toHaveBeenCalledWith(
+        expectedFilteredPackages,
+        '/test/workspace',
+      );
 
       // Check filtering log messages
       expect(logging.log).toHaveBeenCalledWith('Runtime targets filter: 2 → 1 packages (package-b)', 'info');
@@ -1251,7 +1254,10 @@ describe('Version Strategies', () => {
         },
       ];
 
-      expect(PackageProcessor.prototype.processPackages).toHaveBeenCalledWith(expectedFilteredPackages);
+      expect(PackageProcessor.prototype.processPackages).toHaveBeenCalledWith(
+        expectedFilteredPackages,
+        '/test/workspace',
+      );
 
       // Check filtering log messages
       expect(logging.log).toHaveBeenCalledWith('Runtime targets filter: 3 → 2 packages (@scope/*)', 'info');
@@ -1271,7 +1277,7 @@ describe('Version Strategies', () => {
       await asyncStrategy(mockPackages);
 
       // Verify that all packages are processed (no filtering)
-      expect(PackageProcessor.prototype.processPackages).toHaveBeenCalledWith(mockPackages.packages);
+      expect(PackageProcessor.prototype.processPackages).toHaveBeenCalledWith(mockPackages.packages, '/test/workspace');
 
       // Should not show runtime filter message
       expect(logging.log).toHaveBeenCalledWith('Processing 2 packages', 'info');
@@ -1290,7 +1296,7 @@ describe('Version Strategies', () => {
       await asyncStrategy(mockPackages);
 
       // Verify packages are processed
-      expect(PackageProcessor.prototype.processPackages).toHaveBeenCalledWith(mockPackages.packages);
+      expect(PackageProcessor.prototype.processPackages).toHaveBeenCalledWith(mockPackages.packages, '/test/workspace');
       expect(logging.log).toHaveBeenCalledWith('Processing 2 packages', 'info');
     });
 

--- a/packages/version/test/unit/utils/confinedPath.spec.ts
+++ b/packages/version/test/unit/utils/confinedPath.spec.ts
@@ -1,0 +1,42 @@
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { VersionError } from '../../../src/errors/versionError.js';
+import { resolveConfinedManifestPath } from '../../../src/utils/confinedPath.js';
+
+const repoRoot = path.resolve('/repo');
+const pkgDir = path.join(repoRoot, 'packages', 'foo');
+
+describe('resolveConfinedManifestPath', () => {
+  it('should resolve a manifest inside the package directory', () => {
+    const resolved = resolveConfinedManifestPath(repoRoot, pkgDir, 'rust', 'Cargo.toml');
+    expect(resolved).toBe(path.join(pkgDir, 'rust', 'Cargo.toml'));
+  });
+
+  it('should resolve a sibling manifest that stays inside the repository root', () => {
+    const resolved = resolveConfinedManifestPath(repoRoot, pkgDir, '../bar', 'pubspec.yaml');
+    expect(resolved).toBe(path.join(repoRoot, 'packages', 'bar', 'pubspec.yaml'));
+  });
+
+  it('should reject a path that escapes the repository root via ..', () => {
+    expect(() => resolveConfinedManifestPath(repoRoot, pkgDir, '../../../../other-repo/crate', 'Cargo.toml')).toThrow(
+      VersionError,
+    );
+  });
+
+  it('should reject an absolute path outside the repository root', () => {
+    expect(() => resolveConfinedManifestPath(repoRoot, pkgDir, path.resolve('/tmp/evil'), 'Cargo.toml')).toThrow(
+      /outside the repository root/,
+    );
+  });
+
+  it('should raise a VersionError carrying the UNSAFE_CONFIG_PATH code', () => {
+    let caught: unknown;
+    try {
+      resolveConfinedManifestPath(repoRoot, pkgDir, '../../..', 'Cargo.toml');
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(VersionError);
+    expect((caught as VersionError).code).toBe('UNSAFE_CONFIG_PATH');
+  });
+});


### PR DESCRIPTION
## Summary

From the 2026-07-19 security review (#559): config-supplied paths and the `{file:}`/`{env:}` substitution primitive were unconfined, letting a config drive writes outside the repo and reads of arbitrary files. This grouped fix confines all three surfaces to the repository root.

- **Manifest writes** — `version.cargo.paths` / `version.pub.paths` are resolved and confined to the workspace root before writing. A `../…` or absolute entry that escapes the tree is rejected with a clear `VersionError` (`UNSAFE_CONFIG_PATH`) instead of rewriting a foreign `Cargo.toml` / `pubspec.yaml`. Applied to both the async `PackageProcessor` and the sync/single `updateCargoFiles` write paths.
- **`npm.copyFiles`** — both the copy source and destination must resolve inside the repo root, else the prepare stage throws a `FILE_COPY_ERROR`.
- **`{file:}` substitution** — confined to the config file's directory; the previous `~` home-directory expansion (the `{file:~/.ssh/id_rsa}` exfiltration vector) is removed. An out-of-bounds reference throws a `ConfigError`; an in-bounds but unreadable path still resolves to an empty string.
- **`{env:}` substitution** — intentionally left unconstrained: it is the trusted-operator injection point for secrets (npm/LLM tokens), so allowlisting it would break every consumer. The trust boundary — config values can read files/env and may surface in bot-authored output — is documented on the substitution helper and in the config README.

The boundary predicate `isPathWithinRoot` is added to `@releasekit/core` and shared across `config`, `version`, and `publish`.

## Test plan

- New/updated unit tests: `@releasekit/core` `paths.spec.ts`; `@releasekit/version` `confinedPath.spec.ts` + `versionStrategies.spec.ts` (threaded root); `@releasekit/config` `substitute.spec.ts` (confinement + escape cases); `@releasekit/publish` `prepare.spec.ts` (escape rejected).
- Rebased onto current `main` (which now includes #561); the two `@releasekit/core` index exports coexist. Re-verified the CI way: `biome check .` exit 0, `pnpm schema:check` up to date, forced `turbo run typecheck test` → 24/24.

Closes #559

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BT6fVBZrmExXZj7vQ29881

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR closes the config-driven path-traversal attack surface identified in security review #559 by introducing a shared `isPathWithinRoot` boundary predicate in `@releasekit/core` and applying it consistently across the three unconfined surfaces.

- **`{file:}` substitution** — confined to the config file's own directory; the `~` home-directory expansion vector is removed and out-of-bounds references now throw a `ConfigError` rather than silently reading arbitrary files.
- **`version.cargo.paths` / `version.pub.paths` manifest writes** — both the `PackageProcessor` (async strategy) and the `updateCargoFiles` helper (sync/single strategies) now resolve config-supplied paths through `resolveConfinedManifestPath`, throwing `UNSAFE_CONFIG_PATH` for any path that escapes the workspace root.
- **`npm.copyFiles`** — both the read source and the write destination are checked against `cwd` before the copy executes; an escaping entry throws `FILE_COPY_ERROR`.
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge — all three unconfined surfaces are now gated by `isPathWithinRoot` before any filesystem read or write, with no regressions to the happy path.

The boundary predicate is correct for POSIX and Windows cross-drive paths, the `resolveConfinedManifestPath` helper is applied consistently across both the async `PackageProcessor` and the sync/single `updateCargoFiles` paths, and the `{file:}` confinement throws before any `readFileSync` call. The `~`-expansion exfiltration vector is fully removed. Tests cover equal-root, child, sibling-prefix, `..`-escape, absolute-outside, and the `..foo` name edge case. No off-by-one or partial-coverage gaps were found.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/core/src/paths.ts | New shared boundary predicate `isPathWithinRoot`; handles equal-path, `..`-escape, and Windows cross-drive cases correctly. The `!path.isAbsolute(relative)` guard is intentionally retained for Windows even though it is always false on POSIX. |
| packages/config/src/substitute.ts | Removes `~`-expansion, adds `isPathWithinRoot` guard before every `fs.readFileSync`; `os` import retained for `loadAuth`/`saveAuth`. The `rootDir` default of `process.cwd()` is a safe fallback for the public API surface. |
| packages/config/src/load.ts | Correctly threads `path.dirname(configPath)` as the confinement root into `substituteInObject`, confining `{file:}` reads to the config file's directory. |
| packages/version/src/utils/confinedPath.ts | New helper `resolveConfinedManifestPath`; correctly resolves config-supplied paths and rejects escaping entries with a typed `VersionError(UNSAFE_CONFIG_PATH)`. |
| packages/version/src/package/packageProcessor.ts | Adds `repoRoot` parameter to `processPackages`; routes both `cargoPaths` and `dartPaths` entries through `resolveConfinedManifestPath`. |
| packages/version/src/core/versionStrategies.ts | Threads `repoRoot` (derived from `packages.root ?? process.cwd()`) through all three strategy paths (sync, single, async); the `process.cwd()` fallback is conservative and documented. |
| packages/publish/src/stages/prepare.ts | Adds pre-copy confinement check for both `src` (resolved via `path.resolve`) and `dest` (joined via `path.join`); the `src` check catches absolute-path injection even when `path.join` embeds the absolute component as a relative segment. |
| packages/version/src/errors/versionError.ts | Adds `UNSAFE_CONFIG_PATH` error code with a clear user-facing message and actionable suggestions. |
| packages/core/src/index.ts | Re-exports `isPathWithinRoot` from the new `paths.ts` module. |
| packages/core/test/unit/paths.spec.ts | Good coverage: equal-root, child, relative-inside, parent-escape, deep-escape, sibling-prefix, and absolute-outside cases all covered. The `..foo` edge case (name starts with `..`) correctly passes. |
| packages/config/test/unit/substitute.spec.ts | Drops the `~`-expansion test (removed feature), adds confinement and escape tests. Calls without `rootDir` are all env-only scenarios so the `process.cwd()` default is never exercised with a `{file:}` reference. |
| packages/version/test/unit/utils/confinedPath.spec.ts | New spec for `resolveConfinedManifestPath`; covers in-bounds, sibling-within-root, `..`-escape, absolute-escape, and error-code assertions. |
| packages/version/test/unit/core/versionStrategies.spec.ts | Updates assertions to expect the `repoRoot` argument (`'/test/workspace'`) in `processPackages` calls. |
| packages/publish/test/unit/stages/prepare.spec.ts | New integration test verifies that a `../../escape.txt` entry in `copyFiles` causes `runPrepareStage` to throw with a message matching `/outside the repository root/`. |
| packages/config/README.md | Updates the API table to reflect the new `rootDir` parameter on `substituteInObject`. |

</details>


<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Config-supplied value] --> B{Which surface?}

    B --> C["{file:PATH} substitution\n(substitute.ts)"]
    B --> D["cargo.paths / pub.paths\n(confinedPath.ts + packageProcessor.ts)"]
    B --> E["npm.copyFiles\n(prepare.ts)"]
    B --> F["{env:NAME} substitution"]

    C --> C1["path.resolve(rootDir, filePath)"]
    C1 --> G{isPathWithinRoot?}
    G -- No --> H["throw ConfigError\n(no read performed)"]
    G -- Yes --> I["fs.readFileSync\n(or '' on ENOENT)"]

    D --> D1["resolveConfinedManifestPath(repoRoot, pkgDir, path, file)"]
    D1 --> D2["path.resolve(pkgDir, configuredPath, manifest)"]
    D2 --> G2{isPathWithinRoot?}
    G2 -- No --> J["throw VersionError\nUNSAFE_CONFIG_PATH"]
    G2 -- Yes --> K["Write manifest"]

    E --> E1["src = path.resolve(cwd, file)\ndest = path.join(pkgDir, file)"]
    E1 --> G3{"isPathWithinRoot(cwd, src)\n&& isPathWithinRoot(cwd, dest)?"}
    G3 -- No --> L["throw PublishError\nFILE_COPY_ERROR"]
    G3 -- Yes --> M["fs.copyFileSync(src, dest)"]

    F --> N["process.env lookup\n(unconstrained — operator trust boundary)"]

    style H fill:#f88,color:#000
    style J fill:#f88,color:#000
    style L fill:#f88,color:#000
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Config-supplied value] --> B{Which surface?}

    B --> C["{file:PATH} substitution\n(substitute.ts)"]
    B --> D["cargo.paths / pub.paths\n(confinedPath.ts + packageProcessor.ts)"]
    B --> E["npm.copyFiles\n(prepare.ts)"]
    B --> F["{env:NAME} substitution"]

    C --> C1["path.resolve(rootDir, filePath)"]
    C1 --> G{isPathWithinRoot?}
    G -- No --> H["throw ConfigError\n(no read performed)"]
    G -- Yes --> I["fs.readFileSync\n(or '' on ENOENT)"]

    D --> D1["resolveConfinedManifestPath(repoRoot, pkgDir, path, file)"]
    D1 --> D2["path.resolve(pkgDir, configuredPath, manifest)"]
    D2 --> G2{isPathWithinRoot?}
    G2 -- No --> J["throw VersionError\nUNSAFE_CONFIG_PATH"]
    G2 -- Yes --> K["Write manifest"]

    E --> E1["src = path.resolve(cwd, file)\ndest = path.join(pkgDir, file)"]
    E1 --> G3{"isPathWithinRoot(cwd, src)\n&& isPathWithinRoot(cwd, dest)?"}
    G3 -- No --> L["throw PublishError\nFILE_COPY_ERROR"]
    G3 -- Yes --> M["fs.copyFileSync(src, dest)"]

    F --> N["process.env lookup\n(unconstrained — operator trust boundary)"]

    style H fill:#f88,color:#000
    style J fill:#f88,color:#000
    style L fill:#f88,color:#000
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/core/src/paths.ts`, line 231-232 ([link](https://github.com/goosewobbler/releasekit/blob/1a6f1b6dbedba5864e4a1617d1345eb47d476508/packages/core/src/paths.ts#L231-L232)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Two unreachable conditions in boundary predicate**

   The early-return `if (resolvedTarget === resolvedRoot) return true` on line 228 ensures that when `resolvedTarget` equals `resolvedRoot`, we return early. After that branch, `path.relative(resolvedRoot, resolvedTarget)` will never return `''` (which only happens when the two paths are identical), making `relative !== ''` permanently `true` and therefore redundant. Similarly, `!path.isAbsolute(relative)` is always `true` on POSIX because `path.relative` never produces an absolute path. Neither condition is harmful, but both add noise to the security-critical boundary predicate and could mislead a future reader into thinking they guard meaningful cases.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fcore%2Fsrc%2Fpaths.ts%0ALine%3A%20231-232%0A%0AComment%3A%0A**Two%20unreachable%20conditions%20in%20boundary%20predicate**%0A%0AThe%20early-return%20%60if%20%28resolvedTarget%20%3D%3D%3D%20resolvedRoot%29%20return%20true%60%20on%20line%20228%20ensures%20that%20when%20%60resolvedTarget%60%20equals%20%60resolvedRoot%60%2C%20we%20return%20early.%20After%20that%20branch%2C%20%60path.relative%28resolvedRoot%2C%20resolvedTarget%29%60%20will%20never%20return%20%60''%60%20%28which%20only%20happens%20when%20the%20two%20paths%20are%20identical%29%2C%20making%20%60relative%20!%3D%3D%20''%60%20permanently%20%60true%60%20and%20therefore%20redundant.%20Similarly%2C%20%60!path.isAbsolute%28relative%29%60%20is%20always%20%60true%60%20on%20POSIX%20because%20%60path.relative%60%20never%20produces%20an%20absolute%20path.%20Neither%20condition%20is%20harmful%2C%20but%20both%20add%20noise%20to%20the%20security-critical%20boundary%20predicate%20and%20could%20mislead%20a%20future%20reader%20into%20thinking%20they%20guard%20meaningful%20cases.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=goosewobbler%2Freleasekit&pr=586&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fcore%2Fsrc%2Fpaths.ts%0ALine%3A%20231-232%0A%0AComment%3A%0A**Two%20unreachable%20conditions%20in%20boundary%20predicate**%0A%0AThe%20early-return%20%60if%20%28resolvedTarget%20%3D%3D%3D%20resolvedRoot%29%20return%20true%60%20on%20line%20228%20ensures%20that%20when%20%60resolvedTarget%60%20equals%20%60resolvedRoot%60%2C%20we%20return%20early.%20After%20that%20branch%2C%20%60path.relative%28resolvedRoot%2C%20resolvedTarget%29%60%20will%20never%20return%20%60''%60%20%28which%20only%20happens%20when%20the%20two%20paths%20are%20identical%29%2C%20making%20%60relative%20!%3D%3D%20''%60%20permanently%20%60true%60%20and%20therefore%20redundant.%20Similarly%2C%20%60!path.isAbsolute%28relative%29%60%20is%20always%20%60true%60%20on%20POSIX%20because%20%60path.relative%60%20never%20produces%20an%20absolute%20path.%20Neither%20condition%20is%20harmful%2C%20but%20both%20add%20noise%20to%20the%20security-critical%20boundary%20predicate%20and%20could%20mislead%20a%20future%20reader%20into%20thinking%20they%20guard%20meaningful%20cases.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=586&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["fix(config): confine config-driven files..."](https://github.com/goosewobbler/releasekit/commit/0d17ccc6cc2074c068ccbe0ea71ee0fd6a6e1f3e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45488384)</sub>

<!-- /greptile_comment -->