### PR TITLE
fix(action): recover the release `tags` output from git when stdout can't be parsed

### DIFF
--- a/scripts/run-action.d.mts
+++ b/scripts/run-action.d.mts
@@ -36,7 +36,7 @@ export function buildPreviewArgs(input: ActionInputs): string[];
 export function parseReleaseOutput(
   stdout: string,
 ): { versionOutput?: { tags?: string[]; updates?: unknown[] } } | undefined;
-export function resolveReleaseTags(args: { parsedTags?: string[]; gitTags?: string[]; dryRun?: boolean }): {
+export function resolveReleaseTags(args: { parsedTags?: string[]; gitTags?: string[]; allowRecovery?: boolean }): {
   tags: string[];
   recovered: boolean;
 };

--- a/scripts/run-action.d.mts
+++ b/scripts/run-action.d.mts
@@ -36,6 +36,10 @@ export function buildPreviewArgs(input: ActionInputs): string[];
 export function parseReleaseOutput(
   stdout: string,
 ): { versionOutput?: { tags?: string[]; updates?: unknown[] } } | undefined;
+export function resolveReleaseTags(args: { parsedTags?: string[]; gitTags?: string[]; dryRun?: boolean }): {
+  tags: string[];
+  recovered: boolean;
+};
 export function parseInputs(env?: NodeJS.ProcessEnv | Record<string, string | undefined>): ActionInputs;
 export function runAction(
   input: ActionInputs,

--- a/scripts/run-action.mjs
+++ b/scripts/run-action.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { spawn } from 'node:child_process';
+import { execFileSync, spawn } from 'node:child_process';
 import { randomBytes } from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
@@ -160,6 +160,33 @@ export function parseReleaseOutput(stdout, verbose = false) {
     }
     return undefined;
   }
+}
+
+// Sync-mode version tags on HEAD, straight from git. The release creates them at HEAD, so they
+// survive a stdout-capture hiccup that would empty the parsed JSON — the authoritative fallback for
+// the `tags` output. Per-package tag formats aren't matched here and still rely on the parsed output.
+function gitVersionTagsAtHead(cwd) {
+  try {
+    const out = execFileSync('git', ['tag', '--points-at', 'HEAD'], { cwd, encoding: 'utf8' });
+    return out
+      .split('\n')
+      .map((tag) => tag.trim())
+      .filter((tag) => /^v\d+\.\d+\.\d+/.test(tag));
+  } catch {
+    return [];
+  }
+}
+
+// Pure tag selection, testable without git or GITHUB_OUTPUT. Prefer the parsed release output; on a
+// real run that parsed no tags, fall back to git's authoritative tags so a stdout hiccup can't
+// silently empty `tags`. `recovered` flags that fallback so the caller can surface it.
+export function resolveReleaseTags({ parsedTags, gitTags, dryRun }) {
+  const parsed = Array.isArray(parsedTags) ? parsedTags : [];
+  if (parsed.length > 0 || dryRun) {
+    return { tags: parsed, recovered: false };
+  }
+  const git = Array.isArray(gitTags) ? gitTags : [];
+  return git.length > 0 ? { tags: git, recovered: true } : { tags: [], recovered: false };
 }
 
 function setOutput(name, value) {
@@ -398,8 +425,19 @@ function writeReleaseOutputs(input, stdout) {
   const versionOutput = parsed?.versionOutput ? JSON.stringify(parsed.versionOutput) : '';
   setOutput('version-output', versionOutput);
 
-  const tags = parsed?.versionOutput?.tags;
-  setOutput('tags', Array.isArray(tags) ? tags.join(',') : '');
+  const dryRun = normalizeBoolean(input.dryRun);
+  const parsedTags = parsed?.versionOutput?.tags;
+  // Only shell out to git when the parsed output gave nothing on a real run — the common path stays a
+  // pure parse. A silent empty `tags` is what let a dist-less tag ship unnoticed before.
+  const needGit = !dryRun && !(Array.isArray(parsedTags) && parsedTags.length > 0);
+  const gitTags = needGit ? gitVersionTagsAtHead(input.projectDir ?? '.') : [];
+  const { tags, recovered } = resolveReleaseTags({ parsedTags, gitTags, dryRun });
+  if (recovered) {
+    console.log(
+      '::warning::releasekit: recovered the `tags` output from git after the release output could not be parsed — check this run for a stdout capture issue',
+    );
+  }
+  setOutput('tags', tags.join(','));
 }
 
 function writePreviewOutputs(input, stdout) {

--- a/scripts/run-action.mjs
+++ b/scripts/run-action.mjs
@@ -177,12 +177,13 @@ function gitVersionTagsAtHead(cwd) {
   }
 }
 
-// Pure tag selection, testable without git or GITHUB_OUTPUT. Prefer the parsed release output; on a
-// real run that parsed no tags, fall back to git's authoritative tags so a stdout hiccup can't
-// silently empty `tags`. `recovered` flags that fallback so the caller can surface it.
-export function resolveReleaseTags({ parsedTags, gitTags, dryRun }) {
+// Pure tag selection, testable without git or GITHUB_OUTPUT. Prefer the parsed release output; only
+// when recovery is allowed (json output was expected but couldn't be parsed — see writeReleaseOutputs)
+// do we fall back to git's authoritative tags so a stdout hiccup can't silently empty `tags`.
+// `recovered` flags that fallback so the caller can surface it.
+export function resolveReleaseTags({ parsedTags, gitTags, allowRecovery }) {
   const parsed = Array.isArray(parsedTags) ? parsedTags : [];
-  if (parsed.length > 0 || dryRun) {
+  if (parsed.length > 0 || !allowRecovery) {
     return { tags: parsed, recovered: false };
   }
   const git = Array.isArray(gitTags) ? gitTags : [];
@@ -417,7 +418,8 @@ function writeCoreOutputs(mode, success) {
 }
 
 function writeReleaseOutputs(input, stdout) {
-  const parsed = normalizeBoolean(input.json) ? parseReleaseOutput(stdout, normalizeBoolean(input.verbose)) : undefined;
+  const jsonMode = normalizeBoolean(input.json);
+  const parsed = jsonMode ? parseReleaseOutput(stdout, normalizeBoolean(input.verbose)) : undefined;
   const hasChanges = !!parsed?.versionOutput?.updates?.length;
   setOutput('has-changes', hasChanges ? 'true' : 'false');
   setOutput('release-output', parsed ? JSON.stringify(parsed) : '');
@@ -425,16 +427,18 @@ function writeReleaseOutputs(input, stdout) {
   const versionOutput = parsed?.versionOutput ? JSON.stringify(parsed.versionOutput) : '';
   setOutput('version-output', versionOutput);
 
-  const dryRun = normalizeBoolean(input.dryRun);
+  // Recover `tags` from git only when json output was expected but did not parse — a stdout hiccup
+  // must not silently empty it. Never when json mode is off (no parse was attempted, so an empty
+  // `tags` is intentional), on a dry run (nothing tagged), or with --skip-git (a version tag on HEAD
+  // would be the *previous* release's, not this run's).
+  const allowRecovery =
+    jsonMode && parsed === undefined && !normalizeBoolean(input.dryRun) && !normalizeBoolean(input.skipGit);
   const parsedTags = parsed?.versionOutput?.tags;
-  // Only shell out to git when the parsed output gave nothing on a real run — the common path stays a
-  // pure parse. A silent empty `tags` is what let a dist-less tag ship unnoticed before.
-  const needGit = !dryRun && !(Array.isArray(parsedTags) && parsedTags.length > 0);
-  const gitTags = needGit ? gitVersionTagsAtHead(input.projectDir ?? '.') : [];
-  const { tags, recovered } = resolveReleaseTags({ parsedTags, gitTags, dryRun });
+  const gitTags = allowRecovery ? gitVersionTagsAtHead(input.projectDir ?? '.') : [];
+  const { tags, recovered } = resolveReleaseTags({ parsedTags, gitTags, allowRecovery });
   if (recovered) {
     console.log(
-      '::warning::releasekit: recovered the `tags` output from git after the release output could not be parsed — check this run for a stdout capture issue',
+      '::warning::releasekit: recovered the `tags` output from git after the release JSON output could not be parsed — check this run for a stdout capture issue',
     );
   }
   setOutput('tags', tags.join(','));

--- a/test/integration/action-runner.spec.ts
+++ b/test/integration/action-runner.spec.ts
@@ -239,36 +239,36 @@ describe('action runner', () => {
     expect(parseReleaseOutput('plain logs')).toBeUndefined();
   });
 
-  it('prefers parsed tags over the git fallback', () => {
-    expect(resolveReleaseTags({ parsedTags: ['v1.2.3'], gitTags: ['v9.9.9'], dryRun: false })).toEqual({
+  it('should prefer parsed tags over the git fallback', () => {
+    expect(resolveReleaseTags({ parsedTags: ['v1.2.3'], gitTags: ['v9.9.9'], allowRecovery: true })).toEqual({
       tags: ['v1.2.3'],
       recovered: false,
     });
   });
 
-  it('recovers tags from git when the parsed output has none on a real run', () => {
-    expect(resolveReleaseTags({ parsedTags: [], gitTags: ['v1.2.3'], dryRun: false })).toEqual({
+  it('should recover tags from git when recovery is allowed and parsed tags are empty', () => {
+    expect(resolveReleaseTags({ parsedTags: [], gitTags: ['v1.2.3'], allowRecovery: true })).toEqual({
       tags: ['v1.2.3'],
       recovered: true,
     });
   });
 
-  it('treats missing parsed tags as empty and recovers from git', () => {
-    expect(resolveReleaseTags({ parsedTags: undefined, gitTags: ['v1.2.3'], dryRun: false })).toEqual({
+  it('should treat missing parsed tags as empty and recover from git when allowed', () => {
+    expect(resolveReleaseTags({ parsedTags: undefined, gitTags: ['v1.2.3'], allowRecovery: true })).toEqual({
       tags: ['v1.2.3'],
       recovered: true,
     });
   });
 
-  it('does not fall back to git on a dry run', () => {
-    expect(resolveReleaseTags({ parsedTags: [], gitTags: ['v1.2.3'], dryRun: true })).toEqual({
+  it('should not recover from git when recovery is not allowed', () => {
+    expect(resolveReleaseTags({ parsedTags: [], gitTags: ['v1.2.3'], allowRecovery: false })).toEqual({
       tags: [],
       recovered: false,
     });
   });
 
-  it('emits empty tags when neither source has any', () => {
-    expect(resolveReleaseTags({ parsedTags: [], gitTags: [], dryRun: false })).toEqual({
+  it('should emit empty tags when neither source has any', () => {
+    expect(resolveReleaseTags({ parsedTags: [], gitTags: [], allowRecovery: true })).toEqual({
       tags: [],
       recovered: false,
     });

--- a/test/integration/action-runner.spec.ts
+++ b/test/integration/action-runner.spec.ts
@@ -13,6 +13,7 @@ import {
   buildStandingPRUpdateArgs,
   parseInputs,
   parseReleaseOutput,
+  resolveReleaseTags,
   runAction,
 } from '../../scripts/run-action.mjs';
 
@@ -236,6 +237,41 @@ describe('action runner', () => {
 
   it('should return undefined for non-JSON release output', () => {
     expect(parseReleaseOutput('plain logs')).toBeUndefined();
+  });
+
+  it('prefers parsed tags over the git fallback', () => {
+    expect(resolveReleaseTags({ parsedTags: ['v1.2.3'], gitTags: ['v9.9.9'], dryRun: false })).toEqual({
+      tags: ['v1.2.3'],
+      recovered: false,
+    });
+  });
+
+  it('recovers tags from git when the parsed output has none on a real run', () => {
+    expect(resolveReleaseTags({ parsedTags: [], gitTags: ['v1.2.3'], dryRun: false })).toEqual({
+      tags: ['v1.2.3'],
+      recovered: true,
+    });
+  });
+
+  it('treats missing parsed tags as empty and recovers from git', () => {
+    expect(resolveReleaseTags({ parsedTags: undefined, gitTags: ['v1.2.3'], dryRun: false })).toEqual({
+      tags: ['v1.2.3'],
+      recovered: true,
+    });
+  });
+
+  it('does not fall back to git on a dry run', () => {
+    expect(resolveReleaseTags({ parsedTags: [], gitTags: ['v1.2.3'], dryRun: true })).toEqual({
+      tags: [],
+      recovered: false,
+    });
+  });
+
+  it('emits empty tags when neither source has any', () => {
+    expect(resolveReleaseTags({ parsedTags: [], gitTags: [], dryRun: false })).toEqual({
+      tags: [],
+      recovered: false,
+    });
   });
 
   it('should run cli with generated args', async () => {


### PR DESCRIPTION
Implements **Tier 1** of #594.

## Problem

The Action advertises release-mode outputs (`tags`, `has-changes`, `version-output`), but `run-action.mjs` derives them by parsing the CLI's **stdout**. A rare stdout-capture hiccup — the same failure mode behind the dist-less `v0.41.1` action tag — silently empties them. A user gating a downstream step on the advertised contract:

```yaml
- uses: goosewobbler/releasekit@vX
  id: release
  with: { mode: release }
- if: steps.release.outputs.tags != ''
  run: ./promote "${{ steps.release.outputs.tags }}"
```

then skips their step even though the release actually tagged — a silent footgun on an output people build automation on.

## Fix

When the parsed output yields no tags on a real (non-dry) run, recover them from git — `git tag --points-at HEAD`, filtered to version tags — which is authoritative because the release creates the tag at HEAD. A `::warning::` is emitted on that fallback so the underlying stdout issue **surfaces** instead of leaving a silently empty output.

- **Common path unchanged:** when stdout parses (the normal case), the parsed tags are used and git is never consulted.
- **Pure + tested:** the selection logic is extracted into `resolveReleaseTags({ parsedTags, gitTags, dryRun })` and unit-tested (prefer-parsed, git-recovery, dry-run-skip, both-empty, missing-parsed).
- **Dry run:** never shells out to git (no tags exist); uses the parsed/intended tags.

## Scope

This is **Tier 1** — it hardens the single most load-bearing output (`tags`) for the common **sync-mode** version tag. **Per-package** tag formats (`@scope/pkg@vX.Y.Z`) still rely on the parsed output, and the full structured outputs (`version-output`/`release-output`) still come from stdout. The comprehensive fix — **Tier 2**, a CLI `--output <file>` so `run-action.mjs` reads the result from a file instead of capturing stdout — remains tracked in #594 and is left as a follow-up so this change stays small and shippable.

## Validation

- `test/integration/action-runner.spec.ts` — 5 new `resolveReleaseTags` cases; full suite green (179 tests).
- `pnpm typecheck` clean; `biome check` clean (the remaining env-var warnings are pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a git-based recovery path for the `tags` output in release mode: when JSON stdout can't be parsed (a known rare stdout-capture hiccup), the action now runs `git tag --points-at HEAD` and filters to semver tags rather than silently emitting an empty `tags` output. The recovery is guarded behind `jsonMode && parsed === undefined && !dryRun && !skipGit`, and a `::warning::` annotation is emitted when the fallback fires.

- **`gitVersionTagsAtHead`** shells out synchronously via `execFileSync` only on the recovery path (never on the common path), silently returning `[]` on any git error.
- **`resolveReleaseTags`** is a pure, exported function that centralises the prefer-parsed / fall-back-to-git / no-recovery logic, covered by 5 new unit tests.
- Both previously-raised review concerns — recovery firing when `json` mode is off, and stale tags leaking through `--skip-git` — are addressed by the `allowRecovery` guard conditions.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the recovery path is narrowly scoped to cases where JSON parsing failed, and the common path is unchanged.

Both previously flagged issues (recovery firing with json mode off, stale tags leaking through --skip-git) are correctly guarded by the allowRecovery condition. The new resolveReleaseTags function is pure and well-tested. The git call is synchronous but only executes on the rare fallback path, not the normal flow.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/run-action.mjs | Adds gitVersionTagsAtHead (sync fallback via execFileSync) and resolveReleaseTags (pure tag selector); writeReleaseOutputs now guards recovery behind jsonMode && parsed === undefined && !dryRun && !skipGit, correctly addressing both prior review concerns. |
| scripts/run-action.d.mts | Exports resolveReleaseTags with allowRecovery?: boolean typed as optional — consistent with the implementation treating undefined as falsy (no recovery). |
| test/integration/action-runner.spec.ts | Adds 5 unit tests for resolveReleaseTags covering: prefer-parsed, git-recovery, missing-parsed, no-recovery-when-disallowed, and both-empty; all cases are well-specified. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[writeReleaseOutputs called\nrelease mode, success] --> B{jsonMode?}
    B -- No --> C[parsed = undefined\nallowRecovery = false]
    B -- Yes --> D[parseReleaseOutput stdout]
    D --> E{parse OK?}
    E -- Yes --> F[parsed = object]
    E -- No --> G{dryRun or skipGit?}
    G -- Yes --> H[allowRecovery = false]
    G -- No --> I[allowRecovery = true\ngitVersionTagsAtHead]
    F --> J[resolveReleaseTags\nallowRecovery=false]
    C --> J
    H --> J
    I --> J
    J --> K{parsedTags non-empty\nor allowRecovery=false?}
    K -- Yes --> L[tags = parsedTags\nrecovered = false]
    K -- No --> M{gitTags non-empty?}
    M -- Yes --> N[tags = gitTags\nrecovered = true\nemit warning]
    M -- No --> O[tags = empty\nrecovered = false]
    L --> P[setOutput tags]
    N --> P
    O --> P
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[writeReleaseOutputs called\nrelease mode, success] --> B{jsonMode?}
    B -- No --> C[parsed = undefined\nallowRecovery = false]
    B -- Yes --> D[parseReleaseOutput stdout]
    D --> E{parse OK?}
    E -- Yes --> F[parsed = object]
    E -- No --> G{dryRun or skipGit?}
    G -- Yes --> H[allowRecovery = false]
    G -- No --> I[allowRecovery = true\ngitVersionTagsAtHead]
    F --> J[resolveReleaseTags\nallowRecovery=false]
    C --> J
    H --> J
    I --> J
    J --> K{parsedTags non-empty\nor allowRecovery=false?}
    K -- Yes --> L[tags = parsedTags\nrecovered = false]
    K -- No --> M{gitTags non-empty?}
    M -- Yes --> N[tags = gitTags\nrecovered = true\nemit warning]
    M -- No --> O[tags = empty\nrecovered = false]
    L --> P[setOutput tags]
    N --> P
    O --> P
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(action): gate git tag recovery on js..."](https://github.com/goosewobbler/releasekit/commit/77417fb534fa265600fe40b0f82ef58f9d92c505) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45760421)</sub>

<!-- /greptile_comment -->