### PR TITLE
fix(ci): derive action tag from git to stop silent action-dist skips

### DIFF
--- a/.github/workflows/_action-release.reusable.yml
+++ b/.github/workflows/_action-release.reusable.yml
@@ -33,13 +33,29 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+      - name: Skip if dist already committed on the tag
+        id: guard
+        run: |
+          # Idempotency + loop-break: on a fresh release the tag points at a dist-less commit
+          # (proceed); after a heal it points at the dist commit (no-op) — so re-running on the
+          # force-moved tag can't loop or double-commit. Lets action-dist-heal.yml reuse this job.
+          if git cat-file -e "HEAD:packages/release/dist/cli.js" 2>/dev/null; then
+            echo "already_healed=true" >> "$GITHUB_OUTPUT"
+            echo "dist already committed on ${{ inputs.tag }} — skipping (no-op)."
+          else
+            echo "already_healed=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Setup workspace
+        if: steps.guard.outputs.already_healed != 'true'
         uses: ./.github/workflows/actions/setup-workspace
 
       - name: Build packages
+        if: steps.guard.outputs.already_healed != 'true'
         run: pnpm build
 
       - name: Commit dist and tag
+        if: steps.guard.outputs.already_healed != 'true'
         env:
           RELEASE_TAG: ${{ inputs.tag }}
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/_action-release.reusable.yml
+++ b/.github/workflows/_action-release.reusable.yml
@@ -39,6 +39,9 @@ jobs:
           # Idempotency + loop-break: on a fresh release the tag points at a dist-less commit
           # (proceed); after a heal it points at the dist commit (no-op) — so re-running on the
           # force-moved tag can't loop or double-commit. Lets action-dist-heal.yml reuse this job.
+          # The sentinel is the action's entry point (what run-action.mjs loads / the releasekit-release
+          # bin); if the dist layout ever moves, update this path too — otherwise the guard silently
+          # stops no-op'ing and every scheduled heal rebuilds and re-moves the tag.
           if git cat-file -e "HEAD:packages/release/dist/cli.js" 2>/dev/null; then
             echo "already_healed=true" >> "$GITHUB_OUTPUT"
             echo "dist already committed on ${{ inputs.tag }} — skipping (no-op)."

--- a/.github/workflows/_release.reusable.yml
+++ b/.github/workflows/_release.reusable.yml
@@ -224,9 +224,11 @@ jobs:
           # and to gate reconcile-standing-pr in standing-pr.yml.
           ACTION_TAG=$(git tag --points-at HEAD | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)
 
-          # Fail loud when a publish that MUST tag produced none: a red run beats a silently broken
-          # published tag. The standing-PR publish of a merged PR always releases; the normal release
-          # path may legitimately find no changes (no tag expected).
+          # Fail loud when a publish that must tag produced none — a red run beats a silently broken
+          # published tag. Two gates by design: the standing-PR publish of a merged PR always releases,
+          # so a missing tag there is authoritative (no stdout dependency). The normal release path may
+          # legitimately have no changes, so it falls back to HAS_CHANGES — best-effort, since that
+          # signal comes from the same stdout we no longer trust for the tag; in practice they agree.
           if [ -z "$ACTION_TAG" ] && { [ -n "$STANDING_PR" ] || [ "$HAS_CHANGES" = "true" ]; }; then
             echo "::error::Publish reported success but no vX.Y.Z tag is on HEAD — the action-dist build would be skipped, stranding a dist-less action tag."
             exit 1

--- a/.github/workflows/_release.reusable.yml
+++ b/.github/workflows/_release.reusable.yml
@@ -213,14 +213,25 @@ jobs:
       - name: Extract action tag
         id: extract-tag
         if: ${{ !inputs.dry_run }}
+        env:
+          STANDING_PR: ${{ inputs.standing_pr_number }}
+          HAS_CHANGES: ${{ steps.release.outputs.has_changes || steps.release-standing-pr.outputs.has_changes }}
         run: |
