### PR TITLE
fix(action): expose refresh-after-release mode; fix template reconcile step

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ branding:
 
 inputs:
   mode:
-    description: Action mode (release, preview, gate, standing-pr-update, standing-pr-publish, or backfill)
+    description: Action mode (release, preview, gate, standing-pr-update, standing-pr-publish, backfill, or refresh-after-release)
     required: false
     default: preview
   config:

--- a/scripts/run-action.d.mts
+++ b/scripts/run-action.d.mts
@@ -33,6 +33,7 @@ export interface RunActionOptions {
 
 export function buildReleaseArgs(input: ActionInputs): string[];
 export function buildPreviewArgs(input: ActionInputs): string[];
+export function buildRefreshAfterReleaseArgs(input: ActionInputs): string[];
 export function parseReleaseOutput(
   stdout: string,
 ): { versionOutput?: { tags?: string[]; updates?: unknown[] } } | undefined;

--- a/scripts/run-action.mjs
+++ b/scripts/run-action.mjs
@@ -140,6 +140,15 @@ export function buildBackfillArgs(input) {
   return args;
 }
 
+export function buildRefreshAfterReleaseArgs(input) {
+  const args = ['refresh-after-release'];
+
+  pushOptionalArg(args, '--config', input.config);
+  pushOptionalArg(args, '--project-dir', input.projectDir);
+
+  return args;
+}
+
 export function writeGateOutputs(stdout, verbose = false) {
   const parsed = parseReleaseOutput(stdout, verbose);
   setOutput('should-release', parsed?.shouldRelease ? 'true' : 'false');
@@ -253,7 +262,15 @@ export function parseInputs(env = process.env) {
     backfillApply: env.INPUT_APPLY,
   };
 
-  const validModes = ['release', 'preview', 'gate', 'standing-pr-update', 'standing-pr-publish', 'backfill'];
+  const validModes = [
+    'release',
+    'preview',
+    'gate',
+    'standing-pr-update',
+    'standing-pr-publish',
+    'backfill',
+    'refresh-after-release',
+  ];
   if (!validModes.includes(input.mode)) {
     throw new Error(`Invalid mode: ${input.mode}. Must be one of: ${validModes.join(', ')}`);
   }
@@ -263,7 +280,15 @@ export function parseInputs(env = process.env) {
 
 export async function runAction(input, options = {}) {
   const mode = input.mode;
-  const validModes = ['release', 'preview', 'gate', 'standing-pr-update', 'standing-pr-publish', 'backfill'];
+  const validModes = [
+    'release',
+    'preview',
+    'gate',
+    'standing-pr-update',
+    'standing-pr-publish',
+    'backfill',
+    'refresh-after-release',
+  ];
   if (!validModes.includes(mode)) {
     throw new Error(`Invalid mode: ${mode}. Expected one of: ${validModes.join(', ')}.`);
   }
@@ -279,6 +304,7 @@ export async function runAction(input, options = {}) {
     'standing-pr-publish': buildStandingPRPublishArgs,
     backfill: buildBackfillArgs,
     preview: buildPreviewArgs,
+    'refresh-after-release': buildRefreshAfterReleaseArgs,
   };
   // `mode` is validated against validModes above, and every entry has a key here.
   const args = argBuilders[mode](input);
@@ -620,8 +646,8 @@ async function main() {
     writeGateOutputs(result.stdout ?? '', verbose);
   } else if (result.mode === 'standing-pr-update' || result.mode === 'standing-pr-publish') {
     writeStandingPROutputs(result.stdout ?? '', verbose);
-  } else if (result.mode === 'backfill') {
-    // Backfill streams its own progress and exposes only the core success/mode outputs.
+  } else if (result.mode === 'backfill' || result.mode === 'refresh-after-release') {
+    // These stream their own progress and expose only the core success/mode outputs.
   } else {
     writePreviewOutputs(input, result.stdout ?? '');
   }

--- a/templates/workflows/standing-pr.yml
+++ b/templates/workflows/standing-pr.yml
@@ -182,10 +182,12 @@ jobs:
           # OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
 
       - name: Reconcile standing PR
-        # The release above tagged new versions. Re-run standing PR update so the queued
-        # release reflects the post-immediate state (released packages drop out of the
-        # queue, anything still queued stays). Zero-staleness reconciliation.
-        run: pnpm exec releasekit standing-pr update
+        # The release above tagged new versions. Use refresh-after-release, not `standing-pr update`:
+        # HEAD is now a `chore: release …` commit, which the skip-pattern guard matches, so a plain
+        # update no-ops. refresh-after-release forces the reconcile bypass so the queued release
+        # actually reflects the post-immediate state (released packages drop out, anything still
+        # queued stays) and refreshes stale feeder-PR previews. Zero-staleness reconciliation.
+        run: pnpm exec releasekit refresh-after-release
         env:
           GITHUB_TOKEN: ${{ github.token }}
           # OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/test/integration/action-runner.spec.ts
+++ b/test/integration/action-runner.spec.ts
@@ -7,6 +7,7 @@ import {
   buildGateArgs,
   buildGateSummary,
   buildPreviewArgs,
+  buildRefreshAfterReleaseArgs,
   buildReleaseArgs,
   buildReleaseSummary,
   buildStandingPRPublishArgs,
@@ -203,6 +204,26 @@ describe('action runner', () => {
 
     expect(args).not.toContain('--reconcile');
     expect(args).toEqual(expect.arrayContaining(['standing-pr', 'update', '--json']));
+  });
+
+  it('should build refresh-after-release args', () => {
+    const args = buildRefreshAfterReleaseArgs({ config: 'releasekit.config.json', projectDir: '.' });
+    expect(args).toEqual(['refresh-after-release', '--config', 'releasekit.config.json', '--project-dir', '.']);
+  });
+
+  it('should accept refresh-after-release mode and run the cli with its args', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'releasekit-action-runner-test-'));
+    tempDirs.push(tempDir);
+    const cliPath = path.join(tempDir, 'fake-cli.mjs');
+    fs.writeFileSync(cliPath, "console.log('ok')\n", 'utf-8');
+
+    const result = await runAction(
+      { mode: 'refresh-after-release', projectDir: '.', config: 'releasekit.config.json' },
+      { cliPath },
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.args).toEqual(['refresh-after-release', '--config', 'releasekit.config.json', '--project-dir', '.']);
   });
 
   it('should parse INPUT_RECONCILE into the reconcile input', () => {


### PR DESCRIPTION
Closes #601 — both facets of "the canonical post-release reconcile isn't cleanly adoptable."

## Problem 1 — the Action couldn't invoke `refresh-after-release`
It's a registered CLI command but wasn't in the action's `mode` allowlist, so `uses: goosewobbler/releasekit@…` users couldn't call the canonical post-release step — the closest reachable substitute (`mode: standing-pr-update` + `reconcile: true`) is only its Half 1 (no feeder-preview refresh).

**Fix** (`scripts/run-action.mjs`, `action.yml`):
- Add `refresh-after-release` to both `validModes` checks (`parseInputs` + `runAction`).
- Add `buildRefreshAfterReleaseArgs` → `['refresh-after-release', --config, --project-dir]` and wire it into `argBuilders`.
- Give it core-only outputs (success/mode), like `backfill`.
- List it in the `action.yml` `mode` description.

## Problem 2 — the canonical template's reconcile step silently no-ops
`templates/workflows/standing-pr.yml`'s `immediate-release` job ran `releasekit standing-pr update` **without** `--reconcile`. After the release, HEAD is a `chore: release …` commit, which the skip-pattern guard matches, so the update returns `noop` — the "zero-staleness reconciliation" its comment promises never happens.

**Fix:** switch that step to `releasekit refresh-after-release`, whose Half 1 forces the reconcile bypass (so it runs even on the release commit) and whose Half 2 refreshes stale feeder-PR previews. Comment updated to explain *why* (not `standing-pr update`).

## Validation
- `test/integration/action-runner.spec.ts` — 2 new cases (arg builder + `runAction` accepts the mode); full suite green (181).
- `pnpm typecheck` 15/15; `biome` clean; `actionlint` clean on the template (its `action.yml` "errors" are false — it's a composite-action file, not a workflow).

## ⚠️ Unrelated pre-existing CI drift (not fixed here)
`pnpm examples:smoke:check` fails on **clean main** — the committed `.github/workflows/examples-smoke.yml` has `actions/setup-node@v7` but the generator emits `@v6`. It's independent of this PR (I reverted the regen to keep scope clean). Worth a one-line `pnpm examples:smoke:generate` fix on its own — flagging so it's not mistaken for a regression here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR exposes the canonical post-release reconciliation flow through the action and workflow template. The main changes are:

- Adds `refresh-after-release` to the action mode allowlists and argument dispatch.
- Declares the new argument builder in the TypeScript module surface.
- Uses the new command in the standing-PR workflow template.
- Adds integration coverage for argument construction and action execution.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- The new runtime export and TypeScript declaration now match.
- No blocking issues remain in the updated declaration path.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| action.yml | Documents `refresh-after-release` as a supported action mode. |
| scripts/run-action.d.mts | Adds the missing declaration for the new argument builder. |
| scripts/run-action.mjs | Adds mode validation, argument construction, dispatch, and output handling for `refresh-after-release`. |
| templates/workflows/standing-pr.yml | Runs the canonical refresh command after an immediate release. |
| test/integration/action-runner.spec.ts | Tests the new argument builder and action mode. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(action): declare buildRefreshAfterRe..."](https://github.com/goosewobbler/releasekit/commit/4ea62b904f1aa12a6e21dc92fb66955646927f23) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45817163)</sub>

<!-- /greptile_comment -->