### PR TITLE
chore(ci): stop dependabot re-drifting the generated examples-smoke.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,3 +26,10 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - 'area:dependencies'
+    ignore:
+      # Major action bumps here silently drift the GENERATED .github/workflows/examples-smoke.yml
+      # out of sync with its source templates/workflows/ (which dependabot does not scan), failing
+      # examples:smoke:check. Dependabot has no per-file ignore, so mirror the npm policy above:
+      # review major action bumps by hand instead of auto-opening them.
+      - dependency-name: '*'
+        update-types: ['version-update:semver-major']

--- a/.github/workflows/examples-smoke.yml
+++ b/.github/workflows/examples-smoke.yml
@@ -117,7 +117,7 @@ jobs:
       - name: Restore fixture into workspace
         run: git clone --quiet "$RUNNER_TEMP/fixture/minimal.bundle" .
       - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@v6
         with:
           node-version: "24"
           cache: pnpm
@@ -140,7 +140,7 @@ jobs:
       - name: Restore fixture into workspace
         run: git clone --quiet "$RUNNER_TEMP/fixture/label-driven.bundle" .
       - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@v6
         with:
           node-version: "24"
           cache: pnpm
@@ -163,7 +163,7 @@ jobs:
       - name: Restore fixture into workspace
         run: git clone --quiet "$RUNNER_TEMP/fixture/oidc.bundle" .
       - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@v6
         with:
           node-version: "24"
           cache: pnpm
@@ -186,7 +186,7 @@ jobs:
       - name: Restore fixture into workspace
         run: git clone --quiet "$RUNNER_TEMP/fixture/monorepo-rust.bundle" .
       - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@v6
         with:
           node-version: "24"
           cache: pnpm
@@ -212,7 +212,7 @@ jobs:
       - name: Restore fixture into workspace
         run: git clone --quiet "$RUNNER_TEMP/fixture/prerelease.bundle" .
       - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@v6
         with:
           node-version: "24"
           cache: pnpm
@@ -235,7 +235,7 @@ jobs:
       - name: Restore fixture into workspace
         run: git clone --quiet "$RUNNER_TEMP/fixture/standing-pr.bundle" .
       - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@v6
         with:
           node-version: "24"
           cache: pnpm


### PR DESCRIPTION
Durable fix for the `examples:smoke:check` drift that was failing CI (raised on #598).

## The drift mechanism
`examples-smoke.yml` is **generated** from `templates/workflows/` by `scripts/examples-smoke/generate-smoke-workflow.ts`. Dependabot scans `.github/workflows/` (where the *generated* file lives) but **not** `templates/workflows/` (its source). So a major action bump — `actions/setup-node@v6 → @v7` — landed on the generated file only, drifting it out of sync with its `@v6` source → `examples:smoke:check` failed on every PR.

## Fix
- **Ignore github-actions major bumps** in `dependabot.yml`, mirroring the policy the npm ecosystem already uses in the same file. The actions are major-tag-pinned (`@v6`, `@v4`, …), so this fully stops the drift while still allowing the manual major bumps the repo already does by review. (Dependabot has no per-file ignore, so this is the consistent equivalent.)
- **Regenerated `examples-smoke.yml`** to clear the current `@v7` drift so `smoke:check` passes now.

The generator already emits a `# GENERATED FILE — do not edit by hand.` banner, so the human/agent signal is in place; this stops the *bot* from editing it.

## Note
#598's branch carries an interim regen of the same file to unblock its own CI; once this lands on `main`, that commit reconciles cleanly (same content).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR prevents Dependabot from changing generated smoke workflows independently of their sources. The main changes are:

- Ignore major GitHub Actions updates in Dependabot.
- Restore six generated `actions/setup-node` references from `v7` to `v6`.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/dependabot.yml | Adds the intended repository-wide ignore rule for major GitHub Actions updates. |
| .github/workflows/examples-smoke.yml | Restores generated setup-node versions to match the source workflows. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(ci): stop dependabot re-drifting t..."](https://github.com/goosewobbler/releasekit/commit/b9c94cbc5c7911cef2a815abb6c9192d366b83c7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45819288)</sub>

<!-- /greptile_comment -->