### PR TITLE
chore: sweep bare issue refs from source comments; enforce in eslint

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -33,8 +33,9 @@ export default [
     ignores: ['**/dist/**/*', '**/coverage/**/*', '**/out/**/*', '**/.turbo/**/*'],
   },
   {
-    // Comment hygiene across all package sources. `warn` until the codebase sweep lands, then `error`.
-    files: ['packages/**/*.ts'],
+    // Comment hygiene in production sources only. Test comments legitimately reference mock issue/PR
+    // data (fixture numbers, external-repo PRs), so bare `#NNN` there isn't a citation to flag.
+    files: ['packages/**/src/**/*.ts'],
     languageOptions: {
       parser: tsParser,
       parserOptions: { ecmaVersion: 'latest', sourceType: 'module' },
@@ -43,7 +44,7 @@ export default [
       local: { rules: { 'no-bare-issue-refs': noBareIssueRefs } },
     },
     rules: {
-      'local/no-bare-issue-refs': 'warn',
+      'local/no-bare-issue-refs': 'error',
     },
   },
   {

--- a/packages/config/test/unit/generate-schema.spec.ts
+++ b/packages/config/test/unit/generate-schema.spec.ts
@@ -62,7 +62,7 @@ describe('generate-schema', () => {
       const schema = buildSchema() as {
         properties?: Record<string, { properties?: Record<string, { description?: string }> }>;
       };
-      // ci.scopeLabels is the field #277 is about — it must keep its description
+      // ci.scopeLabels must keep its description
       // (an empty description here is the exact regression this generator prevents).
       const scopeLabels = schema.properties?.ci?.properties?.scopeLabels;
       expect(scopeLabels?.description).toBeDefined();

--- a/packages/config/test/unit/parse.spec.ts
+++ b/packages/config/test/unit/parse.spec.ts
@@ -106,7 +106,7 @@ describe('parseJsonc', () => {
     expect(result).toEqual({ url: 'https://example.com/path?q=1&a=2' });
   });
 
-  // Regression for #247: a real comment forces the JSONC path, and the `//`
+  // Regression: a real comment forces the JSONC path, and the `//`
   // inside the $schema URL must not be treated as a line comment.
   it('should parse a config with a comment and an https URL ($schema)', () => {
     const jsonc = `{

--- a/packages/core/src/changelogRefs.ts
+++ b/packages/core/src/changelogRefs.ts
@@ -1,3 +1,4 @@
+/* eslint-disable local/no-bare-issue-refs -- the #NNN below are examples of the reference format this module renders, not issue citations */
 /**
  * Neutralising bare GitHub-autolinked tokens in changelog output. GitHub auto-links a bare `#NNN`
  * issue/PR ref (with a hovercard) and treats a bare `@scope/pkg` / `@user` as a mention (a stray

--- a/packages/core/src/selectionRegion.ts
+++ b/packages/core/src/selectionRegion.ts
@@ -34,7 +34,7 @@ export function rkPreMarker(packageName: string): string {
 }
 
 /**
- * Identity marker for a prerelease row's channel toggle — "graduate this package to stable" (#521),
+ * Identity marker for a prerelease row's channel toggle — "graduate this package to stable",
  * the inverse of {@link rkPreMarker}. Machine-read, never the row's prose.
  */
 export function rkGradMarker(packageName: string): string {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -52,7 +52,7 @@ export interface VersionPackageChangelog {
 }
 
 /**
- * The resolved action a package's version landed on — purely additive observability (#420), it
+ * The resolved action a package's version landed on — purely additive observability, it
  * never changes which version resolves. `'graduated'` means a prerelease was promoted to stable and
  * any requested bump was ignored; `'bumped'` is the ordinary commit/label-driven bump;
  * `'first-release'` is a package with no prior tag. Defined as a string-literal union (core cannot
@@ -64,8 +64,7 @@ export type VersionAction = 'first-release' | 'graduated' | 'bumped';
  * The release channel a version sits on. Derived per-package and purely from the resolved
  * version: `'prerelease'` when the version carries a semver prerelease segment (`…-<preid>.N`), else
  * `'stable'`. A standing PR with permanently-mixed maturity carries both at once — some `'stable'`
- * packages, some `'prerelease'` — each advancing along its own line. #486 (per-package graduation)
- * and #487 (channel-grouped rendering) build on this.
+ * packages, some `'prerelease'` — each advancing along its own line.
  */
 export type ReleaseChannel = 'stable' | 'prerelease';
 
@@ -126,8 +125,8 @@ export interface VersionPackageUpdate {
   /**
    * The resolved baseline version this update bumped from — the package's prior release, in the same
    * consumer-tag display form the changelog carries ({@link VersionPackageChangelog.previousVersion}).
-   * Absent for a first release and whenever the baseline was unreachable / fell back to all-history
-   * (#339), so consumers derive the bump magnitude only when it is present. Optional for backwards
+   * Absent for a first release and whenever the baseline was unreachable / fell back to all-history,
+   * so consumers derive the bump magnitude only when it is present. Optional for backwards
    * compatibility: standing-PR manifests written before this field existed omit it (old PRs still
    * open), so every consumer must tolerate its absence (render a dash / skip the delta).
    */
@@ -163,7 +162,7 @@ export interface VersionPackageUpdate {
    */
   prerequisiteOf?: string[];
   /**
-   * The resolved version action for this update (#420): `'graduated'` (prerelease → stable, bump
+   * The resolved version action for this update: `'graduated'` (prerelease → stable, bump
    * ignored), `'bumped'` (commit/label-driven), or `'first-release'`. Purely additive observability —
    * it never affects which version resolved. Optional for backwards compatibility: standing-PR
    * manifests produced before this field existed won't carry it, so every consumer must tolerate
@@ -173,12 +172,12 @@ export interface VersionPackageUpdate {
   /** Short human-readable reason for {@link action} (e.g. `Graduated 1.0.0-next.1 → 1.0.0 (bump ignored).`). Optional, same back-compat rule as {@link action}. */
   actionReason?: string;
   /**
-   * The release channel this package's new version sits on (#485): `'prerelease'` when `newVersion`
+   * The release channel this package's new version sits on: `'prerelease'` when `newVersion`
    * carries a semver prerelease segment, else `'stable'`. Derived from the resolved version via
    * {@link deriveReleaseChannel}; a mixed standing PR carries both, each package advancing on its own
    * line. Purely additive observability — it never affects which version resolves. Optional for
    * backwards compatibility: standing-PR manifests written before this field existed omit it, so every
-   * consumer must tolerate its absence (re-derive from `newVersion`). #486/#487 build on it.
+   * consumer must tolerate its absence (re-derive from `newVersion`).
    */
   channel?: ReleaseChannel;
 }

--- a/packages/core/test/unit/changelogRefs.spec.ts
+++ b/packages/core/test/unit/changelogRefs.spec.ts
@@ -157,7 +157,7 @@ describe('neutralizeDescriptionRefs', () => {
   const repo = 'https://github.com/octocat/hello';
 
   it('should remove a parenthesised ref that is duplicated in the appended label', () => {
-    // #507: `(#467)` in the subject-derived description also appears as `closes #467` in the label.
+    // `(#467)` in the subject-derived description also appears as `closes #467` in the label.
     expect(neutralizeDescriptionRefs('failed queued batch (#467)', ['#475', '#467'], 'link', repo)).toBe(
       'failed queued batch',
     );

--- a/packages/forge/src/fake.ts
+++ b/packages/forge/src/fake.ts
@@ -34,7 +34,7 @@ interface FakeComment {
    */
   prNumber?: number;
   /** The comment's author. Left undefined, a seeded comment reads as bot-authored (the common case).
-   *  Seed `{ type: 'User' }` to simulate a human-authored forgery for author-binding tests (#556). */
+   *  Seed `{ type: 'User' }` to simulate a human-authored forgery for author-binding tests. */
   user?: CommentAuthor;
 }
 
@@ -204,7 +204,7 @@ export class FakeForge implements Forge {
 
   async findOpenIssueByLabel(label: string): Promise<IssueRef | null> {
     // GitHub returns newest-first; approximate "newest" with the highest number so multiple seeded
-    // matches resolve the way production would (#462 review).
+    // matches resolve the way production would.
     const matches = this.openIssues.filter((i) => i.labels.includes(label)).sort((a, b) => b.number - a.number);
     return matches[0] ? { number: matches[0].number, url: matches[0].url } : null;
   }
@@ -214,7 +214,7 @@ export class FakeForge implements Forge {
       (c) => c.body.startsWith(marker) && (c.prNumber === undefined || c.prNumber === prNumber),
     );
     // Mirror the real adapter: prefer a bot-authored match, falling back to a human-authored one so
-    // the caller can still see (and reject) it when it's the only marker comment present (#556).
+    // the caller can still see (and reject) it when it's the only marker comment present.
     return matches.find((c) => isBotComment(c)) ?? matches[0] ?? null;
   }
 
@@ -232,7 +232,7 @@ export class FakeForge implements Forge {
   async upsertMarkerComment(prNumber: number, marker: string, body: string): Promise<void> {
     this.upsertedComments.push({ prNumber, marker, body });
     const existing = await this.findComment(prNumber, marker);
-    // Only adopt a bot-authored comment; a human-authored marker is left alone (#556).
+    // Only adopt a bot-authored comment; a human-authored marker is left alone.
     if (existing && isBotComment(existing)) {
       await this.updateComment(existing.id, body);
     } else {

--- a/packages/forge/src/github.ts
+++ b/packages/forge/src/github.ts
@@ -156,8 +156,8 @@ export class GitHubForge implements Forge {
   async findOpenIssueByLabel(label: string): Promise<IssueRef | null> {
     // listForRepo returns issues AND PRs; a PR carries a `pull_request` field, so skip those — we
     // only want a real issue. Paginate rather than read one page, so a page full of label-carrying
-    // PRs (or an older reusable issue) can't hide the issue and leave the caller stacking a duplicate
-    // (#462 review). Default sort is newest-first, so the first real issue we reach is the most recent.
+    // PRs (or an older reusable issue) can't hide the issue and leave the caller stacking a duplicate.
+    // Default sort is newest-first, so the first real issue we reach is the most recent.
     const iterator = this.octokit.paginate.iterator(this.octokit.rest.issues.listForRepo, {
       ...this.base,
       state: 'open',
@@ -211,7 +211,7 @@ export class GitHubForge implements Forge {
       per_page: 100,
     });
     // Prefer a bot-authored match over a human-authored one carrying the same marker: a pre-seeded
-    // marker comment (write access, or the upsert race) must never shadow the bot's real one (#556).
+    // marker comment (write access, or the upsert race) must never shadow the bot's real one.
     // A human-authored match is still returned when it's the only one, so the caller can reject it.
     let humanMatch: ForgeComment | null = null;
     for await (const response of iterator) {
@@ -241,7 +241,7 @@ export class GitHubForge implements Forge {
     const existing = await this.findComment(prNumber, marker);
     // Only adopt (update in place) a comment the bot itself authored. A human-authored comment
     // carrying the marker — pre-seeded to win the adoption race — is left alone; the bot posts its
-    // own so its content is authoritative and never laundered through an attacker-owned comment (#556).
+    // own so its content is authoritative and never laundered through an attacker-owned comment.
     if (existing && isBotComment(existing)) {
       await this.updateComment(existing.id, body);
     } else {

--- a/packages/forge/src/types.ts
+++ b/packages/forge/src/types.ts
@@ -74,7 +74,7 @@ export interface PullRequestDetails {
 
 /** The author of a comment, as reported by the forge. `type` is `'Bot'` for a GitHub App / bot
  *  actor (the tool itself), `'User'` for a human. Used to bind a machine-state marker comment (e.g.
- *  the release manifest) to the bot identity so a human-authored forgery is never trusted (#556). */
+ *  the release manifest) to the bot identity so a human-authored forgery is never trusted. */
 export interface CommentAuthor {
   login?: string;
   type?: string;
@@ -92,7 +92,7 @@ export interface ForgeComment {
  * Whether a marker comment was authored by the bot/app identity (the tool) rather than a human.
  * A machine-state marker (the release manifest, previews, failure reports) is only trustworthy when
  * the bot wrote it; a human-authored comment carrying the same marker is a forgery/pre-seed and must
- * not be adopted or trusted (#556).
+ * not be adopted or trusted.
  *
  * Fails open on an unknown author (`user` absent) — the real GitHub adapter always reports one, so
  * `undefined` only occurs on the fake/legacy paths, where treating it as ours preserves behavior.

--- a/packages/notes/src/input/conventional-changelog.ts
+++ b/packages/notes/src/input/conventional-changelog.ts
@@ -1,3 +1,4 @@
+/* eslint-disable local/no-bare-issue-refs -- the #NNN here are regex format examples, not issue citations */
 import * as fs from 'node:fs';
 import type { ChangelogEntry, ChangelogInput, PackageChangelog } from '../core/types.js';
 import { InputParseError } from '../errors/index.js';

--- a/packages/notes/src/output/versioned.ts
+++ b/packages/notes/src/output/versioned.ts
@@ -15,7 +15,7 @@ import type { TemplateContext } from '../core/types.js';
  * flat path would silently overwrite another package that shares a version number — the history loss
  * this mode exists to prevent. Each release writes a *new* file keyed by version; re-running the same
  * release rewrites it idempotently. Standalone so both the live pipeline and the notes-backfill
- * command (#293) share one writer.
+ * command share one writer.
  */
 export function writeVersionedNotes(
   contexts: TemplateContext[],

--- a/packages/publish/src/stages/prepare.ts
+++ b/packages/publish/src/stages/prepare.ts
@@ -57,7 +57,7 @@ export async function runPrepareStage(ctx: PipelineContext): Promise<void> {
 
   // Update Cargo.toml versions for cargo packages
   if (config.cargo.enabled) {
-    // Cargo.lock files to stage alongside the manifests (#496), deduped — crates in one workspace
+    // Cargo.lock files to stage alongside the manifests, deduped — crates in one workspace
     // share a single workspace-root lock. We re-sync the lock here (rather than trust the version
     // step) so the direct-commit flow — git-commit stages an explicit file list, not `git add -A` —
     // is self-sufficient and correct even run in isolation. The standing-PR flow stages the lock via

--- a/packages/publish/src/utils/cargo.ts
+++ b/packages/publish/src/utils/cargo.ts
@@ -12,7 +12,7 @@ export { parseCargoToml };
 
 /**
  * Refresh a crate's `Cargo.lock` self-version entry after its `Cargo.toml` was bumped, so the
- * committed lock doesn't drift (#496). `cargo update --workspace --offline` moves only workspace
+ * committed lock doesn't drift. `cargo update --workspace --offline` moves only workspace
  * members' own lock entries to match their manifests — registry dependencies are never re-resolved.
  *
  * Returns the lock path (so the caller can stage it) or `undefined` when there's no committed lock,

--- a/packages/publish/test/integration/publish-e2e.spec.ts
+++ b/packages/publish/test/integration/publish-e2e.spec.ts
@@ -1,9 +1,9 @@
 /**
- * End-to-end coverage of the NON-dry-run publish pipeline (#580).
+ * End-to-end coverage of the NON-dry-run publish pipeline.
  *
  * Every other test layer bypasses the real publish path — Examples Smoke runs `--dry-run` (registry
  * auth is dry-run-exempt), the Action harness sets `SKIP_PUBLISH`, and unit specs mock the registries.
- * That gap is exactly why #578 (cargo auth demanded on a crateless repo) shipped despite a green suite.
+ * That gap is exactly why cargo auth demanded on a crateless repo shipped despite a green suite.
  * This spec drives the real `runPipeline` with `dryRun: false` so registry auth, discovery, stage
  * ordering, tagging and the GitHub-Release call all run for real.
  *
@@ -16,7 +16,7 @@
  *           ordering, not the upload itself.
  *
  * The lightweight guards (enabled-but-empty no-op, missing-credential detection) run by default — they
- * need no network and are the direct #578-class regression net. The heavier real-`npm publish` cases
+ * need no network and are the direct regression net. The heavier real-`npm publish` cases
  * are opt-in via `RELEASEKIT_PUBLISH_E2E=1` so the default gate stays fast (see the PR body).
  */
 import { execFileSync } from 'node:child_process';
@@ -265,7 +265,7 @@ afterEach(async () => {
 // ===========================================================================
 describe('Publish pipeline e2e (non-dry-run guards)', () => {
   it('should no-op enabled-but-empty cargo and pub stages without demanding credentials', async () => {
-    // The #578 regression class: cargo/pub enabled on a repo with no crates/pub packages must not
+    // The regression class: cargo/pub enabled on a repo with no crates/pub packages must not
     // fail on a missing registry token. A dry run can't catch this (auth is dry-run-exempt); this is
     // a REAL non-dry-run run with no CARGO_REGISTRY_TOKEN / PUB_TOKEN present.
     delete process.env.CARGO_REGISTRY_TOKEN;

--- a/packages/publish/test/unit/stages/github-release.spec.ts
+++ b/packages/publish/test/unit/stages/github-release.spec.ts
@@ -338,7 +338,7 @@ describe('github-release stage', () => {
   });
 
   it('should match a sanitized "name@vX.Y.Z" tag to release notes keyed by scoped package name', async () => {
-    // Regression for #288: tagTemplate "${packageName}@v${version}" sanitizes a scoped name into
+    // Regression: tagTemplate "${packageName}@v${version}" sanitizes a scoped name into
     // the tag (e.g. wdio-tauri-plugin@v1.1.0). Previously neither the raw-"@" nor the sanitized-"-"
     // branch matched it, so notes silently fell back to GitHub auto-generated notes.
     const { execCommand } = await import('../../../src/utils/exec.js');

--- a/packages/release/src/backfill/reconstruct.ts
+++ b/packages/release/src/backfill/reconstruct.ts
@@ -54,7 +54,7 @@ export interface ReconstructedVersion {
  * tag with its predecessor to scope the commit range (`prevTag..tag`; the first tag uses all commits
  * reachable from it). Tags are re-sorted ascending by semver so the pairing is chronological by
  * version regardless of creation order. This is the offline counterpart of the live version stage's
- * per-package changelog build, for the notes-backfill command (#293).
+ * per-package changelog build, for the notes-backfill command.
  */
 export async function reconstructChangelogs(opts: ReconstructOptions): Promise<ReconstructedVersion[]> {
   // Package-specific repos tag each package (`pkg@v1.2.0`); sync/single repos share one global tag

--- a/packages/release/src/commands/backfill-command.ts
+++ b/packages/release/src/commands/backfill-command.ts
@@ -43,7 +43,7 @@ function readPackageJson(pkgPath: string): { name?: string; repoUrl?: string } {
  * version's notes from git history. Renders each version through the notes pipeline and writes the
  * result to per-version files (`notes.releaseNotes.file.dir`), to the matching GitHub release bodies
  * (`--update-releases`), or both. Single package by default; `--all` discovers every workspace
- * package. Dry-run by default. (#293 — LLM caching and the Action surface are follow-ups.)
+ * package. Dry-run by default. (LLM caching and the Action surface are follow-ups.)
  */
 export function createBackfillCommand(): Command {
   return new Command('backfill')

--- a/packages/release/src/draft/draft.ts
+++ b/packages/release/src/draft/draft.ts
@@ -50,7 +50,7 @@ function planFingerprint(v: VersionOutput): string {
  * just the publishable name@version projection. A recompute at the pinned baseSha can keep identical
  * package versions yet differ in tags, commit message, the root update, or changelog shape (drifted
  * flags or config); the narrow check would wave those through and publish a plan the human never
- * reviewed (#463 review).
+ * reviewed.
  */
 function samePlan(a: VersionOutput | undefined, b: VersionOutput): boolean {
   if (!a) return false;
@@ -60,7 +60,7 @@ function samePlan(a: VersionOutput | undefined, b: VersionOutput): boolean {
 /**
  * Whether a marker comment body actually decodes to a release manifest. Guards the `--draft` reuse
  * path against an unrelated issue that was hand-labelled `release:draft` and happens to carry a
- * marker-prefixed comment: without this, `--draft` would overwrite that issue's title/body (#463 review).
+ * marker-prefixed comment: without this, `--draft` would overwrite that issue's title/body.
  */
 function isReleaseManifestComment(body: string): boolean {
   try {
@@ -96,7 +96,7 @@ function renderDraftBody(versionOutput: VersionOutput, releaseNotes: Record<stri
 }
 
 /**
- * Phase 1 of manual-mode draft-then-dispatch (#319). Computes the release without mutating the tree
+ * Phase 1 of manual-mode draft-then-dispatch. Computes the release without mutating the tree
  * or publishing (a dry-run pass), then opens — or updates in place — a tracking issue holding the
  * editable per-package notes in its body and the base64 manifest in a marker comment. A human edits
  * the notes; {@link publishFromDraft} consumes them.
@@ -122,7 +122,7 @@ export async function runReleaseDraft(options: ReleaseOptions): Promise<ReleaseO
     // Store the drafted notes alongside the editable copy in the issue body. The draft is pinned to
     // baseSha (no drift), so these are the reviewed baseline: at dispatch they back-stop any package
     // whose editable region was removed/mangled, so a lost marker degrades to the reviewed notes
-    // rather than silently regenerating different ones (#463 review).
+    // rather than silently regenerating different ones.
     releaseNotes: releaseNotes ?? {},
     notesFiles: [],
     createdAt: nowIso(),
@@ -138,7 +138,7 @@ export async function runReleaseDraft(options: ReleaseOptions): Promise<ReleaseO
   // Reuse the existing draft only if it's actually ours — an open issue carrying the label AND a
   // comment that decodes to a real release manifest. A human-labelled, unrelated issue (even one with
   // an accidental marker-prefixed comment) must not have its title/body overwritten with a release
-  // draft (#463 review); fall through to creating a fresh draft instead.
+  // draft; fall through to creating a fresh draft instead.
   const existing = await forge.findOpenIssueByLabel(DRAFT_LABEL);
   const existingManifest = existing ? await forge.findComment(existing.number, MANIFEST_MARKER) : undefined;
   const reusable = existing && existingManifest && isReleaseManifestComment(existingManifest.body) ? existing : null;
@@ -158,7 +158,7 @@ export async function runReleaseDraft(options: ReleaseOptions): Promise<ReleaseO
 }
 
 /**
- * Phase 2 of manual-mode draft-then-dispatch (#319). Reads the manifest + human-edited notes from the
+ * Phase 2 of manual-mode draft-then-dispatch. Reads the manifest + human-edited notes from the
  * draft issue, recomputes the release against HEAD (identical to the drafted plan because the baseSha
  * guard requires HEAD to match), applies the edited notes (edited wins per package), publishes, and
  * closes the issue on success.
@@ -189,7 +189,7 @@ export async function publishFromDraft(issueNumber: number, options: ReleaseOpti
   // baseSha pins the commit, but not the CLI flags: a dispatch run with different --target / --scope /
   // --bump (or drifted config) would recompute a different plan than the reviewed draft. Recompute the
   // plan (dry-run, no notes) and refuse if it no longer matches the manifest, so we never publish a
-  // plan the human didn't review (#463 review).
+  // plan the human didn't review.
   const preview = await runRelease({ ...options, dryRun: true, skipNotes: true });
   if (!samePlan(preview?.versionOutput, manifest.versionOutput)) {
     throw new Error(
@@ -206,7 +206,7 @@ export async function publishFromDraft(issueNumber: number, options: ReleaseOpti
   );
   // Reviewed notes win: edits read back from the body override the drafted baseline; any package
   // whose editable region went missing (markers removed/mangled) falls back to the drafted notes
-  // rather than fresh regeneration, and is flagged (#463 review).
+  // rather than fresh regeneration, and is flagged.
   const editedNotes = { ...draftedNotes, ...extracted };
   const droppedRegions = Object.keys(draftedNotes).filter((pkg) => !(pkg in extracted));
   if (droppedRegions.length > 0) {
@@ -219,11 +219,11 @@ export async function publishFromDraft(issueNumber: number, options: ReleaseOpti
     info(`Applying reviewed notes for ${Object.keys(editedNotes).length} package(s) from draft #${issueNumber}.`);
   }
 
-  // Respect --dry-run: a dry dispatch validates without publishing or closing the issue (#463 review).
+  // Respect --dry-run: a dry dispatch validates without publishing or closing the issue.
   const result = await runRelease({ ...options, dryRun: options.dryRun, editedNotes });
 
   // Close the draft only after a real publish landed — never on a dry run or a --skip-publish run,
-  // which compute without publishing anything (#463 review).
+  // which compute without publishing anything.
   if (result && !options.dryRun && !options.skipPublish) {
     await forge.updateIssue(issueNumber, { state: 'closed' });
     success(`Published from draft #${issueNumber}; closed the draft issue.`);

--- a/packages/release/src/failure-report/failure-report.ts
+++ b/packages/release/src/failure-report/failure-report.ts
@@ -170,9 +170,9 @@ export interface RecoveryContext {
   /** Standing PR number (standing-pr mode) used to phrase the dispatch/retry instruction. */
   standingPrNumber?: number;
   /**
-   * Whether the `release:retry` label flow is wired (issue #245). When set, the label is the
+   * Whether the `release:retry` label flow is wired. When set, the label is the
    * primary standing-pr recovery path; dispatch is offered as the manual fallback. Defaults off
-   * for callers that have not opted in (e.g. tests asserting the pre-#245 copy).
+   * for callers that have not opted in (e.g. tests asserting the pre-retry-label copy).
    */
   retryLabelAvailable?: boolean;
 }
@@ -321,7 +321,7 @@ export interface SupersedeWarningInput {
   total: number;
   /** Standing PR number carrying the failure report (the retry surface). */
   standingPrNumber?: number;
-  /** Whether the `release:retry` label flow is wired (issue #245) — makes it the primary hint. */
+  /** Whether the `release:retry` label flow is wired — makes it the primary hint. */
   retryLabelAvailable?: boolean;
 }
 

--- a/packages/release/src/failure-report/post.ts
+++ b/packages/release/src/failure-report/post.ts
@@ -19,7 +19,7 @@ export interface PostFailureReportContext {
   /** PR to comment on. Omit for manual dispatch with no PR — the report goes to the step summary. */
   prNumber?: number;
   standingPrNumber?: number;
-  /** Whether the `release:retry` label flow is wired (issue #245) — makes it the primary hint. */
+  /** Whether the `release:retry` label flow is wired — makes it the primary hint. */
   retryLabelAvailable?: boolean;
 }
 

--- a/packages/release/src/label-definitions.ts
+++ b/packages/release/src/label-definitions.ts
@@ -26,7 +26,7 @@ const COLOR_STANDING = 'ededed'; // grey — standing PR markers (matches legacy
  * if a rename collides with another label (or a scope label reuses a reserved name) the first
  * definition wins, so we never emit two definitions for the same label name.
  *
- * `graduatablePackages` (#486) seeds the per-package `graduate:<package>` labels — GitHub can only
+ * `graduatablePackages` seeds the per-package `graduate:<package>` labels — GitHub can only
  * apply labels that already exist, so the standing-PR update passes the names of packages currently
  * on a prerelease line so a maintainer can pick one from the label picker. Callers without that
  * context (the label-sync command) omit it; those labels are then minted lazily on the next update.
@@ -84,7 +84,7 @@ export function deriveLabelDefinitions(
     });
   }
 
-  // Per-package graduate labels (#486): one `graduate:<package>` per package currently on a
+  // Per-package graduate labels: one `graduate:<package>` per package currently on a
   // prerelease line, so a maintainer can graduate just that package (and its lockstep group) to
   // stable from the GitHub label picker. Channel-blue like the prerelease label — they steer channel.
   for (const pkg of graduatablePackages) {

--- a/packages/release/src/label-utils.ts
+++ b/packages/release/src/label-utils.ts
@@ -1,6 +1,6 @@
 export interface LabelConfig {
   graduate: string;
-  /** Prefix for per-package graduate labels (`graduate:<package>`); see #486. */
+  /** Prefix for per-package graduate labels (`graduate:<package>`). */
   graduatePackagePrefix: string;
   prerelease: string;
   skip: string;
@@ -36,7 +36,7 @@ function graduatePrefix(labels: Partial<LabelConfig> | undefined): string {
 }
 
 /**
- * The per-package graduate label for a package (#486), e.g. `graduate:@scope/pkg`. Adding it to the
+ * The per-package graduate label for a package, e.g. `graduate:@scope/pkg`. Adding it to the
  * standing PR graduates that one prerelease package (and its fixed/linked group) to stable.
  */
 export function graduatePackageLabel(packageName: string, labels?: Partial<LabelConfig>): string {
@@ -44,7 +44,7 @@ export function graduatePackageLabel(packageName: string, labels?: Partial<Label
 }
 
 /**
- * Whether a label is a per-package graduate label (#486). The prefix alone (no package suffix) is not
+ * Whether a label is a per-package graduate label. The prefix alone (no package suffix) is not
  * a valid per-package graduate, so it doesn't match. Comparison is case-insensitive to mirror
  * GitHub's case-insensitive label uniqueness.
  */
@@ -54,7 +54,7 @@ export function isGraduatePackageLabel(label: string, labels?: Partial<LabelConf
 }
 
 /**
- * The package name carried by a per-package graduate label (#486), or `undefined` when the label
+ * The package name carried by a per-package graduate label, or `undefined` when the label
  * isn't one. `graduate:@scope/pkg` → `@scope/pkg`.
  */
 export function graduatedPackageFromLabel(label: string, labels?: Partial<LabelConfig>): string | undefined {
@@ -100,7 +100,7 @@ export function detectLabelConflicts(prLabels: string[], labels: LabelConfig = D
  * `pre*` bump (`premajor`/`preminor`/`prepatch`) — a *fresh* prerelease line at that magnitude.
  * Critically, `pre<type>` ESCALATES: `bump:major` + prerelease on `1.1.1-next.1` → `premajor`
  * → `2.0.0-next.0`. Passing `major` + a separate prerelease flag would instead increment the
- * existing prerelease (`1.1.1-next.2`) — the #335 degradation. To *iterate* an existing
+ * existing prerelease (`1.1.1-next.2`) — the degradation. To *iterate* an existing
  * prerelease (`2.0.0-next.0` → `2.0.0-next.1`), use the prerelease label alone (no `bump:*`),
  * which returns `'prerelease'`.
  *

--- a/packages/release/src/preview/format.ts
+++ b/packages/release/src/preview/format.ts
@@ -306,7 +306,7 @@ export function formatPreviewComment(result: ReleaseOutput | null, options?: For
     pkgSummary = syncVersionRange(versionOutput);
   } else if (pkgCount === 1) {
     const only = versionOutput.updates[0];
-    // Annotate the resolved version action (#420) when present; absent on pre-field manifests.
+    // Annotate the resolved version action when present; absent on pre-field manifests.
     const annotation = only?.action ? ` (${only.action})` : '';
     pkgSummary = `${only?.packageName} ${only?.newVersion}${annotation}`;
   } else {
@@ -319,7 +319,7 @@ export function formatPreviewComment(result: ReleaseOutput | null, options?: For
   lines.push(getIntroMessage(effectiveStrategy, options?.standingPrNumber), '');
 
   // Changelog section
-  // How bare `#NNN` refs render + always-on mention escaping (#499/#504). All packages in a release
+  // How bare `#NNN` refs render + always-on mention escaping. All packages in a release
   // share one repo, so the first non-null changelog repoUrl governs the project-wide (shared) entries.
   const refs = options?.refs ?? 'link';
   const sharedRepoUrl = versionOutput.changelogs.find((cl) => cl.repoUrl)?.repoUrl ?? null;
@@ -327,7 +327,7 @@ export function formatPreviewComment(result: ReleaseOutput | null, options?: For
   // A changelog whose entries are *all* synthetic `Update version to X` placeholders (a sync/
   // lockstep carry with no commits of its own) has nothing real to show — treat it like an empty
   // changelog so the package collapses into the "Also bumped" list below rather than rendering a
-  // full block of placeholder noise (#468).
+  // full block of placeholder noise.
   const hasRealEntries = (cl: VersionPackageChangelog) => cl.entries.some((e) => !e.synthetic);
   const hasPackageChangelogs = versionOutput.changelogs.some(hasRealEntries);
 
@@ -537,7 +537,7 @@ function formatEntryGroup(
 
   for (const entry of entries) {
     // Always neutralise `@`-mentions in the description; the scope is already backticked (safe). Bare
-    // `#N` refs carried over from the commit subject are neutralised / de-duped against the label (#507).
+    // `#N` refs carried over from the commit subject are neutralised / de-duped against the label.
     const appendedRefs = [...(entry.issueIds ?? []), entry.prNumber];
     let line = `- ${escapeChangelogMentions(neutralizeDescriptionRefs(entry.description, appendedRefs, refs, repoUrl))}`;
     if (entry.scope) {

--- a/packages/release/src/preview/preview.ts
+++ b/packages/release/src/preview/preview.ts
@@ -76,7 +76,7 @@ export async function runPreview(options: PreviewOptions): Promise<void> {
   // Don't preview the standing PR itself — its head is the release branch, whose commits already
   // carry the release-prep bump, so re-analysing double-counts the version (e.g. 0.32.1 → 0.32.2).
   // The standing PR's manifest comment is authoritative for what it releases; a preview on it is
-  // noise (#424). Mirrors the inverse publish-side guard in standing-pr.ts.
+  // noise. Mirrors the inverse publish-side guard in standing-pr.ts.
   if (
     strategy === 'standing-pr' &&
     event?.pull_request?.head?.ref === (ciConfig?.standingPr?.branch ?? 'release/next')
@@ -146,7 +146,7 @@ export async function runPreview(options: PreviewOptions): Promise<void> {
 
   // Run version analysis unless release is skipped or in label mode with no bump label
   let result = null;
-  // How bare `#NNN` refs render in the preview changelog (#499/#504); resolved from config below.
+  // How bare `#NNN` refs render in the preview changelog; resolved from config below.
   let refs: ChangelogRefsMode = 'link';
   if (!labelContext.skip && !labelContext.noBumpLabel) {
     // Determine prerelease mode
@@ -400,7 +400,7 @@ async function applyLabelOverrides(
     }
     if (!labelContext.noBumpLabel) {
       // Carry the COMPOSED bump (e.g. premajor) so a major+prerelease on an existing
-      // prerelease escalates to a fresh line rather than degrading to an increment (#335).
+      // prerelease escalates to a fresh line rather than degrading to an increment.
       // The banner still shows the magnitude.
       const composedBump = composeBumpFromLabels(prLabels, labels);
       const magnitude = magnitudeFromBump(composedBump);
@@ -438,7 +438,7 @@ async function applyLabelOverrides(
       }
     } else {
       // Releasing — carry the gate's COMPOSED bump (e.g. premajor) verbatim so the preview
-      // matches what the release will compute; the banner shows the magnitude (#335).
+      // matches what the release will compute; the banner shows the magnitude.
       const magnitude = magnitudeFromBump(evaluation.bump);
       if (magnitude) {
         info(`PR label "bump:${magnitude}" detected — ${magnitude} release`);

--- a/packages/release/src/preview/refresh.ts
+++ b/packages/release/src/preview/refresh.ts
@@ -81,7 +81,7 @@ export async function refreshFeederPreviews(options: RefreshAfterReleaseOptions)
     const eligible: OpenPullRequest[] = [];
     for (const pr of open) {
       if (pr.draft) continue; // drafts don't carry previews
-      if (pr.headRef === branch) continue; // the standing PR's manifest is authoritative, never previewed (#424)
+      if (pr.headRef === branch) continue; // the standing PR's manifest is authoritative, never previewed
       // Only refresh PRs that already have a preview — never manufacture one on a PR that opted out.
       if (!(await forge.findComment(pr.number, MARKER))) continue;
       eligible.push(pr);

--- a/packages/release/src/release.ts
+++ b/packages/release/src/release.ts
@@ -292,7 +292,7 @@ export async function runRelease(inputOptions: ReleaseOptions): Promise<ReleaseO
 
   info(`Found ${versionOutput.updates.length} package update(s)`);
   for (const update of versionOutput.updates) {
-    // Annotate the resolved version action when present (#420). Absent on manifests produced
+    // Annotate the resolved version action when present. Absent on manifests produced
     // before the field existed — render nothing rather than an empty parenthetical.
     const annotation = update.action ? ` (${update.action})` : '';
     info(`  ${update.packageName} → ${update.newVersion}${annotation}`);

--- a/packages/release/src/standing-pr/changelog-region.ts
+++ b/packages/release/src/standing-pr/changelog-region.ts
@@ -80,7 +80,7 @@ function dedupeKey(e: VersionChangelogEntry): string {
 }
 
 /** De-duplicate by underlying change, preserving first-seen order and collecting contributing
- *  packages. Synthetic lockstep-carry placeholders (`Update version to X`, #468) are dropped — they
+ *  packages. Synthetic lockstep-carry placeholders (`Update version to X`) are dropped — they
  *  are not real changes. */
 function dedupe(attributed: AttributedEntry[]): DedupedEntry[] {
   const byKey = new Map<string, DedupedEntry>();
@@ -105,7 +105,7 @@ function shortName(pkg: string): string {
   return slash === -1 ? pkg : pkg.slice(slash + 1);
 }
 
-/** How bare `#NNN` refs render plus the repo to resolve canonical issue links against (#499). */
+/** How bare `#NNN` refs render plus the repo to resolve canonical issue links against. */
 interface RefRenderOptions {
   refs: ChangelogRefsMode;
   repoUrl: string | null;
@@ -115,7 +115,7 @@ function entryLine(d: DedupedEntry, attribution: boolean, refOpts: RefRenderOpti
   const { entry, pkgs } = d;
   // GitHub treats a bare `@scope/pkg` / `@user` in the description as a mention (stray link, can ping
   // a real org/team on the standing PR) — always neutralise it, regardless of the refs mode. Bare `#N`
-  // refs carried over from the commit subject are neutralised / de-duped against the appended label (#507).
+  // refs carried over from the commit subject are neutralised / de-duped against the appended label.
   const appendedRefs = [...(entry.issueIds ?? []), entry.prNumber];
   const description = escapeChangelogMentions(
     neutralizeDescriptionRefs(entry.description, appendedRefs, refOpts.refs, refOpts.repoUrl),
@@ -127,14 +127,14 @@ function entryLine(d: DedupedEntry, attribution: boolean, refOpts: RefRenderOpti
   return `- ${description}${scope}${issues}${attr}`;
 }
 
-/** Bare heading for the trailing demoted subsection (#522) — deliberately no count and no
+/** Bare heading for the trailing demoted subsection — deliberately no count and no
  *  "shared across packages" descriptor: the descriptor isn't reliably true (`Update version to X` is
  *  package-specific), and where provenance matters it's already carried by the per-entry attribution. */
 const DEMOTED_HEADING = 'Dependencies & version bumps';
 
 /** Render the deduped entries as flat, type-grouped Markdown (no per-package sections). Entries whose
  *  scope is in `demoteScopes` are pulled out of their type buckets and rendered last, under a bare
- *  `#### Dependencies & version bumps` subsection — organized, never hidden (#522). Nothing is
+ *  `#### Dependencies & version bumps` subsection — organized, never hidden. Nothing is
  *  removed, so the caller's de-duplicated change count is unchanged. */
 function renderGrouped(deduped: DedupedEntry[], refOpts: RefRenderOptions, demoteScopes: readonly string[]): string[] {
   const distinct = new Set<string>();
@@ -165,9 +165,9 @@ function renderGrouped(deduped: DedupedEntry[], refOpts: RefRenderOptions, demot
   const emit = (label: string): void => {
     const list = byLabel.get(label);
     if (!list?.length) return;
-    // `#### `, not bold `**…**`: inside the blockquote (#506) GitHub gives a heading paragraph-level
+    // `#### `, not bold `**…**`: inside the blockquote GitHub gives a heading paragraph-level
     // top margin, so consecutive sections stay visually separated — bold text collapses to near-zero
-    // spacing there (#508). Matches the preview surface, which already uses `#### ` headings.
+    // spacing there. Matches the preview surface, which already uses `#### ` headings.
     lines.push(`#### ${label}`, '');
     for (const d of list) lines.push(entryLine(d, attribution, refOpts));
     lines.push('');
@@ -220,11 +220,12 @@ function repoUrlOf(changelogs: VersionOutput['changelogs']): string | null {
  * the indent that nests the block under its row. It returns the collapsed `<details>` block, or `''`
  * when those packages have no real changelog entries.
  *
- * #487 regroups *where* rows are placed; it reuses this renderer unchanged to keep *how* changelogs
- * attach to a row identical. `refs` (`changelog.refs`, default `'link'`) controls how bare `#NNN`
- * refs render (#499). `demoteScopes` (`changelog.demoteScopes`, default `['deps']`) routes matching-
+ * The channel-section grouping regroups *where* rows are placed; it reuses this renderer unchanged
+ * to keep *how* changelogs attach to a row identical. `refs` (`changelog.refs`, default `'link'`)
+ * controls how bare `#NNN`
+ * refs render. `demoteScopes` (`changelog.demoteScopes`, default `['deps']`) routes matching-
  * scope entries into a trailing "Dependencies & version bumps" subsection instead of interleaving
- * them; the `(N entries)` count still counts every entry, demoted included (#522).
+ * them; the `(N entries)` count still counts every entry, demoted included.
  */
 export function makeRowChangelogRenderer(
   changelogs: VersionOutput['changelogs'],
@@ -251,7 +252,7 @@ export function makeRowChangelogRenderer(
 
 /** Collect the changelog + shared entries the combined footer draws from, ready to dedupe. `sharedOnly`
  *  narrows to the project-wide (`sharedEntries`) changes with no per-row home. Shared by the footer and
- *  the release summary's change count (#520) so both read one authoritative set. */
+ *  the release summary's change count so both read one authoritative set. */
 function collectAttributed(versionOutput: VersionOutput, sharedOnly: boolean): AttributedEntry[] {
   const attributed: AttributedEntry[] = [];
   if (!sharedOnly) {
@@ -265,7 +266,7 @@ function collectAttributed(versionOutput: VersionOutput, sharedOnly: boolean): A
 
 /** The de-duplicated change count the full combined footer totals — every distinct change once, across
  *  every package changelog plus shared entries. Held-back packages are already excluded from the write
- *  output, so this mirrors exactly what will publish. Feeds the release summary line (#520). */
+ *  output, so this mirrors exactly what will publish. Feeds the release summary line. */
 export function countCombinedChanges(versionOutput: VersionOutput): number {
   return dedupe(collectAttributed(versionOutput, false)).length;
 }

--- a/packages/release/src/standing-pr/notes-region.ts
+++ b/packages/release/src/standing-pr/notes-region.ts
@@ -16,7 +16,7 @@ const REGION_HINT =
  * Upper bound on a single package's rendered release notes. Release notes are otherwise unbounded
  * (the LLM output isn't length-capped, and raw commit bodies flow through), so an inflated note —
  * accidental or adversarial — could push the standing-PR body past GitHub's hard limit and wedge
- * every update (#558). Generous enough that normal notes are untouched; a note beyond it is trimmed
+ * every update. Generous enough that normal notes are untouched; a note beyond it is trimmed
  * at a line boundary with an explicit marker.
  */
 export const MAX_NOTES_CHARS_PER_PACKAGE = 8000;

--- a/packages/release/src/standing-pr/selection-region.ts
+++ b/packages/release/src/standing-pr/selection-region.ts
@@ -29,7 +29,7 @@ const REGION_HINT =
   '> Untick a package to hold it back from the next release, then save — the bot re-runs and updates this PR. ' +
   'Keep the `<!-- rk-sel... -->` marker comments; they identify each row.';
 
-/** Render order for channel sections — stable first, prereleases after (#487). */
+/** Render order for channel sections — stable first, prereleases after. */
 const CHANNEL_ORDER: readonly ReleaseChannel[] = ['stable', 'prerelease'] as const;
 
 /** Section headings shown only when a standing PR mixes channels; a single-channel PR drops them so
@@ -44,8 +44,8 @@ function checkbox(selected: boolean): string {
   return selected ? '[x]' : '[ ]';
 }
 
-/** The channel a row sits on: the per-package value stamped by #485, falling back to deriving it from
- *  the version for manifests written before that field existed (old PRs still open). */
+/** The channel a row sits on: the per-package value stamped on the update, falling back to deriving it
+ *  from the version for manifests written before that field existed (old PRs still open). */
 function channelOf(update: Update): ReleaseChannel {
   return update.channel ?? deriveReleaseChannel(update.newVersion);
 }
@@ -81,8 +81,8 @@ function pushSectionHeading(lines: string[], channel: ReleaseChannel): void {
  *  per-package maturity at a glance. */
 function versionDisplay(update: Update): string {
   if (channelOf(update) !== 'prerelease') return update.newVersion;
-  // SEAM (#486): the per-package "graduate to stable" affordance — gated on a `graduate:<package>`
-  // label — attaches to prerelease rows here once that mechanism merges. #487 renders the channel
+  // SEAM: the per-package "graduate to stable" affordance — gated on a `graduate:<package>`
+  // label — attaches to prerelease rows here once that mechanism merges. This renders the channel
   // grouping + dist-tag only; it deliberately renders no affordance yet.
   return `${update.newVersion} · \`${getDistTag(update.newVersion)}\``;
 }
@@ -121,7 +121,7 @@ export interface ReleaseUnit {
   children: Update[];
   /** Sync mode of the primary's `version.group` (`fixed`/`linked`/`independent`), when it has one.
    *  Drives the members' wording: `fixed`/`linked` members share a version (`coupled`), `independent`
-   *  members version on their own lines but ship atomically (`bundled`, #509). */
+   *  members version on their own lines but ship atomically (`bundled`). */
   groupSync?: string;
 }
 
@@ -206,7 +206,7 @@ export function cascadeDeselection(hierarchy: SelectionHierarchy, deselected: Re
   // A directly held-back *child* only reaches here from a legacy flat body the first run after
   // `primaryPackages` is enabled (streamlined children carry no marker, so steady state never has
   // one). Escalate it to holding its whole unit: a package a maintainer held back must never silently
-  // ship, and holding the unit keeps the render coherent (the primary shows unticked) (#471).
+  // ship, and holding the unit keeps the render coherent (the primary shows unticked).
   for (const [child, owners] of hierarchy.childOwners) {
     if (deselected.has(child)) for (const owner of owners) deselectedPrimaries.add(owner);
   }
@@ -254,7 +254,7 @@ function primaryRow(unit: ReleaseUnit, selected: boolean): string {
 
 /** How a group's members relate to their primary: `independent`-group members version on their own
  *  commit-driven lines but ship atomically (`bundled`); `fixed`/`linked` members share a version
- *  (`coupled`). Un-grouped members fall through to `coupled` — the existing wording (#509). */
+ *  (`coupled`). Un-grouped members fall through to `coupled` — the existing wording. */
 function couplingWord(groupSync?: string): string {
   return groupSync === 'independent' ? 'bundled' : 'coupled';
 }
@@ -282,7 +282,8 @@ function childBullet(child: Update, groupSync?: string): string {
  * Renders the collapsed per-row changelog for the package(s) a checkbox gates, indented to nest under
  * its row, returning `''` when those packages have no changelog entries. Injected by the caller so
  * selection-region stays free of changelog formatting (the implementation lives in
- * `changelog-region.ts`). #487 reuses it unchanged when it regroups *where* rows are placed.
+ * `changelog-region.ts`). The channel-section grouping reuses it unchanged when it regroups *where*
+ * rows are placed.
  */
 export type RowChangelogRenderer = (packageNames: string[], heldBack: boolean, indent: string) => string;
 
@@ -300,7 +301,7 @@ function attachChangelog(
 }
 
 /**
- * The per-row channel toggle (#521): a nested, interactive task item under a selectable row letting a
+ * The per-row channel toggle: a nested, interactive task item under a selectable row letting a
  * maintainer shift just that package's channel without narrowing the release — "ship as prerelease"
  * under a stable row (rk-pre), "graduate to stable" under a prerelease row (rk-grad). Gated on
  * `ci.standingPr.channelToggle`; the parsed tick state round-trips via {@link extractChannelSelection}.
@@ -320,7 +321,7 @@ function stableBase(version: string): string {
 }
 
 /**
- * Append the channel toggle (#521) under a selectable row when enabled and the row is NOT held back —
+ * Append the channel toggle under a selectable row when enabled and the row is NOT held back —
  * a held-back row's channel is moot, so it shows no toggle. A stable row offers "ship as prerelease"
  * (rk-pre); a prerelease row offers "graduate to stable" (rk-grad). These are real `- [ ]` task items
  * (interactive, unlike the streamlined children), indented one level under their row.
@@ -382,7 +383,7 @@ function renderFlatSection(
   }
 }
 
-/** Flat render split into channel sections (#487): stable then prereleases, each a self-contained
+/** Flat render split into channel sections: stable then prereleases, each a self-contained
  *  flat list. A single-channel PR drops the headings and renders exactly as before.
  *
  *  Caveat: the `↳ prerequisite` nesting in `renderFlatSection` only holds when a target and its
@@ -470,7 +471,7 @@ function renderHierarchical(
 ): void {
   const hierarchy = computeHierarchy(updates, primary);
   const streamlined = primary.selection !== 'granular';
-  // A unit stays intact and lands in its primary's channel section (#487); orphans land in their own.
+  // A unit stays intact and lands in its primary's channel section; orphans land in their own.
   const unitsByChannel = byChannel(hierarchy.units, unitChannel);
   const orphansByChannel = byChannel(hierarchy.orphans, channelOf);
   const channels = CHANNEL_ORDER.filter(
@@ -495,13 +496,13 @@ function renderHierarchical(
  * Every row is ticked unless its package is in `deselected`. When `rowChangelog` is supplied, each
  * row gets its co-located collapsed changelog covering exactly the package(s) that row gates.
  *
- * Rows are grouped into channel sections (#487): a **Stable** section (advancing on `latest`) and a
+ * Rows are grouped into channel sections: a **Stable** section (advancing on `latest`) and a
  * **Prereleases** section (advancing on each row's pre-release dist-tag). The hierarchy/flat render is
  * preserved *within* each section — a unit lands in its primary's channel. When every package shares
  * one channel the headings are dropped, so single-channel PRs render byte-for-byte as before.
  *
  * With `channelToggle` supplied (`ci.standingPr.channelToggle`), each selectable, non-held row also
- * gets a nested interactive channel toggle (#521): "ship as prerelease" under a stable row, "graduate
+ * gets a nested interactive channel toggle: "ship as prerelease" under a stable row, "graduate
  * to stable" under a prerelease row. Returns the marker-wrapped block.
  */
 export function renderSelectionRegion(
@@ -570,7 +571,7 @@ function markerHits(region: string, marker: string): Array<{ name: string; ticke
 }
 
 /**
- * Read the maintainer's channel toggles (#521) back from a live PR body: the packages ticked to ship
+ * Read the maintainer's channel toggles back from a live PR body: the packages ticked to ship
  * as a prerelease (`rk-pre`) or graduate to stable (`rk-grad`). Pure marker slicing over the selection
  * region; empty result when the body carries no region or no toggles. A row held back via its `rk-sel`
  * untick WINS over its channel toggle — held back ⇒ channel is moot, so it's dropped here.
@@ -591,7 +592,7 @@ export function extractChannelSelection(body: string): { prereleased: string[]; 
 }
 
 /**
- * Resolve a package caught in both channel scopes (#521): the `rk-pre` toggle and a `graduate` label
+ * Resolve a package caught in both channel scopes: the `rk-pre` toggle and a `graduate` label
  * (or `rk-grad`) can name the same package, but a run can't graduate and go prerelease at once. The
  * `rk-pre` toggle is the explicit in-body action so it wins — the package is dropped from `graduate`
  * and returned in `conflicts` for the caller to surface. Without this the engine's authoritative

--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -52,11 +52,11 @@ import { renderReleaseSummaryLine, renderVersionSummaryTable } from './summary-r
 
 export const MANIFEST_MARKER = '<!-- releasekit-manifest -->';
 const MANIFEST_SCHEMA_VERSION = 2;
-/** Marker for the idempotent "your selection change was ignored" notice posted to an unauthorized editor (#401). */
+/** Marker for the idempotent "your selection change was ignored" notice posted to an unauthorized editor. */
 const SELECTION_DENIED_MARKER = '<!-- releasekit-selection-denied -->';
-/** Marker for the idempotent "your release-label change was ignored" notice (#402). */
+/** Marker for the idempotent "your release-label change was ignored" notice. */
 const LABEL_DENIED_MARKER = '<!-- releasekit-label-denied -->';
-/** Marker for the idempotent "your channel-toggle change was ignored" notice (#526). */
+/** Marker for the idempotent "your channel-toggle change was ignored" notice. */
 const CHANNEL_DENIED_MARKER = '<!-- releasekit-channel-denied -->';
 const MANIFEST_SCHEMA_MIN_VERSION = 1;
 
@@ -148,7 +148,7 @@ export interface StandingPRManifest {
   firstUpdatedAt?: string;
   /**
    * Override-relevant labels (bump/channel/scope) present on the standing PR when this manifest was
-   * computed, sorted. Lets publish refuse a manifest whose labels diverged from the merged PR (#337).
+   * computed, sorted. Lets publish refuse a manifest whose labels diverged from the merged PR.
    * Optional: absent on manifests written before this field existed — consumers must tolerate that.
    */
   overrideLabels?: string[];
@@ -160,16 +160,16 @@ export interface StandingPRManifest {
    */
   deselected?: string[];
   /**
-   * Packages graduated from prerelease to stable on this update (#486), driven by `graduate:<package>`
+   * Packages graduated from prerelease to stable on this update, driven by `graduate:<package>`
    * labels (or the whole-batch `release:graduate`). Group-atomic — a graduated fixed/linked group lists
-   * every releasing member. Recorded for provenance and so consumers (#487's channel-grouped render)
+   * every releasing member. Recorded for provenance and so consumers (the channel-grouped render)
    * can flag a row as graduated; the resolved stable versions already live in `versionOutput`. Optional:
    * absent when nothing graduated, and on manifests written before this field existed (consumers
    * re-derive from each update's `channel` / `action`).
    */
   graduated?: string[];
   /**
-   * Packages shifted onto a prerelease line this update via the per-row channel toggle (#521), scoped
+   * Packages shifted onto a prerelease line this update via the per-row channel toggle, scoped
    * to just these packages (and their groups) without narrowing the release. Recorded for provenance
    * and round-trip; the resolved prerelease versions already live in `versionOutput`. Optional: absent
    * when nothing was channel-shifted, and on manifests written before this field existed.
@@ -186,7 +186,7 @@ async function getHeadSha(cwd: string): Promise<string> {
 }
 
 /**
- * True when this run was triggered by a maintainer acting on the standing PR itself (#336/#367),
+ * True when this run was triggered by a maintainer acting on the standing PR itself,
  * not by a commit landing: a label added/removed (`labeled`/`unlabeled`) adjusting override labels,
  * or the body `edited` to tick/untick the ad-hoc selection region. The CLI reads the event itself
  * (rather than taking a flag) so it works whether the workflow invokes the action, the reusable
@@ -367,7 +367,7 @@ async function deleteReleaseBranch(releaseBranch: string, cwd: string): Promise<
 
 // GitHub rejects a PR body over 65,536 chars with a 422. Cap below that (with margin) so an
 // oversized changelog — almost always a package with no baseline tag whose changelog spans the
-// entire git history (#333) — truncates gracefully instead of failing PR creation outright.
+// entire git history — truncates gracefully instead of failing PR creation outright.
 export const STANDING_PR_BODY_CAP = 64000;
 
 function truncateAtLineBoundary(text: string, maxChars: number): string {
@@ -400,9 +400,9 @@ interface RenderPrBodyOptions {
   renderSelectionBlock?: (withChangelogs: boolean) => string;
   /** The flat, de-duplicated combined footer, already rendered; `''` when disabled or empty. */
   footer: string;
-  /** The one-line release headline (#520), already rendered; absent for sync releases. */
+  /** The one-line release headline, already rendered; absent for sync releases. */
   summaryLine?: string;
-  /** The collapsed version-summary table (#520), already rendered; absent when disabled or for sync. */
+  /** The collapsed version-summary table, already rendered; absent when disabled or for sync. */
   summaryTable?: string;
 }
 
@@ -421,7 +421,7 @@ function renderPrBody(versionOutput: VersionOutput, options: RenderPrBodyOptions
   ): string => {
     const lines: string[] = ['## Release', ''];
 
-    // One-line release headline (#520) under the heading — a neutral "what will publish" scan before
+    // One-line release headline under the heading — a neutral "what will publish" scan before
     // the (conditional) supersede alert and the package list. Absent for sync (its own display leads).
     if (summaryLine) lines.push(summaryLine, '');
 
@@ -431,7 +431,7 @@ function renderPrBody(versionOutput: VersionOutput, options: RenderPrBodyOptions
       lines.push(...supersedeWarning);
     }
 
-    // The scannable current → next table (#520), opt-in via ci.standingPr.summaryTable, sits above the
+    // The scannable current → next table, opt-in via ci.standingPr.summaryTable, sits above the
     // selection region (and after any supersede warning) — it complements the checkbox list, which
     // GitHub renders interactively only as a list, never in a table cell.
     if (summaryTable) lines.push(summaryTable, '');
@@ -665,7 +665,7 @@ interface StandingPrOverrides {
   /** Also release the targeted packages' changed prerequisites (the `release:with-prerequisites` label). */
   withPrerequisites?: boolean;
   /**
-   * Per-package graduation (#486): package names parsed from `graduate:<package>` labels — graduate
+   * Per-package graduation: package names parsed from `graduate:<package>` labels — graduate
    * just these prereleases to stable, leaving others on their line. Empty when none. Ignored when
    * `stable` (the whole-batch `release:graduate`) is set, which graduates everything.
    */
@@ -691,8 +691,8 @@ function relevantOverrideLabelNames(ciConfig: CIConfig | undefined): Set<string>
 
 /**
  * Whether a label steers the next release, so it must be tracked by the manifest's `overrideLabels`
- * (staleness guard, #337) and the label-authorization reconcile (#402). Covers the fixed control
- * labels plus the dynamic per-package `graduate:<package>` labels (#486), whose names aren't known up
+ * (staleness guard) and the label-authorization reconcile. Covers the fixed control
+ * labels plus the dynamic per-package `graduate:<package>` labels, whose names aren't known up
  * front but still drive output and so can't be left for an unauthorized actor to add unchecked.
  */
 function isRelevantOverrideLabel(label: string, ciConfig: CIConfig | undefined): boolean {
@@ -702,20 +702,20 @@ function isRelevantOverrideLabel(label: string, ciConfig: CIConfig | undefined):
 /**
  * The override-relevant labels (bump/channel/scope/graduate) present on a PR, sorted and de-duplicated.
  * This is the set that actually drives the next release, so it's what the manifest records and what
- * publish compares against the merged PR to detect a stale manifest (#337). The standing-PR marker
+ * publish compares against the merged PR to detect a stale manifest. The standing-PR marker
  * label and any unrelated labels (area:*, etc.) are deliberately excluded — they don't affect output.
  */
 function extractOverrideLabels(prLabels: string[], ciConfig: CIConfig | undefined): string[] {
   return [...new Set(prLabels.filter((l) => isRelevantOverrideLabel(l, ciConfig)))].sort();
 }
 
-/** A package update's channel — the persisted `channel` (#485), else re-derived from its version. */
+/** A package update's channel — the persisted `channel`, else re-derived from its version. */
 function updateChannel(update: VersionPackageUpdate): ReturnType<typeof deriveReleaseChannel> {
   return update.channel ?? deriveReleaseChannel(update.newVersion);
 }
 
 /**
- * Publishable packages currently on a prerelease line (#486) — the candidates a maintainer can
+ * Publishable packages currently on a prerelease line — the candidates a maintainer can
  * graduate. Used to seed the per-package `graduate:<package>` labels so they exist in the picker.
  */
 function prereleasePackageNames(versionOutput: VersionOutput): string[] {
@@ -725,7 +725,7 @@ function prereleasePackageNames(versionOutput: VersionOutput): string[] {
 }
 
 /**
- * Packages graduated from prerelease to stable on this run (#486), for the manifest's `graduated`
+ * Packages graduated from prerelease to stable on this run, for the manifest's `graduated`
  * provenance field. Sourced from each update's resolved `action` (`'graduated'`), then widened for
  * group atomicity: a fixed/linked group where any member graduated lists every releasing member, even
  * one whose own action read `'bumped'` because it adopted the group version from a different baseline.
@@ -774,7 +774,7 @@ function resolveStandingPrLabelOverrides(prLabels: string[], ciConfig: CIConfig 
     if (hasPrerelease) prerelease = true;
   }
 
-  // Per-package graduation (#486): each `graduate:<package>` label graduates that one prerelease to
+  // Per-package graduation: each `graduate:<package>` label graduates that one prerelease to
   // stable. The whole-batch `release:graduate` (stable) supersedes them — it graduates everything, so
   // a per-package subset would only narrow it; drop the per-package set then. `channel:prerelease`
   // forces a prerelease line, which directly contradicts graduating, so flag it as a conflict.
@@ -807,7 +807,7 @@ function resolveStandingPrLabelOverrides(prLabels: string[], ciConfig: CIConfig 
   //   - release:graduate wins and drops the bump — graduation is bump-less, so don't leak a stale
   //     magnitude into { bump, stable } (engine ignores it today, but the contract must hold).
   //   - prerelease + magnitude escalates to a fresh line (premajor → 2.0.0-next.0) rather than
-  //     incrementing an existing prerelease (#335).
+  //     incrementing an existing prerelease.
   // (The one deliberate divergence from the SSOT: prerelease *alone* stays commit-driven here —
   // bump undefined + prerelease flag — rather than forcing a 'prerelease' bump, so a standing PR's
   // channel:prerelease label still lets commits pick the magnitude.)
@@ -836,9 +836,9 @@ interface BuildOptionsExtras {
   stable?: boolean;
   prerelease?: boolean;
   includePrerequisites?: boolean;
-  /** Per-package graduation (#486): package patterns to graduate to stable; others stay on their line. */
+  /** Per-package graduation: package patterns to graduate to stable; others stay on their line. */
   graduate?: string[];
-  /** Per-package prerelease (#521): package patterns to shift onto a prerelease line; others stay on
+  /** Per-package prerelease: package patterns to shift onto a prerelease line; others stay on
    *  their projected line. The symmetric twin of `graduate`. */
   prereleaseScope?: string[];
   /** Packages to hold back from the release (standing-PR ad-hoc deselection). Exact name match. */
@@ -877,7 +877,7 @@ function buildBaseReleaseOptions(
 
 /**
  * Close the standing PR (when one exists and we have a token) or noop — the empty-queue outcome.
- * Shared by the dry-run empty-queue guard and the write-step empty guard (#396), so a queue that
+ * Shared by the dry-run empty-queue guard and the write-step empty guard, so a queue that
  * empties out is handled identically whichever step observes it.
  */
 async function closeEmptyQueue(
@@ -907,7 +907,7 @@ function setsEqual(a: ReadonlySet<string>, b: ReadonlySet<string>): boolean {
  * {@link isAuthorizedActor}, but it never throws. The permission check is a forge API call that can
  * fail (rate-limit, network, a mis-scoped token — `getActorPermission` rethrows non-404s); on failure
  * we warn and fail **closed** (treat the actor as unauthorized), so a transient hiccup reverts the
- * standing PR to its authoritative manifest state rather than crashing the whole update (#401).
+ * standing PR to its authoritative manifest state rather than crashing the whole update.
  */
 async function authorizedOrWarn(forge: Forge, actor: EventActor, authz: StandingPrAuthorization): Promise<boolean> {
   try {
@@ -929,7 +929,7 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
 
   const branch = standingPrConfig?.branch ?? 'release/next';
   const base = releaseKitConfig.git?.branch ?? 'main';
-  // How bare `#NNN` refs render in the PR-body changelogs (#499). The setting lives under
+  // How bare `#NNN` refs render in the PR-body changelogs. The setting lives under
   // notes.changelog; when that's disabled (`changelog: false`) the standing PR still renders
   // changelogs, so fall back to the 'link' default.
   // `changelog` is `false` (disabled), a config object, or absent; `false` and `undefined` are both
@@ -937,11 +937,11 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
   const changelogConfig = releaseKitConfig.notes?.changelog;
   const changelogRefsMode = (changelogConfig ? changelogConfig.refs : undefined) ?? 'link';
   // Scopes whose changelog entries are demoted into a trailing "Dependencies & version bumps"
-  // subsection rather than interleaved (#522). Same narrowing as refs: `false`/absent → the default.
+  // subsection rather than interleaved. Same narrowing as refs: `false`/absent → the default.
   const demoteScopes = (changelogConfig ? changelogConfig.demoteScopes : undefined) ?? ['deps'];
   const skipPatterns = releaseKitConfig.release?.ci?.skipPatterns ?? ['chore: release '];
 
-  // Label-triggered runs (a maintainer added/removed an override label on the standing PR, #336)
+  // Label-triggered runs (a maintainer added/removed an override label on the standing PR)
   // must bypass the skip-pattern guards just like reconcile: the guards reject runs reacting to a
   // release commit on HEAD, but a label event isn't reacting to HEAD at all — skipping would leave
   // the new override unapplied until the next push or the hourly cron.
@@ -1006,24 +1006,24 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
   // The maintainer's prior package selection — names whose row was unticked (held back). Reconciled
   // against the actually-changed set after the dry-run below (a name no longer changed is dropped).
   //
-  // Authorization (#401): when `ci.standingPr.authorization` is set, the manifest's recorded
+  // Authorization: when `ci.standingPr.authorization` is set, the manifest's recorded
   // selection is AUTHORITATIVE; the live body is only trusted when an authorized actor `edited` it.
   // Otherwise (an unauthorized edit, or a push/schedule run) we keep the manifest's selection so the
   // re-render reverts any unauthorized tick/untick. With no policy configured, the body is
   // authoritative (original behavior).
   const bodyDeselected = new Set<string>((liveBody && extractSelection(liveBody)?.deselected) || []);
-  // Per-row channel toggles (#521): the packages a maintainer ticked to ship as a prerelease (rk-pre)
+  // Per-row channel toggles: the packages a maintainer ticked to ship as a prerelease (rk-pre)
   // or graduate to stable (rk-grad). Only read when the feature is enabled. A held-back row's toggle is
   // already dropped by extractChannelSelection. Fed into the version WRITE step below (not the dry run,
   // so the projected-channel render keeps the marker that round-trips the tick), like ad-hoc
   // deselection. Reassigned to the manifest's approved channels for an unauthorized editor by the
-  // channel-toggle gate (#526) at the write wiring.
+  // channel-toggle gate at the write wiring.
   const channelToggleEnabled = standingPrConfig?.channelToggle === true;
   let channelSelection =
     channelToggleEnabled && liveBody ? extractChannelSelection(liveBody) : { prereleased: [], graduated: [] };
   const authz = standingPrConfig?.authorization;
   // Resolve the triggering actor and whether their body `edited` event is authorized ONCE, so the
-  // ad-hoc selection gate (#401) here and the channel-toggle gate (#526) at the write wiring share a
+  // ad-hoc selection gate here and the channel-toggle gate at the write wiring share a
   // single collaborator-permission lookup. A non-`edited` trigger (push/schedule/label) is never an
   // authorized edit, so those runs fall through to the manifest's recorded selection.
   let eventActor: EventActor | undefined;
@@ -1053,7 +1053,7 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
     }
   }
 
-  // Label authorization (#402): release-control labels (bump:/scope:/channel:/with-prerequisites and
+  // Label authorization: release-control labels (bump:/scope:/channel:/with-prerequisites and
   // configured scope:*) on the standing PR drive the next release, but GitHub can't restrict who
   // applies a label. When authorization is set, the manifest's `overrideLabels` are AUTHORITATIVE; an
   // unauthorized `labeled`/`unlabeled` event is ignored and the PR's release-control labels are
@@ -1088,7 +1088,7 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
     }
   }
 
-  // Preview-notes opt-in (#200): when the standing PR carries the preview-notes label, generate LLM
+  // Preview-notes opt-in: when the standing PR carries the preview-notes label, generate LLM
   // release notes on demand into an editable region in the PR body. Default path stays LLM-free.
   const previewNotesLabel = (ciConfig?.labels ?? DEFAULT_LABELS).previewNotes;
   const previewNotesEnabled = effectiveLabels.includes(previewNotesLabel);
@@ -1111,7 +1111,7 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
   // the CLI flag OR the `release:with-prerequisites` label, either way.
   const cliTarget = options.target ?? overrides.target;
   const includePrerequisites = options.includePrerequisites || overrides.withPrerequisites;
-  // Per-package graduation (#486) is a non-sync concept — a sync release moves as one atomic unit
+  // Per-package graduation is a non-sync concept — a sync release moves as one atomic unit
   // (no selection region, single shared version), so `graduate:<package>` has no meaning there; the
   // whole-batch `release:graduate` still graduates the synced unit. Drop the per-package set for sync.
   const graduate = sync ? undefined : overrides.graduate;
@@ -1168,7 +1168,7 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
   // but not yet tagged; recomputing from it would double-bump (package.json ahead of the last tag →
   // bump again under `mismatchStrategy: prefer-package`). Re-check the skip pattern post-reset and
   // bow out — the post-release reconcile (or the next push) rebuilds the standing PR cleanly once the
-  // release has tagged. Reconcile runs are exempt: HEAD is a release commit by design there. See #323.
+  // release has tagged. Reconcile runs are exempt: HEAD is a release commit by design there.
   if (!options.reconcile) {
     const resetHeadSubject = await getHeadCommitMessage(cwd);
     if (resetHeadSubject && matchesSkipPattern(resetHeadSubject, skipPatterns)) {
@@ -1185,7 +1185,7 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
   const dryUpdates = publishableUpdates(versionOutputDry);
   const groups = releaseKitConfig.version?.groups ?? {};
   const changedNames = new Set(dryUpdates.map((u) => u.packageName));
-  // Release-unit selection (#464): with `primaryPackages` configured the list renders primaries as
+  // Release-unit selection: with `primaryPackages` configured the list renders primaries as
   // parent rows with their coupled members nested beneath. Resolving primaries — including ones not
   // bumping this run — needs the full workspace package list, loaded lazily only when the feature is
   // on. Sync releases never render a selection region, so this is all skipped for them.
@@ -1230,7 +1230,7 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
     }
   }
 
-  // Per-row channel toggles (#521) resolved for the WRITE step. A held-back package is dropped
+  // Per-row channel toggles resolved for the WRITE step. A held-back package is dropped
   // (held back ⇒ channel moot; and it's excluded anyway). Group atomicity: a channel shift must move
   // the package's whole group, so each toggled package is expanded to its group-mates — independent
   // groups release each member on its own prerelease line, fixed/linked share one (via
@@ -1247,7 +1247,7 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
     return [...out];
   };
 
-  // Channel-toggle authorization (#526): the twin of the ad-hoc selection gate (#401). When channel
+  // Channel-toggle authorization: the twin of the ad-hoc selection gate. When channel
   // toggles are enabled and an unauthorized actor edited the body, the manifest's recorded channel
   // selection is AUTHORITATIVE — reset to it so the WRITE publishes the approved channels and the
   // re-render below reverts the rogue tick, exactly as deselection does. The manifest stores the
@@ -1326,8 +1326,8 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
   // The write step recomputes from the post-reset HEAD, which can differ from the dry run when a
   // release landed on `base` mid-run (a reconcile race exempt from the skip-pattern bail above): the
   // dry-run guard saw updates, but the write set is now empty. Without this second guard the empty
-  // output renders a degenerate `****` body and an empty `chore: release ` title onto the open PR
-  // (#396). Gate on publishable updates so a sync root-only bump with nothing to publish is caught too.
+  // output renders a degenerate `****` body and an empty `chore: release ` title onto the open PR.
+  // Gate on publishable updates so a sync root-only bump with nothing to publish is caught too.
   if (publishableUpdates(versionOutput).length === 0) {
     return closeEmptyQueue(existingStandingPr, githubContext);
   }
@@ -1341,7 +1341,7 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
   }
 
   // Generate per-package CHANGELOG.md always; LLM release notes only when previewing. To keep LLM
-  // load low (#200), skip generation when every releasing package already has an edited region —
+  // load low, skip generation when every releasing package already has an edited region —
   // notes are seeded once when the label is first applied, then preserved on later pushes.
   info('Generating changelog...');
   const allPackagesHaveRegions = previewPackages.length > 0 && previewPackages.every((p) => p in editedNotes);
@@ -1433,7 +1433,7 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
     // Per-row changelogs are sourced from the DRY changelogs (the full changed set) so a held-back
     // row still shows its greyed changelog — the write output omits held-back packages entirely.
     const rowChangelog = makeRowChangelogRenderer(versionOutputDry.changelogs, changelogRefsMode, demoteScopes);
-    // The per-row channel toggle (#521), reflecting the parsed tick state so it round-trips. Only when
+    // The per-row channel toggle, reflecting the parsed tick state so it round-trips. Only when
     // the feature is enabled; a held-back row's toggle is suppressed by the renderer.
     const channelToggle: ChannelToggleConfig | undefined = channelToggleEnabled
       ? {
@@ -1463,7 +1463,7 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
       ? renderCombinedFooter(versionOutput, { refs: changelogRefsMode, demoteScopes })
       : renderCombinedFooter(versionOutput, { sharedOnly: true, refs: changelogRefsMode, demoteScopes });
 
-  // Additive top-of-body summaries (#520), for the per-package path only — sync ships atomically with
+  // Additive top-of-body summaries, for the per-package path only — sync ships atomically with
   // its own single-version display. The headline always renders; the table is opt-in. Held-back count
   // is the changed set (dry) minus what the write output will publish.
   let summaryLine: string | undefined;
@@ -1503,9 +1503,9 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
 
   // Ensure the full ReleaseKit label set exists in the repo from the shared definitions. The
   // retry label is created but NOT applied — a maintainer applies it on demand after merge to
-  // retry a failed publish (issue #245). Best-effort: a sync failure must not block the update.
+  // retry a failed publish. Best-effort: a sync failure must not block the update.
   try {
-    // Seed a `graduate:<package>` label for every package currently on a prerelease line (#486) so a
+    // Seed a `graduate:<package>` label for every package currently on a prerelease line so a
     // maintainer can pick one from GitHub's label list — labels must exist before they can be applied.
     await syncLabels(forge, deriveLabelDefinitions(ciConfig, prereleasePackageNames(versionOutput)));
   } catch (err) {
@@ -1516,7 +1516,7 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
   // scope:foo) by taking the union of the currently-applied labels and the configured set. Without
   // this, every update would wipe maintainer overrides. Base the union on `effectiveLabels` (not the
   // raw live labels) so an unauthorized release-control label reconciled out above is removed here
-  // rather than re-added (#402); run even with no configured labels when that reconcile changed the set.
+  // rather than re-added; run even with no configured labels when that reconcile changed the set.
   const labelsReconciled = !setsEqual(new Set(effectiveLabels), new Set(existingStandingPr?.labels ?? []));
   if (labels.length > 0 || labelsReconciled) {
     try {
@@ -1533,8 +1533,8 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
     firstUpdatedAt = existingManifest.firstUpdatedAt ?? existingManifest.createdAt;
   }
 
-  // Packages that graduated to stable this run (#486), recorded in the manifest below for provenance
-  // and for the channel-grouped render (#487). Derived from what actually resolved, so it reflects
+  // Packages that graduated to stable this run, recorded in the manifest below for provenance
+  // and for the channel-grouped render. Derived from what actually resolved, so it reflects
   // group atomicity and the whole-batch graduate as well as the per-package labels.
   const graduatedPackages = graduatedPackageNames(versionOutput);
 
@@ -1550,15 +1550,15 @@ export async function runStandingPRUpdate(options: StandingPROptions): Promise<S
     baseSha,
     firstUpdatedAt,
     // Record the labels this manifest was computed under so publish can detect a stale manifest if
-    // they're changed after this update without a re-run (#337).
+    // they're changed after this update without a re-run.
     overrideLabels: extractOverrideLabels(effectiveLabels, ciConfig),
     // Record any packages held back via the selection region (provenance; the release set in
     // `versionOutput` is already narrowed). Omitted when nothing was deselected.
     deselected: effectiveDeselected.size > 0 ? [...effectiveDeselected].sort() : undefined,
-    // Record which packages graduated to stable this run (#486) so the state survives re-runs and
-    // consumers (#487) can flag a graduated row. Omitted when nothing graduated.
+    // Record which packages graduated to stable this run so the state survives re-runs and
+    // consumers can flag a graduated row. Omitted when nothing graduated.
     graduated: graduatedPackages.length > 0 ? graduatedPackages : undefined,
-    // Record which packages were channel-shifted onto a prerelease line via the per-row toggle (#521),
+    // Record which packages were channel-shifted onto a prerelease line via the per-row toggle,
     // group-expanded, for provenance/round-trip. Omitted when nothing was channel-shifted.
     prereleased: writePrereleaseScope.length > 0 ? [...writePrereleaseScope].sort() : undefined,
   };
@@ -1721,11 +1721,11 @@ export async function publishFromManifest(prNumber: number, options: StandingPRO
     );
   }
 
-  // Publish-author gate (#403): defense-in-depth behind a branch-protection ruleset (the primary
+  // Publish-author gate: defense-in-depth behind a branch-protection ruleset (the primary
   // merge gate). Refuse to publish when the actor who merged the PR isn't authorized to steer
   // releases — catching a missing/misconfigured ruleset. On an unverifiable permission check we
   // proceed rather than block a legitimate release (the ruleset already gated the merge). Mirrors
-  // the #337 staleness refusal: a publish that shouldn't happen is stopped here, not retried.
+  // the staleness refusal: a publish that shouldn't happen is stopped here, not retried.
   const authz = standingPrConfig?.authorization;
   if (authz?.enforceMergeAuthor) {
     const actor = getEventActor();
@@ -1806,7 +1806,7 @@ export async function publishFromManifest(prNumber: number, options: StandingPRO
     warn(`Could not read PR #${prNumber}: ${err instanceof Error ? err.message : String(err)}`);
   }
 
-  // Staleness guard (#337): refuse to publish a manifest whose override labels diverge from the
+  // Staleness guard: refuse to publish a manifest whose override labels diverge from the
   // merged PR's. This catches "label changed then merged before the standing-PR update re-ran" —
   // publishing then would ship a release the labels no longer describe. Only enforced when the
   // manifest actually recorded labels; manifests written before this field skip the check.
@@ -1837,7 +1837,7 @@ export async function publishFromManifest(prNumber: number, options: StandingPRO
     }
   }
 
-  // Pull any human-edited release notes from the live PR body (#200). Marker slicing only — the
+  // Pull any human-edited release notes from the live PR body. Marker slicing only — the
   // manifest never stores prose, so "manifest = machine state only" holds.
   let editedNotes: Record<string, string> = {};
   if (livePr) {

--- a/packages/release/src/standing-pr/summary-region.ts
+++ b/packages/release/src/standing-pr/summary-region.ts
@@ -6,7 +6,7 @@ import { publishableUpdates, toDisplayVersion } from '../version-display.js';
 import { countCombinedChanges } from './changelog-region.js';
 
 /**
- * The two additive, non-interactive summary surfaces at the top of a standing-PR body (#520):
+ * The two additive, non-interactive summary surfaces at the top of a standing-PR body:
  *  - {@link renderReleaseSummaryLine} — a one-line headline (package count, channel split, change
  *    count, major-bump flag, held-back count).
  *  - {@link renderVersionSummaryTable} — a collapsed `current → next` table with bump magnitude and
@@ -20,8 +20,8 @@ import { countCombinedChanges } from './changelog-region.js';
 
 type Update = VersionOutput['updates'][number];
 
-/** The channel a row sits on: the per-package value stamped by #485, falling back to deriving it from
- *  the resolved version for manifests written before that field existed (old PRs still open). */
+/** The channel a row sits on: the per-package value stamped on the update, falling back to deriving it
+ *  from the resolved version for manifests written before that field existed (old PRs still open). */
 function channelOf(update: Update): ReleaseChannel {
   return update.channel ?? deriveReleaseChannel(update.newVersion);
 }

--- a/packages/release/src/types.ts
+++ b/packages/release/src/types.ts
@@ -7,14 +7,14 @@ export interface ReleaseOptions {
   bump?: string;
   prerelease?: string | boolean;
   stable?: boolean;
-  /** Per-package graduation (#486): package name patterns to graduate to stable, leaving other
+  /** Per-package graduation: package name patterns to graduate to stable, leaving other
    *  prereleases on their line. Distinct from `stable`, which graduates ALL prereleases. */
   graduate?: string[];
-  /** Per-package prerelease (#521): package name patterns to shift onto a prerelease line, leaving
+  /** Per-package prerelease: package name patterns to shift onto a prerelease line, leaving
    *  every other package on its projected version. The symmetric twin of `graduate`; distinct from
    *  `prerelease`, which shifts ALL packages. */
   prereleaseScope?: string[];
-  /** Acknowledge a first-release bump on an already-stable manifest (silences the #388 overshoot guard). */
+  /** Acknowledge a first-release bump on an already-stable manifest (silences the overshoot guard). */
   allowFirstBump?: boolean;
   sync: boolean;
   target?: string;
@@ -52,7 +52,7 @@ export interface ReleaseOptions {
   baseRef?: string;
   /**
    * Per-package human-edited release notes that win over freshly generated notes (edited wins per
-   * package, new packages fall back to fresh). Set by the manual-mode draft dispatch (#319) from the
+   * package, new packages fall back to fresh). Set by the manual-mode draft dispatch from the
    * edited tracking-issue body; not a CLI flag.
    */
   editedNotes?: Record<string, string>;

--- a/packages/release/test/unit/dispatcher.spec.ts
+++ b/packages/release/test/unit/dispatcher.spec.ts
@@ -99,7 +99,7 @@ describe('createDispatcherProgram', () => {
 
   // Durable drift guard: the public `releasekit` bin (dispatcher) must expose every release-domain
   // command the `releasekit-release` bin does, or `releasekit <cmd>` silently routes to the default
-  // `preview` command (#519). Registering a new command in cli.ts without the dispatcher trips this.
+  // `preview` command. Registering a new command in cli.ts without the dispatcher trips this.
   it('should expose every release-domain command the release CLI does', () => {
     const dispatcher = new Set(createDispatcherProgram().commands.map((c) => c.name()));
     const releaseCli = createReleaseProgram().commands.map((c) => c.name());
@@ -110,7 +110,7 @@ describe('createDispatcherProgram', () => {
   });
 
   it('should route `refresh-after-release` to its own command, not the default preview', () => {
-    // The reported symptom (#519): an unregistered command falls through to the default `preview`, which
+    // The reported symptom: an unregistered command falls through to the default `preview`, which
     // rejects the stray positional. preview is mocked with exitOverride and refresh with a no-op action
     // (both above), so a misroute throws instead of exiting — a clean parse proves correct routing.
     const program = createDispatcherProgram().exitOverride();

--- a/packages/release/test/unit/preview-format.spec.ts
+++ b/packages/release/test/unit/preview-format.spec.ts
@@ -206,7 +206,7 @@ describe('formatPreviewComment', () => {
     expect(result).toContain('#### Added');
     expect(result).toContain('- New dry-run flag (`cli`)');
     expect(result).toContain('#### Fixed');
-    // #499: bare #NNN renders as a canonical link by default (refs: 'link'); the ref group carries
+    // Bare #NNN renders as a canonical link by default (refs: 'link'); the ref group carries
     // its own parens (an entry with no identified PR falls back to the plain list).
     expect(result).toContain(
       '- Fix prerelease sorting (`semver`) ([#42](https://github.com/goosewobbler/releasekit/issues/42))',
@@ -972,7 +972,7 @@ describe('formatPreviewComment', () => {
     });
   });
 
-  // --- Synthetic version-bump entries (#468) ---
+  // --- Synthetic version-bump entries ---
 
   describe('synthetic version-bump entries', () => {
     // A sync/lockstep carry: a bumped package with no commits of its own gets a fabricated

--- a/packages/release/test/unit/preview.spec.ts
+++ b/packages/release/test/unit/preview.spec.ts
@@ -211,7 +211,7 @@ describe('runPreview', () => {
 
     it('should skip the preview when the PR is the standing release PR', async () => {
       // The standing PR's head IS the release branch; its commits already carry the release-prep
-      // bump, so previewing it would double-count the version (#424).
+      // bump, so previewing it would double-count the version.
       mockLoadCIConfig.mockReturnValue({
         releaseStrategy: 'standing-pr',
         standingPr: { branch: 'release/next' },
@@ -475,7 +475,7 @@ describe('runPreview', () => {
         await runPreview({ projectDir: '/test', dryRun: false, target: '@test/package' });
 
         // minor + prerelease composes to preminor so an existing prerelease escalates a fresh
-        // line rather than degrading to a prerelease increment (#335).
+        // line rather than degrading to a prerelease increment.
         expect(mockRunRelease).toHaveBeenCalledWith(expect.objectContaining({ bump: 'preminor', prerelease: true }));
       });
 
@@ -590,7 +590,7 @@ describe('runPreview', () => {
       });
 
       it('should surface the gate reason in the banner when channel:prerelease + scope but no bump (honest preview)', async () => {
-        // Reproduces the wdio-desktop-mobile #225 scenario: channel:prerelease + scope:tauri.
+        // Reproduces the wdio-desktop-mobile scenario: channel:prerelease + scope:tauri.
         // The OLD preview lied — it showed a version bump table because scope was present.
         // The NEW preview matches the gate's verdict: this PR will NOT trigger a release.
         mockLoadCIConfig.mockReturnValue({

--- a/packages/release/test/unit/selection-region.spec.ts
+++ b/packages/release/test/unit/selection-region.spec.ts
@@ -178,7 +178,7 @@ describe('selection-region', () => {
     });
   });
 
-  // --- Hierarchical / release-unit selection (#464) ---
+  // --- Hierarchical / release-unit selection ---
 
   describe('hierarchical selection', () => {
     const tauriGroups = { tauri: { sync: 'linked' as const, packages: ['@wdio/tauri-*', 'tauri-plugin-*'] } };
@@ -430,7 +430,7 @@ describe('selection-region', () => {
     });
   });
 
-  // --- Channel-grouped sections (#487) ---
+  // --- Channel-grouped sections ---
 
   describe('channel-grouped sections', () => {
     const STABLE = '#### Stable — advancing on `latest`';
@@ -492,7 +492,7 @@ describe('selection-region', () => {
     });
 
     it('should derive the channel from the version when the update carries none (old manifest)', () => {
-      // No `channel` field (pre-#485 manifest): the section split falls back to deriveReleaseChannel.
+      // No `channel` field (old manifest): the section split falls back to deriveReleaseChannel.
       const updates: Update[] = [
         { packageName: '@scope/a', newVersion: '1.1.0', filePath: '' },
         { packageName: '@scope/b', newVersion: '2.0.0-next.1', filePath: '' },
@@ -697,7 +697,7 @@ describe('selection-region', () => {
 
       it('should drop a package from graduate when it is also prereleased — the rk-pre toggle wins', () => {
         // Otherwise the engine's authoritative stableOnly silently overrides the accepted prerelease
-        // toggle: the PR shows the toggle ticked but the write publishes stable (#521).
+        // toggle: the PR shows the toggle ticked but the write publishes stable.
         expect(resolveChannelConflicts(['@scope/a', '@scope/b'], ['@scope/a'])).toEqual({
           graduate: ['@scope/b'],
           conflicts: ['@scope/a'],
@@ -706,7 +706,7 @@ describe('selection-region', () => {
 
       it('should treat a graduate glob target that covers a prereleased package as a conflict', () => {
         // A broad graduate label like `graduate:@scope/*` must not slip past the exact prerelease name
-        // — an exact-string check would miss it and pass both scopes to the engine (#521).
+        // — an exact-string check would miss it and pass both scopes to the engine.
         expect(resolveChannelConflicts(['@scope/*'], ['@scope/a'])).toEqual({
           graduate: [],
           conflicts: ['@scope/*'],

--- a/packages/release/test/unit/standing-pr.spec.ts
+++ b/packages/release/test/unit/standing-pr.spec.ts
@@ -21,7 +21,7 @@ import {
  * two formatted `log` reads that need independent control:
  *  - `getHeadCommitMessage` (`--format=%s`) — the HEAD commit subject the skip-pattern guards key on;
  *    `nextSubject` is a queue so a single test can return different subjects across the two guard
- *    calls (the #323 / #336 mid-run-reset scenarios).
+ *    calls (the mid-run-reset scenarios).
  *  - `createReleaseTags`' tag→commit resolution (`--format=%H`) — answered with the seeded HEAD SHA so
  *    a present tag reads as "at HEAD".
  * Everything else (commit/tag/push/checkout/reset/fetch/add) is the real FakeGit recorder, so specs
@@ -544,7 +544,7 @@ describe('runStandingPRUpdate', () => {
     expect(updatedBody).toContain('- [x] `@scope/a`');
   });
 
-  // --- Release-unit selection: primaryPackages wiring (#464) ---
+  // --- Release-unit selection: primaryPackages wiring ---
 
   // Config with `@wdio/tauri-service` as a primary over a linked `tauri` group, and the workspace
   // resolver returning both packages so the primary (changed here) anchors the plugin as its child.
@@ -658,7 +658,7 @@ describe('runStandingPRUpdate', () => {
     } as unknown as ReturnType<typeof loadConfig>);
   };
 
-  // Authorization AND per-row channel toggles both enabled — the combination the #526 gate protects.
+  // Authorization AND per-row channel toggles both enabled — the combination the gate protects.
   const withAuthzChannel = async () => {
     const { loadConfig } = await import('@releasekit/config');
     vi.mocked(loadConfig).mockReturnValue({
@@ -868,7 +868,7 @@ describe('runStandingPRUpdate', () => {
     expect(writeCall.bump).toBe('major'); // authorized override honoured
   });
 
-  // #526 — channel toggles (rk-pre/rk-grad) get the same manifest reconciliation as ad-hoc deselection.
+  // Channel toggles (rk-pre/rk-grad) get the same manifest reconciliation as ad-hoc deselection.
   const channelWriteOutput = async () => {
     const { runVersionStep, runNotesStep } = await import('../../src/steps.js');
     const versionOutput = {
@@ -1389,7 +1389,7 @@ describe('runStandingPRUpdate', () => {
     expect(body).toContain('<details><summary>Changelog (1 entry)</summary>');
   });
 
-  // Build a mixed-channel async version output whose updates carry the #520 baseline/channel fields the
+  // Build a mixed-channel async version output whose updates carry the baseline/channel fields the
   // summary line and table render from.
   function mixedChannelOutput() {
     return {
@@ -2079,7 +2079,7 @@ describe('runStandingPRUpdate', () => {
       await runStandingPRUpdate({ projectDir: '/test', verbose: false, quiet: false, json: false });
 
       // Composed so an already-prerelease package escalates a fresh line (premajor → 2.0.0-next.0)
-      // rather than degrading to a prerelease increment (#335). Both dry-run and write calls agree.
+      // rather than degrading to a prerelease increment. Both dry-run and write calls agree.
       expect(runVersionStepMock.mock.calls[0]?.[0]).toMatchObject({ bump: 'premajor', prerelease: true });
       expect(runVersionStepMock.mock.calls[1]?.[0]).toMatchObject({ bump: 'premajor', prerelease: true });
     });
@@ -2574,7 +2574,7 @@ describe('runStandingPRPublish', () => {
       { '@scope/core': '- regenerated at publish time' },
       expect.arrayContaining(['RELEASE_NOTES.md', ...baseManifest.notesFiles]),
     );
-    // The publish moved `main`, so feeder-PR previews are refreshed in-process (#459).
+    // The publish moved `main`, so feeder-PR previews are refreshed in-process.
     const { refreshFeederPreviews } = await import('../../src/preview/refresh.js');
     expect(vi.mocked(refreshFeederPreviews)).toHaveBeenCalledWith(expect.objectContaining({ projectDir: '/test' }));
   });
@@ -2747,7 +2747,7 @@ describe('runStandingPRPublish', () => {
       JSON.stringify({ pull_request: { head: { ref: 'release/next' }, number: 42, merged: true } }),
     );
 
-    // baseManifest has no overrideLabels (pre-#337) — the check must be skipped even if labels differ.
+    // baseManifest has no overrideLabels — the check must be skipped even if labels differ.
     await mockForge({
       comments: [{ id: 1, body: serializeManifest(baseManifest) }],
       pullRequests: { 42: { body: '', labels: ['bump:major'] } },

--- a/packages/version/src/changelog/commitParser.ts
+++ b/packages/version/src/changelog/commitParser.ts
@@ -293,6 +293,7 @@ function parseCommitMessage(message: string): ChangelogEntry | null {
     const prNumber = prMatch ? `#${prMatch[1]}` : undefined;
     const subjectText = prMatch ? subjectRaw.slice(0, prMatch.index).trimEnd() : subjectRaw;
 
+    // eslint-disable-next-line local/no-bare-issue-refs -- the "Fixes" footer example on the next line is a format sample, not a citation
     // Extract issue IDs from footer (assuming format like "Fixes #123"). issueIds is the full flat
     // list: the PR (when present) plus the closed issues, so a consumer that ignores prNumber still
     // shows every ref.

--- a/packages/version/src/core/baselineResolver.ts
+++ b/packages/version/src/core/baselineResolver.ts
@@ -24,7 +24,7 @@ export interface BaselineResolverOptions {
   /** CWD for the repo-level nearest-reachable floor lookup (shared floor). Defaults to `process.cwd()`. */
   sharedFloorCwd?: string;
   /**
-   * How the repo-level shared floor (C) is bounded in package-specific-tag mode (#398). `'union'`
+   * How the repo-level shared floor (C) is bounded in package-specific-tag mode. `'union'`
    * (default): each package contributes its own range, so the shared block is the union floored by
    * the oldest baseline. `'sinceLastRelease'`: every package's shared block is floored by the single
    * global nearest-reachable tag, collapsing the union so global commits don't recur.
@@ -57,7 +57,7 @@ export interface BaselineInput {
 
 export interface PackageBaseline {
   /** `<floor>..HEAD`, floored by the package's own baseline when reachable, else by the nearest
-   *  reachable tag (#370); `'HEAD'` only when the repo has no reachable tag at all (fresh repo). */
+   *  reachable tag; `'HEAD'` only when the repo has no reachable tag at all (fresh repo). */
   revisionRange: string;
   /** The package's own previous version in consumer-facing display form, or `null` when its own
    *  baseline is unreachable/absent — even if the range was floored by a nearest-reachable tag, that
@@ -74,14 +74,14 @@ export interface PackageBaseline {
  * `<tag>..HEAD` range a package's changelog is collected from, and is that baseline reachable" (the
  * per-package floor, B), plus the repo-level shared floor (C). B and C now bound an unreachable /
  * untagged baseline the same way — by the nearest reachable tag, never full history except in a
- * fresh repo (#370) — so neither floods. See `CONTEXT.md` for the three baseline notions; the
+ * fresh repo — so neither floods. See `CONTEXT.md` for the three baseline notions; the
  * version source (A) is a separate seam.
  *
  * Constructed once per version run so the shared floor is computed a single time and reused across
  * packages. Receives already-discovered tag facts; does not re-run tag discovery.
  *
  * Consolidates the copies in `createSyncStrategy`, `createSingleStrategy`, `groupStrategy`, and
- * `PackageProcessor`. Only the async path previously had the merge-base reachability check (#339)
+ * `PackageProcessor`. Only the async path previously had the merge-base reachability check
  * and the graduation-since-stable floor; this is now the single behaviour for every mode.
  */
 export class BaselineResolver {
@@ -125,14 +125,14 @@ export class BaselineResolver {
     if (baseForRange && (baseRef || hasRealTag)) {
       // A real tag (or explicit baseRef): verify it. Existence alone isn't enough — a tag from a
       // shallow clone or a non-ancestor branch can `rev-parse` but produce a meaningless range, so
-      // require ancestry (#339).
+      // require ancestry.
       const verification = await verifyTag(baseForRange, pkgDir);
       if (verification.exists && verification.reachable) {
         revisionRange = `${baseForRange}..HEAD`;
       } else if (!baseRef && strictReachable) {
         // A dedicated type, not a bare Error: the per-package changelog try/catch in each strategy
         // degrades genuine extraction failures to a minimal entry, but must rethrow THIS so it
-        // aborts the run (#372) — strictReachable's whole job is to fail loudly on an unreachable
+        // aborts the run — strictReachable's whole job is to fail loudly on an unreachable
         // baseline (shallow clone / fetch-depth), not ship a silently whole-history changelog.
         throw new StrictReachableError(
           `Cannot generate changelog: ref '${baseForRange}' is not reachable from the current commit. ` +
@@ -142,7 +142,7 @@ export class BaselineResolver {
       } else if (baseRef) {
         // An unreachable `baseRef` keeps the full-history fallback: baseRef scopes the run to a PR's
         // commits, a different intent from the tag-based release floor, so the nearest-reachable tag
-        // floor (#370) deliberately doesn't apply here — mirrors `sharedFloor` skipping baseRef mode.
+        // floor deliberately doesn't apply here — mirrors `sharedFloor` skipping baseRef mode.
         log(
           `Baseline ref '${baseForRange}' could not be verified from HEAD (${verification.error}) — generating ` +
             `the changelog from ALL history instead of since the last release. The ref is likely missing from the ` +
@@ -153,7 +153,7 @@ export class BaselineResolver {
         baselineUnreachable = true;
       } else {
         // A real tag we can't reach (shallow clone / non-ancestor). Bound the range by the nearest
-        // reachable tag rather than flooding with all history (#370) — the same floor `sharedFloor`
+        // reachable tag rather than flooding with all history — the same floor `sharedFloor`
         // applies. previousVersion is still omitted (below): we diffed the nearest tag, not the
         // package's own (unreachable) baseline, so we don't claim that baseline.
         revisionRange = await this.nearestReachableRange();
@@ -172,12 +172,12 @@ export class BaselineResolver {
     } else if (baseForRange) {
       // No real tag — `baseForRange` is the manifest-fallback's synthetic tag, which isn't a git ref.
       // Skip verifyTag (it would emit a misleading "shallow clone" message) and bound by the nearest
-      // reachable tag instead of flooding the package's own changelog with all history (#370).
+      // reachable tag instead of flooding the package's own changelog with all history.
       revisionRange = await this.nearestReachableRange();
       baselineUnreachable = true;
     } else {
       // No baseline at all — an untagged package with no manifest version. Still bound by the nearest
-      // reachable tag (#370); a genuinely fresh repo with no tags falls through to full history.
+      // reachable tag; a genuinely fresh repo with no tags falls through to full history.
       revisionRange = await this.nearestReachableRange();
     }
 
@@ -186,9 +186,9 @@ export class BaselineResolver {
     // prior stable tag, `changelogBaseTag` widens to '' (so the range spans the whole prerelease
     // line) but the package's real predecessor is still its prerelease `latestTag` — fall back to it
     // for the label so a graduating package reads `<prerelease> → <stable>` instead of being
-    // mislabeled a first release (#474). Kept in tag form: `generateCompareUrl` rebuilds the `to` tag
+    // mislabeled a first release. Kept in tag form: `generateCompareUrl` rebuilds the `to` tag
     // from it, so a bare value would break compare links. Omit it when we fell back to all-history so
-    // the changelog doesn't claim a baseline it never diffed against (#339); a genuine first release
+    // the changelog doesn't claim a baseline it never diffed against; a genuine first release
     // (no tag at all) leaves both empty and stays null.
     const previousTag = changelogBaseTag || latestTag;
     const previousVersion =
@@ -203,12 +203,12 @@ export class BaselineResolver {
    * Repo-level shared floor (C): the range for project-wide "shared" entries (CI, infra, shared
    * packages). `baseRef` (a PR-scoped run) is passed through unbounded.
    *
-   * In `'sinceLastRelease'` mode (#398) every package's shared block is floored by the single global
+   * In `'sinceLastRelease'` mode every package's shared block is floored by the single global
    * nearest-reachable tag, so a genuinely-global commit consumed by the most recent release across
    * the repo doesn't recur in every later per-package release. In `'union'` mode (default) the
    * package's own range is used (the union across packages floors by the oldest baseline); a `'HEAD'`
-   * range — only a fresh repo now that the per-package floor is itself bounded (#370) — is floored by
-   * the nearest reachable tag rather than flooding with full history (#348).
+   * range — only a fresh repo now that the per-package floor is itself bounded — is floored by
+   * the nearest reachable tag rather than flooding with full history.
    */
   async sharedFloor(perPackageRange: string): Promise<string> {
     if (this.opts.baseRef) return perPackageRange;
@@ -219,8 +219,8 @@ export class BaselineResolver {
 
   /**
    * The `<tag>..HEAD` range floored by the nearest tag reachable from HEAD, or `'HEAD'` when the repo
-   * has no reachable tag at all. Shared by the per-package floor's fallback (B, #370) and the shared
-   * floor (C, #348) so both bound the same way; computed once per run and cached.
+   * has no reachable tag at all. Shared by the per-package floor's fallback (B) and the shared
+   * floor (C) so both bound the same way; computed once per run and cached.
    *
    * Uses `git describe` (prefix-agnostic, reachable by construction) — NOT the semver-tag lookup,
    * which only matches bare-semver tags and collapses to full history in per-package-tag monorepos.

--- a/packages/version/src/core/groupStrategy.ts
+++ b/packages/version/src/core/groupStrategy.ts
@@ -159,7 +159,7 @@ interface GroupComputation {
 }
 
 /**
- * Whether this whole group is graduating to stable on this run (#486). A fixed/linked group shares
+ * Whether this whole group is graduating to stable on this run. A fixed/linked group shares
  * one version and channel, so graduation is all-or-nothing: graduating ANY member graduates the
  * group. True when `stableOnly` is set and either there's no per-package `graduateScope` (the global
  * `release:graduate` path → every group graduates) or some member falls inside that scope.
@@ -172,7 +172,7 @@ function isGroupGraduating(group: ResolvedGroup, config: Config): boolean {
 }
 
 /**
- * Whether this whole group belongs on a prerelease line by explicit request (#521) — the symmetric
+ * Whether this whole group belongs on a prerelease line by explicit request — the symmetric
  * twin of {@link isGroupGraduating}. A fixed/linked group shares one version and channel, so a single
  * scoped member pulls the whole group onto the prerelease line. True when `isPrerelease` is set and
  * either there's no per-package `prereleaseScope` (the global `channel:prerelease` path → every group)
@@ -205,7 +205,7 @@ function computeGroup(group: ResolvedGroup, plans: MemberPlan[], config: Config)
 
   const maxBaseline = plans.map((p) => p.baseline).sort(semver.rcompare)[0];
 
-  // Group graduation (#486): drop the prerelease segment of the highest baseline so the whole
+  // Group graduation: drop the prerelease segment of the highest baseline so the whole
   // fixed/linked group lands on its stable base (e.g. 1.2.0-next.3 → 1.2.0), atomically — every
   // member adopts it regardless of which one carried the graduate label, and the bump magnitude is
   // ignored (graduation is bump-less). Only when the group is actually on a prerelease line; an
@@ -227,7 +227,7 @@ function computeGroup(group: ResolvedGroup, plans: MemberPlan[], config: Config)
 
   // Whether this release belongs on a prerelease line. Two signals, by design: the group-scoped
   // prerelease flag is the explicit, authoritative request (the user passed --prerelease / the
-  // prerelease channel, possibly scoped to a subset of packages via `prereleaseScope`, #521); the
+  // prerelease channel, possibly scoped to a subset of packages via `prereleaseScope`); the
   // member-scan is the inference fallback for when the flag isn't set but a member's own calculation
   // already produced a prerelease. `isGroupPrereleasing` (not the raw `config.isPrerelease`) keeps a
   // per-package prerelease scoped: a group with no scoped member falls through to the member-scan
@@ -248,9 +248,9 @@ function computeGroup(group: ResolvedGroup, plans: MemberPlan[], config: Config)
   // graduation requires stable=true. This covers two ways the published baseline would otherwise be
   // re-emitted, neither of which never-regress can recover when a member's ownNext sits below it:
   //  - a *stable* aggregate magnitude that's spurious because a member's manifest lags its prerelease
-  //    tag, so the backwards `semver.diff` reads as a `major` (#458); and
+  //    tag, so the backwards `semver.diff` reads as a `major`; and
   //  - a *prerelease* aggregate rank with no identifier, where the legacy branch returned the
-  //    baseline unchanged (#460).
+  //    baseline unchanged.
   // It is gated on a prerelease baseline, so incrementing never regresses a stable release.
   const stayOnPrereleaseLine = !!semver.prerelease(maxBaseline) && wantsPrerelease;
 
@@ -343,7 +343,7 @@ async function extractEntries(
     previousVersion = baseline.previousVersion;
     entries = await extractChangelogEntriesFromCommits(input.pkgDir, revisionRange);
   } catch (error) {
-    // A strictReachable violation must abort the run, not degrade to a minimal entry (#372).
+    // A strictReachable violation must abort the run, not degrade to a minimal entry.
     if (error instanceof StrictReachableError) throw error;
     log(`Error extracting changelog entries: ${error instanceof Error ? error.message : String(error)}`, 'warning');
   }
@@ -351,9 +351,9 @@ async function extractEntries(
     // No changelog entries to show. Flag the placeholder synthetic only for a genuine lockstep
     // carry — a member that earned no releasable change of its own and is written purely to stay at
     // the fixed-group version (`isCarry`). The preview collapses those into "Also bumped" rather
-    // than a full "Update version to X" block (#468). A member that DID earn a change yet still came
+    // than a full "Update version to X" block. A member that DID earn a change yet still came
     // back empty means extraction couldn't read its commits — extractChangelogEntriesFromCommits
-    // swallows git failures and returns [] (#469) — so leave it unflagged and let the bump render a
+    // swallows git failures and returns [] — so leave it unflagged and let the bump render a
     // visible block instead of vanishing as a no-change carry.
     const fallback: ChangelogEntry = { type: 'changed', description: `Update version to ${input.nextVersion}` };
     if (input.isCarry) fallback.synthetic = true;
@@ -430,7 +430,7 @@ async function releaseGroup(
     addTag(tag);
     setPackageUpdateTag(name, tag);
     setPackageUpdateGroup(name, group.name);
-    // Resolved version action (#420), derived from the member's own tag facts and the version it
+    // Resolved version action, derived from the member's own tag facts and the version it
     // actually resolved to (group version for fixed/linked, own line for independent).
     const { action: memberAction, reason: memberReason } = resolveVersionAction({
       hasNoTags: plan.latestTag === '',
@@ -459,7 +459,7 @@ async function releaseGroup(
       repoUrl: readRepoUrl(pkg.dir),
       entries,
     });
-    // Baseline for the bump delta (#520) — the member's own prior version, even when it rode along to
+    // Baseline for the bump delta — the member's own prior version, even when it rode along to
     // a higher group version. Same value the changelog carries; null (unreachable baseline) omits it.
     setPackageUpdatePreviousVersion(name, previousVersion);
 
@@ -581,7 +581,7 @@ export function createGroupStrategy(config: Config): (packages: PackagesWithRoot
         const tag = formatTag(plan.ownNext, formattedPrefix, name, config.tagTemplate, config.packageSpecificTags);
         addTag(tag);
         setPackageUpdateTag(name, tag);
-        // Resolved version action (#420) for an independently-versioned ungrouped package.
+        // Resolved version action for an independently-versioned ungrouped package.
         const { action: ungroupedAction, reason: ungroupedReason } = resolveVersionAction({
           hasNoTags: plan.latestTag === '',
           latestTag: plan.latestTag,

--- a/packages/version/src/core/versionCalculator.ts
+++ b/packages/version/src/core/versionCalculator.ts
@@ -23,8 +23,8 @@ import {
 /**
  * Map a standard bump magnitude to the prerelease form that ESCALATES an existing prerelease's base
  * to a new line — used only when a maintainer explicitly declares the magnitude via a `bump:*` label
- * (#485). The commit-inferred default does NOT escalate; it increments the counter (the base is a
- * fixed target until graduation, #500).
+ * The commit-inferred default does NOT escalate; it increments the counter (the base is a
+ * fixed target until graduation).
  *  - `patch` → `prerelease` — advance the counter   (1.0.0-next.1 → 1.0.0-next.2)
  *  - `minor` → `preminor`   — escalate the base      (1.0.0-next.1 → 1.1.0-next.0)
  *  - `major` → `premajor`   — escalate the base      (1.0.0-next.1 → 2.0.0-next.0)
@@ -47,7 +47,7 @@ function toPrereleaseLineBump(bumpType: ReleaseType): ReleaseType {
  * The prerelease identifier embedded in a version (e.g. `1.0.0-next.1` → `next`), or undefined when
  * the version is stable or its prerelease segment carries no string identifier. Advancing along a
  * channel keeps the *current* line's identifier, so this is preferred over the configured default
- * (a config change is a deliberate line switch, out of scope for the advance-along-line default) (#485).
+ * (a config change is a deliberate line switch, out of scope for the advance-along-line default).
  */
 function prereleaseIdOf(version: string): string | undefined {
   const pre = semver.prerelease(version);
@@ -76,7 +76,7 @@ export function applyOverrideScope(
       options: { ...scoped.options, type: undefined },
     };
   }
-  // Per-package graduation (#486): `graduateScope` membership is AUTHORITATIVE for `stableOnly`. A
+  // Per-package graduation: `graduateScope` membership is AUTHORITATIVE for `stableOnly`. A
   // package in scope graduates — re-assert `stableOnly` even when the `overrideScope` clearing above
   // stripped it, because a graduate target can be a transitive prerequisite that sits OUTSIDE
   // `overrideScope` when `release:with-prerequisites` is also active; without this re-assert the
@@ -90,7 +90,7 @@ export function applyOverrideScope(
     const inGraduateScope = shouldMatchPackageTargets(options.name, graduateScope);
     scoped = { ...scoped, config: { ...scoped.config, stableOnly: inGraduateScope ? true : undefined } };
   }
-  // Per-package prerelease (#521): the symmetric twin of the graduateScope branch. `prereleaseScope`
+  // Per-package prerelease: the symmetric twin of the graduateScope branch. `prereleaseScope`
   // membership is AUTHORITATIVE for `isPrerelease` — a package in scope is re-asserted onto its
   // prerelease line even when the `overrideScope` clearing above stripped it (a scoped package can sit
   // outside `overrideScope` when a bump is also scoped elsewhere), and an out-of-scope package keeps
@@ -106,14 +106,14 @@ export function applyOverrideScope(
 }
 
 /**
- * First-release overshoot guard (#388): on a first release (no prior tag) with an already-stable
+ * First-release overshoot guard: on a first release (no prior tag) with an already-stable
  * manifest, `--stable --bump <type>` APPLIES the bump (1.0.0 → 2.0.0) rather than graduating, which
  * silently overshoots the staged first version. The resolved version is deliberately left unchanged
  * — a bump is sometimes legitimate (importing a package with prior external history) — so this only
  * makes the case visible/escapable per `mismatchStrategy`: `error` aborts, `ignore` is silent,
  * everything else (default `warn`) warns. `version.allowFirstBump` (or `--allow-first-bump`)
  * acknowledges it and stays silent. (prefer-package/prefer-git have no distinct meaning on the
- * no-tag axis, so they warn like the default — see #388.)
+ * no-tag axis, so they warn like the default.)
  */
 function guardFirstReleaseBump(config: Config, name: string | undefined, currentVer: string, type: ReleaseType): void {
   if (config.allowFirstBump) return;
@@ -263,7 +263,7 @@ async function calculateVersionInner(config: Config, options: VersionOptions): P
     // First release scenario: no previous tag. Emit a warning but fall through to normal
     // bump/stable/prerelease logic using the manifest version as the base. Returning the
     // manifest verbatim here would silently ignore --stable, --bump, and prereleaseIdentifier
-    // inputs, causing wrong identifiers or missed graduations on first release (#347).
+    // inputs, causing wrong identifiers or missed graduations on first release.
     log(
       `Checking first release scenario: latestTag=${latestTag}, type=${type}, stableOnly=${config.stableOnly}`,
       'debug',
@@ -298,7 +298,7 @@ async function calculateVersionInner(config: Config, options: VersionOptions): P
         return '';
       } else if (hasNoTags) {
         // Stable manifest + explicit bump on a FIRST release: the bump is APPLIED (e.g. 1.0.0 +
-        // major = 2.0.0), not graduated, silently overshooting the staged first version (#388).
+        // major = 2.0.0), not graduated, silently overshooting the staged first version.
         // Make it visible/escapable per mismatchStrategy; the resolved version is unchanged.
         guardFirstReleaseBump(config, name, currentVer, type);
       }
@@ -323,14 +323,14 @@ async function calculateVersionInner(config: Config, options: VersionOptions): P
         'debug',
       );
 
-      // Per-package channel default (#485): a package whose current version is a prerelease advances
+      // Per-package channel default: a package whose current version is a prerelease advances
       // along its own prerelease line rather than graduating to stable — UNLESS an explicit channel
       // action is in play (`--stable` / release:graduate sets stableOnly and graduates above;
       // `--prerelease` / channel:prerelease sets isPrerelease, handled by the existing branch below).
       // This is the EXPLICIT-bump path (a `bump:*` label set `type`): the maintainer declared a
       // magnitude, so honour it — a minor/major escalates the base to a fresh line (1.0.0-next.6 →
       // 1.1.0-next.0), a patch advances the counter. The commit-inferred DEFAULT instead always
-      // increments the counter (the base is a fixed target until graduation, #500) — see the
+      // increments the counter (the base is a fixed target until graduation) — see the
       // conventional-commits branch below. Keystone that removes the global auto-graduate.
       if (
         isCurrentPrerelease &&
@@ -389,7 +389,7 @@ async function calculateVersionInner(config: Config, options: VersionOptions): P
       // ENTIRE history — the repo's baseline tags (e.g. `release/v0.29.0`) aren't in a format its
       // default tag-detection recognises — so accumulated historical feats inflate the bump magnitude
       // (a docs-only window bumps minor instead of patch). Guard the tag with rev-parse so an absent
-      // ref falls back to the unbounded default rather than throwing. See #330.
+      // ref falls back to the unbounded default rather than throwing.
       const latestTagReachable = !!latestTag && (await refExists(latestTag, pkgPath));
       const bumpFrom = config.baseRef ?? (latestTagReachable ? latestTag : undefined);
       if (bumpFrom) {
@@ -450,7 +450,7 @@ async function calculateVersionInner(config: Config, options: VersionOptions): P
 
       // The bumper returns 'major' for a breaking change without consulting the current version,
       // so pre-1.0 it would jump 0.x straight to 1.0.0. Keep inferred breaking changes on the 0.x
-      // minor instead (rationale + the zeroMajor escape hatch: docs/configuration.md, issue #274).
+      // minor instead (rationale + the zeroMajor escape hatch: docs/configuration.md).
       // Inferred-only: the explicit-override branch above is intentionally left to graduate to 1.0.
       // Only 'major' needs downgrading — the bumper never emits a pre-type here.
       let effectiveReleaseType = releaseTypeFromCommits;
@@ -460,10 +460,10 @@ async function calculateVersionInner(config: Config, options: VersionOptions): P
         log("Pre-1.0 breaking change: downgrading inferred 'major' to 'minor' (zeroMajor: 'spec')", 'info');
       }
 
-      // Per-package channel default (#485): advance an existing prerelease along its own line rather
+      // Per-package channel default: advance an existing prerelease along its own line rather
       // than graduating it, unless an explicit channel action is in play. This is the COMMIT-INFERRED
       // default (no `bump:*` label) — it always increments the prerelease counter regardless of the
-      // inferred magnitude, because the base is a fixed target until graduation (#500). An explicit
+      // inferred magnitude, because the base is a fixed target until graduation. An explicit
       // `bump:*` label takes the specified-type branch above and escalates the base instead.
       if (
         semver.prerelease(currentVersion) !== null &&

--- a/packages/version/src/core/versionEngine.ts
+++ b/packages/version/src/core/versionEngine.ts
@@ -58,7 +58,7 @@ export class VersionEngine {
         effective.isPrerelease = true;
       }
       if (runOptions.stable) effective.stableOnly = true;
-      // Per-package graduation (#486): graduate only the named packages, leaving other prereleases on
+      // Per-package graduation: graduate only the named packages, leaving other prereleases on
       // their line. Sets stableOnly + graduateScope; applyOverrideScope clears stableOnly for any
       // package outside the scope. The global `stable` flag wins — when it's set we graduate ALL
       // prereleases, so a per-package scope would only narrow it (don't set graduateScope then).
@@ -66,7 +66,7 @@ export class VersionEngine {
         effective.stableOnly = true;
         effective.graduateScope = runOptions.graduate;
       }
-      // Per-package prerelease (#521): the symmetric twin of graduate. Shift only the named packages
+      // Per-package prerelease: the symmetric twin of graduate. Shift only the named packages
       // onto a prerelease line, leaving others on their projected version. Sets isPrerelease +
       // prereleaseScope; applyOverrideScope clears isPrerelease for any package outside the scope, and
       // computeGroup gates the group-level prerelease on scope membership. The global `prerelease` flag
@@ -466,7 +466,7 @@ export class VersionEngine {
 
       // Capture the FULL discovered workspace (name+dir) before any release-set filtering below, so
       // the repo-level changelog classifier can tell "touches a non-releasing package" apart from
-      // "genuinely repo-level" (#397) and resolve shared-package globs against every package (#406).
+      // "genuinely repo-level" and resolve shared-package globs against every package.
       this.config.allWorkspacePackages = mergedPackages.packages.map((p) => ({
         name: p.packageJson.name,
         dir: p.dir,

--- a/packages/version/src/core/versionStrategies.ts
+++ b/packages/version/src/core/versionStrategies.ts
@@ -89,7 +89,7 @@ function updateCargoFiles(
   const cargoPaths = cargoConfig?.paths;
 
   // After rewriting a Cargo.toml version, sync its Cargo.lock self-entry so the committed lock
-  // doesn't drift (#496). The returned lock path is staged alongside the manifest; deduped because
+  // doesn't drift. The returned lock path is staged alongside the manifest; deduped because
   // crates in one workspace share a single workspace-root lock.
   const stageCargo = (cargoTomlPath: string): void => {
     updatePackageVersion(cargoTomlPath, version, dryRun);
@@ -347,7 +347,7 @@ export function createSyncStrategy(config: Config): StrategyFunction {
           changelogEntries = [{ type: 'changed', description: `Update version to ${nextVersion}` }];
         }
       } catch (error) {
-        // A strictReachable violation must abort the run, not degrade to a minimal entry (#372).
+        // A strictReachable violation must abort the run, not degrade to a minimal entry.
         if (error instanceof StrictReachableError) throw error;
         log(`Error extracting changelog entries: ${error instanceof Error ? error.message : String(error)}`, 'warning');
         changelogEntries = [{ type: 'changed', description: `Update version to ${nextVersion}` }];
@@ -392,9 +392,9 @@ export function createSyncStrategy(config: Config): StrategyFunction {
       // In per-package tag mode, emit one changelog entry per workspace package so the
       // notes pipeline can write a CHANGELOG.md to each package directory and the
       // publish pipeline can match tags to the right release notes.
-      // Omit previousVersion when we fell back to all-history (#339): claiming a baseline the
+      // Omit previousVersion when we fell back to all-history: claiming a baseline the
       // changelog never diffed against produces a self-contradictory "since <tag>" + full log.
-      // previousVersion is resolved by BaselineResolver (null when we fell back to all-history, #339).
+      // previousVersion is resolved by BaselineResolver (null when we fell back to all-history).
       const displayPrevious = previousVersion;
       if (config.packageSpecificTags && workspaceNames.length > 0) {
         for (const pkgName of workspaceNames) {
@@ -477,7 +477,7 @@ export function createSyncStrategy(config: Config): StrategyFunction {
           if (pkgName && pkgTag) setPackageUpdateTag(pkgName, pkgTag);
         }
       }
-      // Resolved version action (#420). Every package moves in lockstep to the same nextVersion
+      // Resolved version action. Every package moves in lockstep to the same nextVersion
       // against the same latestTag, so the action is identical across the sync unit — record it on
       // every update record (including the root lockstep bump).
       const { action: syncAction, reason: syncReason } = resolveVersionAction({
@@ -486,7 +486,7 @@ export function createSyncStrategy(config: Config): StrategyFunction {
         nextVersion,
       });
       setAllPackageUpdateActions(syncAction, syncReason);
-      // Every package moved in lockstep from the same baseline, so the prior version (#520) is shared.
+      // Every package moved in lockstep from the same baseline, so the prior version is shared.
       setAllPackageUpdatePreviousVersions(displayPrevious);
       setCommitMessage(formattedCommitMessage);
 
@@ -617,7 +617,7 @@ export function createSingleStrategy(config: Config): StrategyFunction {
           changelogEntries = [{ type: 'changed', description: `Update version to ${nextVersion}` }];
         }
       } catch (error) {
-        // A strictReachable violation must abort the run, not degrade to a minimal entry (#372).
+        // A strictReachable violation must abort the run, not degrade to a minimal entry.
         if (error instanceof StrictReachableError) throw error;
         log(`Error extracting changelog entries: ${error instanceof Error ? error.message : String(error)}`, 'warning');
         // Fall back to minimal entry
@@ -651,7 +651,7 @@ export function createSingleStrategy(config: Config): StrategyFunction {
       }
 
       // Track changelog data for JSON output. previousVersion is resolved by BaselineResolver and is
-      // null when we fell back to all-history (#339) so the changelog doesn't claim an undiffed baseline.
+      // null when we fell back to all-history so the changelog doesn't claim an undiffed baseline.
       addChangelogData({
         packageName,
         version: nextVersion,
@@ -690,7 +690,7 @@ export function createSingleStrategy(config: Config): StrategyFunction {
 
       addTag(tagName);
       setPackageUpdateTag(packageName, tagName);
-      // Resolved version action (#420). In single mode an empty `latestTag` means no prior tag
+      // Resolved version action. In single mode an empty `latestTag` means no prior tag
       // (no manifest-fallback synthetic tag here), matching the baseline resolve's `hasRealTag`.
       const { action: singleAction, reason: singleReason } = resolveVersionAction({
         hasNoTags: latestTag === '',
@@ -741,7 +741,7 @@ export function createAsyncStrategy(config: Config): StrategyFunction {
       prereleaseIdentifier: config.prereleaseIdentifier,
       type: config.type,
       // Without this the per-package resolver always saw strictReachable=false, so the async path
-      // never enforced it — the guard silently no-op'd for per-package repos (#372).
+      // never enforced it — the guard silently no-op'd for per-package repos.
       strictReachable: config.strictReachable,
     },
   };

--- a/packages/version/src/errors/strictReachableError.ts
+++ b/packages/version/src/errors/strictReachableError.ts
@@ -8,7 +8,7 @@ import { BaseVersionError } from './baseError.js';
  * apart from a genuine changelog-extraction failure: genuine failures degrade to a minimal entry and
  * the run continues, but this one is **rethrown** so it aborts the whole run — which is the entire
  * point of `strictReachable` (surface the misconfiguration loudly, don't ship a silently-degraded
- * whole-history changelog on a green run). See #372.
+ * whole-history changelog on a green run).
  */
 export class StrictReachableError extends BaseVersionError {
   constructor(message: string) {

--- a/packages/version/src/git/tagsAndBranches.ts
+++ b/packages/version/src/git/tagsAndBranches.ts
@@ -63,7 +63,7 @@ export function refExists(ref: string, cwd?: string, git: Git = createGitCli()):
  * Unlike `getLatestTag` — which goes through git-semver-tags and only matches *bare* semver tags
  * (`v1.2.3`) — this walks HEAD's ancestors via `git describe`, so it also finds the per-package
  * tags monorepos actually use (`pkg@vX.Y.Z`, `release/vX.Y.Z`). The result is reachable by
- * construction, which is exactly what a `<tag>..HEAD` baseline floor needs (#348).
+ * construction, which is exactly what a `<tag>..HEAD` baseline floor needs.
  *
  * @returns The nearest reachable tag, or '' when none is reachable (no releases yet / shallow clone).
  */

--- a/packages/version/src/package/packageProcessor.ts
+++ b/packages/version/src/package/packageProcessor.ts
@@ -113,7 +113,7 @@ export class PackageProcessor {
     const sharedEntriesMap = new Map<string, ChangelogEntry>();
 
     // BaselineResolver owns the per-package changelog floor (B) and the repo-level shared floor (C),
-    // constructed once per run so the nearest-reachable shared floor (#348) is computed a single time
+    // constructed once per run so the nearest-reachable shared floor is computed a single time
     // and reused across packages.
     const baselineResolver = new BaselineResolver({
       versionPrefix: this.versionPrefix,
@@ -208,9 +208,9 @@ export class PackageProcessor {
       // back to its consumer-facing form so `release/v0.22.0` appears as `v0.22.0`.
       const baselineTagPrefix = deriveBaselineTagPrefix(this.fullConfig.baselineTagTemplate, formattedPrefix, name);
 
-      // #334: a package with no prior git tag has its changelog computed from the FULL git history,
+      // A package with no prior git tag has its changelog computed from the FULL git history,
       // which in standing-PR mode can push the rendered PR body past GitHub's 65,536-char limit and
-      // fail PR creation with an opaque 422 (#333). Surface it loudly with an actionable baseline-tag
+      // fail PR creation with an opaque 422. Surface it loudly with an actionable baseline-tag
       // suggestion. (baseRef-scoped runs — advisory preview — are bounded to the PR, so skip them.)
       if (!hasRealTag && !this.fullConfig.baseRef) {
         const currentVersion = pkg.packageJson.version;
@@ -252,13 +252,13 @@ export class PackageProcessor {
         // packages whose changes belong project-wide). Classify against the FULL discovered
         // workspace, not the filtered release set (`packages`) — otherwise a commit touching only a
         // *non-releasing* package's dir touches "no package" and wrongly leaks into the shared block
-        // (#397). Falls back to the processing set when the engine didn't populate the workspace
+        // Falls back to the processing set when the engine didn't populate the workspace
         // (e.g. a direct PackageProcessor construction in tests).
         const workspace =
           this.fullConfig.allWorkspacePackages ?? packages.map((p) => ({ name: p.packageJson.name, dir: p.dir }));
         const allPackageDirs = workspace.map((p) => p.dir);
         // Foundational packages whose changes route to repo-level, from config (exact name or glob).
-        // No hardcoded names — a consumer declares its own via `version.sharedPackages` (#406).
+        // No hardcoded names — a consumer declares its own via `version.sharedPackages`.
         const sharedPackagePatterns = this.fullConfig.sharedPackages ?? [];
         const sharedPackageDirs =
           sharedPackagePatterns.length === 0
@@ -266,7 +266,7 @@ export class PackageProcessor {
             : workspace.filter((p) => shouldMatchPackageTargets(p.name, sharedPackagePatterns)).map((p) => p.dir);
         // Bound the repo-level ("shared") entries by the run's nearest-reachable floor when this
         // package's own range collapsed to full history (untagged / unreachable), so a single
-        // untagged package doesn't flood "Project-wide changes" with the entire history (#348).
+        // untagged package doesn't flood "Project-wide changes" with the entire history.
         const sharedRevisionRange = await baselineResolver.sharedFloor(revisionRange);
 
         const repoLevelEntries = await extractRepoLevelChangelogEntries(
@@ -296,7 +296,7 @@ export class PackageProcessor {
           ];
         }
       } catch (error) {
-        // A strictReachable violation must abort the run, not degrade to a minimal entry (#372).
+        // A strictReachable violation must abort the run, not degrade to a minimal entry.
         if (error instanceof StrictReachableError) throw error;
         log(`Error extracting changelog entries: ${error instanceof Error ? error.message : String(error)}`, 'warning');
         // Fall back to minimal entry
@@ -335,7 +335,7 @@ export class PackageProcessor {
       }
 
       // Track changelog data for JSON output. previousVersion is resolved by BaselineResolver (the
-      // floor tag in consumer-facing display form, null when we fell back to all-history, #339).
+      // floor tag in consumer-facing display form, null when we fell back to all-history).
       addChangelogData({
         packageName: name,
         version: nextVersion,
@@ -438,7 +438,7 @@ export class PackageProcessor {
       // Track tag for JSON output (git ops now handled by publish)
       addTag(packageTag);
       setPackageUpdateTag(name, packageTag);
-      // Resolved version action (#420) — derived from the same tag facts the calculator saw.
+      // Resolved version action — derived from the same tag facts the calculator saw.
       // `hasNoTags` is `!hasRealTag`: a manifest-fallback synthetic tag isn't a real prior tag.
       const { action, reason } = resolveVersionAction({ hasNoTags: !hasRealTag, latestTag, nextVersion });
       setPackageUpdateAction(name, action, reason);

--- a/packages/version/src/types.ts
+++ b/packages/version/src/types.ts
@@ -24,7 +24,7 @@ export interface VersionRunOptions {
    *  unless bump is also set, in which case bump applies to stable packages. */
   stable?: boolean;
   /**
-   * Per-package graduation (#486): package name patterns to graduate to stable on this run, leaving
+   * Per-package graduation: package name patterns to graduate to stable on this run, leaving
    * every other prerelease package on its own line. Drives `stableOnly` scoped to just these packages
    * (see {@link Config.graduateScope}). Distinct from the global `stable` flag, which graduates ALL
    * prereleases. When both are set, `stable` wins (graduate everything). Empty/undefined → no
@@ -32,7 +32,7 @@ export interface VersionRunOptions {
    */
   graduate?: string[];
   /**
-   * Per-package prerelease (#521): the symmetric twin of {@link graduate}. Package name patterns to
+   * Per-package prerelease: the symmetric twin of {@link graduate}. Package name patterns to
    * shift onto a prerelease line on this run, leaving every other package on its projected line. Drives
    * `isPrerelease` scoped to just these packages (see {@link Config.prereleaseScope}) WITHOUT narrowing
    * the release — out-of-scope packages keep their commit-driven versions. Distinct from the global
@@ -40,7 +40,7 @@ export interface VersionRunOptions {
    * everything). Empty/undefined → no per-package prerelease.
    */
   prereleaseScope?: string[];
-  /** Acknowledge a first-release bump on a stable manifest, silencing the #388 overshoot guard. */
+  /** Acknowledge a first-release bump on a stable manifest, silencing the overshoot guard. */
   allowFirstBump?: boolean;
   dryRun?: boolean;
   sync?: boolean;
@@ -136,12 +136,12 @@ export interface Config extends VersionConfigBase {
   /** Runtime override: package patterns the forced bump/prerelease/stable applies to. When set,
    *  non-matching packages ignore the override and compute commit-driven. See VersionRunOptions.overrideScope. */
   overrideScope?: string[];
-  /** Runtime override (#486): package patterns to graduate to stable. Set together with `stableOnly`
+  /** Runtime override: package patterns to graduate to stable. Set together with `stableOnly`
    *  by per-package graduation; a package outside this scope keeps `stableOnly` cleared and advances
    *  along its own line. `undefined`/empty with `stableOnly` set means "graduate every prerelease"
    *  (the global `release:graduate` path). See VersionRunOptions.graduate. */
   graduateScope?: string[];
-  /** Runtime override (#521): package patterns to shift onto a prerelease line. Set together with
+  /** Runtime override: package patterns to shift onto a prerelease line. Set together with
    *  `isPrerelease` by per-package prerelease; a package outside this scope keeps `isPrerelease`
    *  cleared and advances along its projected line. `undefined`/empty with `isPrerelease` set means
    *  "prerelease every package" (the global `channel:prerelease` path). The symmetric twin of
@@ -150,10 +150,10 @@ export interface Config extends VersionConfigBase {
   /** Runtime (engine-populated): the FULL discovered workspace — every package's name+dir, before
    *  the release-set filters (targets/exclude/config.packages). The repo-level changelog classifier
    *  uses this so a commit touching a non-releasing package's dir is attributed to that package, not
-   *  leaked into "Project-wide changes" (#397). Not user config. */
+   *  leaked into "Project-wide changes". Not user config. */
   allWorkspacePackages?: Array<{ name: string; dir: string }>;
   mismatchStrategy?: 'error' | 'warn' | 'ignore' | 'prefer-package' | 'prefer-git';
-  /** Acknowledge a first-release bump on an already-stable manifest, silencing the #388 overshoot
+  /** Acknowledge a first-release bump on an already-stable manifest, silencing the overshoot
    *  guard (which otherwise warns, or aborts under mismatchStrategy 'error'). See VersionConfig.allowFirstBump. */
   allowFirstBump?: boolean;
   strictReachable?: boolean;

--- a/packages/version/src/utils/jsonOutput.ts
+++ b/packages/version/src/utils/jsonOutput.ts
@@ -103,7 +103,7 @@ export function setVersioningStrategy(strategy: 'sync' | 'single' | 'async' | 'g
  * `Cargo.toml`/`pubspec.yaml`) is a SINGLE package — npm owns its identity. Every strategy writes the
  * `package.json` first, then syncs the sibling native manifest to the same version; that second write
  * must not register a second update under the crate/pub name, or the package surfaces twice
- * downstream — a phantom selection row / extra changelog entry under its crate name (#476). Dedupe by
+ * downstream — a phantom selection row / extra changelog entry under its crate name. Dedupe by
  * directory, mirroring discovery's dir-keyed merge (`mergePackageLists`): npm wins, so a `package.json`
  * supersedes a previously-recorded native sibling and a native sibling is dropped once a `package.json`
  * for the same directory exists.
@@ -111,8 +111,8 @@ export function setVersioningStrategy(strategy: 'sync' | 'single' | 'async' | 'g
 export function addPackageUpdate(packageName: string, newVersion: string, filePath: string, isRoot?: boolean): void {
   if (!_jsonOutputMode) return;
 
-  // Channel is derived per-package from the resolved version (#485) so every consumer (preview,
-  // standing PR, #486/#487) reads a single authoritative value rather than re-deriving it.
+  // Channel is derived per-package from the resolved version so every consumer (preview,
+  // standing PR) reads a single authoritative value rather than re-deriving it.
   const update = {
     packageName,
     newVersion,
@@ -160,7 +160,7 @@ export function setPackageUpdateGroup(packageName: string, group: string): void 
 }
 
 /**
- * Record the resolved version action (#420) on a package update — `graduated` / `bumped` /
+ * Record the resolved version action on a package update — `graduated` / `bumped` /
  * `first-release` plus a short human reason. Purely additive observability; never affects the
  * resolved version. Called by each strategy after the update record exists. No-op when the update
  * isn't found (mirrors the other setPackageUpdate* helpers).
@@ -175,7 +175,7 @@ export function setPackageUpdateAction(packageName: string, action: VersionActio
 }
 
 /**
- * Record the resolved baseline version (#520) on a package update — the prior release it bumped from,
+ * Record the resolved baseline version on a package update — the prior release it bumped from,
  * in the same consumer-tag display form the changelog carries. `null` (an unreachable / all-history
  * baseline, or a first release) leaves the field absent so consumers skip the bump delta. Called by
  * each strategy after the update record exists; no-op when the update isn't found (mirrors the other
@@ -188,7 +188,7 @@ export function setPackageUpdatePreviousVersion(packageName: string, previousVer
 }
 
 /**
- * Record the same resolved version action (#420) on every package update. Used by the sync strategy,
+ * Record the same resolved version action on every package update. Used by the sync strategy,
  * where all packages move in lockstep to the same version against the same baseline, so the action
  * is identical across the whole unit. Owns the iteration internally so callers don't read back the
  * (otherwise-private) update list.
@@ -202,7 +202,7 @@ export function setAllPackageUpdateActions(action: VersionAction, reason: string
 }
 
 /**
- * Record the same resolved baseline version (#520) on every package update. Used by the sync strategy,
+ * Record the same resolved baseline version on every package update. Used by the sync strategy,
  * where all packages move in lockstep from the same baseline. `null` (unreachable / all-history) leaves
  * the field absent everywhere. Owns the iteration internally, mirroring {@link setAllPackageUpdateActions}.
  */

--- a/packages/version/src/utils/versionAction.ts
+++ b/packages/version/src/utils/versionAction.ts
@@ -1,7 +1,7 @@
 /**
  * Resolved version action: the *reason* a package's version landed where it did.
  *
- * This is purely additive observability (#420) — it never changes which version is resolved. It
+ * This is purely additive observability — it never changes which version is resolved. It
  * surfaces, in the human summary and `--json`, the graduate-vs-bump reasoning that previously lived
  * only in DEBUG logs, so a dry run can explain *why* a version resolved as it did.
  *

--- a/packages/version/src/workspace.ts
+++ b/packages/version/src/workspace.ts
@@ -5,7 +5,7 @@ import { VersionEngine } from './core/versionEngine.js';
  * Resolve the names of every package in the workspace (npm + cargo + pub), independent of whether
  * each earned a releasable change this run. The standing-PR selection layer needs this to resolve
  * `ci.standingPr.primaryPackages` patterns — including a primary that isn't bumping, which never
- * appears in `VersionOutput.updates[]` yet must still anchor its release unit (#464).
+ * appears in `VersionOutput.updates[]` yet must still anchor its release unit.
  */
 export async function getWorkspacePackageNames(options: { cwd?: string; configPath?: string } = {}): Promise<string[]> {
   const config = loadConfig({ cwd: options.cwd, configPath: options.configPath });
@@ -20,7 +20,7 @@ export async function getWorkspacePackageNames(options: { cwd?: string; configPa
  * The current on-disk version of every workspace package (npm + cargo + pub), keyed by package name.
  * Reads each package's manifest as it stands in the checkout — the ground truth of what a publish will
  * ship. The standing-PR publish path compares this against the release manifest's claimed versions to
- * refuse a forged manifest whose versions/packages don't match the merged source (#556).
+ * refuse a forged manifest whose versions/packages don't match the merged source.
  */
 export async function getWorkspacePackageVersions(
   options: { cwd?: string; configPath?: string } = {},

--- a/packages/version/test/unit/core/applyOverrideScope.spec.ts
+++ b/packages/version/test/unit/core/applyOverrideScope.spec.ts
@@ -67,7 +67,7 @@ describe('applyOverrideScope', () => {
   });
 });
 
-// Per-package graduation (#486): `graduateScope` gates ONLY the `stableOnly` graduation, leaving any
+// Per-package graduation: `graduateScope` gates ONLY the `stableOnly` graduation, leaving any
 // bump/prerelease the run also carries intact. A graduate config carries stableOnly (no other override).
 const gradCfg = (graduateScope?: string[]): Config =>
   ({
@@ -115,7 +115,7 @@ describe('applyOverrideScope — graduateScope (#486)', () => {
 
 // `release:with-prerequisites` scopes the bump override to the explicit targets (overrideScope), while
 // `graduate:<pkg>` can target a transitive prerequisite that sits OUTSIDE that overrideScope. The two
-// scopes interact: graduateScope must win for stableOnly so the explicit graduation isn't lost (#486).
+// scopes interact: graduateScope must win for stableOnly so the explicit graduation isn't lost.
 const comboCfg = (): Config =>
   ({
     tagTemplate: '${prefix}${version}',
@@ -151,7 +151,7 @@ describe('applyOverrideScope — graduateScope + overrideScope combo (#486)', ()
   });
 });
 
-// Per-package prerelease (#521): the symmetric twin of graduateScope. `prereleaseScope` gates ONLY the
+// Per-package prerelease: the symmetric twin of graduateScope. `prereleaseScope` gates ONLY the
 // `isPrerelease` shift, re-asserting it for an in-scope package and clearing it for an out-of-scope one
 // so the latter advances along its projected (commit-driven) line. A prerelease config carries
 // isPrerelease (folded from runOptions.prereleaseScope) with no other override.

--- a/packages/version/test/unit/core/baselineResolver.spec.ts
+++ b/packages/version/test/unit/core/baselineResolver.spec.ts
@@ -52,7 +52,7 @@ describe('BaselineResolver.resolve', () => {
     vi.mocked(verifyTag).mockResolvedValue(unreachable);
     vi.mocked(getNearestReachableTag).mockResolvedValue('v0.9.0');
     const result = await new BaselineResolver(makeOpts()).resolve(makeInput());
-    // The own (unreachable) baseline floods full history; #370 floors it by the nearest reachable tag.
+    // The own (unreachable) baseline floods full history; the nearest reachable tag floors it.
     expect(result.revisionRange).toBe('v0.9.0..HEAD');
     // …but previousVersion stays null: we diffed the nearest tag, not the package's own baseline.
     expect(result.previousVersion).toBeNull();
@@ -70,7 +70,7 @@ describe('BaselineResolver.resolve', () => {
 
   it('should throw a StrictReachableError on an unreachable baseline when strictReachable is set', async () => {
     vi.mocked(verifyTag).mockResolvedValue(unreachable);
-    // The type — not just the message — is the contract (#372): the per-package changelog catch in
+    // The type — not just the message — is the contract: the per-package changelog catch in
     // each strategy distinguishes this from a genuine extraction error by `instanceof` and rethrows
     // it so the run aborts, instead of degrading to a minimal changelog entry.
     const promise = new BaselineResolver(makeOpts({ strictReachable: true })).resolve(makeInput());
@@ -167,8 +167,8 @@ describe('BaselineResolver.resolve', () => {
       makeInput({ latestTag: 'v1.0.0-next.1', nextVersion: '1.0.0' }),
     );
     expect(result.revisionRange).toBe('v0.9.0..HEAD');
-    // Range floors by the nearest reachable tag (#370); the LABEL still falls back to the prerelease
-    // predecessor rather than rendering N/A (#474) — the two are decoupled.
+    // Range floors by the nearest reachable tag; the LABEL still falls back to the prerelease
+    // predecessor rather than rendering N/A — the two are decoupled.
     expect(result.previousVersion).toBe('v1.0.0-next.1');
     expect(verifyTag).not.toHaveBeenCalled();
   });

--- a/packages/version/test/unit/core/versionCalculator.spec.ts
+++ b/packages/version/test/unit/core/versionCalculator.spec.ts
@@ -372,7 +372,7 @@ describe('Version Calculator', () => {
       expect(version).toBe('1.0.0-next.0');
     });
 
-    // #388: a stable manifest on a first release with --stable applies the bump (1.0.0 → 2.0.0)
+    // A stable manifest on a first release with --stable applies the bump (1.0.0 → 2.0.0)
     // rather than graduating, silently overshooting. The guard makes it visible/escapable without
     // changing the resolved version.
     function stableFirstReleaseMocks() {
@@ -832,7 +832,7 @@ describe('Version Calculator', () => {
     });
 
     it('should bound the bumper to latestTag when baseRef is absent and the tag exists', async () => {
-      // Regression for #330: without baseRef the scan must still be bounded to the last release
+      // Regression: without baseRef the scan must still be bounded to the last release
       // tag. Otherwise conventional-recommended-bump scans the entire history and historical feats
       // inflate the bump magnitude (a docs-only window bumps minor instead of patch).
       const commitsSpy = vi.spyOn(Bumper.prototype, 'commits').mockReturnThis();
@@ -847,7 +847,7 @@ describe('Version Calculator', () => {
     });
 
     it('should bound the bumper to a multi-segment baseline tag when baseRef is absent', async () => {
-      // Mirrors the standing-PR / sync shape that surfaced #330: the baseline tag carries the
+      // Mirrors the standing-PR / sync shape that surfaced the regression: the baseline tag carries the
       // `baselineTagTemplate` prefix (e.g. `release/v0.29.0`), which must still bound the scan.
       const commitsSpy = vi.spyOn(Bumper.prototype, 'commits').mockReturnThis();
       vi.spyOn(gitTags, 'refExists').mockReturnValue(true);
@@ -1184,7 +1184,7 @@ describe('Version Calculator', () => {
     });
 
     it('should apply bump to manifest version for first release with explicit bump', async () => {
-      // After #347 fix: first release no longer returns manifest verbatim; bump is applied.
+      // After the fix: first release no longer returns manifest verbatim; bump is applied.
       vi.spyOn(manifestHelpers, 'getVersionFromManifests').mockReturnValue({
         version: '1.0.0-beta.1',
         manifestFound: true,
@@ -1213,7 +1213,7 @@ describe('Version Calculator', () => {
     });
 
     it('should apply bump to prerelease manifest version on first release', async () => {
-      // After #347 fix: bump is applied to the manifest version as the base.
+      // After the fix: bump is applied to the manifest version as the base.
       vi.spyOn(manifestHelpers, 'getVersionFromManifests').mockReturnValue({
         version: '1.0.0-next.0',
         manifestFound: true,
@@ -1244,7 +1244,7 @@ describe('Version Calculator', () => {
     });
 
     it('should apply bump to stable manifest version on first release', async () => {
-      // After #347 fix: bump is applied even when the manifest is already stable.
+      // After the fix: bump is applied even when the manifest is already stable.
       vi.spyOn(manifestHelpers, 'getVersionFromManifests').mockReturnValue({
         version: '1.0.0',
         manifestFound: true,
@@ -1486,7 +1486,7 @@ describe('Version Calculator', () => {
     });
 
     it('should apply bump to package.json version for first release when hasNoTags is true', async () => {
-      // After #347 fix: first release applies bump/stable/prerelease logic, not verbatim.
+      // After the fix: first release applies bump/stable/prerelease logic, not verbatim.
       vi.spyOn(versionUtils, 'getBestVersionSource').mockResolvedValueOnce({
         source: 'package',
         version: '1.0.0',

--- a/packages/version/test/unit/core/versionChannel.spec.ts
+++ b/packages/version/test/unit/core/versionChannel.spec.ts
@@ -7,7 +7,7 @@ import type { Config, VersionOptions } from '../../../src/types.js';
 import * as manifestHelpers from '../../../src/utils/manifestHelpers.js';
 import * as versionUtils from '../../../src/utils/versionUtils.js';
 
-// Per-package release channel (#485): a package's channel is DERIVED from its current version and
+// Per-package release channel: a package's channel is DERIVED from its current version and
 // the default (no explicit channel action) advances it ALONG that channel — a prerelease stays a
 // prerelease, a stable stays stable, and a `-next` package never graduates without an explicit
 // graduate action. These specs drive the real `calculateVersion` with real semver and a real
@@ -69,7 +69,7 @@ describe('Per-package release channel — advance along the current line (#485)'
     });
 
     it('should increment the counter for a minor-level change, not escalate the base (1.0.0-next.1 -> 1.0.0-next.2)', async () => {
-      // The base is a fixed target until graduation (#500) — a minor doesn't move it to 1.1.0-next.0.
+      // The base is a fixed target until graduation — a minor doesn't move it to 1.1.0-next.0.
       baselineAt('1.0.0-next.1');
       inferredBump('minor');
       const next = await calculateVersion(baseConfig as Config, options());
@@ -129,7 +129,7 @@ describe('Per-package release channel — advance along the current line (#485)'
   describe('explicit bump magnitude (release:major/minor/patch) without a channel action', () => {
     // A bump LABEL is a deliberate magnitude declaration, so it is honoured: on a prerelease it
     // escalates the base to a fresh line (unlike the commit-inferred default, which increments the
-    // counter — the base is a fixed target until graduation, #500). It still doesn't graduate.
+    // counter — the base is a fixed target until graduation). It still doesn't graduate.
     it('should escalate the base under an explicit minor bump (1.0.0-next.1 -> 1.1.0-next.0)', async () => {
       baselineAt('1.0.0-next.1');
       const next = await calculateVersion(baseConfig as Config, options({ type: 'minor' }));

--- a/packages/version/test/unit/core/versionEngine.spec.ts
+++ b/packages/version/test/unit/core/versionEngine.spec.ts
@@ -214,7 +214,7 @@ describe('Version Engine', () => {
     it('should discover from an explicit workspaceRoot instead of process cwd', async () => {
       // The standing-PR primary-package resolver loads config and discovers packages from the same
       // caller-provided root; without honouring the argument, discovery would silently fall back to
-      // process.cwd() and could match a different workspace (#471).
+      // process.cwd() and could match a different workspace.
       const engine = new VersionEngine(defaultConfig as Config);
       await engine.getWorkspacePackages('/custom/root');
 
@@ -454,7 +454,7 @@ describe('Version Engine', () => {
 
     it('should exclude private npm packages from the release set by default', async () => {
       // A private package can't be published to any registry, so it never belongs in the release
-      // set — discovery drops it without a version.skip entry (#477).
+      // set — discovery drops it without a version.skip entry.
       vi.mocked(getPackagesSync, { partial: true }).mockReturnValue({
         root: '/test/workspace',
         tool: 'pnpm' as any,

--- a/packages/version/test/unit/package/packageProcessor.spec.ts
+++ b/packages/version/test/unit/package/packageProcessor.spec.ts
@@ -148,7 +148,7 @@ describe('Package Processor', () => {
     vi.spyOn(path, 'join').mockImplementation((...args) => args.join('/'));
 
     // Baseline tag verification — default to a valid, reachable baseline so changelog ranges
-    // resolve to `<tag>..HEAD`. Tests exercising the all-history fallback (#339) override this.
+    // resolve to `<tag>..HEAD`. Tests exercising the all-history fallback override this.
     vi.spyOn(tagVerification, 'verifyTag').mockResolvedValue({ exists: true, reachable: true });
 
     // Calculator mock - fix to return a Promise
@@ -557,7 +557,7 @@ describe('Package Processor', () => {
     it('should warn when a package has no prior tag (full-history changelog)', async () => {
       // No package tag and no global tag — only the manifest version is available, so hasRealTag is
       // false and the changelog spans the full history. The warning makes this visible (and heads off
-      // the opaque oversized-PR-body 422 in #333).
+      // the opaque oversized-PR-body 422).
       vi.spyOn(gitTags, 'getLatestTagForPackage').mockResolvedValue('');
       vi.spyOn(manifestHelpers, 'getVersionFromManifests').mockReturnValue({
         version: '0.1.0',
@@ -577,7 +577,7 @@ describe('Package Processor', () => {
       await processor.processPackages([mockPackages[1]]);
 
       expect(logging.log).toHaveBeenCalledWith(expect.stringContaining('No prior tag found for package-b'), 'warning');
-      // ...and NOT the misleading #339 "shallow clone / unpushed" warning about the synthetic
+      // ...and NOT the misleading "shallow clone / unpushed" warning about the synthetic
       // manifest-fallback tag, which never existed as a git ref.
       expect(logging.log).not.toHaveBeenCalledWith(
         expect.stringContaining('could not be verified from HEAD'),
@@ -1529,7 +1529,7 @@ describe('Package Processor', () => {
     });
   });
 
-  // #372 — strictReachable must abort the run, not silently degrade. Both tests run with the SAME
+  // strictReachable must abort the run, not silently degrade. Both tests run with the SAME
   // strictReachable:true config so the only variable is the error TYPE: an unreachable-baseline
   // StrictReachableError aborts; a genuine extraction error still degrades to a minimal entry.
   describe('strictReachable (#372)', () => {

--- a/packages/version/test/unit/utils/jsonOutput.spec.ts
+++ b/packages/version/test/unit/utils/jsonOutput.spec.ts
@@ -125,7 +125,7 @@ describe('JSON Output Utilities', () => {
 
     // A hybrid package (one dir, both package.json + a native manifest) is a single package — npm
     // owns its identity. Without dir-keyed dedup the native sibling's write registers a second
-    // update under its crate/pub name and the package surfaces twice downstream (#476).
+    // update under its crate/pub name and the package surfaces twice downstream.
     it('should keep one update per directory for a hybrid, with npm winning regardless of write order', () => {
       enableJsonOutput();
       // package.json written first (the order every strategy uses), then the Cargo.toml sibling.
@@ -177,7 +177,7 @@ describe('JSON Output Utilities', () => {
       addPackageUpdate('pre-pkg', '1.0.0-next.2', '/ws/packages/pre/package.json');
 
       const updates = getJsonData().updates;
-      // A mixed standing PR carries both channels at once, each on its own line (#485).
+      // A mixed standing PR carries both channels at once, each on its own line.
       expect(updates.find((u) => u.packageName === 'stable-pkg')?.channel).toBe('stable');
       expect(updates.find((u) => u.packageName === 'pre-pkg')?.channel).toBe('prerelease');
     });
@@ -186,7 +186,7 @@ describe('JSON Output Utilities', () => {
       enableJsonOutput();
       addPackageUpdate('@scope/x-y', '1.1.0', '/ws/packages/x/package.json');
       // Same directory, written via a non-normalized path form — keying on path.dirname alone would
-      // miss this and re-admit the crate-name duplicate; resolving first dedupes it (#476).
+      // miss this and re-admit the crate-name duplicate; resolving first dedupes it.
       addPackageUpdate('x-y', '1.1.0', '/ws/packages/./x/Cargo.toml');
 
       const data = getJsonData();


### PR DESCRIPTION
Completes #573 — the codebase sweep + enforcement, the deterministic counterpart to the AGENTS.md rework (#598) and the lint rules (#599). **Stacked on #599** (needs its `local/no-bare-issue-refs` rule to flip to `error`); base retargets to `main` once #599 lands.

## What changed
- **Dropped ~237 bare `#NNN` provenance citations** from `packages/*/src` comments. Every one was a standalone origin tag (the issue a piece of code came from) — the comment reads fine without it and git history is the canonical trace. **None were load-bearing** (`until #X` / `remove when #X`), so none needed converting to URLs.
- **Flipped `local/no-bare-issue-refs` → `error`, scoped to `packages/*/src`.** Test comments legitimately reference **mock** issue/PR data (fixture numbers, and even external-repo PRs like `#224/#225` from `wdio-desktop-mobile`), so a releasekit-issue URL would be *wrong* there — the rule doesn't enforce test comments.
- **Exempted three ref-*parsing* files** whose `#NNN` are format examples, not citations: `changelogRefs.ts`, `conventional-changelog.ts`, `commitParser.ts`.
- **Opportunistically dropped ~55 provenance refs from test comments** too (cleanup, even though the rule doesn't enforce them).

Done via three parallel per-package triage passes + one test-comment pass, all applying the same drop-vs-link criteria.

## Verification
- **Comment-only** — confirmed the entire diff touches only comments (the sole non-comment changes are the two intentional `eslint.config.js` edits).
- `eslint packages/**/*.ts` → **0 errors**; `pnpm typecheck` → 15/15; `biome check` clean (8 pre-existing warnings).
- Test failures in a full run (`templates`, `sync-tags`, `pipeline` fixture) are **pre-existing/environmental** — they fail identically on the base with these changes stashed.

## Release
Touches `packages/*/src`, so — per `commitParser`'s "every merged change is surfaced" logic — this should drive a **natural standing-PR 0.41.2** once the stack merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR enforces linked issue references in production source comments. The main changes are:

- Removes bare issue-number provenance tags from package comments.
- Promotes `local/no-bare-issue-refs` from a warning to an error.
- Limits enforcement to `packages/**/src/**/*.ts`.
- Exempts three parsing files whose bare references are format examples.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| eslint.config.js | Scopes comment-reference enforcement to production package sources and changes violations to errors. |
| packages/core/src/changelogRefs.ts | Exempts issue-reference examples used to document rendered formats. |
| packages/notes/src/input/conventional-changelog.ts | Exempts bare issue tokens used as parser and regular-expression examples. |
| packages/version/src/changelog/commitParser.ts | Exempts issue-reference examples used by commit parsing logic. |

</details>

<sub>Reviews (2): Last reviewed commit: ["chore(573): sweep bare issue refs from s..."](https://github.com/goosewobbler/releasekit/commit/2aa40ed7efc62c05b2d45d6c7023866a40ecd9ea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45809355)</sub>

<!-- /greptile_comment -->