-          # Sync-mode produces a single shared tag like `v0.21.0`. Pick the first one matching
-          # the version-prefix pattern as the action_tag (used to trigger _action-release for the
-          # GitHub Action build, and to gate reconcile-standing-pr in standing-pr.yml).
-          ACTION_TAG=""
-          if [ -f release-output.json ]; then
-            ACTION_TAG=$(jq -r '.versionOutput.tags[] | select(test("^v[0-9]+\\."))' release-output.json 2>/dev/null | head -1)
+          # Source of truth is git, not the captured JSON. The publish creates the sync-mode release
+          # tag at HEAD (createReleaseTags), so a tag on HEAD is authoritative and immune to a stdout
+          # hiccup emptying release-output.json — which could otherwise leave action_tag empty and
+          # silently skip the action-dist build. Consumed by _action-release (the GitHub Action build)
+          # and to gate reconcile-standing-pr in standing-pr.yml.
+          ACTION_TAG=$(git tag --points-at HEAD | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)
+
+          # Fail loud when a publish that MUST tag produced none: a red run beats a silently broken
+          # published tag. The standing-PR publish of a merged PR always releases; the normal release
+          # path may legitimately find no changes (no tag expected).
+          if [ -z "$ACTION_TAG" ] && { [ -n "$STANDING_PR" ] || [ "$HAS_CHANGES" = "true" ]; }; then
+            echo "::error::Publish reported success but no vX.Y.Z tag is on HEAD — the action-dist build would be skipped, stranding a dist-less action tag."
+            exit 1
           fi
+
           echo "action_tag=${ACTION_TAG}" >> "$GITHUB_OUTPUT"
 
       - name: Summary

--- a/.github/workflows/action-dist-heal.yml
+++ b/.github/workflows/action-dist-heal.yml
@@ -1,0 +1,58 @@
+name: Action Dist Heal
+
+# Backstop for the action tag's committed dist. The in-run build (release.yml -> _action-release) is
+# the primary path; this heals a vX.Y.Z tag that ended up dist-less anyway — e.g. the release job died
+# after pushing the tag but before committing dist. Reuses _action-release, which no-ops when the dist
+# is already committed, so it is safe to run any time. Deliberately NOT triggered on tag push, so it
+# never races the in-run path.
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Version tag to heal (e.g. v1.2.3)'
+        required: true
+        type: string
+  schedule:
+    - cron: '17 6 * * *' # daily: heal the newest stable release if it is missing dist
+
+permissions:
+  contents: write
+
+jobs:
+  resolve:
+    name: Resolve tag
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.pick.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Pick tag to heal
+        id: pick
+        env:
+          DISPATCH_TAG: ${{ github.event.inputs.tag }}
+        run: |
+          # Manual dispatch heals the requested tag; the scheduled run heals the newest stable
+          # release (the realistic failure — a just-cut release missing its dist). Use the exact-tag
+          # dispatch input to heal a prerelease.
+          if [ -n "$DISPATCH_TAG" ]; then
+            TAG="$DISPATCH_TAG"
+          else
+            TAG=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' | grep -vE -- '-' | sort -V | tail -1)
+          fi
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+
+  heal:
+    name: Heal action dist
+    needs: resolve
+    if: needs.resolve.outputs.tag != ''
+    uses: ./.github/workflows/_action-release.reusable.yml
+    permissions:
+      contents: write
+    with:
+      tag: ${{ needs.resolve.outputs.tag }}
+    secrets:
+      ssh_key: ${{ secrets.DEPLOY_KEY }}


### PR DESCRIPTION
## Problem

`v0.41.1` shipped **without `packages/release/dist/`** committed to its tag, so `uses: goosewobbler/releasekit@v0.41.1` fails at runtime with `Cannot find module '.../packages/release/dist/cli.js'`.

Root cause: `_action-release` (which builds `dist/`, commits it, and force-moves the consumable `vX.Y.Z` tag) is gated on `action_tag`, and `action_tag` was **scraped from the publish command's stdout JSON** (`RELEASE_OUTPUT | jq '.versionOutput.tags[]'`). In the `v0.41.1` publish that stdout came back without parseable `.versionOutput`, so `has_changes=false` → `release-output.json` was never written → `action_tag` was empty → the action-dist build was **silently skipped with a green check**. Every code path that could contaminate stdout checks out as correct, so the trigger was a rare/transient hiccup in the stdout capture — but the real defect is that a momentary blip becomes a permanently broken public tag with no error signal.

Scope: these are all `.github/workflows/` changes to how releasekit releases **itself**. Nothing in the shipped npm package or the consumer-facing action changes.

## What changed

