### PR TITLE
fix(lint): keep agent worktrees out of Biome's scope

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -14,6 +14,9 @@
       "!**/out",
       "!.turbo",
       "!**/node_modules",
+      // Agent worktrees are full checkouts carrying their own root biome.jsonc, and Biome refuses to
+      // run at all on a nested root config — in scope, one breaks `pnpm lint` for the whole repo.
+      "!**/.claude",
       // Recorded eval fixtures — opaque provider-response blobs in the cache's native (compact) format.
       // Formatting them would churn on every re-record and diverge from what the harness writes.
       "!packages/notes/test/eval/fixtures/cache"


### PR DESCRIPTION
Agent worktrees under `.claude/worktrees/` are full checkouts, each carrying its own root `biome.jsonc`. Biome refuses to run at all when it discovers a nested root config, so a single leftover worktree broke `pnpm lint` for the whole repo:

```
× Found a nested root configuration, but there's already a root configuration.
× Biome exited because the configuration resulted in errors.
```

The error points at the config rather than the worktree, which makes it awkward to attribute — and it only shows up when a worktree happens to exist, so it comes and goes.

Gitignoring them isn't enough: `vcs.useIgnoreFile` is off, so Biome never reads `.gitignore` (where `.claude/worktrees/` is already listed). Excluding the directory in `files.includes` is what actually takes it out of scope.

## Verification

With a worktree present, `pnpm lint` exits 1 without this change and 0 with it — checked both directions against the same worktree rather than just confirming the happy path.

Repo-wide `pnpm lint` is green (462 files, 29 warnings, exit 0). Those warnings are pre-existing and non-failing (13 `noNonNullAssertion`, 6 `noUndeclaredEnvVars`, and a scattering of others); left alone here, happy to clear them separately if you want them gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FADRmu9uhtCk3StMoqwV27

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR prevents agent worktrees from breaking repository-wide Biome runs.
- Excludes `.claude` directories from Biome file discovery.
- Documents why Git ignore handling alone does not prevent nested root configuration errors.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The new exclusion prevents Biome from traversing nested agent worktrees, and the repository currently contains no tracked `.claude` files whose lint coverage would be lost.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| biome.jsonc | Adds a correctly scoped Biome exclusion for agent worktrees, with no current tracked repository files unintentionally removed from lint coverage. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(lint): keep agent worktrees out of B..."](https://github.com/goosewobbler/releasekit/commit/f9542f3a90366097f0d422806e93436046e3e21b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49363193)</sub>

<!-- /greptile_comment -->