### PR TITLE
docs: document the standing-PR body as an interface, add agent guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,9 +162,11 @@ See the [package docs](#documentation) for the full option reference.
 - [Rust / Cargo](./docs/rust.md) — Rust crate versioning and crates.io publishing
 - [Dart / pub.dev](./docs/dart.md) — Dart/Flutter versioning and pub.dev publishing
 - [Migration](./docs/migration.md) — from semantic-release or changesets
+- [Agents](./docs/agents.md) — AGENTS.md snippet, the propose → approve → publish boundary
 
 **Reference**
 - [CLI](./docs/cli.md) — every command and flag for the `releasekit` CLI
+- [Standing-PR body](./docs/standing-pr-body.md) — the editable regions, what an edit does, what is bot-owned
 - [Configuration](./docs/configuration.md) — full config reference (all `releasekit.config.json` options)
 - [GitHub Action](./docs/action.md) — `goosewobbler/releasekit` action inputs, outputs, and rollout
 - [@releasekit/release](./packages/release/README.md) — unified pipeline, CI automation, programmatic API

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,0 +1,51 @@
+# Agents
+
+releasekit's agent surface is its CLI contract, not an MCP server — see [ADR-0002](./adr/0002-no-mcp-server-cli-is-the-agent-surface.md). Every orchestration command speaks the same [JSON envelope](./cli.md#json-output-contract), with structured error codes and a `changed` flag, so an agent can act on results without scraping prose.
+
+This page covers the rest: what an agent needs to know about a repo that uses releasekit, and where the safety boundary sits.
+
+## AGENTS.md snippet
+
+Paste into your repository's `AGENTS.md` (or `CLAUDE.md`):
+
+```markdown
+## Releases (releasekit)
+
+Releases run from an open standing release PR. Its body contains machine-read regions
+delimited by `<!-- releasekit-* -->` / `<!-- rk-* -->` markers — reflowing the markdown or
+stripping those comments changes what ships.
+
+- Never edit, move, or delete a marker comment. Rewording a row's visible label is fine.
+- Write release notes only between the `releasekit-notes` markers.
+- Don't tick/untick the "Packages to release" rows unless that is the change being asked for —
+  each decides whether, and on which channel, a package releases.
+- Don't edit the manifest comment; run `releasekit standing-pr update` to regenerate it.
+- Never publish, tag, or push a release directly. Releases happen on merge, from CI.
+- To see what would release: `releasekit preview --dry-run`, or `releasekit release --dry-run --json`.
+```
+
+Full detail on the regions: [The standing-PR body is an interface](./standing-pr-body.md).
+
+## The safety boundary
+
+releasekit's standing-PR mode already has the shape the post-incident guidance converged on. Stated explicitly:
+
+**Agent proposes → human approves → CI publishes.**
+
+- An agent contributes the way anyone else does: a feeder PR, or an edit to the standing PR's notes region. It never holds a registry credential.
+- The **merge is the approval**, and a branch-protection ruleset on the release branch is what enforces it. This is the actual gate — not the instructions above, which are advisory.
+- **CI publishes**, authenticating with short-lived OIDC tokens rather than a long-lived token an agent (or a compromised dependency) could exfiltrate. See [OIDC setup](../packages/release/docs/ci-setup.md).
+
+The properties that matter fall out of that split: nothing an agent does reaches a registry without a human merge, and the credential that can publish exists only inside a CI job, only for its duration.
+
+Two supporting checks: the manifest is validated against the merged source before publishing — versions re-read from the actual package manifests, base SHA required to be an ancestor of `HEAD` — so an edited manifest is refused, not trusted; and selection, channel, and release-control label changes are reverted when made by an unauthorized actor, if [`ci.standingPr.authorization`](./configuration.md) is configured.
+
+## Why not have an AI write your release script?
+
+Because the bespoke release script is the thing that keeps getting attacked, and the one you generate is the one nobody maintains.
+
+The 2024–25 supply-chain incidents that hit publishing pipelines — Ultralytics, s1ngularity, GhostAction — all landed through **bespoke release workflows**, not through a maintained release tool. A generated script has the same exposure with none of the review: it embeds whatever token handling was idiomatic the day it was written, and no one revisits it.
+
+It also rots silently. npm's revocation of classic tokens broke every hand-rolled publish script written before December 2025, all at once. A maintained tool absorbs that kind of registry policy change as an upgrade; a generated script fails at the worst moment, in a job nobody watches until a release is due.
+
+The argument isn't that an agent can't write the script. It's that a release pipeline is a security boundary with a moving spec, which is precisely the thing you want maintained rather than generated once.

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -34,9 +34,11 @@ releasekit's standing-PR mode already has the shape the post-incident guidance c
 
 - An agent contributes the way anyone else does: a feeder PR, or an edit to the standing PR's notes region. It never holds a registry credential.
 - The **merge is the approval**, and a branch-protection ruleset on the release branch is what enforces it. This is the actual gate — not the instructions above, which are advisory.
-- **CI publishes**, authenticating with short-lived OIDC tokens rather than a long-lived token an agent (or a compromised dependency) could exfiltrate. See [OIDC setup](../packages/release/docs/ci-setup.md).
+- **CI publishes**, using short-lived OIDC tokens where the registry supports them — npm and pub.dev do. See [OIDC setup](../packages/release/docs/ci-setup.md).
 
-The properties that matter fall out of that split: nothing an agent does reaches a registry without a human merge, and the credential that can publish exists only inside a CI job, only for its duration.
+The property that holds regardless of registry is the one that matters most: nothing an agent does reaches a registry without a human merge, because the credential lives in CI and CI only runs the publish after the merge.
+
+**crates.io is the exception on credentials.** It has no OIDC support yet, so cargo publishing needs a long-lived `CARGO_REGISTRY_TOKEN` repository secret. That secret outlives any single job, so it wants the handling a long-lived credential always wants — scoped as narrowly as the registry allows, rotated, and restricted to the environment the release job runs in. Tracked in [#546](https://github.com/goosewobbler/releasekit/issues/546).
 
 Two supporting checks: the manifest is validated against the merged source before publishing — versions re-read from the actual package manifests, base SHA required to be an ancestor of `HEAD` — so an edited manifest is refused, not trusted; and selection, channel, and release-control label changes are reverted when made by an unauthorized actor, if [`ci.standingPr.authorization`](./configuration.md) is configured.
 

--- a/docs/standing-pr-body.md
+++ b/docs/standing-pr-body.md
@@ -1,0 +1,54 @@
+# The standing-PR body is an interface
+
+In standing-PR mode, releasekit keeps one open pull request — the standing release PR — describing the next release. Its body is **not prose**. Parts of it are read back by the bot and decide what ships.
+
+This matters because a pull request body is the one place people (and coding agents) edit freely. Reflowing the markdown, tidying the wording, or stripping HTML comments can change what gets published or break the region entirely, and none of it looks wrong in review — the prose still reads fine.
+
+This page says which parts are inputs, what an edit does, and what is bot-owned.
+
+## The regions
+
+Everything machine-read is delimited by an HTML comment marker. **The markers are the contract.** The bot never parses the surrounding prose — it slices between markers and, for checkboxes, reads only the `[x]` / `[ ]` glyph. That means you can reword a row's visible label freely; you cannot move, edit, or delete its marker.
+
+| Marker | What it is | What an edit does |
+|---|---|---|
+| `<!-- releasekit-notes -->` … `<!-- releasekit-notes-end -->`<br>(keyed `<!-- releasekit-notes:<pkg> -->` when multi-package) | Editable release notes, one region per releasing package | Text inside **replaces** the generated release notes for that package, at publish |
+| `<!-- rk-sel:<pkg> -->` | A row in the **Packages to release** checklist | Unticking holds that package back from the next release |
+| `<!-- rk-pre:<pkg> -->` | Channel toggle on a stable row | Ticking ships that package as a prerelease |
+| `<!-- rk-grad:<pkg> -->` | Channel toggle on a prerelease row | Ticking graduates that package to stable |
+| `<!-- releasekit-manifest -->` | The release manifest, in a bot comment | **Bot-owned.** Drives the entire publish |
+
+The checklist rows live inside `<!-- releasekit-selection -->` … `<!-- releasekit-selection-end -->`, and the manifest lives in its own comment rather than the body.
+
+### Editable release notes
+
+Only present when the standing PR carries the preview-notes label (`release:preview-notes` by default — see [`ci.labels`](./configuration.md)). With the label on, releasekit generates notes into the region once; edits made there survive the branch being regenerated and force-pushed, and are what lands in the GitHub Release.
+
+Write inside the markers. Content outside them is regenerated.
+
+### The manifest
+
+The manifest comment carries the machine state for the merge: the computed versions, the base SHA the plan was built against, and the labels in force. At publish it is validated against the merged source — versions are re-read from the actual package manifests, and the base SHA must be an ancestor of `HEAD` — so a hand-edited manifest is refused rather than trusted. Don't edit it; re-run `standing-pr update` to regenerate.
+
+## Who can change what
+
+Two different rules, and the difference is worth knowing before you rely on either.
+
+**Selection, channel, and release-control labels are authorization-gated** when [`ci.standingPr.authorization`](./configuration.md) is configured. An edit from an actor without the required permission is **reverted** — the checklist is reset to the approved selection and a comment explains why. The manifest, not the body, is authoritative for these.
+
+**Release-notes prose is not gated.** Anyone who can edit the PR body can change the text that ships in the GitHub Release. The publish path reads the region from the live body with no author check. That is a deliberate difference in kind — prose doesn't decide what version of what package goes to a registry — but it does mean the notes region inherits whatever your repository's write access already allows.
+
+Neither substitutes for branch protection. The merge is the approval gate; a branch-protection ruleset on the release branch is what actually decides whether a release happens.
+
+## For agents
+
+If you are an AI agent working in a repository with an open standing release PR:
+
+- **Don't reformat the PR body.** It contains machine-read regions. Reflowing markdown or stripping HTML comments can change what ships.
+- **Don't edit, move, or delete any `<!-- releasekit-* -->` or `<!-- rk-* -->` marker.** Rewording a row's visible label is safe; touching its marker is not.
+- **Write release notes only between the `releasekit-notes` markers**, and only when asked to.
+- **Don't tick or untick checklist rows** unless the change is what was asked for — each one decides whether, and on which channel, a package releases.
+- **Don't edit the manifest comment.** Re-run `releasekit standing-pr update` instead.
+- **Don't publish, tag, or push directly.** The release happens on merge, from CI.
+
+A paste-ready version of this list for your own `AGENTS.md` is in [Agents](./agents.md#agentsmd-snippet).


### PR DESCRIPTION
Covers items 1–4 of #549, which was rescoped away from leading with a skill.

## The gap

The standing-PR body carries machine-read regions that decide what ships, and nothing in `docs/` said so. Standing PRs are referenced across the docs, but no page stated where a human or agent may write, what an edit does, or what is bot-owned.

An agent — or a person — tidying the body, reflowing the markdown, or stripping HTML comments changes the release. It looks fine in review, because the prose still reads correctly.

## `docs/standing-pr-body.md`

The reference: every marker (`releasekit-notes`, `rk-sel`, `rk-pre`, `rk-grad`, `releasekit-manifest`), what an edit to each does, and what the bot owns and will overwrite. Written for humans as much as agents.

It also states plainly a distinction that's currently only discoverable by reading the source — **the two access rules differ**:

- **Selection, channel, and release-control labels are reverted** when an unauthorized actor changes them (given `ci.standingPr.authorization`), with a comment explaining why. The manifest is authoritative.
- **Release-notes prose has no author check** on the publish path — `publishFromManifest` reads the region from the live PR body unconditionally.

That's defensible, since prose doesn't decide what version of what package reaches a registry. But it should be known rather than discovered.

## `docs/agents.md`

- The paste-ready **AGENTS.md snippet** — the highest value-per-byte item, since it's what an agent actually reads before touching a release PR.
- The **propose → approve → publish** boundary, with the enforcement named at each step: rulesets gate the merge, OIDC scopes the credential, and the advisory text gates nothing.
- The **positioning** section on why a generated release script is the wrong thing to own — the incident receipts were all bespoke workflows, and npm's classic-token revocation broke every pre-Dec-2025 hand-rolled script at once.

## No SKILL.md

Deferred per the rescoped issue: it ships only if these prove insufficient against a real consumer (wdio-desktop-mobile, zubridge). The sampo precedent doesn't transfer — sampo needs a skill because changesets requires authoring a file in a bespoke format, while releasekit is commit-first on conventional commits, which agents already know.

## Verification

Every marker, the `release:preview-notes` label default, the manifest-validation behaviour, and every cross-link checked against source rather than written from memory. `rk-pre`/`rk-grad` semantics corrected after reading their definitions.

Closes #549.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FADRmu9uhtCk3StMoqwV27

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds documentation that treats the standing-release-PR body as a machine-read interface and gives coding agents explicit release safety guidance.
- Documents editable, authorization-gated, and bot-owned standing-PR regions.
- Adds a paste-ready AGENTS.md snippet and explains the propose → approve → publish boundary.
- Qualifies OIDC guidance by documenting crates.io’s long-lived `CARGO_REGISTRY_TOKEN` requirement.
- Links the new guides from the README.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The previous Cargo credential concern is resolved by limiting the OIDC claim to supported registries and explicitly documenting crates.io’s long-lived token requirement; no blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| README.md | Adds navigation links for the new agent and standing-PR body documentation. |
| docs/agents.md | Documents agent-facing release guidance, approval boundaries, registry credential differences, and why release pipelines should remain maintained infrastructure. |
| docs/standing-pr-body.md | Defines the standing-PR markers, ownership rules, edit semantics, authorization behavior, and agent precautions. |

</details>

<sub>Reviews (2): Last reviewed commit: ["docs: qualify the OIDC claim — crates.io..."](https://github.com/goosewobbler/releasekit/commit/fa2f7e59e80fac39fcc8a3c659bbceaf09a26263) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49375845)</sub>

<!-- /greptile_comment -->