### PR TITLE
feat(cli): uniform JSON envelope with structured errors and changed reporting

### DIFF
--- a/.github/workflows/_release.reusable.yml
+++ b/.github/workflows/_release.reusable.yml
@@ -165,6 +165,13 @@ jobs:
             exit $EXIT_CODE
           fi
 
+          # Unwrap the uniform CLI envelope ({ schemaVersion, status, data, … }) to its data payload so
+          # the .versionOutput / .releaseNotes reads below (and in release-output.json) work unchanged.
+          # Tolerate non-enveloped output.
+          if echo "$RELEASE_OUTPUT" | jq -e 'type == "object" and has("schemaVersion") and has("data")' > /dev/null 2>&1; then
+            RELEASE_OUTPUT=$(echo "$RELEASE_OUTPUT" | jq '.data')
+          fi
+
           # Check if output is valid JSON (releasekit returns null for no changes)
           if echo "$RELEASE_OUTPUT" | jq -e '.versionOutput' > /dev/null 2>&1; then
             echo "has_changes=true" >> "$GITHUB_OUTPUT"
@@ -201,6 +208,11 @@ jobs:
           if [ $EXIT_CODE -ne 0 ]; then
             echo "::error::standing-pr publish failed with exit code $EXIT_CODE"
             exit $EXIT_CODE
+          fi
+
+          # Unwrap the uniform CLI envelope (see the release path above) so the reads below work.
+          if echo "$RELEASE_OUTPUT" | jq -e 'type == "object" and has("schemaVersion") and has("data")' > /dev/null 2>&1; then
+            RELEASE_OUTPUT=$(echo "$RELEASE_OUTPUT" | jq '.data')
           fi
 
           if echo "$RELEASE_OUTPUT" | jq -e '.versionOutput' > /dev/null 2>&1; then

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -18,6 +18,44 @@ The `releasekit` dispatcher re-exports `version`, `notes`, and `publish`, so `re
 
 ---
 
+## JSON output contract
+
+Every command that accepts `-j, --json` emits its result as a single **envelope** — one uniform shape shared by humans, CI, and agents. `--output <path>` writes the same envelope to a file instead of stdout (the reliable channel for the GitHub Action, since stdout can be polluted by subprocess or log noise, and a single stray byte breaks JSON parsing).
+
+```jsonc
+{
+  "schemaVersion": 1,   // envelope contract version; stable across minor releases
+  "status": "success",  // "success" | "error"
+  "changed": true,      // did the command change state, or was everything already as desired?
+  "data": { /* … */ },  // command-specific payload (VersionOutput, gate result, …); null on error
+  "warnings": [{ "code": "…", "message": "…" }],
+  "errors": [{ "code": "…", "category": "…", "retryable": false, "message": "…" }]
+}
+```
+
+- **`data`** carries the command's payload verbatim — the envelope wraps it, never replaces it. `releasekit release --json` still exposes its `VersionOutput` at `data.versionOutput`.
+- **`changed`** separates real work from a no-op: a dry run is never `changed`; `standing-pr publish` reports `changed: false` when the release was already published (skip-if-published); `gate` is read-only and always `changed: false`.
+- **`errors[]`** replaces prose-only failures in JSON mode. Each carries a stable machine `code`, a coarse `category`, a `retryable` flag (only `true` for known-transient failures — a timeout, 429, or 5xx from a provider — so an agent never retries an unknown failure), and a human `message`.
+- **Stream discipline:** the envelope is the only thing on stdout; all diagnostics (progress, warnings, error text) go to stderr. Parsing stdout as JSON is always safe, and no command prompts interactively on a CI path.
+
+### Error codes and exit codes
+
+| `code` | `category` | Exit code |
+|---|---|---|
+| `GENERAL_ERROR` | `general` | 1 |
+| `CONFIG_ERROR` | `config` | 2 |
+| `INPUT_ERROR` / `INPUT_PARSE_ERROR` | `input` / `input-parse` | 3 |
+| `TEMPLATE_ERROR` | `template` | 4 |
+| `LLM_ERROR` | `llm` | 5 |
+| `GITHUB_ERROR` | `github` | 6 |
+| `GIT_ERROR` | `git` | 7 |
+| `VERSION_ERROR` | `version` | 8 |
+| `PUBLISH_ERROR` | `publish` | 9 |
+
+`schemaVersion` bumps only on a breaking change to the envelope shape and is stable across minor releases, so agents and CI can pin against it.
+
+---
+
 ## `releasekit preview`
 
 Post a release preview comment on the current pull request. This is the default command, so `releasekit` with no arguments runs `preview`.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -20,7 +20,9 @@ The `releasekit` dispatcher re-exports `version`, `notes`, and `publish`, so `re
 
 ## JSON output contract
 
-Every command that accepts `-j, --json` emits its result as a single **envelope** — one uniform shape shared by humans, CI, and agents. `--output <path>` writes the same envelope to a file instead of stdout (the reliable channel for the GitHub Action, since stdout can be polluted by subprocess or log noise, and a single stray byte breaks JSON parsing).
+The orchestration commands — `release`, `gate`, and `standing-pr` — emit their `-j, --json` result as a single **envelope**, one uniform shape shared by humans, CI, and agents. `--output <path>` writes the same envelope to a file instead of stdout (the reliable channel for the GitHub Action, since stdout can be polluted by subprocess or log noise, and a single stray byte breaks JSON parsing).
+
+> **Not yet enveloped:** the pipe commands `version`, `notes`, and `publish` still print their payload bare. They pipe JSON between processes, so wrapping their output means teaching the consuming side to unwrap on input — a separate change. Don't unwrap `.data` from those; check for `schemaVersion` if you need to handle both.
 
 ```jsonc
 {
@@ -34,7 +36,7 @@ Every command that accepts `-j, --json` emits its result as a single **envelope*
 ```
 
 - **`data`** carries the command's payload verbatim — the envelope wraps it, never replaces it. `releasekit release --json` still exposes its `VersionOutput` at `data.versionOutput`.
-- **`changed`** separates real work from a no-op: a dry run is never `changed`; `standing-pr publish` reports `changed: false` when the release was already published (skip-if-published); `gate` is read-only and always `changed: false`.
+- **`changed`** separates real work from a no-op: a dry run is never `changed`; `standing-pr publish` reads its registry results, so a re-run where every version was already published reports `changed: false`; `gate` is read-only and always `changed: false`.
 - **`errors[]`** replaces prose-only failures in JSON mode. Each carries a stable machine `code`, a coarse `category`, a `retryable` flag (only `true` for known-transient failures — a timeout, 429, or 5xx from a provider — so an agent never retries an unknown failure), and a human `message`.
 - **Stream discipline:** the envelope is the only thing on stdout; all diagnostics (progress, warnings, error text) go to stderr. Parsing stdout as JSON is always safe, and no command prompts interactively on a CI path.
 

