### PR TITLE
test(notes): make the LLM e2e infra-tolerant and close a false green

### DIFF
--- a/packages/notes/test/integration/infra-tolerance.spec.ts
+++ b/packages/notes/test/integration/infra-tolerance.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { LLMError } from '../../src/errors/index.js';
+import { isProviderUnreachable } from './infra-tolerance.js';
+
+/**
+ * The real-provider e2e is opt-in, but this predicate decides whether that check can go red at all —
+ * a version that returns `true` too readily turns every regression into a silent skip. So it is
+ * covered here, in a spec that always runs.
+ */
+describe('isProviderUnreachable', () => {
+  it('should treat a provider-classified transient failure as infra', () => {
+    expect(isProviderUnreachable(new LLMError('Ollama request timed out after 120000ms', { retryable: true }))).toBe(
+      true,
+    );
+  });
+
+  it('should treat a non-retryable request failure as our bug', () => {
+    // A 4xx is a malformed request — retrying won't fix it and neither will waiting for the host.
+    expect(isProviderUnreachable(new LLMError('Ollama request failed: 400', { retryable: false }))).toBe(false);
+  });
+
+  it('should treat an unclassified LLMError as our bug', () => {
+    // Every provider sets the flag explicitly, so an absent one means something unrecognised happened.
+    expect(isProviderUnreachable(new LLMError('something odd'))).toBe(false);
+  });
+
+  it('should never classify a non-LLM failure as infra', () => {
+    // Assertion failures and pipeline TypeErrors are exactly what the check exists to catch.
+    expect(isProviderUnreachable(new Error('expected 35 entries, got 34'))).toBe(false);
+    expect(isProviderUnreachable(new TypeError('x.map is not a function'))).toBe(false);
+    expect(isProviderUnreachable('a string')).toBe(false);
+    expect(isProviderUnreachable(undefined)).toBe(false);
+  });
+});

--- a/packages/notes/test/integration/infra-tolerance.ts
+++ b/packages/notes/test/integration/infra-tolerance.ts
@@ -1,0 +1,18 @@
+import { LLMError } from '../../src/errors/index.js';
+
+/**
+ * Is this failure the provider being unreachable, rather than a regression in our code?
+ *
+ * Separates the two things a real-provider check can fail on. A hosted model going down must not read
+ * as "releasekit broke" — but the inverse mistake is worse: a mis-classified regression skips green
+ * and the blocking check silently stops checking. So the bar for "infra" is deliberately high.
+ *
+ * Only an {@link LLMError} the provider *positively* classified as transient qualifies: a timeout,
+ * 429, 5xx, or socket error. A non-retryable 4xx is a malformed request — our bug — and so is anything
+ * that isn't an LLMError at all, including assertion failures and TypeErrors from our own pipeline.
+ * `retryable: undefined` (unclassified) fails too: every provider sets the flag explicitly, so an
+ * absent one means something unrecognised happened, and a visible red beats a silent skip.
+ */
+export function isProviderUnreachable(error: unknown): boolean {
+  return error instanceof LLMError && error.retryable === true;
+}

