### PR TITLE
chore(lint): enforce comment + test-title issue-ref conventions in eslint

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,9 +1,50 @@
 import tsParser from '@typescript-eslint/parser';
 import vitest from '@vitest/eslint-plugin';
 
+// Bare `#NNN` issue references in comments aren't clickable and rot as the code moves; link them as a
+// full URL or drop them (git history is the canonical trace). Matches `#` + 2+ digits that aren't part
+// of a URL fragment or an identifier.
+const noBareIssueRefs = {
+  meta: {
+    type: 'suggestion',
+    docs: { description: 'Disallow bare #NNN issue references in comments; use a full URL or drop it.' },
+    messages: {
+      bareRef:
+        "Bare issue reference '{{ref}}' in a comment — link it as a full URL (…/issues/{{num}}) or drop it; git history is the canonical trace.",
+    },
+  },
+  create(context) {
+    const sourceCode = context.sourceCode ?? context.getSourceCode();
+    const pattern = /(?<![\w/])#(\d{2,})\b/g;
+    return {
+      Program() {
+        for (const comment of sourceCode.getAllComments()) {
+          for (const match of comment.value.matchAll(pattern)) {
+            context.report({ loc: comment.loc, messageId: 'bareRef', data: { ref: match[0], num: match[1] } });
+          }
+        }
+      },
+    };
+  },
+};
+
 export default [
   {
     ignores: ['**/dist/**/*', '**/coverage/**/*', '**/out/**/*', '**/.turbo/**/*'],
+  },
+  {
+    // Comment hygiene across all package sources. `warn` until the codebase sweep lands, then `error`.
+    files: ['packages/**/*.ts'],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: { ecmaVersion: 'latest', sourceType: 'module' },
+    },
+    plugins: {
+      local: { rules: { 'no-bare-issue-refs': noBareIssueRefs } },
+    },
+    rules: {
+      'local/no-bare-issue-refs': 'warn',
+    },
   },
   {
     files: ['packages/**/test/**/*.spec.ts', 'packages/**/test/**/*.test.ts'],
@@ -20,8 +61,11 @@ export default [
     rules: {
       ...vitest.configs.recommended.rules,
       'vitest/prefer-called-exactly-once-with': 'off',
-      // Behaviour-spec titles: every it/test starts with "should" (describe stays free-form).
-      'vitest/valid-title': ['error', { mustMatch: { it: '^should', test: '^should' } }],
+      // Behaviour-spec titles start with "should" (describe stays free-form) and carry no issue refs.
+      'vitest/valid-title': [
+        'error',
+        { mustMatch: { it: '^should', test: '^should' }, mustNotMatch: { it: '#\\d', test: '#\\d' } },
+      ],
     },
   },
 ];

--- a/packages/forge/test/unit/fake.spec.ts
+++ b/packages/forge/test/unit/fake.spec.ts
@@ -179,7 +179,7 @@ describe('FakeForge', () => {
     });
   });
 