--- a/packages/core/src/envelope.ts
+++ b/packages/core/src/envelope.ts
@@ -1,0 +1,114 @@
+import { EXIT_CODES, ReleaseKitError } from './errors.js';
+
+/**
+ * Version of the `--json` envelope contract. Bumped only on a breaking change to the envelope
+ * shape, and stable across minor releases, so agents and CI can pin against it.
+ */
+export const ENVELOPE_SCHEMA_VERSION = 1;
+
+export type EnvelopeStatus = 'success' | 'error';
+
+export interface EnvelopeError {
+  /** Stable machine code mirroring `ReleaseKitError.code` (e.g. CONFIG_ERROR, LLM_ERROR). */
+  code: string;
+  /** Coarse grouping derived from the code (e.g. config, llm, github). */
+  category: string;
+  /** Whether the failure is transient and worth retrying. Only true when known-transient. */
+  retryable: boolean;
+  message: string;
+}
+
+export interface EnvelopeWarning {
+  code?: string;
+  message: string;
+}
+
+/**
+ * The uniform result envelope every command emits in `--json` mode. `data` carries the
+ * command-specific payload (VersionOutput, gate result, standing-PR result) verbatim — the
+ * envelope wraps it, never replaces it, so the manifest-compat invariant holds.
+ */
+export interface Envelope<T = unknown> {
+  schemaVersion: number;
+  status: EnvelopeStatus;
+  /** Whether the command changed state, vs. found everything already in the desired state. */
+  changed: boolean;
+  data: T;
+  warnings: EnvelopeWarning[];
+  errors: EnvelopeError[];
+}
+
+export function successEnvelope<T>(
+  data: T,
+  opts: { changed?: boolean; warnings?: EnvelopeWarning[] } = {},
+): Envelope<T> {
+  return {
+    schemaVersion: ENVELOPE_SCHEMA_VERSION,
+    status: 'success',
+    changed: opts.changed ?? false,
+    data,
+    warnings: opts.warnings ?? [],
+    errors: [],
+  };
+}
+
+export function errorEnvelope(errors: EnvelopeError[], opts: { warnings?: EnvelopeWarning[] } = {}): Envelope<null> {
+  return {
+    schemaVersion: ENVELOPE_SCHEMA_VERSION,
+    status: 'error',
+    changed: false,
+    data: null,
+    warnings: opts.warnings ?? [],
+    errors,
+  };
+}
+
+const CODE_TO_EXIT: Record<string, number> = {
+  CONFIG_ERROR: EXIT_CODES.CONFIG_ERROR,
+  INPUT_ERROR: EXIT_CODES.INPUT_ERROR,
+  INPUT_PARSE_ERROR: EXIT_CODES.INPUT_ERROR,
+  TEMPLATE_ERROR: EXIT_CODES.TEMPLATE_ERROR,
+  LLM_ERROR: EXIT_CODES.LLM_ERROR,
+  GITHUB_ERROR: EXIT_CODES.GITHUB_ERROR,
+  GIT_ERROR: EXIT_CODES.GIT_ERROR,
+  VERSION_ERROR: EXIT_CODES.VERSION_ERROR,
+  PUBLISH_ERROR: EXIT_CODES.PUBLISH_ERROR,
+};
+
+/** Map any thrown value to its process exit code, defaulting to GENERAL_ERROR. */
+export function exitCodeForError(error: unknown): number {
+  if (ReleaseKitError.isReleaseKitError(error)) {
+    return CODE_TO_EXIT[error.code] ?? EXIT_CODES.GENERAL_ERROR;
+  }
+  return EXIT_CODES.GENERAL_ERROR;
+}
+
+/** Derive a coarse category from a code: CONFIG_ERROR -> config, INPUT_PARSE_ERROR -> input-parse. */
+function categoryForCode(code: string): string {
+  return (
+    code
+      .replace(/_ERROR$/, '')
+      .replace(/_/g, '-')
+      .toLowerCase() || 'general'
+  );
+}
+
+/** Convert a thrown value into a structured envelope error. */
+export function toEnvelopeError(error: unknown): EnvelopeError {
+  if (ReleaseKitError.isReleaseKitError(error)) {
+    return {
+      code: error.code,
+      category: categoryForCode(error.code),
+      // Only ReleaseKitError subclasses that classify transience (LLMError) carry this; a missing or
+      // undefined flag stays conservatively non-retryable so an agent never retries an unknown failure.
+      retryable: (error as { retryable?: boolean }).retryable === true,
+      message: error.message,
+    };
+  }
+  return {
+    code: 'GENERAL_ERROR',
+    category: 'general',
+    retryable: false,
+    message: error instanceof Error ? error.message : String(error),
+  };
+}

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -29,6 +29,12 @@ export abstract class ReleaseKitError extends Error {
   }
 }
 