**Derive the action tag from git instead of stdout** (`_release.reusable.yml`)
The publish creates the sync-mode release tag at `HEAD` (`createReleaseTags`), so `git tag --points-at HEAD` is an authoritative source that a stdout hiccup can't empty. This removes the fragile dependency that stranded `v0.41.1`. `release-output.json` is kept only for the (now cosmetic) step summary.

**Fail loud when a publish that must tag produces none** (`_release.reusable.yml`)
If the standing-PR publish of a merged PR — or a release that reported changes — ends with no version tag on `HEAD`, the job now errors instead of quietly continuing. A red run is recoverable; a silently broken published tag is not.

**Make `_action-release` idempotent** (`_action-release.reusable.yml`)
It now no-ops when the tag's commit already carries the built `dist/`. On a fresh release the tag is dist-less (proceed); after a repair it points at the dist commit (skip) — so re-running on the force-moved tag can't loop or double-commit. This is what makes a tag safe to rebuild on demand.

**Add a heal backstop** (`action-dist-heal.yml`, new)
A manual (`workflow_dispatch <tag>`) and daily-scheduled job that reuses the now-idempotent `_action-release` to repair a dist-less tag — e.g. if the release job dies after pushing the tag but before committing `dist/`, or to fix a tag that was stranded before this change. Deliberately **not** tag-triggered, so it never races the in-run build.

### How each failure mode is covered
| Failure mode | Addressed by |
|---|---|
| Tag exists but the stdout capture flaked (the `v0.41.1` case) | git-derived action tag — builds `dist/` in-run regardless |
| Publish succeeded but produced no tag at all | fail-loud — surfaces as a red run |
| Release job died after the tag push, before committing `dist/` | heal backstop — manual dispatch or the daily sweep |

## Validation
- `actionlint` clean on all three files (the pre-existing `TURBO_TOKEN` / `TURBO_TEAM` / SC2086 warnings are unrelated).
- Idempotency check (safe, no side effects): dispatch **Action Dist Heal** against an already-good tag (e.g. `v0.41.0`) → expect a no-op, no tag move.

## Follow-up
- After merge, repair the stranded tag by dispatching **Action Dist Heal** with `tag: v0.41.1`; it commits `dist/` to the tag in place. This doubles as the real-world test of the heal path.
- The zubridge consumer PR pinned to `@v0.41.1` then just needs its Release Preview CI re-run — no version bump required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR hardens the CI pipeline for releasekit's self-release by fixing the root cause of `v0.41.1` shipping without a committed `dist/`. The core change switches the action-tag source from fragile stdout JSON to `git tag --points-at HEAD`, adds a fail-loud guard when an expected tag is absent, makes `_action-release` idempotent, and introduces a manual/scheduled heal backstop workflow.

- **`_release.reusable.yml`**: `action_tag` now comes from git rather than parsed stdout; a fail-loud `exit 1` fires if a tag-producing publish produces no git tag at HEAD.
- **`_action-release.reusable.yml`**: An idempotency guard (`git cat-file -e "HEAD:packages/release/dist/cli.js"`) skips the entire build/commit/tag cycle when dist is already present, making the workflow safe to re-run after partial failures or via the heal backstop.
- **`action-dist-heal.yml`** (new): A `workflow_dispatch` + daily-scheduled workflow that targets the newest stable tag (or a manually specified tag) and delegates to the now-idempotent `_action-release`, enabling on-demand repair of dist-less tags without racing the primary release path.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — all three files are workflow-only changes with no impact on the shipped npm package or consumer-facing action.

The git-based tag derivation is more reliable than stdout parsing, the idempotency guard is correctly implemented using git cat-file -e, the fail-loud check fires on the right conditions, and the heal workflow handles both dispatch and scheduled triggers cleanly.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/_release.reusable.yml | Replaces stdout-parsed action tag with git-authoritative source; adds fail-loud guard when a tag-producing publish leaves no git tag at HEAD. |
| .github/workflows/_action-release.reusable.yml | Idempotency guard added via git cat-file -e; downstream steps correctly conditioned on guard output. |
| .github/workflows/action-dist-heal.yml | New heal-backstop workflow; correctly handles both manual dispatch and scheduled runs with proper tag resolution and idempotency. |

</details>

<sub>Reviews (2): Last reviewed commit: ["docs(ci): note the fail-loud gate split ..."](https://github.com/goosewobbler/releasekit/commit/5bfbe4d310d3457d9009b98cde2a99652bc8c7e8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45736453)</sub>

<!-- /greptile_comment -->