--- a/packages/notes/test/integration/notes-llm-e2e.spec.ts
+++ b/packages/notes/test/integration/notes-llm-e2e.spec.ts
@@ -54,19 +54,24 @@ async function callProvider<T>(ctx: TestContext, label: string, run: () => Promi
 describe.skipIf(!E2E_ENABLED)('notes LLM e2e (real Ollama)', () => {
   const provider = new OllamaProvider({ model: MODEL });
 
-  // Establish reachability once, up front, rather than inferring it from a failed assertion later.
   // enhanceAndCategorize never throws on a provider failure — its per-chunk fallback preserves the
-  // input entries — so a test that only counts entries passes against a server that isn't there. The
-  // probe is what lets the assertions below be strict about the model having actually done work.
+  // input entries — so nothing downstream can tell "the model declined to rewrite" from "the model
+  // wasn't there". A cheap completion answers that directly, and is the only thing that can.
+  async function probeReachability(): Promise<string | undefined> {
+    try {
+      await provider.complete([{ role: 'user', content: 'ping' }], { maxTokens: 1 });
+      return undefined;
+    } catch (error) {
+      if (!isProviderUnreachable(error)) throw error;
+      return error instanceof Error ? error.message : String(error);
+    }
+  }
+
+  // Established up front so the assertions below can be strict about the model having done work.
   let unreachable: string | undefined;
 
   beforeAll(async () => {
-    try {
-      await provider.complete([{ role: 'user', content: 'ping' }], { maxTokens: 1 });
-    } catch (error) {
-      if (!isProviderUnreachable(error)) throw error;
-      unreachable = error instanceof Error ? error.message : String(error);
-    }
+    unreachable = await probeReachability();
   }, 120_000);
 
   function skipIfUnreachable(ctx: TestContext): void {
@@ -91,6 +96,21 @@ describe.skipIf(!E2E_ENABLED)('notes LLM e2e (real Ollama)', () => {
     // The model has to have actually rewritten something. The fallback returns descriptions verbatim,
     // so without this the entry-count assertions below hold just as well with no provider at all.
     const rewritten = result.enhancedEntries.filter((e, i) => e.description !== entries[i]?.description);
+
+    // "Nothing was rewritten" is ambiguous, because the fallback produces exactly that when the host
+    // goes away mid-run — and the up-front probe can't see an outage that starts after it. Ask again
+    // before calling it a regression, so a blocking red always means releasekit broke.
+    if (rewritten.length === 0) {
+      const wentAway = await probeReachability();
+      if (wentAway) {
+        console.warn(`[notes-e2e] SKIPPED mid-run: provider became unreachable — ${wentAway}`);
+        // A runtime skip on a proven outage, not a test parked with .skip — .todo() would disable it
+        // permanently, which is the opposite of the intent.
+        // eslint-disable-next-line vitest/no-disabled-tests
+        ctx.skip();
+      }
+    }
+
     expect(rewritten.length).toBeGreaterThan(0);
 
     // Every input entry is accounted for exactly once (enhanced or fallback-preserved), with non-empty

--- a/packages/notes/test/integration/notes-llm-e2e.spec.ts
+++ b/packages/notes/test/integration/notes-llm-e2e.spec.ts
@@ -1,5 +1,6 @@
 import { beforeAll, describe, expect, it, type TestContext } from 'vitest';
 import type { ChangelogEntry } from '../../src/core/types.js';
+import { LLM_DEFAULTS } from '../../src/llm/defaults.js';
 import { OllamaProvider } from '../../src/llm/ollama.js';
 import { enhanceAndCategorize } from '../../src/llm/tasks/enhance-and-categorize.js';
 import { generateReleaseNotes } from '../../src/llm/tasks/release-notes.js';
@@ -28,6 +29,10 @@ import { isProviderUnreachable } from './infra-tolerance.js';
 const E2E_ENABLED = process.env.RELEASEKIT_NOTES_E2E === '1' || process.env.RELEASEKIT_NOTES_E2E === 'true';
 const MODEL = process.env.RELEASEKIT_NOTES_E2E_MODEL ?? 'llama3.2';
 const context = { packageName: 'my-lib', version: '2.0.0', previousVersion: '1.0.0' };
+
+// Read from the source of truth so the case keeps straddling the boundary if the chunk size moves.
+const CHUNK_SIZE = LLM_DEFAULTS.enhanceCategorizeChunkSize;
+const ENTRY_COUNT = CHUNK_SIZE + 5;
 
 /**
  * Run a provider call, skipping the test when the model host is unreachable. This check is meant to
@@ -83,8 +88,8 @@ describe.skipIf(!E2E_ENABLED)('notes LLM e2e (real Ollama)', () => {
   it('should enhance and categorize a large release across chunk boundaries', async (ctx) => {
     skipIfUnreachable(ctx);
 
-    // 35 entries crosses the 30-entry chunk boundary → two real structured calls, then a category merge.
-    const entries: ChangelogEntry[] = Array.from({ length: 35 }, (_, i) => ({
+    // Crosses the chunk boundary → two real structured calls, then a category merge.
+    const entries: ChangelogEntry[] = Array.from({ length: ENTRY_COUNT }, (_, i) => ({
       type: i % 2 === 0 ? 'fixed' : 'added',
       description: `${i % 2 === 0 ? 'Fix' : 'Add'} behaviour ${i} in the widget subsystem`,
     }));
@@ -93,14 +98,20 @@ describe.skipIf(!E2E_ENABLED)('notes LLM e2e (real Ollama)', () => {
       enhanceAndCategorize(provider, entries, context),
     );
 
-    // The model has to have actually rewritten something. The fallback returns descriptions verbatim,
-    // so without this the entry-count assertions below hold just as well with no provider at all.
-    const rewritten = result.enhancedEntries.filter((e, i) => e.description !== entries[i]?.description);
+    // The model has to have actually rewritten something — the fallback returns descriptions verbatim,
+    // so entry counts alone hold just as well with no provider at all. Counted per chunk rather than
+    // over the whole set: chunks fall back independently, so a healthy first chunk would otherwise mask
+    // a second that got nothing, which is exactly what a mid-run outage looks like at the boundary this
+    // test exists to cover.
+    const rewrittenIn = (from: number, to: number) =>
+      result.enhancedEntries.slice(from, to).filter((e, i) => e.description !== entries[from + i]?.description).length;
+    const firstChunk = rewrittenIn(0, CHUNK_SIZE);
+    const lastChunk = rewrittenIn(CHUNK_SIZE, entries.length);
 
-    // "Nothing was rewritten" is ambiguous, because the fallback produces exactly that when the host
-    // goes away mid-run — and the up-front probe can't see an outage that starts after it. Ask again
+    // Either chunk coming back untouched is ambiguous: the fallback produces exactly that when the host
+    // goes away mid-run, and the up-front probe can't see an outage that starts after it. Ask again
     // before calling it a regression, so a blocking red always means releasekit broke.
-    if (rewritten.length === 0) {
+    if (firstChunk === 0 || lastChunk === 0) {
       const wentAway = await probeReachability();
       if (wentAway) {
         console.warn(`[notes-e2e] SKIPPED mid-run: provider became unreachable — ${wentAway}`);
@@ -111,17 +122,18 @@ describe.skipIf(!E2E_ENABLED)('notes LLM e2e (real Ollama)', () => {
       }
     }
 
-    expect(rewritten.length).toBeGreaterThan(0);
+    expect(firstChunk).toBeGreaterThan(0);
+    expect(lastChunk).toBeGreaterThan(0);
 
     // Every input entry is accounted for exactly once (enhanced or fallback-preserved), with non-empty
     // descriptions, and lands in some non-empty category.
-    expect(result.enhancedEntries).toHaveLength(35);
+    expect(result.enhancedEntries).toHaveLength(ENTRY_COUNT);
     expect(result.enhancedEntries.every((e) => typeof e.description === 'string' && e.description.length > 0)).toBe(
       true,
     );
     expect(result.categories.length).toBeGreaterThan(0);
     const categorized = result.categories.reduce((total, c) => total + c.entries.length, 0);
-    expect(categorized).toBe(35);
+    expect(categorized).toBe(ENTRY_COUNT);
   }, 180_000);
 
   it('should produce a prose summary and release notes via the text path', async (ctx) => {

--- a/packages/notes/test/integration/notes-llm-e2e.spec.ts
+++ b/packages/notes/test/integration/notes-llm-e2e.spec.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it, type TestContext } from 'vitest';
 import type { ChangelogEntry } from '../../src/core/types.js';
 import { OllamaProvider } from '../../src/llm/ollama.js';
 import { enhanceAndCategorize } from '../../src/llm/tasks/enhance-and-categorize.js';
 import { generateReleaseNotes } from '../../src/llm/tasks/release-notes.js';
 import { summarizeEntries } from '../../src/llm/tasks/summarize.js';
+import { isProviderUnreachable } from './infra-tolerance.js';
 
 /**
  * Opt-in real-provider e2e for the LLM notes pipeline. The unit specs drive a mock provider and verify
@@ -20,22 +21,77 @@ import { summarizeEntries } from '../../src/llm/tasks/summarize.js';
  * mangles a structured response, the pipeline's per-chunk fallback preserves every entry, so the
  * counts below hold regardless of model quality; the point is that the real provider path runs end to
  * end without hanging or dropping entries.
+ *
+ * Infra-tolerant so this can be a blocking check without making a hosted model's uptime a merge gate:
+ * an unreachable provider skips, everything else fails. See {@link isProviderUnreachable}.
  */
 const E2E_ENABLED = process.env.RELEASEKIT_NOTES_E2E === '1' || process.env.RELEASEKIT_NOTES_E2E === 'true';
 const MODEL = process.env.RELEASEKIT_NOTES_E2E_MODEL ?? 'llama3.2';
 const context = { packageName: 'my-lib', version: '2.0.0', previousVersion: '1.0.0' };
 
+/**
+ * Run a provider call, skipping the test when the model host is unreachable. This check is meant to
+ * block merges, so a red must mean "releasekit broke" and not "the host was down" — but the skip is
+ * narrow ({@link isProviderUnreachable}) and loud, because a skip that swallows a regression defeats
+ * the check entirely.
+ *
+ * Only the provider call is wrapped. Assertions run on the returned value in the caller, so a
+ * wrong-output failure is never mistaken for infrastructure.
+ */
+async function callProvider<T>(ctx: TestContext, label: string, run: () => Promise<T>): Promise<T> {
+  try {
+    return await run();
+  } catch (error) {
+    if (isProviderUnreachable(error)) {
+      const detail = error instanceof Error ? error.message : String(error);
+      console.warn(`[notes-e2e] SKIPPED ${label}: provider unreachable — ${detail}`);
+      ctx.skip();
+    }
+    throw error;
+  }
+}
+
 describe.skipIf(!E2E_ENABLED)('notes LLM e2e (real Ollama)', () => {
   const provider = new OllamaProvider({ model: MODEL });
 
-  it('should enhance and categorize a large release across chunk boundaries', async () => {
+  // Establish reachability once, up front, rather than inferring it from a failed assertion later.
+  // enhanceAndCategorize never throws on a provider failure — its per-chunk fallback preserves the
+  // input entries — so a test that only counts entries passes against a server that isn't there. The
+  // probe is what lets the assertions below be strict about the model having actually done work.
+  let unreachable: string | undefined;
+
+  beforeAll(async () => {
+    try {
+      await provider.complete([{ role: 'user', content: 'ping' }], { maxTokens: 1 });
+    } catch (error) {
+      if (!isProviderUnreachable(error)) throw error;
+      unreachable = error instanceof Error ? error.message : String(error);
+    }
+  }, 120_000);
+
+  function skipIfUnreachable(ctx: TestContext): void {
+    if (unreachable === undefined) return;
+    console.warn(`[notes-e2e] SKIPPED: provider unreachable — ${unreachable}`);
+    ctx.skip();
+  }
+
+  it('should enhance and categorize a large release across chunk boundaries', async (ctx) => {
+    skipIfUnreachable(ctx);
+
     // 35 entries crosses the 30-entry chunk boundary → two real structured calls, then a category merge.
     const entries: ChangelogEntry[] = Array.from({ length: 35 }, (_, i) => ({
       type: i % 2 === 0 ? 'fixed' : 'added',
       description: `${i % 2 === 0 ? 'Fix' : 'Add'} behaviour ${i} in the widget subsystem`,
     }));
 
-    const result = await enhanceAndCategorize(provider, entries, context);
+    const result = await callProvider(ctx, 'enhanceAndCategorize', () =>
+      enhanceAndCategorize(provider, entries, context),
+    );
+
+    // The model has to have actually rewritten something. The fallback returns descriptions verbatim,
+    // so without this the entry-count assertions below hold just as well with no provider at all.
+    const rewritten = result.enhancedEntries.filter((e, i) => e.description !== entries[i]?.description);
+    expect(rewritten.length).toBeGreaterThan(0);
 
     // Every input entry is accounted for exactly once (enhanced or fallback-preserved), with non-empty
     // descriptions, and lands in some non-empty category.
@@ -48,16 +104,20 @@ describe.skipIf(!E2E_ENABLED)('notes LLM e2e (real Ollama)', () => {
     expect(categorized).toBe(35);
   }, 180_000);
 
-  it('should produce a prose summary and release notes via the text path', async () => {
+  it('should produce a prose summary and release notes via the text path', async (ctx) => {
+    skipIfUnreachable(ctx);
+
     const entries: ChangelogEntry[] = [
       { type: 'added', description: 'Add deeplink support for the mobile client' },
       { type: 'fixed', description: 'Fix a crash when the config file is missing' },
     ];
 
-    const summary = await summarizeEntries(provider, entries, context);
+    const summary = await callProvider(ctx, 'summarizeEntries', () => summarizeEntries(provider, entries, context));
     expect(summary.trim().length).toBeGreaterThan(0);
 
-    const notes = await generateReleaseNotes(provider, entries, context);
+    const notes = await callProvider(ctx, 'generateReleaseNotes', () =>
+      generateReleaseNotes(provider, entries, context),
+    );
     expect(notes.trim().length).toBeGreaterThan(0);
   }, 180_000);
 });


### PR DESCRIPTION
First half of #589 — the spec change that has to land before this check can block merges. The workflow job and the `OLLAMA_API_KEY` secret are still outstanding.

## Infra tolerance

`isProviderUnreachable` splits the two things a real-provider check can fail on. Only an `LLMError` the provider *positively* classified as transient (timeout, 429, 5xx, socket) counts as infra. A non-retryable 4xx is a malformed request — our bug — and so is anything that isn't an `LLMError` at all, including assertion failures and pipeline `TypeError`s. An unclassified `LLMError` fails too: every provider sets the flag explicitly, so an absent one means something unrecognised happened, and a visible red beats a silent skip.

It lives in its own module with its own **always-running** spec, because this predicate decides whether the gated check can go red at all — a version that returns `true` too readily turns every regression into a silent skip, and a test that only runs when the gate is enabled wouldn't catch that.

## The false green this surfaced

While verifying the skip path, the chunk-boundary test **passed against an unreachable server in 20ms**.

`enhanceAndCategorize` never throws on a provider failure — its per-chunk fallback preserves the input entries — so asserting entry counts holds just as well with no provider at all. The test could not have detected the thing #589 wants it to guard, and making it blocking as-is would have bought nothing for the structured path.

Two changes close it:

- A `beforeAll` reachability probe, so an absent host is established up front rather than inferred from a later assertion.
- The chunk test now requires that some descriptions actually **differ from their inputs** — evidence the model did work, which the verbatim-preserving fallback never produces.

## Verification

Against a dead port (`OLLAMA_BASE_URL=http://127.0.0.1:59999`, `RELEASEKIT_NOTES_E2E=1`):

```
[notes-e2e] SKIPPED: provider unreachable — Ollama error: fetch failed
 ↓ should enhance and categorize a large release across chunk boundaries
 ↓ should produce a prose summary and release notes via the text path
      Tests  2 skipped (2)
```

Both skip, where one previously reported a false pass.

**The positive path is unverified locally** — no Ollama on this machine. It needs a run against a reachable model before the check is made blocking; worth doing as part of the workflow half.

Notes suite: 447 passed, 2 skipped. Typecheck and lint clean.

Part of #589.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FADRmu9uhtCk3StMoqwV27

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR strengthens the opt-in Ollama E2E suite’s infrastructure handling and closes the partial-chunk false green.
- Adds a narrowly scoped transient-provider classifier with always-running coverage.
- Probes initial provider reachability and skips tests when infrastructure is unavailable.
- Requires every structured-call chunk to contain actual model rewrites and rechecks reachability before attributing untouched output to a regression.
</details>

<h3>Confidence Score: 4/5</h3>

The PR should not merge until a transient outage that recovers before the follow-up probe can no longer make the blocking E2E check report a product regression.

The partial-chunk false green is fixed, but a provider call can still fall back to untouched entries during a brief outage and then fail the rewrite assertion once the subsequent reachability probe observes the recovered provider.

**Files Needing Attention:** packages/notes/test/integration/notes-llm-e2e.spec.ts

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/notes/test/integration/infra-tolerance.ts | Adds the explicit `LLMError.retryable` predicate used to distinguish transient provider failures from test regressions. |
| packages/notes/test/integration/infra-tolerance.spec.ts | Covers transient, non-retryable, unclassified, and non-LLM error classification. |
| packages/notes/test/integration/notes-llm-e2e.spec.ts | Adds initial and fallback-time reachability probes plus per-chunk rewrite assertions for the real-provider E2E suite. |

</details>

<sub>Reviews (3): Last reviewed commit: ["test(notes): count rewrites per chunk so..."](https://github.com/goosewobbler/releasekit/commit/e752b11ee22bf3b6302da95dbb51efcc1a498b3e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49375489)</sub>

**Context used:**

- Knowledge Base — [packages/notes — Release Notes and Changelog Generation](https://app.greptile.com/goosewobbler/-/custom-context/knowledge-base/goosewobbler/releasekit/-/docs/package-notes.md)

<!-- /greptile_comment -->