-  it('should discover an issue seeded only via the issues map (#462 review)', async () => {
+  it('should discover an issue seeded only via the issues map', async () => {
     const forge = createFakeForge({
       issues: { 7: { body: 'b', title: 't', labels: ['release:draft'], isPullRequest: false } },
     });
@@ -191,7 +191,7 @@ describe('FakeForge', () => {
     expect(await withPr.findOpenIssueByLabel('release:draft')).toBeNull();
   });
 
-  it('should return the newest (highest-numbered) matching open issue (#462 review)', async () => {
+  it('should return the newest (highest-numbered) matching open issue', async () => {
     const forge = createFakeForge({
       openIssues: [
         { number: 3, url: 'u3', labels: ['release:draft'] },

--- a/packages/notes/src/llm/openai.ts
+++ b/packages/notes/src/llm/openai.ts
@@ -62,7 +62,6 @@ export class OpenAIProvider extends BaseLLMProvider {
             type: 'json_schema' as const,
             json_schema: {
               name: options.toolName ?? 'release_notes',
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
               schema: options.schema as any,
               strict: true,
             },

--- a/packages/publish/test/integration/publish-e2e.spec.ts
+++ b/packages/publish/test/integration/publish-e2e.spec.ts
@@ -323,7 +323,7 @@ describe('Publish pipeline e2e (non-dry-run guards)', () => {
     });
   });
 
-  it('should demand a cargo token only when crates are actually present (the #578 inverse)', async () => {
+  it('should demand a cargo token only when crates are actually present (the inverse)', async () => {
     // The complement of the no-op guard: with a crate discovered, a non-dry-run run WITH no token must
     // fail fast at auth — proving the discover-then-auth ordering demands credentials exactly when used.
     delete process.env.CARGO_REGISTRY_TOKEN;

--- a/packages/release/test/unit/draft.spec.ts
+++ b/packages/release/test/unit/draft.spec.ts
@@ -121,7 +121,7 @@ describe('runReleaseDraft', () => {
     expect(seeded.updatedIssues.map((u) => u.issueNumber)).toContain(7);
   });
 
-  it('should NOT overwrite a human-labelled issue that lacks a manifest comment (#463 review)', async () => {
+  it('should NOT overwrite a human-labelled issue that lacks a manifest comment', async () => {
     // An unrelated open issue happens to carry the `release:draft` label but is not a real draft.
     const seeded = createFakeForge({
       openIssues: [{ number: 7, url: 'u', labels: [DRAFT_LABEL] }],
@@ -135,7 +135,7 @@ describe('runReleaseDraft', () => {
     expect(seeded.updatedIssues.map((u) => u.issueNumber)).not.toContain(7);
   });
 
-  it('should NOT reuse an issue whose marker comment is not a valid manifest (#463 review)', async () => {
+  it('should NOT reuse an issue whose marker comment is not a valid manifest', async () => {
     // Hand-labelled issue with an accidental marker-prefixed comment that does not decode to a manifest.
     const seeded = createFakeForge({
       openIssues: [{ number: 7, url: 'u', labels: [DRAFT_LABEL] }],
@@ -208,7 +208,7 @@ describe('publishFromDraft', () => {
     expect(mockRunRelease).not.toHaveBeenCalled();
   });
 
-  it('should refuse when the recomputed plan differs from the reviewed draft (#463 review)', async () => {
+  it('should refuse when the recomputed plan differs from the reviewed draft', async () => {
     // Preview (first runRelease call) recomputes a different plan than the manifest stored.
     mockRunRelease.mockReset();
     mockRunRelease.mockResolvedValueOnce({
@@ -226,7 +226,7 @@ describe('publishFromDraft', () => {
     expect(forge.updatedIssues).not.toContainEqual({ issueNumber: 9, changes: { state: 'closed' } });
   });
 
-  it('should refuse when only tags/commit-message drift even though name@version matches (#463 review)', async () => {
+  it('should refuse when only tags/commit-message drift even though name@version matches', async () => {
     // Same publishable name@version as the manifest, but different tags + commit message — the narrow
     // name@version check would have waved this through; the full-plan fingerprint catches it.
     mockRunRelease.mockReset();
@@ -241,7 +241,7 @@ describe('publishFromDraft', () => {
     expect(forge.updatedIssues).not.toContainEqual({ issueNumber: 9, changes: { state: 'closed' } });
   });
 
-  it('should respect --dry-run: validate without publishing or closing (#463 review)', async () => {
+  it('should respect --dry-run: validate without publishing or closing', async () => {
     const forge = forgeWithDraft('## Release Notes');
     mockForgeFor.mockReturnValue(forge);
 
@@ -251,7 +251,7 @@ describe('publishFromDraft', () => {
     expect(forge.updatedIssues).not.toContainEqual({ issueNumber: 9, changes: { state: 'closed' } });
   });
 
-  it('should not close the issue on a --skip-publish run (#463 review)', async () => {
+  it('should not close the issue on a --skip-publish run', async () => {
     const forge = forgeWithDraft('## Release Notes');
     mockForgeFor.mockReturnValue(forge);
 
@@ -260,7 +260,7 @@ describe('publishFromDraft', () => {
     expect(forge.updatedIssues).not.toContainEqual({ issueNumber: 9, changes: { state: 'closed' } });
   });
 
-  it('should fall back to drafted notes and warn when an editable region was removed (#463 review)', async () => {
+  it('should fall back to drafted notes and warn when an editable region was removed', async () => {
     const { warn } = await import('@releasekit/core');
     // The draft stored notes for @scope/core, but the editable region is gone from the body.
     const draftWithNotes = { ...manifest, releaseNotes: { '@scope/core': '- reviewed in the draft' } };

--- a/packages/release/test/unit/standing-pr.spec.ts
+++ b/packages/release/test/unit/standing-pr.spec.ts
@@ -1435,7 +1435,7 @@ describe('runStandingPRUpdate', () => {
     };
   }
 
-  it('should render the #520 release summary line and omit the version-summary table by default', async () => {
+  it('should render the release summary line and omit the version-summary table by default', async () => {
     const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
     const versionOutput = mixedChannelOutput();
     vi.mocked(runVersionStep)
@@ -1453,7 +1453,7 @@ describe('runStandingPRUpdate', () => {
     expect(body).not.toContain('Version summary (');
   });
 
-  it('should render the #520 version-summary table when ci.standingPr.summaryTable is true', async () => {
+  it('should render the version-summary table when ci.standingPr.summaryTable is true', async () => {
     const { loadConfig } = await import('@releasekit/config');
     vi.mocked(loadConfig).mockReturnValueOnce({
       ci: { standingPr: { branch: 'release/next', deleteBranchOnMerge: true, summaryTable: true } },

--- a/packages/release/test/unit/standing-pr/notes-region.spec.ts
+++ b/packages/release/test/unit/standing-pr/notes-region.spec.ts
@@ -24,7 +24,7 @@ describe('notes-region', () => {
       expect(renderNotesRegion({})).toBe('');
     });
 
-    it('should truncate oversized per-package notes at the documented bound (#558)', () => {
+    it('should truncate oversized per-package notes at the documented bound', () => {
       const oversized = Array.from({ length: 5000 }, (_, i) => `- line ${i} of a very inflated note`).join('\n');
       const rendered = renderNotesRegion({ '@scope/a': oversized });
 
@@ -37,12 +37,12 @@ describe('notes-region', () => {
   });
 
   describe('truncatePackageNotes', () => {
-    it('should leave notes within the bound untouched (#558)', () => {
+    it('should leave notes within the bound untouched', () => {
       const notes = 'a short note\nwith two lines';
       expect(truncatePackageNotes(notes)).toBe(notes);
     });
 
-    it('should trim notes beyond the bound and append the truncation marker (#558)', () => {
+    it('should trim notes beyond the bound and append the truncation marker', () => {
       const oversized = 'x'.repeat(MAX_NOTES_CHARS_PER_PACKAGE + 5000);
       const truncated = truncatePackageNotes(oversized);
 

--- a/packages/version/test/unit/core/baselineResolver.spec.ts
+++ b/packages/version/test/unit/core/baselineResolver.spec.ts
@@ -48,7 +48,7 @@ describe('BaselineResolver.resolve', () => {
     expect(result.baselineUnreachable).toBe(false);
   });
 
-  it('should bound by the nearest reachable tag (not full history) when the tag is unreachable (#370)', async () => {
+  it('should bound by the nearest reachable tag (not full history) when the tag is unreachable', async () => {
     vi.mocked(verifyTag).mockResolvedValue(unreachable);
     vi.mocked(getNearestReachableTag).mockResolvedValue('v0.9.0');
     const result = await new BaselineResolver(makeOpts()).resolve(makeInput());
@@ -59,7 +59,7 @@ describe('BaselineResolver.resolve', () => {
     expect(result.baselineUnreachable).toBe(true);
   });
 
-  it('should fall back to full history only when no reachable tag exists at all (fresh repo, #370)', async () => {
+  it('should fall back to full history only when no reachable tag exists at all (fresh repo)', async () => {
     vi.mocked(verifyTag).mockResolvedValue(unreachable);
     vi.mocked(getNearestReachableTag).mockResolvedValue('');
     const result = await new BaselineResolver(makeOpts()).resolve(makeInput());
@@ -89,7 +89,7 @@ describe('BaselineResolver.resolve', () => {
     expect(getNearestReachableTag).not.toHaveBeenCalled();
   });
 
-  it('should keep the full-history fallback for an unreachable baseRef, not the nearest-reachable floor (#370)', async () => {
+  it('should keep the full-history fallback for an unreachable baseRef, not the nearest-reachable floor', async () => {
     // baseRef scopes the run to a PR's commits — a different intent from the tag floor, so an
     // unreachable baseRef stays at HEAD rather than borrowing the nearest tag (mirrors sharedFloor).
     vi.mocked(verifyTag).mockResolvedValue(unreachable);
@@ -106,7 +106,7 @@ describe('BaselineResolver.resolve', () => {
     expect(result.revisionRange).toBe('abc123..HEAD');
   });
 
-  it('should bound an untagged package by the nearest reachable tag, not full history (#370)', async () => {
+  it('should bound an untagged package by the nearest reachable tag, not full history', async () => {
     // The standing-PR-body flood: a new package in a tagged repo would otherwise summarize ALL
     // history. Floor it by the nearest reachable tag instead; previousVersion stays null (no own tag).
     vi.mocked(getNearestReachableTag).mockResolvedValue('v0.9.0');
@@ -117,7 +117,7 @@ describe('BaselineResolver.resolve', () => {
     expect(verifyTag).not.toHaveBeenCalled();
   });
 
-  it('should produce full history for an untagged package only in a fresh repo with no tags (#370)', async () => {
+  it('should produce full history for an untagged package only in a fresh repo with no tags', async () => {
     vi.mocked(getNearestReachableTag).mockResolvedValue('');
     const result = await new BaselineResolver(makeOpts()).resolve(makeInput({ latestTag: '', hasRealTag: false }));
     expect(result.revisionRange).toBe('HEAD');
@@ -125,7 +125,7 @@ describe('BaselineResolver.resolve', () => {
     expect(verifyTag).not.toHaveBeenCalled();
   });
 
-  it('should bound a manifest-fallback synthetic tag by the nearest reachable tag without calling git verify (#370)', async () => {
+  it('should bound a manifest-fallback synthetic tag by the nearest reachable tag without calling git verify', async () => {
     vi.mocked(getNearestReachableTag).mockResolvedValue('v0.9.0');
     const result = await new BaselineResolver(makeOpts()).resolve(
       makeInput({ latestTag: 'v1.2.3', hasRealTag: false }),
@@ -160,7 +160,7 @@ describe('BaselineResolver.resolve', () => {
     expect(result.revisionRange).toBe('pkg@v0.9.0..HEAD');
   });
 
-  it('should bound by the nearest reachable tag when graduating with no prior stable tag (#370)', async () => {
+  it('should bound by the nearest reachable tag when graduating with no prior stable tag', async () => {
     vi.mocked(getLatestStableTag).mockResolvedValue('');
     vi.mocked(getNearestReachableTag).mockResolvedValue('v0.9.0');
     const result = await new BaselineResolver(makeOpts()).resolve(
@@ -173,7 +173,7 @@ describe('BaselineResolver.resolve', () => {
     expect(verifyTag).not.toHaveBeenCalled();
   });
 
-  it('should label previousVersion with the prerelease predecessor when graduating with no prior stable tag (#474)', async () => {
+  it('should label previousVersion with the prerelease predecessor when graduating with no prior stable tag', async () => {
     // Graduation widens the range to the whole prerelease line by re-basing onto the last stable tag,
     // but with no prior stable that lookup returns '' — so the package's only predecessor is its
     // prerelease latestTag. Fall back to it for the label (kept in tag form so generateCompareUrl can
@@ -188,7 +188,7 @@ describe('BaselineResolver.resolve', () => {
     expect(result.baselineUnreachable).toBe(false);
   });
 
-  it('should still leave previousVersion null for a genuine first release with no prior tag (#474)', async () => {
+  it('should still leave previousVersion null for a genuine first release with no prior tag', async () => {
     // The fallback only kicks in when there IS a tag to fall back to: with no tag at all, both
     // changelogBaseTag and latestTag are empty, so a true first release stays null → N/A.
     vi.mocked(getNearestReachableTag).mockResolvedValue('');
@@ -196,7 +196,7 @@ describe('BaselineResolver.resolve', () => {
     expect(result.previousVersion).toBeNull();
   });
 
-  it('should strip a baseline marker tag back to consumer form for previousVersion (#330)', async () => {
+  it('should strip a baseline marker tag back to consumer form for previousVersion', async () => {
     vi.mocked(verifyTag).mockResolvedValue(reachable);
     const result = await new BaselineResolver(makeOpts()).resolve(
       makeInput({ latestTag: 'release/v1.2.3', nextVersion: '1.2.4', baselineTagPrefix: 'release/v' }),
@@ -217,7 +217,7 @@ describe('BaselineResolver.sharedFloor', () => {
     expect(getNearestReachableTag).not.toHaveBeenCalled();
   });
 
-  it('should bound a HEAD range by the nearest reachable tag and cache it (#348)', async () => {
+  it('should bound a HEAD range by the nearest reachable tag and cache it', async () => {
     vi.mocked(getNearestReachableTag).mockResolvedValue('v1.0.0');
     const resolver = new BaselineResolver(makeOpts());
     expect(await resolver.sharedFloor('HEAD')).toBe('v1.0.0..HEAD');
@@ -243,7 +243,7 @@ describe('BaselineResolver.sharedFloor', () => {
     expect(getNearestReachableTag).not.toHaveBeenCalled();
   });
 
-  it('should floor every package by the global nearest-reachable tag in sinceLastRelease mode (#398)', async () => {
+  it('should floor every package by the global nearest-reachable tag in sinceLastRelease mode', async () => {
     // Collapses the union: even a package with its OWN bounded (older) range is floored by the single
     // global nearest tag, so a global commit consumed by the most recent release doesn't recur.
     vi.mocked(getNearestReachableTag).mockResolvedValue('native-types@v2.4.0');
@@ -253,7 +253,7 @@ describe('BaselineResolver.sharedFloor', () => {
     expect(getNearestReachableTag).toHaveBeenCalledTimes(1); // cached across packages
   });
 
-  it('should pass a baseRef run through unbounded even in sinceLastRelease mode (#398)', async () => {
+  it('should pass a baseRef run through unbounded even in sinceLastRelease mode', async () => {
     const resolver = new BaselineResolver(makeOpts({ sharedChangelogFloor: 'sinceLastRelease', baseRef: 'abc123' }));
     expect(await resolver.sharedFloor('abc123..HEAD')).toBe('abc123..HEAD');
     expect(getNearestReachableTag).not.toHaveBeenCalled();

--- a/packages/version/test/unit/core/groupStrategy.spec.ts
+++ b/packages/version/test/unit/core/groupStrategy.spec.ts
@@ -389,7 +389,7 @@ describe('createGroupStrategy', () => {
       );
     });
 
-    it('should not graduate an explicit prerelease when a member manifest lags its prerelease tag (#458)', async () => {
+    it('should not graduate an explicit prerelease when a member manifest lags its prerelease tag', async () => {
       // Interrupted release: the published prerelease (1.0.0-next.0) lives in the tag, but the member's
       // manifest still reads 0.0.1 AND the tag isn't reachable from HEAD, so the per-package calculator
       // computes ownNext from the manifest (0.0.2-next.0) — *below* the tag-derived group baseline
@@ -423,7 +423,7 @@ describe('createGroupStrategy', () => {
       );
     });
 
-    it('should not graduate an explicit prerelease in a fixed group when a member manifest lags its tag (#458)', async () => {
+    it('should not graduate an explicit prerelease in a fixed group when a member manifest lags its tag', async () => {
       // As above, but `fixed` writes the shared version to ALL members — a silent graduation would
       // stamp a stable 1.0.0 across the whole group. Both must stay on 1.0.0-next.1.
       const service = mkPackage('@wdio/flutter-service', '0.0.1');
@@ -458,7 +458,7 @@ describe('createGroupStrategy', () => {
       );
     });
 
-    it('should still advance the prerelease when no prereleaseIdentifier is configured (#460)', async () => {
+    it('should still advance the prerelease when no prereleaseIdentifier is configured', async () => {
       // Same manifest-lags-tag scenario, but with no configured prereleaseIdentifier. The group must
       // still increment the existing prerelease (1.0.0-next.0 -> 1.0.0-next.1) rather than re-emit the
       // published baseline — never-regress can't help (ownNext sits below maxBaseline).
@@ -487,7 +487,7 @@ describe('createGroupStrategy', () => {
       );
     });
 
-    it('should advance the prerelease when the aggregate rank is itself prerelease and no identifier is set (#460)', async () => {
+    it('should advance the prerelease when the aggregate rank is itself prerelease and no identifier is set', async () => {
       // The changed member earns a *prerelease-rank* bump (its own line increments), while a higher
       // member's prerelease tag sets the group baseline (1.0.0-next.0). Pre-fix, the prerelease-rank
       // branch returned the baseline unchanged when no identifier was set, and never-regress couldn't
@@ -1047,7 +1047,7 @@ describe('createGroupStrategy', () => {
       );
     });
 
-    it('should leave a changed member unflagged when its extraction comes back empty (swallowed git failure, #469)', async () => {
+    it('should leave a changed member unflagged when its extraction comes back empty (swallowed git failure)', async () => {
       const core = mkPackage('@wdio/native-core', '2.3.0');
 
       // core earned a real bump, so it is NOT a carry...

--- a/packages/version/test/unit/core/versionCalculator.spec.ts
+++ b/packages/version/test/unit/core/versionCalculator.spec.ts
@@ -399,7 +399,7 @@ describe('Version Calculator', () => {
       name: 'my-pkg',
     };
 
-    it('should warn but still apply the bump on a first-release stable manifest (#388)', async () => {
+    it('should warn but still apply the bump on a first-release stable manifest', async () => {
       stableFirstReleaseMocks();
       const config = { ...defaultConfig, stableOnly: true, type: 'major' as const };
       const version = await calculateVersion(config as Config, stableFirstReleaseOptions);
@@ -407,7 +407,7 @@ describe('Version Calculator', () => {
       expect(logging.log).toHaveBeenCalledWith(expect.stringContaining('will publish 2.0.0, not 1.0.0'), 'warning');
     });
 
-    it('should abort a first-release stable-manifest bump under mismatchStrategy "error" (#388)', async () => {
+    it('should abort a first-release stable-manifest bump under mismatchStrategy "error"', async () => {
       stableFirstReleaseMocks();
       const config = { ...defaultConfig, stableOnly: true, type: 'major' as const, mismatchStrategy: 'error' as const };
       await expect(calculateVersion(config as Config, stableFirstReleaseOptions)).rejects.toThrow(
@@ -415,7 +415,7 @@ describe('Version Calculator', () => {
       );
     });
 
-    it('should apply the bump silently when allowFirstBump acknowledges it (#388)', async () => {
+    it('should apply the bump silently when allowFirstBump acknowledges it', async () => {
       stableFirstReleaseMocks();
       const config = { ...defaultConfig, stableOnly: true, type: 'major' as const, allowFirstBump: true };
       const version = await calculateVersion(config as Config, stableFirstReleaseOptions);
@@ -423,7 +423,7 @@ describe('Version Calculator', () => {
       expect(logging.log).not.toHaveBeenCalledWith(expect.stringContaining('will publish 2.0.0, not 1.0.0'), 'warning');
     });
 
-    it('should apply the bump silently under mismatchStrategy "ignore" (#388)', async () => {
+    it('should apply the bump silently under mismatchStrategy "ignore"', async () => {
       stableFirstReleaseMocks();
       const config = {
         ...defaultConfig,

--- a/packages/version/test/unit/core/versionChannel.spec.ts
+++ b/packages/version/test/unit/core/versionChannel.spec.ts
@@ -83,7 +83,7 @@ describe('Per-package release channel — advance along the current line (#485)'
       expect(next).toBe('1.0.0-next.2');
     });
 
-    it('should increment a higher prerelease counter without resetting it (#500: 1.0.0-next.3 -> 1.0.0-next.4)', async () => {
+    it('should increment a higher prerelease counter without resetting it (1.0.0-next.3 -> 1.0.0-next.4)', async () => {
       baselineAt('1.0.0-next.3');
       inferredBump('minor');
       const next = await calculateVersion(baseConfig as Config, options({ latestTag: 'v1.0.0-next.3' }));

--- a/packages/version/test/unit/core/versionEngine.spec.ts
+++ b/packages/version/test/unit/core/versionEngine.spec.ts
@@ -174,7 +174,7 @@ describe('Version Engine', () => {
       );
     });
 
-    it('should fold prereleaseScope into isPrerelease + prereleaseScope on effective config (#521)', () => {
+    it('should fold prereleaseScope into isPrerelease + prereleaseScope on effective config', () => {
       new VersionEngine(defaultConfig as Config, { prereleaseScope: ['@scope/a'] });
 
       expect(strategyModule.createStrategyMap).toHaveBeenCalledWith(
@@ -182,7 +182,7 @@ describe('Version Engine', () => {
       );
     });
 
-    it('should keep the configured identifier when folding prereleaseScope (#521)', () => {
+    it('should keep the configured identifier when folding prereleaseScope', () => {
       const configWithAlpha = { ...defaultConfig, prereleaseIdentifier: 'alpha' } as Config;
       new VersionEngine(configWithAlpha, { prereleaseScope: ['@scope/a'] });
 
@@ -191,7 +191,7 @@ describe('Version Engine', () => {
       );
     });
 
-    it('should drop prereleaseScope when the global prerelease flag is also set — global wins (#521)', () => {
+    it('should drop prereleaseScope when the global prerelease flag is also set — global wins', () => {
       new VersionEngine(defaultConfig as Config, { prerelease: true, prereleaseScope: ['@scope/a'] });
 
       // The scope is left unset (key absent) rather than set to undefined, so assert on the passed

--- a/packages/version/test/unit/core/versionStrategies.spec.ts
+++ b/packages/version/test/unit/core/versionStrategies.spec.ts
@@ -584,7 +584,7 @@ describe('Version Strategies', () => {
         );
       });
 
-      it('should warn loudly and omit previousVersion when the baseline tag is unverifiable (#339)', async () => {
+      it('should warn loudly and omit previousVersion when the baseline tag is unverifiable', async () => {
         // The baseline tag fails verification (e.g. shallow clone / unpushed tag).
         vi.mocked(tagVerification.verifyTag, { partial: true }).mockResolvedValue({
           exists: true,
@@ -820,7 +820,7 @@ describe('Version Strategies', () => {
       expect(jsonOutput.setCommitMessage).toHaveBeenCalledWith('chore: release package-a v1.1.0');
     });
 
-    it('should warn and omit previousVersion when the baseline tag is unverifiable (#339)', async () => {
+    it('should warn and omit previousVersion when the baseline tag is unverifiable', async () => {
       // The baseline tag fails verification (shallow clone / unpushed tag).
       vi.mocked(tagVerification.verifyTag, { partial: true }).mockResolvedValue({
         exists: true,

--- a/packages/version/test/unit/package/packageProcessor.spec.ts
+++ b/packages/version/test/unit/package/packageProcessor.spec.ts
@@ -400,7 +400,7 @@ describe('Package Processor', () => {
       expect(calls[0][0]).toMatchObject({ previousVersion: 'v1.0.0' });
     });
 
-    it('should record the resolved previousVersion on the package update (#520)', async () => {
+    it('should record the resolved previousVersion on the package update', async () => {
       vi.spyOn(gitTags, 'getLatestTagForPackage').mockResolvedValue('release/v1.0.0');
       vi.spyOn(formatting, 'deriveBaselineTagPrefix').mockReturnValue('release/v');
       vi.spyOn(formatting, 'displayTag').mockImplementation((tag, baselineTagPrefix, formattedPrefix) => {
@@ -423,7 +423,7 @@ describe('Package Processor', () => {
       expect(jsonOutput.setPackageUpdatePreviousVersion).toHaveBeenCalledWith('package-a', 'v1.0.0');
     });
 
-    it('should warn and omit previousVersion when the baseline tag is unreachable (#339)', async () => {
+    it('should warn and omit previousVersion when the baseline tag is unreachable', async () => {
       vi.spyOn(gitTags, 'getLatestTagForPackage').mockResolvedValue('release/v1.0.0');
       vi.spyOn(formatting, 'deriveBaselineTagPrefix').mockReturnValue('release/v');
       vi.spyOn(formatting, 'displayTag').mockImplementation((tag, baselineTagPrefix, formattedPrefix) => {
@@ -554,7 +554,7 @@ describe('Package Processor', () => {
       expect(calls[0][0]).toMatchObject({ previousVersion: 'v1.0.0' });
     });
 
-    it('should warn when a package has no prior tag (full-history changelog, #334)', async () => {
+    it('should warn when a package has no prior tag (full-history changelog)', async () => {
       // No package tag and no global tag — only the manifest version is available, so hasRealTag is
       // false and the changelog spans the full history. The warning makes this visible (and heads off
       // the opaque oversized-PR-body 422 in #333).
@@ -585,7 +585,7 @@ describe('Package Processor', () => {
       );
     });
 
-    it('should bound repo-level changelog by the nearest reachable tag, even when getLatestTag is prefix-blind (#348)', async () => {
+    it('should bound repo-level changelog by the nearest reachable tag, even when getLatestTag is prefix-blind', async () => {
       // package-a has no specific tag; getVersionFromManifests returns a manifest version via the
       // global beforeEach mock, making hasRealTag=false and revisionRange='HEAD'. The baseline floor
       // must come from getNearestReachableTag (git describe), which finds per-package prefixed tags.
@@ -613,7 +613,7 @@ describe('Package Processor', () => {
       );
     });
 
-    it('should fall back to HEAD range for shared entries when no tag is reachable (#348)', async () => {
+    it('should fall back to HEAD range for shared entries when no tag is reachable', async () => {
       vi.spyOn(gitTags, 'getLatestTagForPackage').mockResolvedValue('');
       vi.spyOn(gitTags, 'getNearestReachableTag').mockResolvedValue('');
       vi.spyOn(calculator, 'calculateVersion').mockResolvedValue('1.1.0');
@@ -630,7 +630,7 @@ describe('Package Processor', () => {
       expect(extractSharedSpy).toHaveBeenCalledWith(expect.any(String), 'HEAD', expect.any(Array), expect.any(Array));
     });
 
-    it('should classify against the full workspace, not the release set, so a non-releasing package does not leak into shared (#397)', async () => {
+    it('should classify against the full workspace, not the release set, so a non-releasing package does not leak into shared', async () => {
       const extractSharedSpy = vi.spyOn(commitParser, 'extractRepoLevelChangelogEntries').mockResolvedValue([]);
       const processor = new PackageProcessor({
         ...defaultOptions,
@@ -655,7 +655,7 @@ describe('Package Processor', () => {
       );
     });
 
-    it('should route a configured sharedPackages package to repo-level via its dir (#406)', async () => {
+    it('should route a configured sharedPackages package to repo-level via its dir', async () => {
       const extractSharedSpy = vi.spyOn(commitParser, 'extractRepoLevelChangelogEntries').mockResolvedValue([]);
       const processor = new PackageProcessor({
         ...defaultOptions,
@@ -676,7 +676,7 @@ describe('Package Processor', () => {
       ]);
     });
 
-    it('should treat no package as shared when sharedPackages is unset — no hardcoded names (#406)', async () => {
+    it('should treat no package as shared when sharedPackages is unset — no hardcoded names', async () => {
       const extractSharedSpy = vi.spyOn(commitParser, 'extractRepoLevelChangelogEntries').mockResolvedValue([]);
       const processor = new PackageProcessor({
         ...defaultOptions,

--- a/packages/version/test/unit/utils/jsonOutput.spec.ts
+++ b/packages/version/test/unit/utils/jsonOutput.spec.ts
@@ -171,7 +171,7 @@ describe('JSON Output Utilities', () => {
       });
     });
 
-    it('should derive the per-package channel from the resolved version (#485)', () => {
+    it('should derive the per-package channel from the resolved version', () => {
       enableJsonOutput();
       addPackageUpdate('stable-pkg', '10.2.0', '/ws/packages/stable/package.json');
       addPackageUpdate('pre-pkg', '1.0.0-next.2', '/ws/packages/pre/package.json');


### PR DESCRIPTION
Makes the #573 comment convention **deterministic** — the lint replacement for the prose #598 removed. **Stacked on #598** (builds on its `vitest/valid-title` rule); base will retarget to `main` once #598 merges.

## What changed
- **`local/no-bare-issue-refs`** — a custom eslint rule flagging bare `#NNN` in comments (link as a full URL, or drop it — git history is the canonical trace). Applied to `packages/**/*.ts` at **`warn`** for now: the ~330 existing source-comment refs are swept in the separate #573 PR, after which this flips to **`error`**.
- **`vitest/valid-title` `mustNotMatch: #\d`** — test titles carry no issue refs. Stripped the refs from the ~50 existing titles (labels only; no assertion changes).
- Removed a **dead `eslint-disable @typescript-eslint/no-explicit-any`** directive (that plugin was never installed; it only surfaced once eslint began linting package sources). Biome — which actually lints this repo — already tolerates the `as any` at `warn`.

## Validation
- `eslint packages/**/*.ts` → **0 errors, 328 warnings** (all the transitional comment-ref warnings; nothing else).
- Retitled specs pass. The 3 failing files in a full run (`templates.spec.ts`, `sync-tags.spec.ts`) are **pre-existing/environmental** — not in this diff, and they fail identically on the base with these changes stashed.

## Follow-up (separate PR, #573)
Sweep the ~330 source-comment refs (convert load-bearing ones to full URLs, drop the rest) and flip `no-bare-issue-refs` to `error`. That PR touches `packages/*/src`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes issue-reference conventions enforceable through ESLint. The main changes are:

- Adds a warning for bare multi-digit issue references in package comments.
- Rejects issue references in Vitest test titles.
- Removes existing issue references from affected test titles.
- Removes an obsolete ESLint suppression from the OpenAI provider.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- The title pattern catches any `#` followed by a digit, including multi-digit issue references.
- Test changes only alter labels; setup and assertions remain unchanged.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| eslint.config.js | Adds the local comment rule, expands TypeScript lint coverage, and configures Vitest title validation. |
| packages/notes/src/llm/openai.ts | Removes an obsolete suppression without changing runtime behavior. |
| packages/forge/test/unit/fake.spec.ts | Removes issue references from test titles without changing assertions. |
| packages/release/test/unit/draft.spec.ts | Removes issue references from test titles without changing test behavior. |
| packages/version/test/unit/core/baselineResolver.spec.ts | Removes issue references from test titles without changing test behavior. |
| packages/version/test/unit/package/packageProcessor.spec.ts | Removes issue references from test titles without changing test behavior. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(lint): enforce comment + test-titl..."](https://github.com/goosewobbler/releasekit/commit/be043b6e1bd937c555bccceb56ed19c99b1aaedb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45799057)</sub>

<!-- /greptile_comment -->