+/** A CLI input-validation failure — a bad flag combination or a malformed argument. */
+export class InputError extends ReleaseKitError {
+  readonly code = 'INPUT_ERROR';
+  readonly suggestions: string[] = [];
+}
+
 export const EXIT_CODES = {
   SUCCESS: 0,
   GENERAL_ERROR: 1,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -24,7 +24,7 @@ export {
   successEnvelope,
   toEnvelopeError,
 } from './envelope.js';
-export { EXIT_CODES, type ExitCode, ReleaseKitError } from './errors.js';
+export { EXIT_CODES, type ExitCode, InputError, ReleaseKitError } from './errors.js';
 export {
   debug,
   error,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,6 +13,17 @@ export {
   type GraphPackage,
   type WorkspaceDependencyGraph,
 } from './dependencyGraph.js';
+export {
+  ENVELOPE_SCHEMA_VERSION,
+  type Envelope,
+  type EnvelopeError,
+  type EnvelopeStatus,
+  type EnvelopeWarning,
+  errorEnvelope,
+  exitCodeForError,
+  successEnvelope,
+  toEnvelopeError,
+} from './envelope.js';
 export { EXIT_CODES, type ExitCode, ReleaseKitError } from './errors.js';
 export {
   debug,

--- a/packages/core/test/unit/envelope.spec.ts
+++ b/packages/core/test/unit/envelope.spec.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ENVELOPE_SCHEMA_VERSION,
+  errorEnvelope,
+  exitCodeForError,
+  successEnvelope,
+  toEnvelopeError,
+} from '../../src/envelope.js';
+import { EXIT_CODES, ReleaseKitError } from '../../src/errors.js';
+
+class TestConfigError extends ReleaseKitError {
+  readonly code = 'CONFIG_ERROR';
+  readonly suggestions: string[] = [];
+}
+
+class TestLLMError extends ReleaseKitError {
+  readonly code = 'LLM_ERROR';
+  readonly suggestions: string[] = [];
+  readonly retryable: boolean;
+  constructor(message: string, retryable: boolean) {
+    super(message);
+    this.retryable = retryable;
+  }
+}
+
+describe('envelope', () => {
+  describe('successEnvelope', () => {
+    it('should wrap data with success status and defaults', () => {
+      expect(successEnvelope({ tags: ['v1.2.3'] })).toEqual({
+        schemaVersion: ENVELOPE_SCHEMA_VERSION,
+        status: 'success',
+        changed: false,
+        data: { tags: ['v1.2.3'] },
+        warnings: [],
+        errors: [],
+      });
+    });
+
+    it('should carry changed and warnings when provided', () => {
+      const env = successEnvelope(null, { changed: true, warnings: [{ message: 'heads up' }] });
+      expect(env.changed).toBe(true);
+      expect(env.warnings).toEqual([{ message: 'heads up' }]);
+    });
+  });
+
+  describe('errorEnvelope', () => {
+    it('should carry error status, null data, and the given errors', () => {
+      const errors = [{ code: 'X_ERROR', category: 'x', retryable: false, message: 'boom' }];
+      expect(errorEnvelope(errors)).toEqual({
+        schemaVersion: ENVELOPE_SCHEMA_VERSION,
+        status: 'error',
+        changed: false,
+        data: null,
+        warnings: [],
+        errors,
+      });
+    });
+  });
+
+  describe('toEnvelopeError', () => {
+    it('should map a ReleaseKitError to its code and derived category', () => {
+      expect(toEnvelopeError(new TestConfigError('bad config'))).toEqual({
+        code: 'CONFIG_ERROR',
+        category: 'config',
+        retryable: false,
+        message: 'bad config',
+      });
+    });
+
+    it('should surface a retryable ReleaseKitError as retryable', () => {
+      expect(toEnvelopeError(new TestLLMError('timeout', true)).retryable).toBe(true);
+    });
+
+    it('should treat an unclassified error as non-retryable', () => {
+      expect(toEnvelopeError(new TestLLMError('auth', false)).retryable).toBe(false);
+    });
+
+    it('should map a plain Error to GENERAL_ERROR', () => {
+      expect(toEnvelopeError(new Error('oops'))).toEqual({
+        code: 'GENERAL_ERROR',
+        category: 'general',
+        retryable: false,
+        message: 'oops',
+      });
+    });
+
+    it('should stringify a non-Error thrown value', () => {
+      expect(toEnvelopeError('just a string').message).toBe('just a string');
+    });
+  });
+
+  describe('exitCodeForError', () => {
+    it('should map a ReleaseKitError code to its exit code', () => {
+      expect(exitCodeForError(new TestConfigError('x'))).toBe(EXIT_CODES.CONFIG_ERROR);
+    });
+
+    it('should default to GENERAL_ERROR for a plain Error', () => {
+      expect(exitCodeForError(new Error('x'))).toBe(EXIT_CODES.GENERAL_ERROR);
+    });
+  });
+});

--- a/packages/release/src/commands/changed.ts
+++ b/packages/release/src/commands/changed.ts
@@ -1,0 +1,20 @@
+import type { ReleaseOutput } from '../types.js';
+
+/**
+ * Did a `standing-pr publish` actually publish anything?
+ *
+ * `versionOutput.updates` cannot answer this. The manifest carries the versions the merge already
+ * landed on `main`, so it is populated on every run — including a re-run where every package was
+ * already published and nothing happened.  Only `publishOutput` records what *this* invocation did.
+ *
+ * Within `publishOutput`, the registry results are the one honest signal. Release tags are created
+ * before the pipeline runs, `git.pushed` is set for any push attempt, and the GitHub-release stage
+ * reports `success: true` for an already-existing release — none of those distinguish a real publish
+ * from an idempotent no-op. A registry result does: `skipped` and `alreadyPublished` mark the
+ * packages that were passed over. Same predicate the verify stage uses to pick what to verify.
+ */
+export function publishDidChange(result: ReleaseOutput | null | undefined): boolean {
+  const output = result?.publishOutput;
+  if (!output || output.dryRun) return false;
+  return [...output.npm, ...output.cargo, ...output.pub].some((r) => r.success && !r.skipped && !r.alreadyPublished);
+}

--- a/packages/release/src/commands/emitResult.ts
+++ b/packages/release/src/commands/emitResult.ts
@@ -1,5 +1,13 @@
 import { writeFileSync } from 'node:fs';
-import { type Envelope, type EnvelopeWarning, errorEnvelope, successEnvelope, toEnvelopeError } from '@releasekit/core';
+import {
+  type Envelope,
+  type EnvelopeWarning,
+  EXIT_CODES,
+  errorEnvelope,
+  InputError,
+  successEnvelope,
+  toEnvelopeError,
+} from '@releasekit/core';
 
 /**
  * Write an envelope to the JSON channel. When `--output` is given, write to that file — the reliable
@@ -32,4 +40,15 @@ export function emitResult(
 export function emitError(error: unknown, opts: { json?: boolean; output?: string }): void {
   if (!opts.json && !opts.output) return;
   writeEnvelope(errorEnvelope([toEnvelopeError(error)]), opts);
+}
+
+/**
+ * Report a CLI input-validation failure through the uniform contract: emit a structured INPUT_ERROR
+ * envelope on the JSON channel, log the message to stderr, and exit with the input-error code. Used
+ * for pre-flight arg checks so they honour the same envelope guarantee as runtime errors.
+ */
+export function failInput(message: string, opts: { json?: boolean; output?: string }): never {
+  emitError(new InputError(message), opts);
+  console.error(message);
+  process.exit(EXIT_CODES.INPUT_ERROR);
 }

--- a/packages/release/src/commands/emitResult.ts
+++ b/packages/release/src/commands/emitResult.ts
@@ -1,16 +1,35 @@
 import { writeFileSync } from 'node:fs';
+import { type Envelope, type EnvelopeWarning, errorEnvelope, successEnvelope, toEnvelopeError } from '@releasekit/core';
 
 /**
- * Emit a command's JSON result. When `--output` is given, write it to that file — the reliable
+ * Write an envelope to the JSON channel. When `--output` is given, write to that file — the reliable
  * channel the GitHub Action reads, since stdout can be polluted by subprocess or log noise and a
- * single stray byte breaks JSON parsing. Otherwise, when `--json` is set, print to stdout as before.
+ * single stray byte breaks JSON parsing. Otherwise, when `--json` is set, print to stdout. Only the
+ * envelope goes to stdout; all diagnostics go to stderr via the logger (stream discipline).
  */
-export function emitResult(result: unknown, opts: { json?: boolean; output?: string }): void {
-  if (result === undefined || result === null) return;
-  const text = JSON.stringify(result, null, 2);
+function writeEnvelope(envelope: Envelope, opts: { json?: boolean; output?: string }): void {
+  const text = JSON.stringify(envelope, null, 2);
   if (opts.output) {
     writeFileSync(opts.output, text);
   } else if (opts.json) {
     console.log(text);
   }
+}
+
+/**
+ * Emit a command's successful result inside the uniform CLI envelope. `data` becomes the envelope's
+ * `data` payload verbatim (VersionOutput etc. are preserved — the envelope wraps, never replaces).
+ */
+export function emitResult(
+  data: unknown,
+  opts: { json?: boolean; output?: string; changed?: boolean; warnings?: EnvelopeWarning[] },
+): void {
+  if (!opts.json && !opts.output) return;
+  writeEnvelope(successEnvelope(data ?? null, { changed: opts.changed, warnings: opts.warnings }), opts);
+}
+
+/** Emit a structured error envelope for a thrown value on the JSON channel. */
+export function emitError(error: unknown, opts: { json?: boolean; output?: string }): void {
+  if (!opts.json && !opts.output) return;
+  writeEnvelope(errorEnvelope([toEnvelopeError(error)]), opts);
 }

--- a/packages/release/src/commands/gate-command.ts
+++ b/packages/release/src/commands/gate-command.ts
@@ -1,7 +1,7 @@
-import { setJsonMode, setLogLevel, setQuietMode } from '@releasekit/core';
+import { exitCodeForError, setJsonMode, setLogLevel, setQuietMode } from '@releasekit/core';
 import { Command } from 'commander';
 import { runGate } from '../gate/gate.js';
-import { emitResult } from './emitResult.js';
+import { emitError, emitResult } from './emitResult.js';
 
 export function createGateCommand(): Command {
   return new Command('gate')
@@ -28,12 +28,14 @@ export function createGateCommand(): Command {
           quiet: opts.quiet,
         });
 
-        emitResult(result, { json: opts.json, output: opts.output });
+        // gate is a read-only check — it never mutates state, so changed is always false.
+        emitResult(result, { json: opts.json, output: opts.output, changed: false });
 
         process.exit(0);
       } catch (error) {
+        emitError(error, { json: opts.json, output: opts.output });
         console.error(error instanceof Error ? error.message : String(error));
-        process.exit(1);
+        process.exit(exitCodeForError(error));
       }
     });
 }

--- a/packages/release/src/commands/release-command.ts
+++ b/packages/release/src/commands/release-command.ts
@@ -1,9 +1,9 @@
-import { EXIT_CODES, exitCodeForError } from '@releasekit/core';
+import { exitCodeForError } from '@releasekit/core';
 import { Command, Option } from 'commander';
 import { publishFromDraft, runReleaseDraft } from '../draft/draft.js';
 import { runRelease } from '../release.js';
 import type { ReleaseOptions } from '../types.js';
-import { emitError, emitResult } from './emitResult.js';
+import { emitError, emitResult, failInput } from './emitResult.js';
 
 export function createReleaseCommand(): Command {
   return new Command('release')
@@ -48,22 +48,21 @@ export function createReleaseCommand(): Command {
     .option('-q, --quiet', 'Suppress non-error output', false)
     .option('--project-dir <path>', 'Project directory', process.cwd())
     .action(async (opts) => {
+      const io = { json: opts.json, output: opts.output };
+
       if (opts.stable && opts.prerelease) {
-        console.error('Error: Cannot use both --stable and --prerelease at the same time');
-        process.exit(EXIT_CODES.INPUT_ERROR);
+        failInput('Cannot use both --stable and --prerelease at the same time', io);
       }
 
       if (opts.draft && opts.fromDraft !== undefined) {
-        console.error('Error: Cannot use both --draft and --from-draft at the same time');
-        process.exit(EXIT_CODES.INPUT_ERROR);
+        failInput('Cannot use both --draft and --from-draft at the same time', io);
       }
 
       let fromDraftNumber: number | undefined;
       if (opts.fromDraft !== undefined) {
         fromDraftNumber = Number(opts.fromDraft);
         if (!Number.isInteger(fromDraftNumber) || fromDraftNumber <= 0) {
-          console.error(`Error: --from-draft expects a positive issue number, got "${opts.fromDraft}"`);
-          process.exit(EXIT_CODES.INPUT_ERROR);
+          failInput(`--from-draft expects a positive issue number, got "${opts.fromDraft}"`, io);
         }
       }
 

--- a/packages/release/src/commands/release-command.ts
+++ b/packages/release/src/commands/release-command.ts
@@ -1,9 +1,9 @@
-import { EXIT_CODES } from '@releasekit/core';
+import { EXIT_CODES, exitCodeForError } from '@releasekit/core';
 import { Command, Option } from 'commander';
 import { publishFromDraft, runReleaseDraft } from '../draft/draft.js';
 import { runRelease } from '../release.js';
 import type { ReleaseOptions } from '../types.js';
-import { emitResult } from './emitResult.js';
+import { emitError, emitResult } from './emitResult.js';
 
 export function createReleaseCommand(): Command {
   return new Command('release')
@@ -99,14 +99,18 @@ export function createReleaseCommand(): Command {
               ? await runReleaseDraft(options)
               : await runRelease(options);
 
-        emitResult(result, { json: options.json, output: opts.output });
+        // A dry run plans but never mutates state, so it is never "changed"; a real run changed
+        // state iff it produced version updates.
+        const changed = !opts.dryRun && Boolean(result?.versionOutput?.updates?.length);
+        emitResult(result, { json: options.json, output: opts.output, changed });
 
         if (!result) {
           process.exit(0);
         }
       } catch (error) {
+        emitError(error, { json: opts.json, output: opts.output });
         console.error(error instanceof Error ? error.message : String(error));
-        process.exit(EXIT_CODES.GENERAL_ERROR);
+        process.exit(exitCodeForError(error));
       }
     });
 }

--- a/packages/release/src/commands/release-command.ts
+++ b/packages/release/src/commands/release-command.ts
@@ -101,13 +101,13 @@ export function createReleaseCommand(): Command {
         // A dry run plans but never mutates state, so it is never "changed"; a real run changed
         // state iff it produced version updates.
         const changed = !opts.dryRun && Boolean(result?.versionOutput?.updates?.length);
-        emitResult(result, { json: options.json, output: opts.output, changed });
+        emitResult(result, { ...io, changed });
 
         if (!result) {
           process.exit(0);
         }
       } catch (error) {
-        emitError(error, { json: opts.json, output: opts.output });
+        emitError(error, io);
         console.error(error instanceof Error ? error.message : String(error));
         process.exit(exitCodeForError(error));
       }

--- a/packages/release/src/commands/standing-pr-command.ts
+++ b/packages/release/src/commands/standing-pr-command.ts
@@ -1,8 +1,8 @@
-import { EXIT_CODES } from '@releasekit/core';
+import { EXIT_CODES, exitCodeForError } from '@releasekit/core';
 import { Command } from 'commander';
 import type { StandingPROptions } from '../standing-pr/standing-pr.js';
 import { runStandingPRMerge, runStandingPRPublish, runStandingPRUpdate } from '../standing-pr/standing-pr.js';
-import { emitResult } from './emitResult.js';
+import { emitError, emitResult } from './emitResult.js';
 
 export function createStandingPRCommand(): Command {
   const cmd = new Command('standing-pr').description(
@@ -49,10 +49,11 @@ export function createStandingPRCommand(): Command {
 
     try {
       const result = await runStandingPRUpdate(options);
-      emitResult(result, { json: opts.json, output: opts.output });
+      emitResult(result, { json: opts.json, output: opts.output, changed: result.action !== 'noop' });
     } catch (err) {
+      emitError(err, { json: opts.json, output: opts.output });
       console.error(err instanceof Error ? err.message : String(err));
-      process.exit(EXIT_CODES.GENERAL_ERROR);
+      process.exit(exitCodeForError(err));
     }
   });
 
@@ -88,10 +89,16 @@ export function createStandingPRCommand(): Command {
 
     try {
       const result = await runStandingPRPublish(options, prNumber);
-      emitResult(result, { json: opts.json, output: opts.output });
+      // skip-if-published returns no updates — surface that as changed:false.
+      emitResult(result, {
+        json: opts.json,
+        output: opts.output,
+        changed: Boolean(result?.versionOutput?.updates?.length),
+      });
     } catch (err) {
+      emitError(err, { json: opts.json, output: opts.output });
       console.error(err instanceof Error ? err.message : String(err));
-      process.exit(EXIT_CODES.GENERAL_ERROR);
+      process.exit(exitCodeForError(err));
     }
   });
 
@@ -112,10 +119,12 @@ export function createStandingPRCommand(): Command {
 
     try {
       const result = await runStandingPRMerge(options, { publish: opts.publish });
-      emitResult(result, { json: opts.json, output: opts.output });
+      // A non-null result means the PR was merged (nothing-to-merge returns null).
+      emitResult(result, { json: opts.json, output: opts.output, changed: result != null });
     } catch (err) {
+      emitError(err, { json: opts.json, output: opts.output });
       console.error(err instanceof Error ? err.message : String(err));
-      process.exit(EXIT_CODES.GENERAL_ERROR);
+      process.exit(exitCodeForError(err));
     }
   });
 

--- a/packages/release/src/commands/standing-pr-command.ts
+++ b/packages/release/src/commands/standing-pr-command.ts
@@ -1,8 +1,8 @@
-import { EXIT_CODES, exitCodeForError } from '@releasekit/core';
+import { exitCodeForError } from '@releasekit/core';
 import { Command } from 'commander';
 import type { StandingPROptions } from '../standing-pr/standing-pr.js';
 import { runStandingPRMerge, runStandingPRPublish, runStandingPRUpdate } from '../standing-pr/standing-pr.js';
-import { emitError, emitResult } from './emitResult.js';
+import { emitError, emitResult, failInput } from './emitResult.js';
 
 export function createStandingPRCommand(): Command {
   const cmd = new Command('standing-pr').description(
@@ -81,8 +81,7 @@ export function createStandingPRCommand(): Command {
       // non-digit characters ('123abc' → 123), which would mask genuine input errors.
       const trimmed = String(opts.pr).trim();
       if (!/^[1-9]\d*$/.test(trimmed)) {
-        console.error(`--pr must be a positive integer (got: ${opts.pr})`);
-        process.exit(EXIT_CODES.GENERAL_ERROR);
+        failInput(`--pr must be a positive integer (got: ${opts.pr})`, { json: opts.json, output: opts.output });
       }
       prNumber = Number.parseInt(trimmed, 10);
     }

--- a/packages/release/src/commands/standing-pr-command.ts
+++ b/packages/release/src/commands/standing-pr-command.ts
@@ -2,6 +2,7 @@ import { exitCodeForError } from '@releasekit/core';
 import { Command } from 'commander';
 import type { StandingPROptions } from '../standing-pr/standing-pr.js';
 import { runStandingPRMerge, runStandingPRPublish, runStandingPRUpdate } from '../standing-pr/standing-pr.js';
+import { publishDidChange } from './changed.js';
 import { emitError, emitResult, failInput } from './emitResult.js';
 
 export function createStandingPRCommand(): Command {
@@ -88,12 +89,8 @@ export function createStandingPRCommand(): Command {
 
     try {
       const result = await runStandingPRPublish(options, prNumber);
-      // skip-if-published returns no updates — surface that as changed:false.
-      emitResult(result, {
-        json: opts.json,
-        output: opts.output,
-        changed: Boolean(result?.versionOutput?.updates?.length),
-      });
+      // Read the publish effects, not the manifest's versions — see publishDidChange.
+      emitResult(result, { json: opts.json, output: opts.output, changed: publishDidChange(result) });
     } catch (err) {
       emitError(err, { json: opts.json, output: opts.output });
       console.error(err instanceof Error ? err.message : String(err));

--- a/packages/release/src/standing-pr/standing-pr.ts
+++ b/packages/release/src/standing-pr/standing-pr.ts
@@ -1678,13 +1678,20 @@ async function assertManifestMatchesSource(
 
 // Core publish logic: finds manifest on the given PR, optionally extracts user-edited
 // notes from the PR body, then runs the publish step and cleans up the release branch.
-export async function publishFromManifest(prNumber: number, options: StandingPROptions): Promise<ReleaseOutput | null> {
+/**
+ * Publish the release described by a merged standing PR's manifest. Every failure throws — there is
+ * no "nothing to do" outcome once a specific PR has been named, so a caller that gets a result back
+ * knows the publish ran.
+ */
+export async function publishFromManifest(prNumber: number, options: StandingPROptions): Promise<ReleaseOutput> {
   const cwd = options.projectDir;
 
   const githubContext = getGitHubContext();
   if (!githubContext?.token) {
-    error('No GitHub context (GITHUB_REPOSITORY or GITHUB_TOKEN) available');
-    return null;
+    throw new Error(
+      `No GitHub context (GITHUB_REPOSITORY or GITHUB_TOKEN) available — cannot read the release manifest from ` +
+        `PR #${prNumber}.`,
+    );
   }
 
   const forge = forgeFor(githubContext);
@@ -1974,6 +1981,15 @@ export async function findLatestMergedStandingPR(forge: Forge, branch: string): 
   return merged[0]?.number ?? null;
 }
 
+/**
+ * Publish from a merged standing release PR.
+ *
+ * `null` means "nothing to do" — this run legitimately had no release to publish, and the caller
+ * reports success. Everything that went *wrong* throws: the JSON envelope reports `status: "error"`
+ * on those, so an agent or workflow can't read a misconfiguration as a successful no-op. The
+ * distinction matters most on the `pull_request: closed` trigger, which fires for every closed PR
+ * and must stay a quiet no-op for the ones that aren't the release branch.
+ */
 export async function runStandingPRPublish(
   options: StandingPROptions,
   explicitPrNumber?: number,
@@ -1998,8 +2014,10 @@ export async function runStandingPRPublish(
     try {
       event = JSON.parse(fs.readFileSync(eventPath, 'utf-8'));
     } catch (err) {
-      error(`Failed to read GitHub event: ${err instanceof Error ? err.message : String(err)}`);
-      return null;
+      throw new Error(
+        `Failed to read the GitHub event at ${eventPath}: ${err instanceof Error ? err.message : String(err)}. ` +
+          `The event payload decides which PR to publish — pass --pr explicitly to bypass it.`,
+      );
     }
   }
 
@@ -2019,8 +2037,10 @@ export async function runStandingPRPublish(
     }
 
     if (!prNumber) {
-      error('Could not determine PR number from GitHub event');
-      return null;
+      throw new Error(
+        `Could not determine the PR number from the GitHub event: its pull_request payload matched release branch ` +
+          `'${releaseBranch}' and is merged, but carries no number. Pass --pr explicitly.`,
+      );
     }
 
     return publishFromManifest(prNumber, options);
@@ -2029,14 +2049,15 @@ export async function runStandingPRPublish(
   // No pull_request context — infer the merged standing PR from the API.
   const githubContext = getGitHubContext();
   if (!githubContext?.token) {
-    error('No GitHub context (GITHUB_REPOSITORY or GITHUB_TOKEN) available — pass --pr explicitly');
-    return null;
+    throw new Error(
+      'No GitHub context (GITHUB_REPOSITORY or GITHUB_TOKEN) available, so the merged standing PR cannot be ' +
+        'inferred — pass --pr explicitly.',
+    );
   }
 
   const inferred = await findLatestMergedStandingPR(forgeFor(githubContext), releaseBranch);
   if (inferred === null) {
-    error(`No merged standing release PR found for branch '${releaseBranch}' — pass --pr explicitly`);
-    return null;
+    throw new Error(`No merged standing release PR found for branch '${releaseBranch}' — pass --pr explicitly.`);
   }
 
   info(

--- a/packages/release/test/unit/commands/changed.spec.ts
+++ b/packages/release/test/unit/commands/changed.spec.ts
@@ -1,0 +1,96 @@
+import type { PublishOutput, PublishResult } from '@releasekit/publish';
+import { describe, expect, it } from 'vitest';
+import { publishDidChange } from '../../../src/commands/changed.js';
+import type { ReleaseOutput } from '../../../src/types.js';
+
+function publishResult(overrides: Partial<PublishResult> = {}): PublishResult {
+  return {
+    packageName: '@acme/widget',
+    version: '2.0.0',
+    registry: 'npm',
+    success: true,
+    skipped: false,
+    ...overrides,
+  };
+}
+
+function publishOutput(overrides: Partial<PublishOutput> = {}): PublishOutput {
+  return {
+    dryRun: false,
+    git: { committed: false, tags: ['v2.0.0'], pushed: true },
+    npm: [],
+    cargo: [],
+    pub: [],
+    verification: [],
+    githubReleases: [],
+    publishSucceeded: true,
+    ...overrides,
+  };
+}
+
+function releaseOutput(publish?: PublishOutput): ReleaseOutput {
+  return {
+    // Always populated from the manifest, whether or not this run published anything — the reason
+    // `changed` can't be derived from it.
+    versionOutput: {
+      dryRun: false,
+      updates: [{ packageName: '@acme/widget', currentVersion: '1.4.2', newVersion: '2.0.0', bumpType: 'major' }],
+      changelogs: [],
+      tags: ['v2.0.0'],
+    } as ReleaseOutput['versionOutput'],
+    notesGenerated: false,
+    publishOutput: publish,
+  };
+}
+
+describe('publishDidChange', () => {
+  it('should be true when a package actually reached a registry', () => {
+    expect(publishDidChange(releaseOutput(publishOutput({ npm: [publishResult()] })))).toBe(true);
+  });
+
+  it('should be false when every package was already published', () => {
+    const output = publishOutput({
+      npm: [publishResult({ skipped: true, alreadyPublished: true, reason: 'already published' })],
+    });
+    expect(publishDidChange(releaseOutput(output))).toBe(false);
+  });
+
+  it('should be false when every package was skipped as private', () => {
+    const output = publishOutput({ npm: [publishResult({ skipped: true, reason: 'private' })] });
+    expect(publishDidChange(releaseOutput(output))).toBe(false);
+  });
+
+  it('should be false for a push of pre-existing tags and releases with nothing published', () => {
+    const output = publishOutput({
+      npm: [publishResult({ skipped: true, alreadyPublished: true })],
+      // Both report success for an already-existing tag/release, so neither is a change signal.
+      git: { committed: true, tags: ['v2.0.0'], pushed: true },
+      githubReleases: [{ tag: 'v2.0.0', draft: false, prerelease: false, success: true }],
+    });
+    expect(publishDidChange(releaseOutput(output))).toBe(false);
+  });
+
+  it('should be true when one package published among already-published ones', () => {
+    const output = publishOutput({
+      npm: [publishResult({ packageName: '@acme/a', skipped: true, alreadyPublished: true }), publishResult()],
+    });
+    expect(publishDidChange(releaseOutput(output))).toBe(true);
+  });
+
+  it('should read cargo and pub results alongside npm', () => {
+    expect(publishDidChange(releaseOutput(publishOutput({ cargo: [publishResult({ registry: 'cargo' })] })))).toBe(
+      true,
+    );
+    expect(publishDidChange(releaseOutput(publishOutput({ pub: [publishResult({ registry: 'pub' })] })))).toBe(true);
+  });
+
+  it('should be false for a dry run that reports successful publishes', () => {
+    const output = publishOutput({ dryRun: true, npm: [publishResult()] });
+    expect(publishDidChange(releaseOutput(output))).toBe(false);
+  });
+
+  it('should be false when there is no publish output at all', () => {
+    expect(publishDidChange(releaseOutput(undefined))).toBe(false);
+    expect(publishDidChange(null)).toBe(false);
+  });
+});

--- a/packages/release/test/unit/commands/emitResult.spec.ts
+++ b/packages/release/test/unit/commands/emitResult.spec.ts
@@ -1,8 +1,9 @@
 import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { ENVELOPE_SCHEMA_VERSION } from '@releasekit/core';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { emitResult } from '../../../src/commands/emitResult.js';
+import { emitError, emitResult } from '../../../src/commands/emitResult.js';
 
 describe('emitResult', () => {
   const dirs: string[] = [];
@@ -13,24 +14,44 @@ describe('emitResult', () => {
     vi.restoreAllMocks();
   });
 
-  it('should write the JSON result to the output file when --output is set', () => {
+  it('should write a success envelope wrapping the result to the output file', () => {
     const dir = mkdtempSync(join(tmpdir(), 'emit-result-'));
     dirs.push(dir);
     const file = join(dir, 'out.json');
     const log = vi.spyOn(console, 'log').mockImplementation(() => {});
 
-    emitResult({ versionOutput: { tags: ['v1.2.3'] } }, { json: true, output: file });
+    emitResult({ versionOutput: { tags: ['v1.2.3'] } }, { json: true, output: file, changed: true });
 
-    expect(JSON.parse(readFileSync(file, 'utf8'))).toEqual({ versionOutput: { tags: ['v1.2.3'] } });
+    expect(JSON.parse(readFileSync(file, 'utf8'))).toEqual({
+      schemaVersion: ENVELOPE_SCHEMA_VERSION,
+      status: 'success',
+      changed: true,
+      data: { versionOutput: { tags: ['v1.2.3'] } },
+      warnings: [],
+      errors: [],
+    });
     expect(log).not.toHaveBeenCalled();
   });
 
-  it('should print to stdout when --json is set and no --output', () => {
+  it('should print a success envelope to stdout when --json is set and no --output', () => {
     const log = vi.spyOn(console, 'log').mockImplementation(() => {});
 
     emitResult({ a: 1 }, { json: true });
 
-    expect(log).toHaveBeenCalledWith(JSON.stringify({ a: 1 }, null, 2));
+    const printed = JSON.parse(log.mock.calls[0][0] as string);
+    expect(printed.status).toBe('success');
+    expect(printed.data).toEqual({ a: 1 });
+    expect(printed.changed).toBe(false);
+  });
+
+  it('should wrap a null result as an envelope with null data', () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    emitResult(null, { json: true });
+
+    const printed = JSON.parse(log.mock.calls[0][0] as string);
+    expect(printed.status).toBe('success');
+    expect(printed.data).toBeNull();
   });
 
   it('should do nothing when neither --json nor --output is set', () => {
@@ -38,11 +59,30 @@ describe('emitResult', () => {
     emitResult({ a: 1 }, {});
     expect(log).not.toHaveBeenCalled();
   });
+});
 
-  it('should do nothing for a null or undefined result', () => {
+describe('emitError', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('should print an error envelope with a structured error to stdout', () => {
     const log = vi.spyOn(console, 'log').mockImplementation(() => {});
-    emitResult(undefined, { json: true });
-    emitResult(null, { json: true });
+
+    emitError(new Error('boom'), { json: true });
+
+    const printed = JSON.parse(log.mock.calls[0][0] as string);
+    expect(printed.status).toBe('error');
+    expect(printed.data).toBeNull();
+    expect(printed.errors[0]).toEqual({
+      code: 'GENERAL_ERROR',
+      category: 'general',
+      retryable: false,
+      message: 'boom',
+    });
+  });
+
+  it('should do nothing when neither --json nor --output is set', () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    emitError(new Error('boom'), {});
     expect(log).not.toHaveBeenCalled();
   });
 });

--- a/packages/release/test/unit/release-command.spec.ts
+++ b/packages/release/test/unit/release-command.spec.ts
@@ -178,4 +178,24 @@ describe('createReleaseCommand', () => {
       consoleSpy.mockRestore();
     });
   });
+
+  describe('input validation', () => {
+    it('should emit an INPUT_ERROR envelope and exit 3 for --stable with --prerelease in json mode', async () => {
+      mockExit.mockImplementation(((code?: number) => {
+        throw new Error(`exit(${code})`);
+      }) as never);
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+      vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+      await expect(
+        createReleaseCommand().parseAsync(['node', 'test', '--json', '--stable', '--prerelease']),
+      ).rejects.toThrow(/exit\(3\)/);
+
+      expect(runRelease).not.toHaveBeenCalled();
+      const envelope = JSON.parse(logSpy.mock.calls[0]?.[0] as string);
+      expect(envelope.status).toBe('error');
+      expect(envelope.errors[0]).toMatchObject({ code: 'INPUT_ERROR', category: 'input', retryable: false });
+      logSpy.mockRestore();
+    });
+  });
 });

--- a/packages/release/test/unit/release-command.spec.ts
+++ b/packages/release/test/unit/release-command.spec.ts
@@ -1,9 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-vi.mock('@releasekit/core');
 vi.mock('../../src/release.js');
 
-import { EXIT_CODES } from '@releasekit/core';
+import { EXIT_CODES, successEnvelope } from '@releasekit/core';
 import { createReleaseCommand } from '../../src/commands/release-command.js';
 import { runRelease } from '../../src/release.js';
 import type { ReleaseOptions, ReleaseOutput } from '../../src/types.js';
@@ -127,10 +126,10 @@ describe('createReleaseCommand', () => {
   });
 
   describe('JSON output', () => {
-    it('should print result as JSON when --json is passed and runRelease returns output', async () => {
+    it('should print result wrapped in a success envelope when --json is passed', async () => {
       const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
       await createReleaseCommand().parseAsync(['node', 'test', '--json']);
-      expect(consoleSpy).toHaveBeenCalledWith(JSON.stringify(mockOutput, null, 2));
+      expect(consoleSpy).toHaveBeenCalledWith(JSON.stringify(successEnvelope(mockOutput, { changed: false }), null, 2));
       consoleSpy.mockRestore();
     });
 
@@ -141,11 +140,11 @@ describe('createReleaseCommand', () => {
       consoleSpy.mockRestore();
     });
 
-    it('should not print JSON when runRelease returns null', async () => {
+    it('should print an envelope with null data when runRelease returns null', async () => {
       vi.mocked(runRelease).mockResolvedValue(null);
       const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
       await createReleaseCommand().parseAsync(['node', 'test', '--json']);
-      expect(consoleSpy).not.toHaveBeenCalled();
+      expect(consoleSpy).toHaveBeenCalledWith(JSON.stringify(successEnvelope(null, { changed: false }), null, 2));
       consoleSpy.mockRestore();
     });
   });

--- a/packages/release/test/unit/standing-pr-command.spec.ts
+++ b/packages/release/test/unit/standing-pr-command.spec.ts
@@ -54,13 +54,36 @@ describe('createStandingPRCommand', () => {
     }) as never);
     const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     try {
+      // Exits with INPUT_ERROR (3), not the general error code.
       await expect(parseCommand(['publish', '--project-dir', '/test', '--pr', '123abc'])).rejects.toThrow(
-        /process\.exit/,
+        /process\.exit\(3\)/,
       );
       expect(runStandingPRPublish).not.toHaveBeenCalled();
       expect(errSpy).toHaveBeenCalledWith(expect.stringContaining('positive integer'));
     } finally {
       exitSpy.mockRestore();
+      errSpy.mockRestore();
+    }
+  });
+
+  it('should emit an INPUT_ERROR envelope for an invalid --pr in json mode', async () => {
+    const { runStandingPRPublish } = await import('../../src/standing-pr/standing-pr.js');
+    vi.mocked(runStandingPRPublish).mockClear();
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit(${code})`);
+    }) as never);
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      await expect(parseCommand(['publish', '--project-dir', '/test', '--json', '--pr', 'abc'])).rejects.toThrow(
+        /process\.exit\(3\)/,
+      );
+      const envelope = JSON.parse(logSpy.mock.calls[0]?.[0] as string);
+      expect(envelope.status).toBe('error');
+      expect(envelope.errors[0]).toMatchObject({ code: 'INPUT_ERROR', category: 'input', retryable: false });
+    } finally {
+      exitSpy.mockRestore();
+      logSpy.mockRestore();
       errSpy.mockRestore();
     }
   });

--- a/packages/release/test/unit/standing-pr-command.spec.ts
+++ b/packages/release/test/unit/standing-pr-command.spec.ts
@@ -88,6 +88,67 @@ describe('createStandingPRCommand', () => {
     }
   });
 
+  // The manifest's versionOutput.updates is populated on every publish run, so it can't distinguish a
+  // real publish from an idempotent re-run — `changed` has to come from the publish effects.
+  describe('publish changed reporting', () => {
+    const manifestVersionOutput = {
+      dryRun: false,
+      updates: [{ packageName: '@acme/widget', currentVersion: '1.4.2', newVersion: '2.0.0', bumpType: 'major' }],
+      changelogs: [],
+      tags: ['v2.0.0'],
+    };
+    const npmResult = { packageName: '@acme/widget', version: '2.0.0', registry: 'npm', success: true };
+
+    async function publishEnvelope(publishOutput: unknown) {
+      const { runStandingPRPublish } = await import('../../src/standing-pr/standing-pr.js');
+      vi.mocked(runStandingPRPublish).mockResolvedValueOnce({
+        versionOutput: manifestVersionOutput,
+        notesGenerated: false,
+        publishOutput,
+      } as never);
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      try {
+        await parseCommand(['publish', '--project-dir', '/test', '--json', '--pr', '189']);
+        return JSON.parse(logSpy.mock.calls[0]?.[0] as string);
+      } finally {
+        logSpy.mockRestore();
+      }
+    }
+
+    it('should report changed:true when a package actually published', async () => {
+      const envelope = await publishEnvelope({
+        dryRun: false,
+        git: { committed: false, tags: ['v2.0.0'], pushed: true },
+        npm: [{ ...npmResult, skipped: false }],
+        cargo: [],
+        pub: [],
+        verification: [],
+        githubReleases: [],
+        publishSucceeded: true,
+      });
+      expect(envelope.status).toBe('success');
+      expect(envelope.changed).toBe(true);
+    });
+
+    it('should report changed:false when every version was already published', async () => {
+      const envelope = await publishEnvelope({
+        dryRun: false,
+        // Tags pushed and the GitHub release "succeeded" (it already existed) — neither is a change.
+        git: { committed: false, tags: ['v2.0.0'], pushed: true },
+        npm: [{ ...npmResult, skipped: true, alreadyPublished: true }],
+        cargo: [],
+        pub: [],
+        verification: [],
+        githubReleases: [{ tag: 'v2.0.0', draft: false, prerelease: false, success: true }],
+        publishSucceeded: true,
+      });
+      expect(envelope.status).toBe('success');
+      expect(envelope.changed).toBe(false);
+      // The manifest payload still rides along untouched — the envelope wraps, never replaces.
+      expect(envelope.data.versionOutput.updates).toHaveLength(1);
+    });
+  });
+
   it('should pass --verbose, --quiet, --json flags through', async () => {
     const { runStandingPRUpdate } = await import('../../src/standing-pr/standing-pr.js');
     await parseCommand(['update', '--verbose', '--quiet', '--json']);

--- a/packages/release/test/unit/standing-pr.spec.ts
+++ b/packages/release/test/unit/standing-pr.spec.ts
@@ -2450,33 +2450,26 @@ describe('runStandingPRPublish', () => {
     ).rejects.toThrow(/manifest not found/);
   });
 
-  it('should return null when API inference finds no merged standing PR', async () => {
+  // The two cases below are failures to resolve a PR, not "nothing to release" — they throw so the
+  // JSON envelope reports status:"error" rather than a successful no-op. Contrast with the head-ref
+  // and not-merged skips below, which stay null: pull_request:closed fires for every closed PR.
+  it('should throw when API inference finds no merged standing PR', async () => {
     delete process.env.GITHUB_EVENT_PATH;
 
     await mockForge({ recentlyClosedPRs: [{ number: 80, mergedAt: null }] });
 
-    const result = await runStandingPRPublish({
-      projectDir: '/test',
-      verbose: false,
-      quiet: false,
-      json: false,
-    });
-
-    expect(result).toBeNull();
+    await expect(
+      runStandingPRPublish({ projectDir: '/test', verbose: false, quiet: false, json: false }),
+    ).rejects.toThrow(/No merged standing release PR found/);
   });
 
-  it('should return null when inference is needed but no GitHub token is available', async () => {
+  it('should throw when inference is needed but no GitHub token is available', async () => {
     delete process.env.GITHUB_EVENT_PATH;
     delete process.env.GITHUB_TOKEN;
 
-    const result = await runStandingPRPublish({
-      projectDir: '/test',
-      verbose: false,
-      quiet: false,
-      json: false,
-    });
-
-    expect(result).toBeNull();
+    await expect(
+      runStandingPRPublish({ projectDir: '/test', verbose: false, quiet: false, json: false }),
+    ).rejects.toThrow(/No GitHub context/);
   });
 
   it('should return null when merged PR head ref does not match release branch', async () => {
@@ -2864,7 +2857,7 @@ describe('runStandingPRPublish', () => {
     expect(branchDeletePushes()).toHaveLength(0);
   });
 
-  it('should return null when no GitHub context is available for a merged release PR', async () => {
+  it('should throw when no GitHub context is available for a merged release PR', async () => {
     delete process.env.GITHUB_REPOSITORY;
     delete process.env.GITHUB_TOKEN;
 
@@ -2875,9 +2868,9 @@ describe('runStandingPRPublish', () => {
       }),
     );
 
-    const result = await runStandingPRPublish({ projectDir: '/test', verbose: false, quiet: false, json: false });
-
-    expect(result).toBeNull();
+    await expect(
+      runStandingPRPublish({ projectDir: '/test', verbose: false, quiet: false, json: false }),
+    ).rejects.toThrow(/No GitHub context/);
   });
 
   it('should throw with actionable message when manifest JSON is malformed', async () => {
@@ -2925,18 +2918,13 @@ describe('publishFromManifest', () => {
     process.env = { ...originalEnv };
   });
 
-  it('should return null when no GitHub context is available', async () => {
+  it('should throw when no GitHub context is available', async () => {
     delete process.env.GITHUB_REPOSITORY;
     delete process.env.GITHUB_TOKEN;
 
-    const result = await publishFromManifest(42, {
-      projectDir: '/test',
-      verbose: false,
-      quiet: false,
-      json: false,
-    });
-
-    expect(result).toBeNull();
+    await expect(
+      publishFromManifest(42, { projectDir: '/test', verbose: false, quiet: false, json: false }),
+    ).rejects.toThrow(/No GitHub context/);
   });
 
   it('should throw when manifest comment is missing from PR', async () => {

--- a/scripts/run-action.d.mts
+++ b/scripts/run-action.d.mts
@@ -36,7 +36,7 @@ export function buildPreviewArgs(input: ActionInputs): string[];
 export function buildRefreshAfterReleaseArgs(input: ActionInputs): string[];
 export function parseReleaseOutput(
   stdout: string,
-): { versionOutput?: { tags?: string[]; updates?: unknown[] } } | undefined;
+): { versionOutput?: { tags?: string[]; updates?: unknown[] } } | null | undefined;
 export function resolveReleaseTags(args: { parsedTags?: string[]; gitTags?: string[]; allowRecovery?: boolean }): {
   tags: string[];
   recovered: boolean;

--- a/scripts/run-action.mjs
+++ b/scripts/run-action.mjs
@@ -162,14 +162,22 @@ export function writeGateOutputs(stdout, verbose = false) {
 export function parseReleaseOutput(stdout, verbose = false) {
   const trimmed = stdout.trim();
   if (!trimmed) return undefined;
+  let parsed;
   try {
-    return JSON.parse(trimmed);
+    parsed = JSON.parse(trimmed);
   } catch (err) {
     if (verbose) {
       console.error(`[run-action] Failed to parse JSON output: ${err.message}`);
     }
     return undefined;
   }
+  // The CLI wraps every result in the uniform envelope { schemaVersion, status, data, ... }; unwrap
+  // to the data payload so output derivation reads result fields (versionOutput, shouldRelease)
+  // directly. Legacy un-enveloped output is returned as-is for backward compatibility.
+  if (parsed && typeof parsed === 'object' && 'schemaVersion' in parsed && 'data' in parsed) {
+    return parsed.data;
+  }
+  return parsed;
 }
 
 // Sync-mode version tags on HEAD, straight from git. The release creates them at HEAD, so they

--- a/scripts/test-packages.ts
+++ b/scripts/test-packages.ts
@@ -215,9 +215,12 @@ function testReleaseDryRun(dir: string): void {
     'Running releasekit release --dry-run --json',
   );
 
-  // Validate JSON output
+  // Validate JSON output. Unwrap the uniform CLI envelope ({ schemaVersion, status, data, … }) to its
+  // data payload; tolerate legacy un-enveloped output.
   try {
-    const result = JSON.parse(output.trim());
+    const parsed = JSON.parse(output.trim());
+    const result =
+      parsed && typeof parsed === 'object' && 'schemaVersion' in parsed && 'data' in parsed ? parsed.data : parsed;
     if (!result.versionOutput) {
       throw new Error('Missing versionOutput in release output');
     }

--- a/test/e2e/lib/helpers.sh
+++ b/test/e2e/lib/helpers.sh
@@ -88,8 +88,14 @@ run_cli_json() {
     cat "$stderrfile" >&2
   fi
 
-  # Output the JSON (stdout only)
-  cat "$tmpfile"
+  # Output the JSON (stdout only). Unwrap the uniform CLI envelope ({ schemaVersion, status, data, … })
+  # to its data payload so callers read result fields (.versionOutput, …) directly. Output that isn't
+  # an envelope — non-JSON, or a command that isn't enveloped yet — passes through unchanged.
+  if jq -e 'type == "object" and has("schemaVersion") and has("data")' "$tmpfile" >/dev/null 2>&1; then
+    jq '.data' "$tmpfile"
+  else
+    cat "$tmpfile"
+  fi
   rm -f "$tmpfile" "$stderrfile"
 
   return $exit_code

--- a/test/integration/action-runner.spec.ts
+++ b/test/integration/action-runner.spec.ts
@@ -256,6 +256,30 @@ describe('action runner', () => {
     expect(parsed?.versionOutput?.tags).toEqual(['v1.0.0']);
   });
 
+  it('should unwrap the data payload from an enveloped success result', () => {
+    const enveloped = JSON.stringify({
+      schemaVersion: 1,
+      status: 'success',
+      changed: true,
+      data: { versionOutput: { updates: [{ packageName: 'a' }], tags: ['v1.0.0'] } },
+      warnings: [],
+      errors: [],
+    });
+    expect(parseReleaseOutput(enveloped)?.versionOutput?.tags).toEqual(['v1.0.0']);
+  });
+
+  it('should unwrap null data from an enveloped error result', () => {
+    const enveloped = JSON.stringify({
+      schemaVersion: 1,
+      status: 'error',
+      changed: false,
+      data: null,
+      warnings: [],
+      errors: [{ code: 'GENERAL_ERROR', category: 'general', retryable: false, message: 'boom' }],
+    });
+    expect(parseReleaseOutput(enveloped)).toBeNull();
+  });
+
   it('should return undefined for non-JSON release output', () => {
     expect(parseReleaseOutput('plain logs')).toBeUndefined();
   });


### PR DESCRIPTION
First PR for the **#544 epic** (agent-grade CLI contract). Establishes the uniform `--json` envelope on the orchestration commands so humans, CI, and agents share one output surface.

## The envelope

Every `--json` / `--output` result from `release`, `gate`, and `standing-pr` is now wrapped:

```jsonc
{
  "schemaVersion": 1,   // contract version; stable across minor releases
  "status": "success",  // "success" | "error"
  "changed": true,      // did work, vs. already in the desired state
  "data": { /* … */ },  // command payload verbatim (VersionOutput, gate result); null on error
  "warnings": [{ "code": "…", "message": "…" }],
  "errors": [{ "code": "…", "category": "…", "retryable": false, "message": "…" }]
}
```

## What's in this PR (mapped to the epic's scope)

- **Uniform envelope** — new `@releasekit/core` module (`successEnvelope` / `errorEnvelope`), applied via `emitResult` / `emitError` in the release, gate, and standing-pr commands. `data` wraps the payload, never replaces it — `release --json` still exposes `VersionOutput` at `data.versionOutput`, so the **manifest-compat invariant holds**.
- **Structured error codes** — `toEnvelopeError` maps thrown errors to `{ code, category, retryable, message }`. `retryable` is conservative (only `true` for known-transient failures, e.g. an `LLMError` that classified a timeout/429/5xx), so an agent never retries an unknown failure. `exitCodeForError` maps the code to the process exit code (`config → 2`, `llm → 5`, …).
- **`changed` reporting** — a dry run is never `changed`; `standing-pr publish` reports `changed: false` on skip-if-published; `gate` is read-only (`changed: false`).
- **Stream discipline** — only the envelope goes to stdout; diagnostics stay on stderr (the logger already uses `console.error`), so parsing stdout as JSON is always safe.
- **Action integration** — `run-action.mjs`'s `parseReleaseOutput` unwraps the envelope's `data`, so every existing Action output (`tags`, `has-changes`, `version-output`, `should-release`, …) is derived unchanged. Legacy un-enveloped output is tolerated.
- **Docs** — new "JSON output contract" section in `docs/cli.md` with the shape, the error-code/exit-code table, and the stability guarantee.

## Deliberately deferred (follow-up PRs within #544)

- **Extend the envelope to the `version | notes | publish` pipe commands.** These pipe JSON between processes, so enveloping their output requires the consuming side to unwrap on input — a self-contained change kept separate to avoid touching the inter-process contract here. This PR leaves that pipe **untouched** (those packages don't import release's `emitResult`).
- **Dry-run as a structured plan diff** — exposing the version→notes→publish plan as a machine-readable `data` plan.

## Testing

- New `envelope.spec.ts` (core) — builders, error mapping, exit-code mapping.
- Updated `emitResult.spec.ts` + `release-command.spec.ts` for the envelope shape; new `emitError` coverage.
- New `parseReleaseOutput` tests for envelope unwrap (success + error envelopes) alongside the legacy path.
- Full suites green: core (195), release (832), root integration (185); repo-wide `typecheck` + `biome check` + eslint clean.

Part of #544.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR establishes a uniform `--json` output envelope for the `release`, `gate`, and `standing-pr` orchestration commands, replacing bare JSON payloads with a versioned `{ schemaVersion, status, changed, data, warnings, errors }` wrapper shared by humans, CI, and agents.

- **New `@releasekit/core` envelope module** — `successEnvelope`/`errorEnvelope` builders, `toEnvelopeError` for structured error mapping, and `exitCodeForError` for process exit routing; all wired into `emitResult`/`emitError`/`failInput` in the release, gate, and standing-pr commands.
- **Input-validation paths made contract-safe** — bare `console.error` + `process.exit` guards in all three commands are replaced by `failInput`, so `--json`/`--output` callers always receive a structured `INPUT_ERROR` envelope even on pre-flight validation failures.
- **`changed` semantics per command** — dry runs always `false`; `standing-pr publish` inspects registry results via `publishDidChange`; `gate` is hardwired to `false`; `runStandingPRPublish` null-return paths converted to throws so they surface as `status:\"error\"` rather than silent no-ops.
- **Action and E2E compatibility** — `run-action.mjs`'s `parseReleaseOutput` unwraps `.data` transparently; the workflow YAML and `helpers.sh` add the same jq unwrap at their respective layers; legacy un-enveloped output is tolerated at every layer.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the envelope contract is additive, all three command layers consistently emit the uniform wrapper, and the input-validation fast-exit paths that previously bypassed the JSON channel are now correctly routed through failInput.

The two previously flagged validation bypass issues are both resolved: bare process.exit guards in release-command and standing-pr-command now go through failInput, which emits an error envelope before exiting. The publishFromManifest and runStandingPRPublish null-return paths are converted to throws, eliminating the silent success no-op risk. The categoryForCode derivation, publishDidChange predicate, and action-layer unwrapping are all correct and covered by the new test suite.

**Files Needing Attention:** No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/core/src/envelope.ts | New file: defines the uniform JSON envelope types and builders, error mapping, and exit-code routing. Logic is correct and well-tested. |
| packages/core/src/errors.ts | Adds InputError (code INPUT_ERROR) — a new concrete ReleaseKitError subclass for CLI input-validation failures. |
| packages/release/src/commands/emitResult.ts | Refactored to emit the uniform envelope; introduces emitError and failInput. All validation paths now honour the JSON contract before exiting. |
| packages/release/src/commands/release-command.ts | Input-validation branches converted from bare console.error + process.exit to failInput; changed derived from version-update count with dry-run guard. |
| packages/release/src/commands/standing-pr-command.ts | All three subcommands now wrap results in the envelope; invalid --pr paths use failInput; changed derived per subcommand semantics. |
| packages/release/src/commands/changed.ts | New publishDidChange helper correctly reads registry results (not manifest data) to detect whether any package actually reached a registry this run. |
| packages/release/src/standing-pr/standing-pr.ts | Error-return paths converted to throws so the envelope command layer reports status:error instead of a silent success no-op. |
| scripts/run-action.mjs | parseReleaseOutput unwraps the envelope data payload; legacy un-enveloped output passes through unchanged. Type declaration updated to include null. |
| .github/workflows/_release.reusable.yml | Shell-level unwrap added to both release jobs; guard fires only after a successful exit. |
| test/e2e/lib/helpers.sh | run_cli_json now extracts .data from the envelope so E2E callers see payload fields directly; non-envelope output passes through unchanged. |

</details>

<sub>Reviews (5): Last reviewed commit: ["fix(cli): derive standing-pr publish \`ch..."](https://github.com/goosewobbler/releasekit/commit/0add3ad3e679b6c01e2ce75b6798405a3f7c2d81) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45828456)</sub>

<!-- /greptile_comment -->